### PR TITLE
Implemented AnonymizeQueryStringValues option (proposal 1 from #927).

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -897,7 +897,9 @@ func TestRequestAndBatch(t *testing.T) {
 					`))
 					assert.NoError(t, err)
 
-					assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET", sr("HTTPBIN_URL/get?a=1&b=some-value&c=https%3A%2F%2Fsome-url.com%3Fa%3D1"), "", 200, "")
+					assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET",
+						sr("HTTPBIN_URL/get?a=1&b=some-value&c=https%3A%2F%2Fsome-url.com%3Fa%3D1"),
+						"", 200, "")
 				})
 
 				t.Run("enabled", func(t *testing.T) {
@@ -911,7 +913,9 @@ func TestRequestAndBatch(t *testing.T) {
 					`))
 					assert.NoError(t, err)
 
-					assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET", sr("HTTPBIN_URL/get?a=1&b=some-value&c=https%3A%2F%2Fsome-url.com%3Fa%3D1"), sr("HTTPBIN_URL/get?a=[]&b=[]&c=[]"), 200, "")
+					assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET",
+						sr("HTTPBIN_URL/get?a=1&b=some-value&c=https%3A%2F%2Fsome-url.com%3Fa%3D1"),
+						sr("HTTPBIN_URL/get?a=[]&b=[]&c=[]"), 200, "")
 				})
 			})
 		})

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -55,7 +55,8 @@ type URL struct {
 	URL  string // http://example.com/thing/1234/
 }
 
-var QueryStringValueRegex = regexp.MustCompile("=[^&]*")
+//nolint:gochecknoglobals
+var queryStringValueRegex = regexp.MustCompile("=[^&]*")
 
 // NewURL returns a new URL for the provided url and name. The error is returned if the url provided
 // can't be parsed
@@ -222,7 +223,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 	if _, ok := tags["name"]; !ok && state.Options.SystemTags["name"] {
 		var name = preq.URL.Name
 		if state.Options.AnonymizeQueryStringValues.Bool {
-			name = QueryStringValueRegex.ReplaceAllString(name, "=[]")
+			name = queryStringValueRegex.ReplaceAllString(name, "=[]")
 		}
 		tags["name"] = name
 	}

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -55,6 +55,8 @@ type URL struct {
 	URL  string // http://example.com/thing/1234/
 }
 
+var QueryStringValueRegex = regexp.MustCompile("=[^&]*")
+
 // NewURL returns a new URL for the provided url and name. The error is returned if the url provided
 // can't be parsed
 func NewURL(urlString, name string) (URL, error) {
@@ -220,8 +222,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 	if _, ok := tags["name"]; !ok && state.Options.SystemTags["name"] {
 		var name = preq.URL.Name
 		if state.Options.AnonymizeQueryStringValues.Bool {
-			var qsValueRegex = regexp.MustCompile("=[^&]*")
-			name = qsValueRegex.ReplaceAllString(name, "=[]")
+			name = QueryStringValueRegex.ReplaceAllString(name, "=[]")
 		}
 		tags["name"] = name
 	}

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -29,6 +29,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -217,7 +218,12 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 
 	// Only set the name system tag if the user didn't explicitly set it beforehand
 	if _, ok := tags["name"]; !ok && state.Options.SystemTags["name"] {
-		tags["name"] = preq.URL.Name
+		var name = preq.URL.Name
+		if state.Options.AnonymizeQueryStringValues.Bool {
+			var qsValueRegex = regexp.MustCompile("=[^&]*")
+			name = qsValueRegex.ReplaceAllString(name, "=[]")
+		}
+		tags["name"] = name
 	}
 	if state.Options.SystemTags["group"] {
 		tags["group"] = state.Group.Path

--- a/lib/options.go
+++ b/lib/options.go
@@ -326,6 +326,8 @@ type Options struct {
 	// Tags to be applied to all samples for this running
 	RunTags *stats.SampleTags `json:"tags" envconfig:"tags"`
 
+	AnonymizeQueryStringValues null.Bool `json:"anonymizeQueryStringValues" envconfig:"anonymize_query_string_values"`
+
 	// Buffer size of the channel for metric samples; 0 means unbuffered
 	MetricSamplesBufferSize null.Int `json:"metricSamplesBufferSize" envconfig:"metric_samples_buffer_size"`
 
@@ -470,6 +472,9 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if !opts.RunTags.IsEmpty() {
 		o.RunTags = opts.RunTags
+	}
+	if opts.AnonymizeQueryStringValues.Valid {
+		o.AnonymizeQueryStringValues = opts.AnonymizeQueryStringValues
 	}
 	if opts.MetricSamplesBufferSize.Valid {
 		o.MetricSamplesBufferSize = opts.MetricSamplesBufferSize

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -396,6 +396,11 @@ func TestOptions(t *testing.T) {
 		opts := Options{}.Apply(Options{RunTags: tags})
 		assert.Equal(t, tags, opts.RunTags)
 	})
+	t.Run("AnonymizeQueryStringValues", func(t *testing.T) {
+		opts := Options{}.Apply(Options{AnonymizeQueryStringValues: null.BoolFrom(true)})
+		assert.True(t, opts.AnonymizeQueryStringValues.Valid)
+		assert.True(t, opts.AnonymizeQueryStringValues.Bool)
+	})
 	t.Run("DiscardResponseBodies", func(t *testing.T) {
 		opts := Options{}.Apply(Options{DiscardResponseBodies: null.BoolFrom(true)})
 		assert.True(t, opts.DiscardResponseBodies.Valid)


### PR DESCRIPTION
This pull requests implements proposal 1 from #927.
The AnonymizeQueryStringValues option is added, which when enabled anonymizes the query string values of the url sent to the `name` tag.
Example: `https://my-url?name=value&name2=value2` => `https://my-url?name=[]&name2=[]`