### PR TITLE
fix setting js options on the wrong object

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -249,7 +249,7 @@ func (b *Bundle) Instantiate() (bi *BundleInstance, instErr error) {
 		bi.exports[k] = fn
 	}
 
-	jsOptions := rt.Get("options")
+	jsOptions := exports.Get("options")
 	var jsOptionsObj *goja.Object
 	if jsOptions == nil || goja.IsNull(jsOptions) || goja.IsUndefined(jsOptions) {
 		jsOptionsObj = rt.NewObject()

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -253,7 +253,9 @@ func (b *Bundle) Instantiate() (bi *BundleInstance, instErr error) {
 	var jsOptionsObj *goja.Object
 	if jsOptions == nil || goja.IsNull(jsOptions) || goja.IsUndefined(jsOptions) {
 		jsOptionsObj = rt.NewObject()
-		rt.Set("options", jsOptionsObj)
+		if err := exports.Set("options", jsOptionsObj); err != nil {
+			return nil, err
+		}
 	} else {
 		jsOptionsObj = jsOptions.ToObject(rt)
 	}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -179,19 +179,19 @@ func TestOptionsSettingToScript(t *testing.T) {
 func TestOptionsPropagationToScript(t *testing.T) {
 	t.Parallel()
 	data := `
-			var options = { setupTimeout: "1s", myOption: "test" };
-			exports.options = options;
+			exports.options = { setupTimeout: "1s", myOption: "test" };
 			exports.default = function() {
-				if (options.external) {
+				if (exports.options.external) {
 					throw new Error("Unexpected property external!");
 				}
-				if (options.myOption != "test") {
-					throw new Error("expected myOption to remain unchanged but it was '" + options.myOption + "'");
+				if (exports.options.myOption != "test") {
+					throw new Error("expected myOption to remain unchanged but it was '" + exports.options.myOption + "'");
 				}
-				if (options.setupTimeout != __ENV.expectedSetupTimeout) {
-					throw new Error("expected setupTimeout to be " + __ENV.expectedSetupTimeout + " but it was " + options.setupTimeout);
+				if (exports.options.setupTimeout != __ENV.expectedSetupTimeout) {
+					throw new Error("expected setupTimeout to be " + __ENV.expectedSetupTimeout + " but it was " + exports.options.setupTimeout);
 				}
-			};`
+			};
+			`
 
 	expScriptOptions := lib.Options{SetupTimeout: types.NullDurationFrom(1 * time.Second)}
 	r1, err := getSimpleRunner("/script.js", data,

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -147,6 +147,7 @@ func TestOptionsSettingToScript(t *testing.T) {
 		t.Run(fmt.Sprintf("Variant#%d", i), func(t *testing.T) {
 			t.Parallel()
 			data := variant + `
+					exports.options = options;
 					exports.default = function() {
 						if (!options) {
 							throw new Error("Expected options to be defined!");


### PR DESCRIPTION
previos to this we were getting a possibly unexported variable "options"
and setting values to it. But the exported options could not have a
local variable with the same name ...

This also fixes a test to specifically need this to work.