### PR TITLE
Fix gometalinter errors

### DIFF
--- a/cmd/collectors.go
+++ b/cmd/collectors.go
@@ -112,7 +112,7 @@ func newCollector(collectorName, arg string, src *lib.SourceData, conf Config) (
 	}
 	if len(missingRequiredTags) > 0 {
 		return collector, fmt.Errorf(
-			"The specified collector '%s' needs the following system tags enabled: %s",
+			"the specified collector '%s' needs the following system tags enabled: %s",
 			collectorName,
 			strings.Join(missingRequiredTags, ", "),
 		)

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v3"
+	null "gopkg.in/guregu/null.v3"
 )
 
 type testErrorWithString string
@@ -55,16 +55,16 @@ func applyNullLogger(e *Engine) *logtest.Hook {
 }
 
 // Wrapper around newEngine that applies a null logger.
-func newTestEngine(ex lib.Executor, opts lib.Options) (*Engine, error, *logtest.Hook) {
+func newTestEngine(ex lib.Executor, opts lib.Options) (*Engine, error) {
 	if !opts.MetricSamplesBufferSize.Valid {
 		opts.MetricSamplesBufferSize = null.IntFrom(200)
 	}
 	e, err := NewEngine(ex, opts)
 	if err != nil {
-		return e, err, nil
+		return e, err
 	}
-	hook := applyNullLogger(e)
-	return e, nil, hook
+	applyNullLogger(e)
+	return e, nil
 }
 
 func LF(fn func(ctx context.Context, out chan<- stats.SampleContainer) error) lib.Executor {
@@ -72,13 +72,13 @@ func LF(fn func(ctx context.Context, out chan<- stats.SampleContainer) error) li
 }
 
 func TestNewEngine(t *testing.T) {
-	_, err, _ := newTestEngine(nil, lib.Options{})
+	_, err := newTestEngine(nil, lib.Options{})
 	assert.NoError(t, err)
 }
 
 func TestNewEngineOptions(t *testing.T) {
 	t.Run("Duration", func(t *testing.T) {
-		e, err, _ := newTestEngine(nil, lib.Options{
+		e, err := newTestEngine(nil, lib.Options{
 			Duration: types.NullDurationFrom(10 * time.Second),
 		})
 		assert.NoError(t, err)
@@ -86,14 +86,14 @@ func TestNewEngineOptions(t *testing.T) {
 		assert.Equal(t, types.NullDurationFrom(10*time.Second), e.Executor.GetEndTime())
 
 		t.Run("Infinite", func(t *testing.T) {
-			e, err, _ := newTestEngine(nil, lib.Options{Duration: types.NullDuration{}})
+			e, err := newTestEngine(nil, lib.Options{Duration: types.NullDuration{}})
 			assert.NoError(t, err)
 			assert.Nil(t, e.Executor.GetStages())
 			assert.Equal(t, types.NullDuration{}, e.Executor.GetEndTime())
 		})
 	})
 	t.Run("Stages", func(t *testing.T) {
-		e, err, _ := newTestEngine(nil, lib.Options{
+		e, err := newTestEngine(nil, lib.Options{
 			Stages: []lib.Stage{
 				{Duration: types.NullDurationFrom(10 * time.Second), Target: null.IntFrom(10)},
 			},
@@ -104,7 +104,7 @@ func TestNewEngineOptions(t *testing.T) {
 		}
 	})
 	t.Run("Stages/Duration", func(t *testing.T) {
-		e, err, _ := newTestEngine(nil, lib.Options{
+		e, err := newTestEngine(nil, lib.Options{
 			Duration: types.NullDurationFrom(60 * time.Second),
 			Stages: []lib.Stage{
 				{Duration: types.NullDurationFrom(10 * time.Second), Target: null.IntFrom(10)},
@@ -117,19 +117,19 @@ func TestNewEngineOptions(t *testing.T) {
 		assert.Equal(t, types.NullDurationFrom(60*time.Second), e.Executor.GetEndTime())
 	})
 	t.Run("Iterations", func(t *testing.T) {
-		e, err, _ := newTestEngine(nil, lib.Options{Iterations: null.IntFrom(100)})
+		e, err := newTestEngine(nil, lib.Options{Iterations: null.IntFrom(100)})
 		assert.NoError(t, err)
 		assert.Equal(t, null.IntFrom(100), e.Executor.GetEndIterations())
 	})
 	t.Run("VUsMax", func(t *testing.T) {
 		t.Run("not set", func(t *testing.T) {
-			e, err, _ := newTestEngine(nil, lib.Options{})
+			e, err := newTestEngine(nil, lib.Options{})
 			assert.NoError(t, err)
 			assert.Equal(t, int64(0), e.Executor.GetVUsMax())
 			assert.Equal(t, int64(0), e.Executor.GetVUs())
 		})
 		t.Run("set", func(t *testing.T) {
-			e, err, _ := newTestEngine(nil, lib.Options{
+			e, err := newTestEngine(nil, lib.Options{
 				VUsMax: null.IntFrom(10),
 			})
 			assert.NoError(t, err)
@@ -139,26 +139,26 @@ func TestNewEngineOptions(t *testing.T) {
 	})
 	t.Run("VUs", func(t *testing.T) {
 		t.Run("no max", func(t *testing.T) {
-			_, err, _ := newTestEngine(nil, lib.Options{
+			_, err := newTestEngine(nil, lib.Options{
 				VUs: null.IntFrom(10),
 			})
 			assert.EqualError(t, err, "can't raise vu count (to 10) above vu cap (0)")
 		})
 		t.Run("negative max", func(t *testing.T) {
-			_, err, _ := newTestEngine(nil, lib.Options{
+			_, err := newTestEngine(nil, lib.Options{
 				VUsMax: null.IntFrom(-1),
 			})
 			assert.EqualError(t, err, "vu cap can't be negative")
 		})
 		t.Run("max too low", func(t *testing.T) {
-			_, err, _ := newTestEngine(nil, lib.Options{
+			_, err := newTestEngine(nil, lib.Options{
 				VUsMax: null.IntFrom(1),
 				VUs:    null.IntFrom(10),
 			})
 			assert.EqualError(t, err, "can't raise vu count (to 10) above vu cap (1)")
 		})
 		t.Run("max higher", func(t *testing.T) {
-			e, err, _ := newTestEngine(nil, lib.Options{
+			e, err := newTestEngine(nil, lib.Options{
 				VUsMax: null.IntFrom(10),
 				VUs:    null.IntFrom(1),
 			})
@@ -167,7 +167,7 @@ func TestNewEngineOptions(t *testing.T) {
 			assert.Equal(t, int64(1), e.Executor.GetVUs())
 		})
 		t.Run("max just right", func(t *testing.T) {
-			e, err, _ := newTestEngine(nil, lib.Options{
+			e, err := newTestEngine(nil, lib.Options{
 				VUsMax: null.IntFrom(10),
 				VUs:    null.IntFrom(10),
 			})
@@ -178,19 +178,19 @@ func TestNewEngineOptions(t *testing.T) {
 	})
 	t.Run("Paused", func(t *testing.T) {
 		t.Run("not set", func(t *testing.T) {
-			e, err, _ := newTestEngine(nil, lib.Options{})
+			e, err := newTestEngine(nil, lib.Options{})
 			assert.NoError(t, err)
 			assert.False(t, e.Executor.IsPaused())
 		})
 		t.Run("false", func(t *testing.T) {
-			e, err, _ := newTestEngine(nil, lib.Options{
+			e, err := newTestEngine(nil, lib.Options{
 				Paused: null.BoolFrom(false),
 			})
 			assert.NoError(t, err)
 			assert.False(t, e.Executor.IsPaused())
 		})
 		t.Run("true", func(t *testing.T) {
-			e, err, _ := newTestEngine(nil, lib.Options{
+			e, err := newTestEngine(nil, lib.Options{
 				Paused: null.BoolFrom(true),
 			})
 			assert.NoError(t, err)
@@ -198,7 +198,7 @@ func TestNewEngineOptions(t *testing.T) {
 		})
 	})
 	t.Run("thresholds", func(t *testing.T) {
-		e, err, _ := newTestEngine(nil, lib.Options{
+		e, err := newTestEngine(nil, lib.Options{
 			Thresholds: map[string]stats.Thresholds{
 				"my_metric": {},
 			},
@@ -207,7 +207,7 @@ func TestNewEngineOptions(t *testing.T) {
 		assert.Contains(t, e.thresholds, "my_metric")
 
 		t.Run("submetrics", func(t *testing.T) {
-			e, err, _ := newTestEngine(nil, lib.Options{
+			e, err := newTestEngine(nil, lib.Options{
 				Thresholds: map[string]stats.Thresholds{
 					"my_metric{tag:value}": {},
 				},
@@ -223,7 +223,7 @@ func TestEngineRun(t *testing.T) {
 	log.SetLevel(log.DebugLevel)
 	t.Run("exits with context", func(t *testing.T) {
 		duration := 100 * time.Millisecond
-		e, err, _ := newTestEngine(nil, lib.Options{})
+		e, err := newTestEngine(nil, lib.Options{})
 		assert.NoError(t, err)
 
 		ctx, cancel := context.WithTimeout(context.Background(), duration)
@@ -233,7 +233,7 @@ func TestEngineRun(t *testing.T) {
 		assert.WithinDuration(t, startTime.Add(duration), time.Now(), 100*time.Millisecond)
 	})
 	t.Run("exits with executor", func(t *testing.T) {
-		e, err, _ := newTestEngine(nil, lib.Options{
+		e, err := newTestEngine(nil, lib.Options{
 			VUs:        null.IntFrom(10),
 			VUsMax:     null.IntFrom(10),
 			Iterations: null.IntFrom(100),
@@ -249,7 +249,7 @@ func TestEngineRun(t *testing.T) {
 
 		signalChan := make(chan interface{})
 		var e *Engine
-		e, err, _ := newTestEngine(LF(func(ctx context.Context, samples chan<- stats.SampleContainer) error {
+		e, err := newTestEngine(LF(func(ctx context.Context, samples chan<- stats.SampleContainer) error {
 			samples <- stats.Sample{Metric: testMetric, Time: time.Now(), Value: 1}
 			close(signalChan)
 			<-ctx.Done()
@@ -296,7 +296,7 @@ func TestEngineRun(t *testing.T) {
 }
 
 func TestEngineAtTime(t *testing.T) {
-	e, err, _ := newTestEngine(nil, lib.Options{})
+	e, err := newTestEngine(nil, lib.Options{})
 	assert.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -307,7 +307,7 @@ func TestEngineAtTime(t *testing.T) {
 func TestEngineCollector(t *testing.T) {
 	testMetric := stats.New("test_metric", stats.Trend)
 
-	e, err, _ := newTestEngine(LF(func(ctx context.Context, out chan<- stats.SampleContainer) error {
+	e, err := newTestEngine(LF(func(ctx context.Context, out chan<- stats.SampleContainer) error {
 		out <- stats.Sample{Metric: testMetric}
 		return nil
 	}), lib.Options{VUs: null.IntFrom(1), VUsMax: null.IntFrom(1), Iterations: null.IntFrom(1)})
@@ -339,7 +339,7 @@ func TestEngine_processSamples(t *testing.T) {
 	metric := stats.New("my_metric", stats.Gauge)
 
 	t.Run("metric", func(t *testing.T) {
-		e, err, _ := newTestEngine(nil, lib.Options{})
+		e, err := newTestEngine(nil, lib.Options{})
 		assert.NoError(t, err)
 
 		e.processSamples(
@@ -352,7 +352,7 @@ func TestEngine_processSamples(t *testing.T) {
 		ths, err := stats.NewThresholds([]string{`1+1==2`})
 		assert.NoError(t, err)
 
-		e, err, _ := newTestEngine(nil, lib.Options{
+		e, err := newTestEngine(nil, lib.Options{
 			Thresholds: map[string]stats.Thresholds{
 				"my_metric{a:1}": ths,
 			},
@@ -383,7 +383,7 @@ func TestEngine_runThresholds(t *testing.T) {
 	t.Run("aborted", func(t *testing.T) {
 		ths.Thresholds[0].AbortOnFail = true
 		thresholds[metric.Name] = ths
-		e, err, _ := newTestEngine(nil, lib.Options{Thresholds: thresholds})
+		e, err := newTestEngine(nil, lib.Options{Thresholds: thresholds})
 		assert.NoError(t, err)
 
 		e.processSamples(
@@ -406,7 +406,7 @@ func TestEngine_runThresholds(t *testing.T) {
 	t.Run("canceled", func(t *testing.T) {
 		ths.Abort = false
 		thresholds[metric.Name] = ths
-		e, err, _ := newTestEngine(nil, lib.Options{Thresholds: thresholds})
+		e, err := newTestEngine(nil, lib.Options{Thresholds: thresholds})
 		assert.NoError(t, err)
 
 		e.processSamples(
@@ -459,7 +459,7 @@ func TestEngine_processThresholds(t *testing.T) {
 				thresholds[m] = ths
 			}
 
-			e, err, _ := newTestEngine(nil, lib.Options{Thresholds: thresholds})
+			e, err := newTestEngine(nil, lib.Options{Thresholds: thresholds})
 			assert.NoError(t, err)
 
 			e.processSamples(

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -175,7 +175,7 @@ func (e *Executor) Run(parent context.Context, engineOut chan<- stats.SampleCont
 			if reterr == nil {
 				reterr = err
 			} else if err != nil {
-				reterr = fmt.Errorf("Teardown error %#v\nPrevious error: %#v", err, reterr)
+				reterr = fmt.Errorf("teardown error %#v\nPrevious error: %#v", err, reterr)
 			}
 		}
 

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -4,8 +4,7 @@
 		"gofmt", "deadcode",
 		"varcheck", "structcheck", "errcheck",
 		"ineffassign", "interfacer", "unconvert",
-		"goconst", "gosimple", "staticcheck",
-		"misspell"
+		"goconst", "staticcheck", "misspell"
 	],
 	"Exclude": ["/usr/local/go/src", "/go/src", "rice-box.go"]
 }

--- a/js/common/bridge_test.go
+++ b/js/common/bridge_test.go
@@ -43,10 +43,14 @@ type bridgeTestFieldsType struct {
 
 type bridgeTestMethodsType struct{}
 
-func (bridgeTestMethodsType) ExportedFn()   {}
+func (bridgeTestMethodsType) ExportedFn() {}
+
+//lint:ignore U1000 needed for the actual test to check that it won't be seen
 func (bridgeTestMethodsType) unexportedFn() {}
 
-func (*bridgeTestMethodsType) ExportedPtrFn()   {}
+func (*bridgeTestMethodsType) ExportedPtrFn() {}
+
+//lint:ignore U1000 needed for the actual test to check that it won't be seen
 func (*bridgeTestMethodsType) unexportedPtrFn() {}
 
 type bridgeTestOddFieldsType struct {

--- a/js/common/randsource.go
+++ b/js/common/randsource.go
@@ -36,7 +36,7 @@ import (
 func NewRandSource() goja.RandSource {
 	var seed int64
 	if err := binary.Read(crand.Reader, binary.LittleEndian, &seed); err != nil {
-		panic(fmt.Errorf("Could not read random bytes: %v", err))
+		panic(fmt.Errorf("could not read random bytes: %v", err))
 	}
 	return rand.New(rand.NewSource(seed)).Float64
 }

--- a/js/modules/k6/html/serialize.go
+++ b/js/modules/k6/html/serialize.go
@@ -84,11 +84,11 @@ func (s Selection) Serialize() string {
 	for i := range formValues {
 		formValue := formValues[i]
 		value := formValue.Value.Export()
-		switch value.(type) {
+		switch v := value.(type) {
 		case string:
-			urlValues.Set(formValue.Name, value.(string))
+			urlValues.Set(formValue.Name, v)
 		case []string:
-			urlValues[formValue.Name] = value.([]string)
+			urlValues[formValue.Name] = v
 		}
 	}
 	return urlValues.Encode()

--- a/js/modules/k6/http/http_request.go
+++ b/js/modules/k6/http/http_request.go
@@ -270,7 +270,7 @@ func (h *HTTP) parseRequest(ctx context.Context, method string, reqURL URL, body
 		case []byte:
 			result.body = bytes.NewBuffer(data)
 		default:
-			return nil, fmt.Errorf("Unknown request body type %T", body)
+			return nil, fmt.Errorf("unknown request body type %T", body)
 		}
 	}
 
@@ -550,7 +550,7 @@ func (h *HTTP) request(ctx context.Context, preq *parsedHTTPRequest) (*HTTPRespo
 			case ResponseTypeBinary:
 				resp.Body = buf.Bytes()
 			default:
-				resErr = fmt.Errorf("Unknown responseType %s", preq.responseType)
+				resErr = fmt.Errorf("unknown responseType %s", preq.responseType)
 			}
 		}
 		_ = res.Body.Close()
@@ -656,11 +656,11 @@ func (h *HTTP) Batch(ctx context.Context, reqsV goja.Value) (goja.Value, error) 
 			// Handling of ["GET", "http://example.com/"]
 			dataLen := len(data)
 			if dataLen < 2 {
-				return nil, fmt.Errorf("Invalid batch request '%#v'", data)
+				return nil, fmt.Errorf("invalid batch request '%#v'", data)
 			}
 			method, ok = data[0].(string)
 			if !ok {
-				return nil, fmt.Errorf("Invalid method type '%#v'", data[0])
+				return nil, fmt.Errorf("invalid method type '%#v'", data[0])
 			}
 			reqURL, err = ToURL(data[1])
 			if err != nil {
@@ -676,7 +676,7 @@ func (h *HTTP) Batch(ctx context.Context, reqsV goja.Value) (goja.Value, error) 
 		case map[string]interface{}:
 			// Handling of {method: "GET", url: "http://test.loadimpact.com"}
 			if murl, ok := data["url"]; !ok {
-				return nil, fmt.Errorf("Batch request %s doesn't have an url key", key)
+				return nil, fmt.Errorf("batch request %s doesn't have an url key", key)
 			} else if reqURL, err = ToURL(murl); err != nil {
 				return nil, err
 			}
@@ -685,7 +685,7 @@ func (h *HTTP) Batch(ctx context.Context, reqsV goja.Value) (goja.Value, error) 
 
 			if newMethod, ok := data["method"]; ok {
 				if method, ok = newMethod.(string); !ok {
-					return nil, fmt.Errorf("Invalid method type '%#v'", newMethod)
+					return nil, fmt.Errorf("invalid method type '%#v'", newMethod)
 				}
 				method = strings.ToUpper(method)
 				if method == HTTP_METHOD_GET || method == HTTP_METHOD_HEAD {

--- a/js/modules/k6/http/http_request_test.go
+++ b/js/modules/k6/http/http_request_test.go
@@ -156,7 +156,7 @@ func TestRequestAndBatch(t *testing.T) {
 
 		http.SetCookie(w, &cookie)
 
-		http.Redirect(w, r, sr("HTTPBIN_URL/get"), 301)
+		http.Redirect(w, r, sr("HTTPBIN_URL/get"), http.StatusMovedPermanently)
 	}))
 
 	t.Run("Redirects", func(t *testing.T) {

--- a/js/modules/k6/http/http_url.go
+++ b/js/modules/k6/http/http_url.go
@@ -48,7 +48,7 @@ func ToURL(u interface{}) (URL, error) {
 		// Unwrap goja values
 		return ToURL(tu.Export())
 	default:
-		return URL{}, fmt.Errorf("Invalid URL value '%#v'", u)
+		return URL{}, fmt.Errorf("invalid URL value '%#v'", u)
 	}
 }
 

--- a/js/modules/k6/http/response.go
+++ b/js/modules/k6/http/response.go
@@ -88,7 +88,7 @@ func (res *HTTPResponse) Json(selector ...string) goja.Value {
 		case string:
 			body = []byte(b)
 		default:
-			common.Throw(common.GetRuntime(res.ctx), errors.New("Invalid response type"))
+			common.Throw(common.GetRuntime(res.ctx), errors.New("invalid response type"))
 		}
 
 		if hasSelector {
@@ -125,7 +125,7 @@ func (res *HTTPResponse) Html(selector ...string) html.Selection {
 	case string:
 		body = b
 	default:
-		common.Throw(common.GetRuntime(res.ctx), errors.New("Invalid response type"))
+		common.Throw(common.GetRuntime(res.ctx), errors.New("invalid response type"))
 	}
 
 	sel, err := html.HTML{}.ParseHTML(res.ctx, body)

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -49,7 +49,7 @@ var ErrMetricsAddInInitContext = common.NewInitContextError("Adding to metrics i
 
 func newMetric(ctxPtr *context.Context, name string, t stats.MetricType, isTime []bool) (interface{}, error) {
 	if common.GetState(*ctxPtr) != nil {
-		return nil, errors.New("Metrics must be declared in the init context")
+		return nil, errors.New("metrics must be declared in the init context")
 	}
 
 	//TODO: move verification outside the JS

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -88,7 +88,7 @@ func TestMetrics(t *testing.T) {
 					t.Run("ExitInit", func(t *testing.T) {
 						*ctxPtr = common.WithState(*ctxPtr, state)
 						_, err := common.RunString(rt, fmt.Sprintf(`new metrics.%s("my_metric")`, fn))
-						assert.EqualError(t, err, "GoError: Metrics must be declared in the init context at apply (native)")
+						assert.EqualError(t, err, "GoError: metrics must be declared in the init context at apply (native)")
 					})
 
 					groups := map[string]*lib.Group{

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -40,7 +40,7 @@ import (
 )
 
 // ErrWSInInitContext is returned when websockets are using in the init context
-var ErrWSInInitContext = common.NewInitContextError("Using websockets in the init context is not supported")
+var ErrWSInInitContext = common.NewInitContextError("using websockets in the init context is not supported")
 
 type WS struct{}
 
@@ -96,13 +96,13 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 		paramsV = goja.Undefined()
 		callableV = args[0]
 	default:
-		return nil, errors.New("Invalid number of arguments to ws.connect")
+		return nil, errors.New("invalid number of arguments to ws.connect")
 	}
 
 	// Get the callable (required)
 	setupFn, isFunc := goja.AssertFunction(callableV)
 	if !isFunc {
-		return nil, errors.New("Last argument to ws.connect must be a function")
+		return nil, errors.New("last argument to ws.connect must be a function")
 	}
 
 	// Leave header to nil by default so we can pass it directly to the Dialer

--- a/stats/cloud/data.go
+++ b/stats/cloud/data.go
@@ -95,7 +95,7 @@ func (ct *Sample) UnmarshalJSON(p []byte) error {
 	case DataTypeAggregatedHTTPReqs:
 		s.Data = new(SampleDataAggregatedHTTPReqs)
 	default:
-		return fmt.Errorf("Unknown sample type '%s'", tmpSample.Type)
+		return fmt.Errorf("unknown sample type '%s'", tmpSample.Type)
 	}
 
 	if err := json.Unmarshal(tmpSample.Data, &s.Data); err != nil {

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -60,10 +60,10 @@ const (
 )
 
 // The serialized metric type is invalid.
-var ErrInvalidMetricType = errors.New("Invalid metric type")
+var ErrInvalidMetricType = errors.New("invalid metric type")
 
 // The serialized value type is invalid.
-var ErrInvalidValueType = errors.New("Invalid value type")
+var ErrInvalidValueType = errors.New("invalid value type")
 
 // A MetricType specifies the type of a metric.
 type MetricType int

--- a/ui/summary.go
+++ b/ui/summary.go
@@ -43,9 +43,9 @@ const (
 )
 
 var (
-	ErrStatEmptyString            = errors.New("Invalid stat, empty string")
-	ErrStatUnknownFormat          = errors.New("Invalid stat, unknown format")
-	ErrPercentileStatInvalidValue = errors.New("Invalid percentile stat value, accepts a number")
+	ErrStatEmptyString            = errors.New("invalid stat, empty string")
+	ErrStatUnknownFormat          = errors.New("invalid stat, unknown format")
+	ErrPercentileStatInvalidValue = errors.New("invalid percentile stat value, accepts a number")
 )
 
 var TrendColumns = []TrendColumn{


### PR DESCRIPTION
- remove now depricated gosimple
- fix issues that staticcheck now reports including:
  - 20 ST1005 - error strings should not be capitalized
  - 2 U1000 - func is unused
  - 1 ST1008 - error should be returned as the last argument. Fixed by
  actually removng the last argument because it was never used
  - 1 ST1013 - should use constant http.StatusMovedPermanently instead of
  numeric literal 301
  - 1 because of not assigning the result of type assertion in a switch