### PR TITLE
cloudapi/logs: Keep connection reliable

### DIFF
--- a/cloudapi/api_test.go
+++ b/cloudapi/api_test.go
@@ -122,7 +122,9 @@ func TestDetailsError(t *testing.T) {
 	assert.EqualError(t, err, "(403) Validation failed\n name: Shorter than minimum length 2.")
 }
 
-func TestRetry(t *testing.T) {
+func TestClientRetry(t *testing.T) {
+	t.Parallel()
+
 	called := 0
 	idempotencyKey := ""
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -146,7 +148,9 @@ func TestRetry(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestRetrySuccessOnSecond(t *testing.T) {
+func TestClientRetrySuccessOnSecond(t *testing.T) {
+	t.Parallel()
+
 	called := 1
 	idempotencyKey := ""
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cloudapi/logs.go
+++ b/cloudapi/logs.go
@@ -23,9 +23,13 @@ package cloudapi
 import (
 	"context"
 	"fmt"
+	"math"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -53,8 +57,11 @@ type msgDroppedEntries struct {
 	Timestamp string            `json:"timestamp"`
 }
 
-func (m *msg) Log(logger logrus.FieldLogger) {
+// Log writes the Streams and Dropped Entries to the passed logger.
+// It returns the most recent timestamp seen overall messages.
+func (m *msg) Log(logger logrus.FieldLogger) int64 {
 	var level string
+	var ts int64
 
 	for _, stream := range m.Streams {
 		fields := labelsToLogrusFields(stream.Stream)
@@ -64,8 +71,8 @@ func (m *msg) Log(logger logrus.FieldLogger) {
 		}
 
 		for _, value := range stream.Values {
-			nsec, _ := strconv.Atoi(value[0])
-			e := logger.WithFields(fields).WithTime(time.Unix(0, int64(nsec)))
+			nsec, _ := strconv.ParseInt(value[0], 10, 64)
+			e := logger.WithFields(fields).WithTime(time.Unix(0, nsec))
 			lvl, err := logrus.ParseLevel(level)
 			if err != nil {
 				e.Info(value[1])
@@ -73,13 +80,24 @@ func (m *msg) Log(logger logrus.FieldLogger) {
 			} else {
 				e.Log(lvl, value[1])
 			}
+
+			// find the latest seen message
+			if nsec > ts {
+				ts = nsec
+			}
 		}
 	}
 
 	for _, dropped := range m.DroppedEntries {
-		nsec, _ := strconv.Atoi(dropped.Timestamp)
-		logger.WithFields(labelsToLogrusFields(dropped.Labels)).WithTime(time.Unix(0, int64(nsec))).Warn("dropped")
+		nsec, _ := strconv.ParseInt(dropped.Timestamp, 10, 64)
+		logger.WithFields(labelsToLogrusFields(dropped.Labels)).WithTime(time.Unix(0, nsec)).Warn("dropped")
+
+		if nsec > ts {
+			ts = nsec
+		}
 	}
+
+	return ts
 }
 
 func labelsToLogrusFields(labels map[string]string) logrus.Fields {
@@ -92,42 +110,47 @@ func labelsToLogrusFields(labels map[string]string) logrus.Fields {
 	return fields
 }
 
-func (c *Config) getRequest(referenceID string, start time.Duration) (*url.URL, error) {
+func (c *Config) logtailConn(ctx context.Context, referenceID string, since time.Time) (*websocket.Conn, error) {
 	u, err := url.Parse(c.LogsTailURL.String)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't parse cloud logs host %w", err)
 	}
 
-	u.RawQuery = fmt.Sprintf(`query={test_run_id="%s"}&start=%d`,
-		referenceID,
-		time.Now().Add(-start).UnixNano(),
-	)
+	u.RawQuery = fmt.Sprintf(`query={test_run_id="%s"}&start=%d`, referenceID, since.UnixNano())
 
-	return u, nil
+	headers := make(http.Header)
+	headers.Add("Sec-WebSocket-Protocol", "token="+c.Token.String)
+
+	var conn *websocket.Conn
+	err = retry(sleeperFunc(time.Sleep), 3, 5*time.Second, 2*time.Minute, func() (err error) {
+		// We don't need to close the http body or use it for anything until we want to actually log
+		// what the server returned as body when it errors out
+		conn, _, err = websocket.DefaultDialer.DialContext(ctx, u.String(), headers) //nolint:bodyclose
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return conn, nil
 }
 
 // StreamLogsToLogger streams the logs for the configured test to the provided logger until ctx is
 // Done or an error occurs.
 func (c *Config) StreamLogsToLogger(
-	ctx context.Context, logger logrus.FieldLogger, referenceID string, start time.Duration,
+	ctx context.Context, logger logrus.FieldLogger, referenceID string, tailFrom time.Duration,
 ) error {
-	u, err := c.getRequest(referenceID, start)
-	if err != nil {
-		return err
-	}
+	var mconn sync.Mutex
 
-	headers := make(http.Header)
-	headers.Add("Sec-WebSocket-Protocol", "token="+c.Token.String)
-
-	// We don't need to close the http body or use it for anything until we want to actually log
-	// what the server returned as body when it errors out
-	conn, _, err := websocket.DefaultDialer.DialContext(ctx, u.String(), headers) //nolint:bodyclose
+	conn, err := c.logtailConn(ctx, referenceID, time.Now().Add(-tailFrom))
 	if err != nil {
 		return err
 	}
 
 	go func() {
 		<-ctx.Done()
+
+		mconn.Lock()
+		defer mconn.Unlock()
 
 		_ = conn.WriteControl(
 			websocket.CloseMessage,
@@ -138,9 +161,9 @@ func (c *Config) StreamLogsToLogger(
 	}()
 
 	msgBuffer := make(chan []byte, 10)
-
 	defer close(msgBuffer)
 
+	var mostRecent int64
 	go func() {
 		for message := range msgBuffer {
 			var m msg
@@ -150,8 +173,8 @@ func (c *Config) StreamLogsToLogger(
 
 				continue
 			}
-
-			m.Log(logger)
+			ts := m.Log(logger)
+			atomic.StoreInt64(&mostRecent, ts)
 		}
 	}()
 
@@ -164,9 +187,34 @@ func (c *Config) StreamLogsToLogger(
 		}
 
 		if err != nil {
-			logger.WithError(err).Warn("error reading a message from the cloud")
+			logger.WithError(err).Warn("error reading a log message from the cloud, trying to establish a fresh connection with the logs service...") //nolint:lll
 
-			return err
+			var since time.Time
+			if ts := atomic.LoadInt64(&mostRecent); ts > 0 {
+				// add 1ns for avoid possible repetition
+				since = time.Unix(0, ts).Add(time.Nanosecond)
+			} else {
+				since = time.Now()
+			}
+
+			// TODO: avoid the "logical" race condition
+			// The case explained:
+			// * The msgBuffer consumer is slow
+			// * ReadMessage is fast and adds at least one more message in the buffer
+			// * An error is got in the meantime and the re-dialing procedure is tried
+			// * Then the latest timestamp used will not be the real latest received
+			// * because it is still waiting to be processed.
+			// In the case the connection will be restored then the first message will be a duplicate.
+			newconn, errd := c.logtailConn(ctx, referenceID, since)
+			if errd != nil {
+				// return the main error
+				return err
+			}
+
+			mconn.Lock()
+			conn = newconn
+			mconn.Unlock()
+			continue
 		}
 
 		select {
@@ -175,4 +223,44 @@ func (c *Config) StreamLogsToLogger(
 		case msgBuffer <- message:
 		}
 	}
+}
+
+// sleeper represents an abstraction for waiting an amount of time.
+type sleeper interface {
+	Sleep(d time.Duration)
+}
+
+// sleeperFunc uses the underhood function for implementing the wait operation.
+type sleeperFunc func(time.Duration)
+
+func (sfn sleeperFunc) Sleep(d time.Duration) {
+	sfn(d)
+}
+
+// retry retries to execute a provided function until it isn't successful
+// or the maximum number of attempts is hit. It waits the specified interval
+// between the latest iteration and the next retry.
+// Interval is used as the base to compute an exponential backoff,
+// if the computed interval overtakes the max interval then max will be used.
+func retry(s sleeper, attempts uint, interval, max time.Duration, do func() error) (err error) {
+	baseInterval := math.Abs(interval.Truncate(time.Second).Seconds())
+	r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
+
+	for i := 0; i < int(attempts); i++ {
+		if i > 0 {
+			// wait = (interval ^ i) + random milliseconds
+			wait := time.Duration(math.Pow(baseInterval, float64(i))) * time.Second
+			wait += time.Duration(r.Int63n(1000)) * time.Millisecond
+
+			if wait > max {
+				wait = max
+			}
+			s.Sleep(wait)
+		}
+		err = do()
+		if err == nil {
+			return nil
+		}
+	}
+	return
 }

--- a/cloudapi/logs_test.go
+++ b/cloudapi/logs_test.go
@@ -21,16 +21,27 @@
 package cloudapi
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"github.com/mailru/easyjson"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/lib/testutils"
+	"go.k6.io/k6/lib/testutils/httpmultibin"
 )
 
 func TestMsgParsing(t *testing.T) {
@@ -122,4 +133,296 @@ func TestMSGLog(t *testing.T) {
 		require.Equal(t, expectedMsg, entry.Message)
 		require.Equal(t, expectTime, entry.Time)
 	}
+}
+
+func TestRetry(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		tests := []struct {
+			name     string
+			attempts int
+			expWaits []time.Duration // pow(abs(interval), attempt index)
+		}{
+			{
+				name:     "NoRetry",
+				attempts: 1,
+			},
+			{
+				name:     "TwoAttempts",
+				attempts: 2,
+				expWaits: []time.Duration{5 * time.Second},
+			},
+			{
+				name:     "MaximumExceeded",
+				attempts: 4,
+				expWaits: []time.Duration{5 * time.Second, 25 * time.Second, 2 * time.Minute},
+			},
+			{
+				name:     "AttemptsLimit",
+				attempts: 5,
+				expWaits: []time.Duration{5 * time.Second, 25 * time.Second, 2 * time.Minute, 2 * time.Minute},
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				var sleepRequests []time.Duration
+				// sleepCollector tracks the request duration value for sleep requests.
+				sleepCollector := sleeperFunc(func(d time.Duration) {
+					sleepRequests = append(sleepRequests, d)
+				})
+
+				var iterations int
+				err := retry(sleepCollector, 5, 5*time.Second, 2*time.Minute, func() error {
+					iterations++
+					if iterations < tt.attempts {
+						return fmt.Errorf("unexpected error")
+					}
+					return nil
+				})
+				require.NoError(t, err)
+				require.Equal(t, tt.attempts, iterations)
+				require.Equal(t, len(tt.expWaits), len(sleepRequests))
+
+				// the added random milliseconds makes difficult to know the exact value
+				// so it asserts that expwait <= actual <= expwait + 1s
+				for i, expwait := range tt.expWaits {
+					assert.GreaterOrEqual(t, sleepRequests[i], expwait)
+					assert.LessOrEqual(t, sleepRequests[i], expwait+(1*time.Second))
+				}
+			})
+		}
+	})
+	t.Run("Fail", func(t *testing.T) {
+		t.Parallel()
+
+		mock := sleeperFunc(func(time.Duration) { /* noop - nowait */ })
+		err := retry(mock, 5, 5*time.Second, 30*time.Second, func() error {
+			return fmt.Errorf("unexpected error")
+		})
+
+		assert.Error(t, err, "unexpected error")
+	})
+}
+
+func TestStreamLogsToLogger(t *testing.T) {
+	t.Parallel()
+
+	// It registers an handler for the logtail endpoint
+	// It upgrades as websocket the HTTP handler and invokes the provided callback.
+	logtailHandleFunc := func(tb *httpmultibin.HTTPMultiBin, fn func(*websocket.Conn, *http.Request)) {
+		upgrader := websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+		}
+		tb.Mux.HandleFunc("/api/v1/tail", func(w http.ResponseWriter, req *http.Request) {
+			conn, err := upgrader.Upgrade(w, req, nil)
+			require.NoError(t, err)
+
+			fn(conn, req)
+			_ = conn.Close()
+		})
+	}
+
+	// a basic config with the logtail endpoint set
+	configFromHTTPMultiBin := func(tb *httpmultibin.HTTPMultiBin) Config {
+		wsurl := strings.TrimPrefix(tb.ServerHTTP.URL, "http://")
+		return Config{
+			LogsTailURL: null.NewString(fmt.Sprintf("ws://%s/api/v1/tail", wsurl), false),
+		}
+	}
+
+	// get all messages from the mocked logger
+	logLines := func(hook *testutils.SimpleLogrusHook) (lines []string) {
+		for _, e := range hook.Drain() {
+			lines = append(lines, e.Message)
+		}
+		return
+	}
+
+	generateLogline := func(key string, ts uint64, msg string) string {
+		return fmt.Sprintf(`{"streams":[{"stream":{"key":%q,"level":"warn"},"values":[["%d",%q]]}],"dropped_entities":[]}`, key, ts, msg)
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		tb := httpmultibin.NewHTTPMultiBin(t)
+		logtailHandleFunc(tb, func(conn *websocket.Conn, _ *http.Request) {
+			rawmsg := json.RawMessage(generateLogline("stream1", 1598282752000000000, "logline1"))
+			err := conn.WriteJSON(rawmsg)
+			require.NoError(t, err)
+
+			rawmsg = json.RawMessage(generateLogline("stream2", 1598282752000000001, "logline2"))
+			err = conn.WriteJSON(rawmsg)
+			require.NoError(t, err)
+
+			// wait the flush on the network
+			time.Sleep(5 * time.Millisecond)
+			cancel()
+		})
+
+		logger := logrus.New()
+		logger.Out = ioutil.Discard
+		hook := &testutils.SimpleLogrusHook{HookedLevels: logrus.AllLevels}
+		logger.AddHook(hook)
+
+		c := configFromHTTPMultiBin(tb)
+		err := c.StreamLogsToLogger(ctx, logger, "ref_id", 0)
+		require.NoError(t, err)
+
+		assert.Equal(t, []string{"logline1", "logline2"}, logLines(hook))
+	})
+
+	t.Run("RestoreConnFromLatestMessage", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		startFilter := func(u url.URL) (start time.Time, err error) {
+			rawstart, err := strconv.ParseInt(u.Query().Get("start"), 10, 64)
+			if err != nil {
+				return start, err
+			}
+
+			start = time.Unix(0, rawstart)
+			return
+		}
+
+		var requestsCount uint64
+
+		tb := httpmultibin.NewHTTPMultiBin(t)
+		logtailHandleFunc(tb, func(conn *websocket.Conn, req *http.Request) {
+			requests := atomic.AddUint64(&requestsCount, 1)
+
+			start, err := startFilter(*req.URL)
+			require.NoError(t, err)
+
+			if requests <= 1 {
+				t0 := time.Date(2021, time.July, 27, 0, 0, 0, 0, time.UTC).UnixNano()
+				t1 := time.Date(2021, time.July, 27, 1, 0, 0, 0, time.UTC).UnixNano()
+				t2 := time.Date(2021, time.July, 27, 2, 0, 0, 0, time.UTC).UnixNano()
+
+				// send a correct logline so we will able to assert
+				// that the connection is restored from t2 as expected
+				rawmsg := json.RawMessage(fmt.Sprintf(`{"streams":[{"stream":{"key":"stream1","level":"warn"},"values":[["%d","newest logline"],["%d","second logline"],["%d","oldest logline"]]}],"dropped_entities":[]}`, t2, t1, t0))
+				err = conn.WriteJSON(rawmsg)
+				require.NoError(t, err)
+
+				// wait the flush of the message on the network
+				time.Sleep(5 * time.Millisecond)
+
+				// it generates a failure closing the connection
+				// in a rude way
+				err = conn.Close()
+				require.NoError(t, err)
+
+				time.Sleep(time.Millisecond)
+				return
+			}
+
+			// assert that the client created the request with `start`
+			// populated from the most recent seen value (t2+1ns)
+			require.Equal(t, time.Unix(0, 1627351200000000001), start)
+
+			// send a correct logline so we will able to assert
+			// that the connection is restored as expected
+			err = conn.WriteJSON(json.RawMessage(generateLogline("stream3", 1627358400000000000, "logline-after-restored-conn")))
+			require.NoError(t, err)
+
+			// wait the flush of the message on the network
+			time.Sleep(5 * time.Millisecond)
+			cancel()
+		})
+
+		logger := logrus.New()
+		logger.Out = ioutil.Discard
+		hook := &testutils.SimpleLogrusHook{HookedLevels: logrus.AllLevels}
+		logger.AddHook(hook)
+
+		c := configFromHTTPMultiBin(tb)
+		err := c.StreamLogsToLogger(ctx, logger, "ref_id", 0)
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			[]string{
+				"newest logline",
+				"second logline",
+				"oldest logline",
+				"error reading a log message from the cloud, trying to establish a fresh connection with the logs service...",
+				"logline-after-restored-conn",
+			}, logLines(hook))
+	})
+
+	t.Run("RestoreConnFromTimeNow", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		startFilter := func(u url.URL) (start time.Time, err error) {
+			rawstart, err := strconv.ParseInt(u.Query().Get("start"), 10, 64)
+			if err != nil {
+				return start, err
+			}
+
+			start = time.Unix(0, rawstart)
+			return
+		}
+
+		var requestsCount uint64
+		t0 := time.Now()
+
+		tb := httpmultibin.NewHTTPMultiBin(t)
+		logtailHandleFunc(tb, func(conn *websocket.Conn, req *http.Request) {
+			requests := atomic.AddUint64(&requestsCount, 1)
+
+			start, err := startFilter(*req.URL)
+			require.NoError(t, err)
+
+			if requests <= 1 {
+				// if it's the first attempt then
+				// it generates a failure closing the connection
+				// in a rude way
+				err = conn.Close()
+				require.NoError(t, err)
+				return
+			}
+
+			// it asserts that the second attempt
+			// has a `start` after the test run
+			require.True(t, start.After(t0))
+
+			// send a correct logline so we will able to assert
+			// that the connection is restored as expected
+			err = conn.WriteJSON(json.RawMessage(`{"streams":[{"stream":{"key":"stream1","level":"warn"},"values":[["1598282752000000000","logline-after-restored-conn"]]}],"dropped_entities":[]}`))
+			require.NoError(t, err)
+
+			// wait the flush of the message on the network
+			time.Sleep(5 * time.Millisecond)
+			cancel()
+		})
+
+		logger := logrus.New()
+		logger.Out = ioutil.Discard
+		hook := &testutils.SimpleLogrusHook{HookedLevels: logrus.AllLevels}
+		logger.AddHook(hook)
+
+		c := configFromHTTPMultiBin(tb)
+		err := c.StreamLogsToLogger(ctx, logger, "ref_id", 0)
+		require.NoError(t, err)
+
+		assert.Equal(t,
+			[]string{
+				"error reading a log message from the cloud, trying to establish a fresh connection with the logs service...",
+				"logline-after-restored-conn",
+			}, logLines(hook))
+	})
 }


### PR DESCRIPTION
It adds some capabilities to reconnect to our log tail service.

Some questions/notes:
* Re-generating `cloudapi` package the `_easyjson` file gets some changes
* Should we support the options from the json configuration? The already existing option doesn't so I replicated it.
* I added `gomock` as a dependency to support mocking some interfaces for unit testing. I find it generally very useful but we are not using it so I expect some cons with k6 that I'm not considering.
* The current abstraction is still tight with the current `gorilla/websocket`, if I'm in the right way with this PR, we could consider designing a better abstraction from the real streaming implementation.
* The current logic closes the connection before re-dial this generates to get some logs like this:
   ```
   INFO[0064] we are reconnecting to tail logs, this might result in either some repeated or missed messages
   ERRO[0065] couldn't unmarshal a message from the cloud:   error=EOF
   ERRO[0065] couldn't unmarshal a message from the cloud:   error=EOF
  ```
  should we improve the UX and avoid this message or log something more specific?

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/k6io/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/k6io/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
Closes #1966 
