### PR TITLE
Fix k6packager push to GHCR

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -16,7 +16,7 @@ jobs:
       VERSION: 0.0.3
       AWSCLI_VERSION: 2.1.36
       S3CMD_VERSION: 2.1.0
-      DOCKER_IMAGE_ID: ghcr.io/k6io/k6packager
+      DOCKER_IMAGE_ID: ghcr.io/grafana/k6packager
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/packaging/docker-compose.yml
+++ b/packaging/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       args:
         - AWSCLI_VERSION=${AWSCLI_VERSION:-2.1.36}
         - S3CMD_VERSION=${S3CMD_VERSION:-2.1.0}
-    image: ghcr.io/k6io/k6packager:latest
+    image: ghcr.io/grafana/k6packager:latest
     environment:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
This fixes the [`permission_denied: The requested installation does not exist.` error](https://github.com/grafana/k6/runs/3271365155?check_suite_focus=true) we've seen when pushing the k6packager image to GHCR since the move to the grafana org.