### PR TITLE
Add option for extra certificate authorities.

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -23,6 +23,7 @@ package js
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -158,6 +159,21 @@ func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, 
 		}
 	}
 
+	pool, _ := x509.SystemCertPool()
+	if pool == nil {
+		// SystemCertPool is not available on Windows.
+		// x509.SystemCertPool will always fail in that environment.
+		// The error can be ignored, instead, we initialize a new pool.
+		pool = x509.NewCertPool()
+	}
+	if cas := r.Bundle.Options.TLSExtraCAs; cas != nil {
+		for _, pem := range cas {
+			if !pool.AppendCertsFromPEM([]byte(pem)) {
+				return nil, errors.New("there are no CAs to add to the system pool")
+			}
+		}
+	}
+
 	dialer := &netext.Dialer{
 		Dialer:    r.BaseDialer,
 		Resolver:  r.Resolver,
@@ -172,6 +188,7 @@ func (r *Runner) newVU(id int64, samplesOut chan<- stats.SampleContainer) (*VU, 
 		Certificates:       certs,
 		NameToCertificate:  nameToCert,
 		Renegotiation:      tls.RenegotiateFreelyAsClient,
+		RootCAs:            pool,
 	}
 	transport := &http.Transport{
 		Proxy:               http.ProxyFromEnvironment,

--- a/lib/options.go
+++ b/lib/options.go
@@ -327,6 +327,7 @@ type Options struct {
 	TLSCipherSuites *TLSCipherSuites `json:"tlsCipherSuites" envconfig:"K6_TLS_CIPHER_SUITES"`
 	TLSVersion      *TLSVersions     `json:"tlsVersion" ignored:"true"`
 	TLSAuth         []*TLSAuth       `json:"tlsAuth" envconfig:"K6_TLSAUTH"`
+	TLSExtraCAs     []string         `json:"tlsExtraCAs" envconfig:"K6_TLS_EXTRA_CAS"`
 
 	// Throw warnings (eg. failed HTTP requests) as errors instead of simply logging them.
 	Throw null.Bool `json:"throw" envconfig:"K6_THROW"`


### PR DESCRIPTION
This allows using custom certificates without having to install their CAs in the system pool, and without having to skip their verification.

The configuration is something like this:

```
export let options = {
  tlsExtraCAs: [
      open(./ca1.pem),
      open(./ca2.pem)
  ]
}
```

I'm not completely sure how to add tests for this, tbh. Help very welcome

Signed-off-by: David Calavera <david.calavera@gmail.com>