### PR TITLE
Add config file flag to archive command

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -97,5 +97,6 @@ func init() {
 	archiveCmd.Flags().SortFlags = false
 	archiveCmd.Flags().AddFlagSet(optionFlagSet())
 	archiveCmd.Flags().AddFlagSet(runtimeOptionFlagSet(false))
+	archiveCmd.Flags().AddFlagSet(configFileFlagSet())
 	archiveCmd.Flags().StringVarP(&archiveOut, "archive-out", "O", archiveOut, "archive output filename")
 }

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -40,6 +40,14 @@ const configFilename = "config.json"
 var configDirs = configdir.New("loadimpact", "k6")
 var configFile = os.Getenv("K6_CONFIG") // overridden by `-c` flag!
 
+// configFileFlagSet returns a FlagSet that contains flags needed for specifying a config file.
+func configFileFlagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("", 0)
+	flags.StringVarP(&configFile, "config", "c", configFile, "specify config file to read")
+	return flags
+}
+
+// configFlagSet returns a FlagSet with the default run configuration flags.
 func configFlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("", 0)
 	flags.SortFlags = false
@@ -47,7 +55,7 @@ func configFlagSet() *pflag.FlagSet {
 	flags.BoolP("linger", "l", false, "keep the API server alive past test end")
 	flags.Bool("no-usage-report", false, "don't send anonymous stats to the developers")
 	flags.Bool("no-thresholds", false, "don't run thresholds")
-	flags.StringVarP(&configFile, "config", "c", configFile, "specify config file to read")
+	flags.AddFlagSet(configFileFlagSet())
 	return flags
 }
 


### PR DESCRIPTION
Closes #519 and supersedes #520 

There might be another issue here, the global flags set for all commands don't make sense all the time. For instance, `archive` command has support for `address` flag (or that's what `--help` shows). It would probably be better to refactor [cmd/root.go](https://github.com/loadimpact/k6/blob/master/cmd/root.go#L90) in a separate PR.

```
$ ./k6 archive --help
Create an archive.

An archive is a fully self-contained test run, and can be executed identically elsewhere.

Usage:
  k6 archive [flags]

Examples:
  # Archive a test run.
  k6 archive -u 10 -d 10s -O myarchive.tar script.js

  # Run the resulting archive.
  k6 run myarchive.tar

Flags:
  -u, --vus int                         number of virtual users (default 1)
  -m, --max int                         max available virtual users
  -d, --duration duration               test duration limit
  -i, --iterations int                  script iteration limit
  -s, --stage stage                     add a stage, as `[duration]:[target]`
  -p, --paused                          start the test in a paused state
      --max-redirects int               follow at most n redirects (default 10)
      --batch int                       max parallel batch reqs (default 10)
      --batch-per-host int              max parallel batch reqs per host
      --rps int                         limit requests per second
      --user-agent string               user agent for http requests (default "k6/0.20.0 (https://k6.io/);")
      --http-debug string[="headers"]   log all HTTP requests and responses. Excludes body by default. To include body use '---http-debug=full'
      --insecure-skip-tls-verify        skip verification of TLS certificates
      --no-connection-reuse             don't reuse connections between iterations
  -w, --throw                           throw warnings (like failed http requests) as errors
      --blacklist-ip ip range           blacklist an ip range from being called
      --summary-trend-stats stats       define stats for trend metrics (response times), one or more as 'avg,p(95),...'
      --system-tags stringSlice         only include these system tags in metrics (default [proto,subproto,status,method,url,name,group,check,error,tls_version])
      --tag tag                         add a tag to be applied to all samples, as `[name]=[value]`
      --include-system-env-vars         pass the real system environment variables to the runtime
  -e, --env VAR=value                   add/override environment variable with VAR=value
  -O, --archive-out string              archive output filename (default "archive.tar")
  -h, --help                            help for archive

Global Flags:
  -a, --address string     address for the api server (default "localhost:6565")
  -c, --config string      config file (default ./k6.yaml or ~/.config/k6.yaml)
      --logformat string   log output format
      --no-color           disable colored output
  -q, --quiet              disable progress updates
  -v, --verbose            enable debug logging```

