### PR TITLE
Enable kafka logs integration (gelf and json format)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,9 +23,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/loadimpact/k6/log"
-	"github.com/mattn/go-colorable"
-	"github.com/mattn/go-isatty"
 	"io"
 	"io/ioutil"
 	stdlog "log"
@@ -34,6 +31,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/loadimpact/k6/log"
+	"github.com/mattn/go-colorable"
+	"github.com/mattn/go-isatty"
 
 	"github.com/fatih/color"
 	"github.com/sirupsen/logrus"
@@ -294,7 +295,10 @@ func (c *rootCommand) setupLoggers() (<-chan struct{}, error) {
 			c.logger.SetOutput(ioutil.Discard) // don't output to anywhere else
 			c.logFmt = "raw"
 			noColor = true // disable color
-		} else if strings.HasPrefix(c.logOutput, "kafka") {
+			break
+		}
+
+		if strings.HasPrefix(c.logOutput, "kafka") {
 			hook, err := log.KafkaFromConfigLine(c.ctx, c.fallbackLogger, c.logOutput)
 			if err != nil {
 				return nil, err
@@ -302,9 +306,10 @@ func (c *rootCommand) setupLoggers() (<-chan struct{}, error) {
 			c.logger.AddHook(hook)
 			c.logger.SetOutput(ioutil.Discard) // don't output to anywhere else
 			noColor = true                     // disable color
-		} else {
-			return nil, fmt.Errorf("unsupported log output `%s`", c.logOutput)
+			break
 		}
+
+		return nil, fmt.Errorf("unsupported log output `%s`", c.logOutput)
 	}
 
 	switch c.logFmt {

--- a/log/kafka.go
+++ b/log/kafka.go
@@ -1,0 +1,144 @@
+package log
+
+// https://github.com/gfremex/logrus-kafka-hook
+
+import (
+	"context"
+	"fmt"
+	"github.com/Shopify/sarama"
+	"github.com/sirupsen/logrus"
+	"log"
+	"strings"
+	"time"
+)
+
+type KafkaHook struct {
+	// Id of the hook
+	id string
+
+	// Log levels allowed
+	levels []logrus.Level
+
+	// sarama.AsyncProducer
+	producer sarama.AsyncProducer
+
+	// Log entry formatter
+	formatter logrus.Formatter
+
+	topics []string
+
+	brokers []string
+}
+
+func KafkaFromConfigLine(ctx context.Context, fallbackLogger logrus.FieldLogger, line string) (*KafkaHook, error) {
+	kafkaConfig := sarama.NewConfig()
+	kafkaConfig.Producer.RequiredAcks = sarama.WaitForLocal // Only wait for the leader to ack
+	kafkaConfig.Producer.Compression = sarama.CompressionNone
+	kafkaConfig.Producer.Flush.Frequency = 500 * time.Millisecond // Flush batches every 500ms
+
+	hook := KafkaHook{}
+	err := hook.parseArgs(line)
+	if err != nil {
+		return nil, err
+	}
+
+	producer, err := sarama.NewAsyncProducer(hook.brokers, kafkaConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// We will just log to STDOUT if we're not able to produce messages.
+	// Note: messages will only be returned here after all retry attempts are exhausted.
+	go func() {
+		for err := range producer.Errors() {
+			log.Printf("Failed to send log entry to kafka: %v\n", err)
+		}
+	}()
+
+	return &hook, nil
+}
+
+func (hook *KafkaHook) parseArgs(line string) error {
+	tokens, err := tokenize(line)
+	if err != nil {
+		return fmt.Errorf("error while parsing loki configuration %w", err)
+	}
+
+	for _, token := range tokens {
+		key := token.key
+		value := token.value
+
+		var err error
+		switch key {
+		case "kafka":
+			hook.brokers = strings.Split(value, ",")
+		case "topics":
+			hook.topics = strings.Split(value, ",")
+		case "format":
+			switch value {
+			case "json":
+				hook.formatter = &logrus.JSONFormatter{}
+			case "gelf":
+				hook.formatter = new(GelfFormatter)
+			}
+		case "level":
+			hook.levels, err = getLevels(value)
+			if err != nil {
+				return err
+			}
+			/*default:
+			if strings.HasPrefix(key, "label.") {
+				labelKey := strings.TrimPrefix(key, "label.")
+				hook.labels = append(hook.labels, [2]string{labelKey, value})
+
+				continue
+			}*/
+		}
+	}
+
+	return nil
+}
+
+func (hook *KafkaHook) Id() string {
+	return hook.id
+}
+
+func (hook *KafkaHook) Levels() []logrus.Level {
+	return hook.levels
+}
+
+func (hook *KafkaHook) Fire(entry *logrus.Entry) error {
+	// Check time for partition key
+	var partitionKey sarama.ByteEncoder
+
+	// Get field time
+	t, _ := entry.Data["time"].(time.Time)
+
+	// Convert it to bytes
+	b, err := t.MarshalBinary()
+
+	if err != nil {
+		return err
+	}
+
+	partitionKey = sarama.ByteEncoder(b)
+
+	// Format before writing
+	b, err = hook.formatter.Format(entry)
+
+	if err != nil {
+		return err
+	}
+
+	value := sarama.ByteEncoder(b)
+
+	for _, topic := range hook.topics {
+		hook.producer.Input() <- &sarama.ProducerMessage{
+			Key:   partitionKey,
+			Topic: topic,
+			Value: value,
+		}
+	}
+
+	return nil
+}

--- a/log/kafka.go
+++ b/log/kafka.go
@@ -1,6 +1,6 @@
 package log
 
-// https://github.com/gfremex/logrus-kafka-hook
+// Code based on the project: https://github.com/gfremex/logrus-kafka-hook
 
 import (
 	"context"

--- a/log/kafka.go
+++ b/log/kafka.go
@@ -12,6 +12,7 @@ import (
 	"time"
 )
 
+// KafkaHook logrus Kafka Hook
 type KafkaHook struct {
 	// Id of the hook
 	id string
@@ -34,6 +35,8 @@ type KafkaHook struct {
 	brokers []string
 }
 
+// KafkaFromConfigLine returns a new logrus.Hook that pushes logrus. Entries to kafka and is configured
+// through the provided line
 func KafkaFromConfigLine(ctx context.Context, fallbackLogger logrus.FieldLogger, line string) (*KafkaHook, error) {
 	kafkaConfig := sarama.NewConfig()
 	kafkaConfig.Producer.RequiredAcks = sarama.WaitForLocal // Only wait for the leader to ack
@@ -106,14 +109,17 @@ func (hook *KafkaHook) parseArgs(line string) error {
 	return nil
 }
 
+// Id returns the logrus Hook id
 func (hook *KafkaHook) Id() string {
 	return hook.id
 }
 
+// Levels returns the logrus Hook levels
 func (hook *KafkaHook) Levels() []logrus.Level {
 	return hook.levels
 }
 
+// Fire logrus fire
 func (hook *KafkaHook) Fire(entry *logrus.Entry) error {
 	// Get field time
 	t, _ := entry.Data["time"].(time.Time)

--- a/log/logrus_gelf_formatter.go
+++ b/log/logrus_gelf_formatter.go
@@ -5,7 +5,6 @@ package log
 import (
 	"encoding/json"
 	"fmt"
-	"log/syslog"
 	"math"
 	"os"
 
@@ -17,16 +16,16 @@ type GelfFormatter struct{}
 
 type fields map[string]interface{}
 
-const defaultLevel = syslog.LOG_INFO
-
-var levelMap = map[logrus.Level]syslog.Priority{ //nolint:gochecknoglobals
-	logrus.PanicLevel: syslog.LOG_EMERG,
-	logrus.FatalLevel: syslog.LOG_CRIT,
-	logrus.ErrorLevel: syslog.LOG_ERR,
-	logrus.WarnLevel:  syslog.LOG_WARNING,
-	logrus.InfoLevel:  syslog.LOG_INFO,
-	logrus.DebugLevel: syslog.LOG_DEBUG,
-}
+// Syslog severity levels
+const (
+	EmergencyLevel = int32(0)
+	CriticalLevel  = int32(2)
+	ErrorLevel     = int32(3)
+	WarningLevel   = int32(4)
+	NoticeLevel    = int32(5)
+	InfoLevel      = int32(6)
+	DebugLevel     = int32(7)
+)
 
 // Format formats the log entry to GELF JSON
 func (f *GelfFormatter) Format(entry *logrus.Entry) ([]byte, error) {
@@ -76,10 +75,24 @@ func round(val float64, places int) float64 {
 	return math.Floor((val*shift)+.5) / shift
 }
 
-func toSyslogLevel(level logrus.Level) syslog.Priority {
-	syslog, ok := levelMap[level]
-	if ok {
-		return syslog
+func toSyslogLevel(l logrus.Level) int32 {
+	var level int32
+	switch l {
+	case logrus.PanicLevel:
+		level = EmergencyLevel
+	case logrus.FatalLevel:
+		level = CriticalLevel
+	case logrus.ErrorLevel:
+		level = ErrorLevel
+	case logrus.WarnLevel:
+		level = WarningLevel
+	case logrus.InfoLevel:
+		level = InfoLevel
+	case logrus.DebugLevel:
+		level = DebugLevel
+	case logrus.TraceLevel:
+		level = NoticeLevel
 	}
-	return defaultLevel
+
+	return level
 }

--- a/log/logrus_gelf_formatter.go
+++ b/log/logrus_gelf_formatter.go
@@ -12,23 +12,21 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Defines a log format type that wil output line separated JSON objects in the GELF format.
-type GelfFormatter struct {
-}
+// GelfFormatter defines a log format type that wil output line separated JSON objects in the GELF format.
+type GelfFormatter struct{}
 
 type fields map[string]interface{}
 
-var (
-	defaultLevel = syslog.LOG_INFO
-	levelMap     = map[logrus.Level]syslog.Priority{ //nolint:gochecknoglobals
-		logrus.PanicLevel: syslog.LOG_EMERG,
-		logrus.FatalLevel: syslog.LOG_CRIT,
-		logrus.ErrorLevel: syslog.LOG_ERR,
-		logrus.WarnLevel:  syslog.LOG_WARNING,
-		logrus.InfoLevel:  syslog.LOG_INFO,
-		logrus.DebugLevel: syslog.LOG_DEBUG,
-	}
-)
+const defaultLevel = syslog.LOG_INFO
+
+var levelMap = map[logrus.Level]syslog.Priority{ //nolint:gochecknoglobals
+	logrus.PanicLevel: syslog.LOG_EMERG,
+	logrus.FatalLevel: syslog.LOG_CRIT,
+	logrus.ErrorLevel: syslog.LOG_ERR,
+	logrus.WarnLevel:  syslog.LOG_WARNING,
+	logrus.InfoLevel:  syslog.LOG_INFO,
+	logrus.DebugLevel: syslog.LOG_DEBUG,
+}
 
 // Format formats the log entry to GELF JSON
 func (f *GelfFormatter) Format(entry *logrus.Entry) ([]byte, error) {
@@ -36,7 +34,6 @@ func (f *GelfFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	blacklist := []string{"_id", "id", "timestamp", "version", "level"}
 
 	for k, v := range entry.Data {
-
 		if contains(k, blacklist) {
 			continue
 		}
@@ -59,7 +56,7 @@ func (f *GelfFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	serialized, err := json.Marshal(data)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal fields to JSON, %v", err)
+		return nil, fmt.Errorf("failed to marshal fields to JSON, %w", err)
 	}
 
 	return append(serialized, '\n'), nil

--- a/log/logrus_gelf_formatter.go
+++ b/log/logrus_gelf_formatter.go
@@ -12,16 +12,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Defines a log format type that wil output line separated JSON objects
-// in the GELF format.
+// Defines a log format type that wil output line separated JSON objects in the GELF format.
 type GelfFormatter struct {
 }
 
 type fields map[string]interface{}
 
 var (
-	DefaultLevel = syslog.LOG_INFO
-	levelMap     = map[logrus.Level]syslog.Priority{
+	defaultLevel = syslog.LOG_INFO
+	levelMap     = map[logrus.Level]syslog.Priority{ //nolint:gochecknoglobals
 		logrus.PanicLevel: syslog.LOG_EMERG,
 		logrus.FatalLevel: syslog.LOG_CRIT,
 		logrus.ErrorLevel: syslog.LOG_ERR,
@@ -60,7 +59,7 @@ func (f *GelfFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	serialized, err := json.Marshal(data)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+		return nil, fmt.Errorf("failed to marshal fields to JSON, %v", err)
 	}
 
 	return append(serialized, '\n'), nil
@@ -85,5 +84,5 @@ func toSyslogLevel(level logrus.Level) syslog.Priority {
 	if ok {
 		return syslog
 	}
-	return DefaultLevel
+	return defaultLevel
 }

--- a/log/logrus_gelf_formatter.go
+++ b/log/logrus_gelf_formatter.go
@@ -1,0 +1,91 @@
+package log
+
+
+// Portions of this files were taken from https://github.com/sirupsen/logrus
+// Copyrighted by Simon Eskildsen under the MIT license
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/syslog"
+	"math"
+	"os"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Defines a log format type that wil output line separated JSON objects
+// in the GELF format.
+type GelfFormatter struct {
+}
+
+type fields map[string]interface{}
+
+var (
+	DefaultLevel = syslog.LOG_INFO
+	levelMap     = map[logrus.Level]syslog.Priority{
+		logrus.PanicLevel: syslog.LOG_EMERG,
+		logrus.FatalLevel: syslog.LOG_CRIT,
+		logrus.ErrorLevel: syslog.LOG_ERR,
+		logrus.WarnLevel:  syslog.LOG_WARNING,
+		logrus.InfoLevel:  syslog.LOG_INFO,
+		logrus.DebugLevel: syslog.LOG_DEBUG,
+	}
+)
+
+// Format formats the log entry to GELF JSON
+func (f *GelfFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	data := make(fields, len(entry.Data)+6)
+	blacklist := []string{"_id", "id", "timestamp", "version", "level"}
+
+	for k, v := range entry.Data {
+
+		if contains(k, blacklist) {
+			continue
+		}
+
+		switch v := v.(type) {
+		case error:
+			// Otherwise errors are ignored by `encoding/json`
+			data["_"+k] = v.Error()
+		default:
+			data["_"+k] = v
+		}
+	}
+
+	data["version"] = "1.1"
+	data["short_message"] = entry.Message
+	data["timestamp"] = round((float64(entry.Time.UnixNano())/float64(1000000))/float64(1000), 4)
+	data["level"] = toSyslogLevel(entry.Level)
+	data["level_name"] = entry.Level.String()
+	data["_pid"] = os.Getpid()
+
+	serialized, err := json.Marshal(data)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to marshal fields to JSON, %v", err)
+	}
+
+	return append(serialized, '\n'), nil
+}
+
+func contains(needle string, haystack []string) bool {
+	for _, a := range haystack {
+		if needle == a {
+			return true
+		}
+	}
+	return false
+}
+
+func round(val float64, places int) float64 {
+	shift := math.Pow(10, float64(places))
+	return math.Floor((val*shift)+.5) / shift
+}
+
+func toSyslogLevel(level logrus.Level) syslog.Priority {
+	syslog, ok := levelMap[level]
+	if ok {
+		return syslog
+	}
+	return DefaultLevel
+}

--- a/log/logrus_gelf_formatter.go
+++ b/log/logrus_gelf_formatter.go
@@ -1,8 +1,6 @@
 package log
 
-
-// Portions of this files were taken from https://github.com/sirupsen/logrus
-// Copyrighted by Simon Eskildsen under the MIT license
+// Code based on the project: https://github.com/seatgeek/logrus-gelf-formatter
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Enable to send logs to a Kafka topic supporting GELF and JSON formats.

To activate this feature

```
k6 run --log-output=kafka=[localhost:29092,localhost:29093,localhost:29094],topics=logs,level=debug,format=gelf,label.project_key=my_project_key,label.project_name=my_project_name demo.js
```

Example used during testing:

```
import { check, sleep } from "k6";
import http from "k6/http";
export let options = {
  duration: "1m",
  vus: 1
};
export default function() {

  console.log("Init test");

  let res;
  res = http.get("https://httpbinn.org/get");
  check(res, { "status is 200": r => r.status === 200 });
  res = http.get("https://httpbin.org/bearer", {
    headers: { Authorization: "Bearer da39a3ee5e6b4b0d3255bfef95601890afd80709-xyz" }
  });

  if (res.status != 200) {
    console.error(res.body);
  }
  check(res, {
    "status is 200": r => r.status === 200,
    "is authenticated": r => r.json()["authenticated"] === true
  });
  res = http.get("https://httpbin.org/base64/azYgaXMgYXdlc29tZSE=");
  check(res, {
    "status is 200": r => r.status === 200,
    "k6 is awesome!": r => r.body === "k6 is awesome!"
  });
  sleep(1);

  console.log("End test");

}
```

Screenshots:
![image](https://user-images.githubusercontent.com/3056856/113031915-8d2fc100-918f-11eb-8390-d797897763fb.png)



