### PR TITLE
Use GITHUB_TOKEN to login to GHCR

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -277,7 +277,7 @@ jobs:
           echo "Publish GHCR ($DOCKER_IMAGE_ID:$VERSION)"
 
           # Log into GitHub Container Registry
-          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
           docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$GHCR_IMAGE_ID:$VERSION"
           docker push "ghcr.io/$GHCR_IMAGE_ID:$VERSION"
           # We also want to tag the latest stable version as latest
@@ -461,7 +461,7 @@ jobs:
           echo "${{ secrets.PGP_SIGN_KEY }}" > packaging/sign-key.gpg
       - name: Publish packages
         run: |
-          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
           cd packaging
           docker-compose pull packager
           docker-compose run --rm packager

--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -26,7 +26,7 @@ jobs:
           docker-compose build packager
       - name: Publish
         run: |
-          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
           docker push "${DOCKER_IMAGE_ID}:latest"
           docker tag "${DOCKER_IMAGE_ID}" "${DOCKER_IMAGE_ID}:${VERSION}"
           docker push "${DOCKER_IMAGE_ID}:${VERSION}"


### PR DESCRIPTION
This fixes the [recent `build-docker` failures on `master`](https://github.com/grafana/k6/runs/3174118226?check_suite_focus=true), as GitHub [has moved away from PATs](https://github.blog/changelog/2021-03-24-packages-container-registry-now-supports-github_token/) for authenticating with the Container Registry.

I confirmed this works by pushing from this branch and [the package was created](https://github.com/grafana/k6/pkgs/container/k6). Hopefully once it's pushed from `master` it will be the default tag. Otherwise we can delete it :)

I'll remove the `CR_PAT` secret when this is merged, since it's not used anywhere else.