### PR TITLE
Basic implementation of variant 2 from #1802

### DIFF
--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -149,6 +149,11 @@ func (i *InitContext) requireModule(name string) (goja.Value, error) {
 	}
 
 	if withContext, ok := mod.(modules.HasWithContext); ok {
+		// check that the original module was per instance as otherwise this will break and if not ... break
+		if _, ok := i.modules[name].(modules.HasModuleInstancePerVU); !ok {
+			// TODO better message ;)
+			return nil, fmt.Errorf("module `%s` implement HasWithContext, but it does not implement HasModuleInstancePerVU which means that the context will be shared between VUs which is not what needs to happen. Please contact the developer of the module with this information.", name) //nolint:lll
+		}
 		withContext.WithContext(func() context.Context {
 			return *i.ctxPtr
 		})

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -147,6 +147,14 @@ func (i *InitContext) requireModule(name string) (goja.Value, error) {
 	if perInstance, ok := mod.(modules.HasModuleInstancePerVU); ok {
 		mod = perInstance.NewModuleInstancePerVU()
 	}
+
+	if withContext, ok := mod.(modules.HasWithContext); ok {
+		withContext.WithContext(func() context.Context {
+			return *i.ctxPtr
+		})
+		return i.runtime.ToValue(mod), nil
+	}
+
 	return i.runtime.ToValue(common.Bind(i.runtime, mod, i.ctxPtr)), nil
 }
 

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -103,16 +103,23 @@ func (m Metric) GetName() string {
 	return m.metric.Name
 }
 
-type MetricsModule struct {
-	getContext func() context.Context
-}
+type (
+	RootMetricsModule struct{}
+	MetricsModule     struct {
+		getContext func() context.Context
+	}
+)
 
 func (m *MetricsModule) WithContext(getContext func() context.Context) {
 	m.getContext = getContext
 }
 
-func New() *MetricsModule {
+func (*RootMetricsModule) NewModuleInstancePerVU() interface{} {
 	return &MetricsModule{}
+}
+
+func New() *RootMetricsModule {
+	return &RootMetricsModule{}
 }
 
 // This is not possible after common.Bind as it wraps the object and doesn't return the original one.

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -64,8 +64,9 @@ func TestMetrics(t *testing.T) {
 
 					ctxPtr := new(context.Context)
 					*ctxPtr = common.WithRuntime(context.Background(), rt)
-					rt.Set("metrics", common.Bind(rt, New(), ctxPtr))
-
+					m := New()
+					m.WithContext(func() context.Context { return *ctxPtr })
+					rt.Set("metrics", m)
 					root, _ := lib.NewGroup("", nil)
 					child, _ := root.Group("child")
 					samples := make(chan stats.SampleContainer, 1000)
@@ -86,7 +87,7 @@ func TestMetrics(t *testing.T) {
 					t.Run("ExitInit", func(t *testing.T) {
 						*ctxPtr = lib.WithState(*ctxPtr, state)
 						_, err := rt.RunString(fmt.Sprintf(`new metrics.%s("my_metric")`, fn))
-						assert.EqualError(t, err, "metrics must be declared in the init context at apply (native)")
+						assert.Contains(t, err.Error(), "metrics must be declared in the init context")
 					})
 
 					groups := map[string]*lib.Group{

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -64,7 +64,8 @@ func TestMetrics(t *testing.T) {
 
 					ctxPtr := new(context.Context)
 					*ctxPtr = common.WithRuntime(context.Background(), rt)
-					m := New()
+					m, ok := New().NewModuleInstancePerVU().(*MetricsModule)
+					require.True(t, ok)
 					m.WithContext(func() context.Context { return *ctxPtr })
 					rt.Set("metrics", m)
 					root, _ := lib.NewGroup("", nil)

--- a/js/modules/modules.go
+++ b/js/modules/modules.go
@@ -21,6 +21,7 @@
 package modules
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -67,6 +68,12 @@ func Register(name string, mod interface{}) {
 // every time a VU imports the module and use its result as the returned object.
 type HasModuleInstancePerVU interface {
 	NewModuleInstancePerVU() interface{}
+}
+
+// HasWithContext should be implemented by modules that need access to the context, which should be all of them
+type HasWithContext interface { // TODO rename?
+	// This specifically is a function *returning* context as it can change between invocations
+	WithContext(func() context.Context) // this can be a different object that just has a context getter
 }
 
 // checks that modules implement HasModuleInstancePerVU


### PR DESCRIPTION
In this case we give the Module a function to get the context and it
needs to that whenever it needs it instead of just caching it's value
... Especially between function call or something like that
