### PR TITLE
Fix cloud config merging

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -278,7 +278,9 @@ func MergeFromExternal(external map[string]json.RawMessage, conf *Config) error 
 
 // GetConsolidatedConfig combines the default config values with the JSON config
 // values and environment variables and returns the final result.
-func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, configArg string) (Config, error) {
+func GetConsolidatedConfig(
+	jsonRawConf json.RawMessage, env map[string]string, configArg string, external map[string]json.RawMessage,
+) (Config, error) {
 	result := NewConfig()
 	if jsonRawConf != nil {
 		jsonConf := Config{}
@@ -286,6 +288,9 @@ func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, c
 			return result, err
 		}
 		result = result.Apply(jsonConf)
+	}
+	if err := MergeFromExternal(external, &result); err != nil {
+		return result, err
 	}
 
 	envConfig := Config{}

--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -34,10 +34,9 @@ import (
 //nolint: lll
 type Config struct {
 	// TODO: refactor common stuff between cloud execution and output
-	Token           null.String `json:"token" envconfig:"K6_CLOUD_TOKEN"`
-	DeprecatedToken null.String `json:"-" envconfig:"K6CLOUD_TOKEN"`
-	ProjectID       null.Int    `json:"projectID" envconfig:"K6_CLOUD_PROJECT_ID"`
-	Name            null.String `json:"name" envconfig:"K6_CLOUD_NAME"`
+	Token     null.String `json:"token" envconfig:"K6_CLOUD_TOKEN"`
+	ProjectID null.Int    `json:"projectID" envconfig:"K6_CLOUD_PROJECT_ID"`
+	Name      null.String `json:"name" envconfig:"K6_CLOUD_NAME"`
 
 	Host        null.String `json:"host" envconfig:"K6_CLOUD_HOST"`
 	LogsTailURL null.String `json:"-" envconfig:"K6_CLOUD_LOGS_TAIL_URL"`
@@ -185,9 +184,6 @@ func NewConfig() Config {
 func (c Config) Apply(cfg Config) Config {
 	if cfg.Token.Valid {
 		c.Token = cfg.Token
-	}
-	if cfg.DeprecatedToken.Valid {
-		c.DeprecatedToken = cfg.DeprecatedToken
 	}
 	if cfg.ProjectID.Valid && cfg.ProjectID.Int64 > 0 {
 		c.ProjectID = cfg.ProjectID

--- a/cloudapi/config_test.go
+++ b/cloudapi/config_test.go
@@ -44,7 +44,6 @@ func TestConfigApply(t *testing.T) {
 
 	full := Config{
 		Token:                           null.NewString("Token", true),
-		DeprecatedToken:                 null.NewString("DeprecatedToken", true),
 		ProjectID:                       null.NewInt(1, true),
 		Name:                            null.NewString("Name", true),
 		Host:                            null.NewString("Host", true),

--- a/cloudapi/config_test.go
+++ b/cloudapi/config_test.go
@@ -73,7 +73,7 @@ func TestConfigApply(t *testing.T) {
 	assert.Equal(t, full, defaults.Apply(full))
 }
 
-func TestConfigConsolidation(t *testing.T) { //nolint:paralleltest
+func TestGetConsolidatedConfig(t *testing.T) { //nolint:paralleltest
 	config, err := GetConsolidatedConfig(json.RawMessage(`{"token":"jsonraw"}`), nil, "", nil)
 	require.NoError(t, err)
 	require.Equal(t, config.Token.String, "jsonraw")

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -137,15 +137,6 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 				return err
 			}
 
-			// Cloud config
-			cloudConfig, err := cloudapi.GetConsolidatedConfig(derivedConf.Collectors["cloud"], osEnvironment, "")
-			if err != nil {
-				return err
-			}
-			if !cloudConfig.Token.Valid {
-				return errors.New("Not logged in, please use `k6 login cloud`.") //nolint:golint
-			}
-
 			modifyAndPrintBar(progressBar, pb.WithConstProgress(0, "Building the archive"))
 			arc := r.MakeArchive()
 			// TODO: Fix this
@@ -164,8 +155,14 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 				}
 			}
 
-			if err = cloudapi.MergeFromExternal(arc.Options.External, &cloudConfig); err != nil {
+			// Cloud config
+			cloudConfig, err := cloudapi.GetConsolidatedConfig(
+				derivedConf.Collectors["cloud"], osEnvironment, "", arc.Options.External)
+			if err != nil {
 				return err
+			}
+			if !cloudConfig.Token.Valid {
+				return errors.New("Not logged in, please use `k6 login cloud`.") //nolint:golint,revive,stylecheck
 			}
 			if tmpCloudConfig == nil {
 				tmpCloudConfig = make(map[string]interface{}, 3)

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -168,13 +168,13 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 				tmpCloudConfig = make(map[string]interface{}, 3)
 			}
 
-			if _, ok := tmpCloudConfig["token"]; !ok && cloudConfig.Token.Valid {
+			if cloudConfig.Token.Valid {
 				tmpCloudConfig["token"] = cloudConfig.Token
 			}
-			if _, ok := tmpCloudConfig["name"]; !ok && cloudConfig.Name.Valid {
+			if cloudConfig.Name.Valid {
 				tmpCloudConfig["name"] = cloudConfig.Name
 			}
-			if _, ok := tmpCloudConfig["projectID"]; !ok && cloudConfig.ProjectID.Valid {
+			if cloudConfig.ProjectID.Valid {
 				tmpCloudConfig["projectID"] = cloudConfig.ProjectID
 			}
 

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -76,7 +76,8 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 
 			// We want to use this fully consolidated config for things like
 			// host addresses, so users can overwrite them with env vars.
-			consolidatedCurrentConfig, err := cloudapi.GetConsolidatedConfig(currentJSONConfigRaw, buildEnvMap(os.Environ()), "")
+			consolidatedCurrentConfig, err := cloudapi.GetConsolidatedConfig(
+				currentJSONConfigRaw, buildEnvMap(os.Environ()), "", nil)
 			if err != nil {
 				return err
 			}

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -97,7 +97,8 @@ func New(params output.Params) (output.Output, error) {
 
 // New creates a new cloud output.
 func newOutput(params output.Params) (*Output, error) {
-	conf, err := cloudapi.GetConsolidatedConfig(params.JSONConfig, params.Environment, params.ConfigArgument)
+	conf, err := cloudapi.GetConsolidatedConfig(
+		params.JSONConfig, params.Environment, params.ConfigArgument, params.ScriptOptions.External)
 	if err != nil {
 		return nil, err
 	}
@@ -107,10 +108,6 @@ func newOutput(params output.Params) (*Output, error) {
 	}
 
 	logger := params.Logger.WithFields(logrus.Fields{"output": "cloud"})
-
-	if err := cloudapi.MergeFromExternal(params.ScriptOptions.External, &conf); err != nil {
-		return nil, err
-	}
 
 	if conf.AggregationPeriod.Duration > 0 &&
 		(params.ScriptOptions.SystemTags.Has(stats.TagVU) || params.ScriptOptions.SystemTags.Has(stats.TagIter)) {

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -132,11 +132,6 @@ func newOutput(params output.Params) (*Output, error) {
 		return nil, errors.New("tests with unspecified duration are not allowed when outputting data to k6 cloud")
 	}
 
-	if !conf.Token.Valid && conf.DeprecatedToken.Valid {
-		logger.Warn("K6CLOUD_TOKEN is deprecated and will be removed. Use K6_CLOUD_TOKEN instead.")
-		conf.Token = conf.DeprecatedToken
-	}
-
 	if !(conf.MetricPushConcurrency.Int64 > 0) {
 		return nil, fmt.Errorf("metrics push concurrency must be a positive number but is %d",
 			conf.MetricPushConcurrency.Int64)


### PR DESCRIPTION
Previously after the usual consolidation of metrics where json config,
script options, cli, env order is followed the `ext.loadimpact` configs
(from within the script options) would take precedence over anything
else.

Now it has the same precedence as the script config.

This likely as always has additional sideeffects ... for example the
K6CLOUD_TOKEN to K6_CLOUD_TOKEN fix is being done after all of this
which should probably be dropped either way.
