### PR TITLE
Pass setup data object into handleSummary callback

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -316,7 +316,7 @@ func (r *Runner) IsExecutable(name string) bool {
 
 // HandleSummary calls the specified summary callback, if supplied.
 func (r *Runner) HandleSummary(ctx context.Context, summary *lib.Summary) (map[string]io.Reader, error) {
-	summaryDataForJS := summarizeMetricsToObject(summary, r.Bundle.Options)
+	summaryDataForJS := summarizeMetricsToObject(summary, r.Bundle.Options, r.setupData)
 
 	out := make(chan stats.SampleContainer, 100)
 	defer close(out)

--- a/js/summary.go
+++ b/js/summary.go
@@ -25,7 +25,7 @@ import (
 	"fmt"
 	"io"
 	"time"
-
+	"encoding/json"
 	"github.com/dop251/goja"
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/lib"
@@ -79,7 +79,7 @@ func metricValueGetter(summaryTrendStats []string) func(stats.Sink, time.Duratio
 
 // summarizeMetricsToObject transforms the summary objects in a way that's
 // suitable to pass to the JS runtime or export to JSON.
-func summarizeMetricsToObject(data *lib.Summary, options lib.Options) map[string]interface{} {
+func summarizeMetricsToObject(data *lib.Summary, options lib.Options, setupData []byte) map[string]interface{} {
 	m := make(map[string]interface{})
 	m["root_group"] = exportGroup(data.RootGroup)
 	m["options"] = map[string]interface{}{
@@ -116,6 +116,17 @@ func summarizeMetricsToObject(data *lib.Summary, options lib.Options) map[string
 		metricsData[name] = metricData
 	}
 	m["metrics"] = metricsData
+
+	var setupDataI interface{}
+	if setupData != nil {
+		if err := json.Unmarshal(setupData, &setupDataI); err != nil {
+			return nil
+		}
+	} else {
+		setupDataI = goja.Undefined()
+	}
+
+	m["setup_data"] = setupDataI
 
 	return m
 }


### PR DESCRIPTION
Issue: #2088

Passing the setup data into handleSummary callback in the same way how it is in Teardown.

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/k6io/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/k6io/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
