### PR TITLE
Fix xk6 test failures in CI

### DIFF
--- a/.github/workflows/xk6-tests/xk6-js-test/go.mod
+++ b/.github/workflows/xk6-tests/xk6-js-test/go.mod
@@ -1,8 +1,5 @@
-module github.com/k6io/xk6-js-test
+module github.com/grafana/xk6-js-test
 
 go 1.15
 
-require (
-	github.com/dop251/goja v0.0.0-20210427212725-462d53687b0d
-	go.k6.io/k6 v0.31.2-0.20210511090412-61f464b99a2d
-)
+require go.k6.io/k6 v0.33.1-0.20210729092242-a460e699c6e2

--- a/.github/workflows/xk6-tests/xk6-output-test/go.mod
+++ b/.github/workflows/xk6-tests/xk6-output-test/go.mod
@@ -1,8 +1,8 @@
-module github.com/k6io/xk6-output-test
+module github.com/grafana/xk6-output-test
 
 go 1.15
 
 require (
 	github.com/spf13/afero v1.1.2
-	go.k6.io/k6 v0.31.2-0.20210511090412-61f464b99a2d
+	go.k6.io/k6 v0.33.1-0.20210729092242-a460e699c6e2
 )

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -55,8 +55,8 @@ jobs:
           fi
           GOPROXY="direct" xk6 build "$COMMIT_ID" \
             --output ./k6ext \
-            --with github.com/k6io/xk6-js-test="$(pwd)/xk6-js-test" \
-            --with github.com/k6io/xk6-output-test="$(pwd)/xk6-output-test"
+            --with github.com/grafana/xk6-js-test="$(pwd)/xk6-js-test" \
+            --with github.com/grafana/xk6-output-test="$(pwd)/xk6-output-test"
           ./k6ext version
           ./k6ext run --out outputtest=output-results.txt xk6-test.js
 

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -48,6 +48,8 @@ jobs:
           fi
           echo "COMMIT_ID=$COMMIT_ID"
           cd .github/workflows/xk6-tests
+          # Temporary hack to ignore the v0.33.0 tag change
+          export GONOSUMDB="go.k6.io/k6"
           go get github.com/k6io/xk6/cmd/xk6@master
           if [ "${{ github.event_name }}" == "pull_request" -a \
                "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then


### PR DESCRIPTION
This is an attempt to fix the xk6 test failures we're seeing for external PRs:
- https://github.com/grafana/k6/pull/2103/checks?check_run_id=3228680151
- https://github.com/grafana/k6/pull/2104/checks?check_run_id=3228681771

```
go: downloading go.k6.io/k6 v0.33.0
go get: go.k6.io/k6@v0.33.0: verifying module: checksum mismatch
	downloaded: h1:zBcinO3oMLQ+AWRBsVOBomLSueOK3tM8qwZIPjaMydk=
	sum.golang.org: h1:NX/6hvAD6A780xg7STngX4ay8Le+V3rz7KOL2o5KzSk=

SECURITY ERROR
This download does NOT match the one reported by the checksum server.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.
```