### PR TITLE
support proxy CONNECT headers

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -170,6 +170,7 @@ func (r *Runner) newVU(samplesOut chan<- stats.SampleContainer) (*VU, error) {
 		DisableKeepAlives:   r.Bundle.Options.NoConnectionReuse.Bool,
 		MaxIdleConns:        int(r.Bundle.Options.Batch.Int64),
 		MaxIdleConnsPerHost: int(r.Bundle.Options.BatchPerHost.Int64),
+		ProxyConnectHeader:  r.Bundle.Options.ProxyHeaders,
 	}
 	_ = http2.ConfigureTransport(transport)
 

--- a/lib/options.go
+++ b/lib/options.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"net/http"
 	"reflect"
 	"strings"
 
@@ -337,6 +338,9 @@ type Options struct {
 
 	// Redirect console logging to a file
 	ConsoleOutput null.String `json:"-" envconfig:"console_output"`
+
+	// Proxy CONNECT headers
+	ProxyHeaders http.Header `json:"proxyHeaders" envconfig:"proxy_headers"`
 }
 
 // Returns the result of overwriting any fields with any that are set on the argument.
@@ -479,6 +483,10 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.ConsoleOutput.Valid {
 		o.ConsoleOutput = opts.ConsoleOutput
+	}
+
+	if opts.ProxyHeaders != nil {
+		o.ProxyHeaders = opts.ProxyHeaders
 	}
 
 	return o


### PR DESCRIPTION
This PR adds support for custom proxy CONNECT headers. The headers can be added using the `proxyHeaders` option.

Example:
Setting proxy headers
```
[k6] cat script.js                                                                                                                                                                                                    proxy-headers  ✱
import http from "k6/http";

export let options = {
    proxyHeaders: {"foo": ["bar"], "bar": ["foo"]}
};

export default function() {
  http.get("https://google.com");
};
```

Setting proxy
```
[k6] export HTTPS_PROXY=http://localhost:12345                                                                                                                                                                        proxy-headers  ✱
[k6] ./k6 run script.js
```

Proxy receives proxy headers
```
[~] ncat  -kv  -l 12345
Ncat: Version 7.70 ( https://nmap.org/ncat )
Ncat: Listening on :::12345
Ncat: Listening on 0.0.0.0:12345
Ncat: Connection from 127.0.0.1.
Ncat: Connection from 127.0.0.1:52001.
POST http://k6reports.loadimpact.com/ HTTP/1.1
Host: k6reports.loadimpact.com
User-Agent: Go-http-client/1.1
Content-Length: 116
Content-Type: application/json
Accept-Encoding: gzip

{"duration":0,"goarch":"amd64","goos":"darwin","iterations":1,"k6_version":"0.26.0-dev","st_duration":0,"vus_max":1}Ncat: Connection from 127.0.0.1.
Ncat: Connection from 127.0.0.1:52002.
CONNECT google.com:443 HTTP/1.1
Host: google.com:443
User-Agent: Go-http-client/1.1
bar: foo
foo: bar
```