### PR TITLE
Remove unused code from stats/stats.go

### DIFF
--- a/stats/stats.go
+++ b/stats/stats.go
@@ -467,12 +467,6 @@ func New(name string, typ MetricType, t ...ValueType) *Metric {
 	return &Metric{Name: name, Type: typ, Contains: vt, Sink: sink}
 }
 
-var unitMap = map[string][]interface{}{
-	"s":  {"s", time.Second},
-	"ms": {"ms", time.Millisecond},
-	"us": {"µs", time.Microsecond},
-}
-
 // A Submetric represents a filtered dataset based on a parent metric.
 type Submetric struct {
 	Name   string      `json:"name"`


### PR DESCRIPTION
i found unitMap is unused in stats/stats.go.

i guess this were forgotten to remove in [this commit](https://github.com/grafana/k6/commit/2810d834ed31108316567b9f96cf9089dfacd54d).
