### PR TITLE
Basic implementation of variant 3 from #1802

### DIFF
--- a/js/common/bridge.go
+++ b/js/common/bridge.go
@@ -294,3 +294,29 @@ type Exports struct {
 	Default interface{}
 	Others  map[string]interface{}
 }
+
+func GenerateExports(v interface{}) Exports {
+	exports := make(map[string]interface{})
+	val := reflect.ValueOf(v)
+	typ := val.Type()
+	for i := 0; i < typ.NumMethod(); i++ {
+		meth := typ.Method(i)
+		name := MethodName(typ, meth)
+		fn := val.Method(i)
+		exports[name] = fn.Interface()
+	}
+
+	// If v is a pointer, we need to indirect it to access fields.
+	if typ.Kind() == reflect.Ptr {
+		val = val.Elem()
+		typ = val.Type()
+	}
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		name := FieldName(typ, field)
+		if name != "" {
+			exports[name] = val.Field(i).Interface()
+		}
+	}
+	return Exports{Default: exports, Others: exports}
+}

--- a/js/common/bridge.go
+++ b/js/common/bridge.go
@@ -280,3 +280,17 @@ func Bind(rt *goja.Runtime, v interface{}, ctxPtr *context.Context) map[string]i
 
 	return exports
 }
+
+// TODO move this
+// ModuleInstance is something that will be provided to modules and they need to embed it.
+type ModuleInstance interface {
+	GetContext() context.Context
+	GetExports() Exports
+	// we can add other methods here
+	// sealing field will help probably with pointing users that they just need to embed this in the
+}
+
+type Exports struct {
+	Default interface{}
+	Others  map[string]interface{}
+}

--- a/js/common/bridge.go
+++ b/js/common/bridge.go
@@ -282,12 +282,17 @@ func Bind(rt *goja.Runtime, v interface{}, ctxPtr *context.Context) map[string]i
 }
 
 // TODO move this
-// ModuleInstance is something that will be provided to modules and they need to embed it.
+// ModuleInstance is what a module needs to return
 type ModuleInstance interface {
-	GetContext() context.Context
+	ModuleInstanceCore
 	GetExports() Exports
+}
+
+// ModuleInstanceCore is something that will be provided to modules and they need to embed it in ModuleInstance
+type ModuleInstanceCore interface {
 	// we can add other methods here
 	// sealing field will help probably with pointing users that they just need to embed this in the
+	GetContext() context.Context
 }
 
 type Exports struct {

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -139,14 +139,44 @@ func (i *InitContext) Require(arg string) goja.Value {
 	}
 }
 
+type moduleInstanceImpl struct {
+	ctxPtr *context.Context
+	// we can technically put lib.State here
+}
+
+func (m *moduleInstanceImpl) GetContext() context.Context {
+	return *m.ctxPtr
+}
+
+func (m *moduleInstanceImpl) GetExports() common.Exports {
+	panic("this needs to be implemented by the module") // maybe 2 interfaces ?
+}
+
+func toEsModuleexports(exp common.Exports) map[string]interface{} {
+	result := make(map[string]interface{}, len(exp.Others)+2)
+
+	for k, v := range exp.Others {
+		result[k] = v
+	}
+	// Maybe check that those weren't set
+	result["default"] = exp.Default
+	result["__esModule"] = true // this so babel works with
+	return result
+}
+
 func (i *InitContext) requireModule(name string) (goja.Value, error) {
 	mod, ok := i.modules[name]
 	if !ok {
 		return nil, fmt.Errorf("unknown module: %s", name)
 	}
+	if modV2, ok := mod.(modules.IsModuleV2); ok {
+		instance := modV2.NewModuleInstance(&moduleInstanceImpl{ctxPtr: i.ctxPtr})
+		return i.runtime.ToValue(toEsModuleexports(instance.GetExports())), nil
+	}
 	if perInstance, ok := mod.(modules.HasModuleInstancePerVU); ok {
 		mod = perInstance.NewModuleInstancePerVU()
 	}
+
 	return i.runtime.ToValue(common.Bind(i.runtime, mod, i.ctxPtr)), nil
 }
 

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -139,17 +139,13 @@ func (i *InitContext) Require(arg string) goja.Value {
 	}
 }
 
-type moduleInstanceImpl struct {
+type moduleInstanceCoreImpl struct {
 	ctxPtr *context.Context
-	// we can technically put lib.State here
+	// we can technically put lib.State here as well as anything else
 }
 
-func (m *moduleInstanceImpl) GetContext() context.Context {
+func (m *moduleInstanceCoreImpl) GetContext() context.Context {
 	return *m.ctxPtr
-}
-
-func (m *moduleInstanceImpl) GetExports() common.Exports {
-	panic("this needs to be implemented by the module") // maybe 2 interfaces ?
 }
 
 func toEsModuleexports(exp common.Exports) map[string]interface{} {
@@ -170,7 +166,7 @@ func (i *InitContext) requireModule(name string) (goja.Value, error) {
 		return nil, fmt.Errorf("unknown module: %s", name)
 	}
 	if modV2, ok := mod.(modules.IsModuleV2); ok {
-		instance := modV2.NewModuleInstance(&moduleInstanceImpl{ctxPtr: i.ctxPtr})
+		instance := modV2.NewModuleInstance(&moduleInstanceCoreImpl{ctxPtr: i.ctxPtr})
 		return i.runtime.ToValue(toEsModuleexports(instance.GetExports())), nil
 	}
 	if perInstance, ok := mod.(modules.HasModuleInstancePerVU); ok {

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -43,32 +43,39 @@ func checkName(name string) bool {
 }
 
 type Metric struct {
-	metric *stats.Metric
+	metric     *stats.Metric
+	getContext func() context.Context
 }
 
 // ErrMetricsAddInInitContext is error returned when adding to metric is done in the init context
 var ErrMetricsAddInInitContext = common.NewInitContextError("Adding to metrics in the init context is not supported")
 
-func newMetric(ctxPtr *context.Context, name string, t stats.MetricType, isTime []bool) (interface{}, error) {
-	if lib.GetState(*ctxPtr) != nil {
+func (m *MetricsModule) newMetric(call goja.ConstructorCall, t stats.MetricType) (*goja.Object, error) {
+	ctx := m.GetContext()
+	if lib.GetState(ctx) != nil {
 		return nil, errors.New("metrics must be declared in the init context")
 	}
+	rt := common.GetRuntime(ctx) // NOTE we can get this differently as well
 
+	// TODO this kind of conversions can possibly be automated by the parts of common.Bind that are curently automating
+	// it and some wrapping
+	name := call.Argument(0).String()
+	isTime := call.Argument(1).ToBoolean()
 	// TODO: move verification outside the JS
 	if !checkName(name) {
 		return nil, common.NewInitContextError(fmt.Sprintf("Invalid metric name: '%s'", name))
 	}
 
 	valueType := stats.Default
-	if len(isTime) > 0 && isTime[0] {
+	if isTime {
 		valueType = stats.Time
 	}
 
-	rt := common.GetRuntime(*ctxPtr)
-	return common.Bind(rt, Metric{stats.New(name, t, valueType)}, ctxPtr), nil
+	return rt.ToValue(Metric{metric: stats.New(name, t, valueType), getContext: m.GetContext}).ToObject(rt), nil
 }
 
-func (m Metric) Add(ctx context.Context, v goja.Value, addTags ...map[string]string) (bool, error) {
+func (m Metric) Add(v goja.Value, addTags ...map[string]string) (bool, error) {
+	ctx := m.getContext()
 	state := lib.GetState(ctx)
 	if state == nil {
 		return false, ErrMetricsAddInInitContext
@@ -96,24 +103,69 @@ func (m Metric) GetName() string {
 	return m.metric.Name
 }
 
-type Metrics struct{}
+type (
+	RootMetricsModule struct{}
+	MetricsModule     struct {
+		common.ModuleInstance
+	}
+)
 
-func New() *Metrics {
-	return &Metrics{}
+func (*RootMetricsModule) NewModuleInstance(m common.ModuleInstance) common.ModuleInstance {
+	return &MetricsModule{ModuleInstance: m}
 }
 
-func (*Metrics) XCounter(ctx *context.Context, name string, isTime ...bool) (interface{}, error) {
-	return newMetric(ctx, name, stats.Counter, isTime)
+func New() *RootMetricsModule {
+	return &RootMetricsModule{}
 }
 
-func (*Metrics) XGauge(ctx *context.Context, name string, isTime ...bool) (interface{}, error) {
-	return newMetric(ctx, name, stats.Gauge, isTime)
+func (m *MetricsModule) GetExports() common.Exports {
+	return common.Exports{
+		Default: "this will be our default export",
+		Others: map[string]interface{}{
+			"Counter": m.XCounter,
+			"Gauge":   m.XGauge,
+			"Trend":   m.XTrend,
+			"Rate":    m.XRate,
+
+			"returnMetricType": m.ReturnMetricType,
+		},
+	}
 }
 
-func (*Metrics) XTrend(ctx *context.Context, name string, isTime ...bool) (interface{}, error) {
-	return newMetric(ctx, name, stats.Trend, isTime)
+// This is not possible after common.Bind as it wraps the object and doesn't return the original one.
+func (m *MetricsModule) ReturnMetricType(metric Metric) string {
+	return metric.metric.Type.String()
 }
 
-func (*Metrics) XRate(ctx *context.Context, name string, isTime ...bool) (interface{}, error) {
-	return newMetric(ctx, name, stats.Rate, isTime)
+// Counter ... // NOTE we still need to use goja.ConstructorCall  somewhere to have access to the
+func (m *MetricsModule) XCounter(call goja.ConstructorCall, rt *goja.Runtime) *goja.Object {
+	v, err := m.newMetric(call, stats.Counter)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+	return v
+}
+
+func (m *MetricsModule) XGauge(call goja.ConstructorCall, rt *goja.Runtime) *goja.Object {
+	v, err := m.newMetric(call, stats.Gauge)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+	return v
+}
+
+func (m *MetricsModule) XTrend(call goja.ConstructorCall, rt *goja.Runtime) *goja.Object {
+	v, err := m.newMetric(call, stats.Trend)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+	return v
+}
+
+func (m *MetricsModule) XRate(call goja.ConstructorCall, rt *goja.Runtime) *goja.Object {
+	v, err := m.newMetric(call, stats.Rate)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+	return v
 }

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -106,12 +106,12 @@ func (m Metric) GetName() string {
 type (
 	RootMetricsModule struct{}
 	MetricsModule     struct {
-		common.ModuleInstance
+		common.ModuleInstanceCore
 	}
 )
 
-func (*RootMetricsModule) NewModuleInstance(m common.ModuleInstance) common.ModuleInstance {
-	return &MetricsModule{ModuleInstance: m}
+func (*RootMetricsModule) NewModuleInstance(m common.ModuleInstanceCore) common.ModuleInstance {
+	return &MetricsModule{ModuleInstanceCore: m}
 }
 
 func New() *RootMetricsModule {
@@ -127,7 +127,8 @@ func (m *MetricsModule) ReturnMetricType(metric Metric) string {
 	return metric.metric.Type.String()
 }
 
-// Counter ... // NOTE we still need to use goja.ConstructorCall  somewhere to have access to the
+// Counter ... // NOTE we still need to use goja.ConstructorCall  somewhere to have automatic constructor support by
+// goja
 func (m *MetricsModule) XCounter(call goja.ConstructorCall, rt *goja.Runtime) *goja.Object {
 	v, err := m.newMetric(call, stats.Counter)
 	if err != nil {

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -119,17 +119,7 @@ func New() *RootMetricsModule {
 }
 
 func (m *MetricsModule) GetExports() common.Exports {
-	return common.Exports{
-		Default: "this will be our default export",
-		Others: map[string]interface{}{
-			"Counter": m.XCounter,
-			"Gauge":   m.XGauge,
-			"Trend":   m.XTrend,
-			"Rate":    m.XRate,
-
-			"returnMetricType": m.ReturnMetricType,
-		},
-	}
+	return common.GenerateExports(m)
 }
 
 // This is not possible after common.Bind as it wraps the object and doesn't return the original one.

--- a/js/modules/modules.go
+++ b/js/modules/modules.go
@@ -72,7 +72,7 @@ type HasModuleInstancePerVU interface {
 
 // IsModuleV2 ... TODO better name
 type IsModuleV2 interface { // TODO rename?
-	NewModuleInstance(common.ModuleInstance) common.ModuleInstance
+	NewModuleInstance(common.ModuleInstanceCore) common.ModuleInstance
 }
 
 // checks that modules implement HasModuleInstancePerVU

--- a/js/modules/modules.go
+++ b/js/modules/modules.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 
+	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules/k6"
 	"go.k6.io/k6/js/modules/k6/crypto"
 	"go.k6.io/k6/js/modules/k6/crypto/x509"
@@ -67,6 +68,11 @@ func Register(name string, mod interface{}) {
 // every time a VU imports the module and use its result as the returned object.
 type HasModuleInstancePerVU interface {
 	NewModuleInstancePerVU() interface{}
+}
+
+// IsModuleV2 ... TODO better name
+type IsModuleV2 interface { // TODO rename?
+	NewModuleInstance(common.ModuleInstance) common.ModuleInstance
 }
 
 // checks that modules implement HasModuleInstancePerVU


### PR DESCRIPTION
This goes all the way and tries (unfortunately not very well, I will try
again) to make the user embed the ModuleInstance it gets in the return
module so that it always has access to the Context and w/e else we
decide to add to it.

I also decided to force some esm along it (this is not required) to
test out some ideas.

