### PR TITLE
Support camelCase CSV output argument for file_name and save_interval.

### DIFF
--- a/output/csv/config.go
+++ b/output/csv/config.go
@@ -85,7 +85,7 @@ func ParseArg(arg string, logger *logrus.Logger) (Config, error) {
 				return c, err
 			}
 		case "file_name":
-			logger.Warnf("CSV output argument '%s' will soon be deprecated, please use 'fileName' instead.", r[0])
+			logger.Warnf("CSV output argument '%s' is deprecated, please use 'fileName' instead.", r[0])
 			fallthrough
 		case "fileName":
 			c.FileName = null.StringFrom(r[1])

--- a/output/csv/config.go
+++ b/output/csv/config.go
@@ -99,8 +99,9 @@ func ParseArg(arg string, logger *logrus.Logger) (Config, error) {
 
 // GetConsolidatedConfig combines {default config values + JSON config +
 // environment vars + arg config values}, and returns the final result.
-//nolint: lll
-func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, arg string, logger *logrus.Logger) (Config, error) {
+func GetConsolidatedConfig(
+	jsonRawConf json.RawMessage, env map[string]string, arg string, logger *logrus.Logger,
+) (Config, error) {
 	result := NewConfig()
 	if jsonRawConf != nil {
 		jsonConf := Config{}

--- a/output/csv/config.go
+++ b/output/csv/config.go
@@ -99,6 +99,7 @@ func ParseArg(arg string, logger *logrus.Logger) (Config, error) {
 
 // GetConsolidatedConfig combines {default config values + JSON config +
 // environment vars + arg config values}, and returns the final result.
+//nolint: lll
 func GetConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, arg string, logger *logrus.Logger) (Config, error) {
 	result := NewConfig()
 	if jsonRawConf != nil {

--- a/output/csv/config.go
+++ b/output/csv/config.go
@@ -77,7 +77,7 @@ func ParseArg(arg string, logger *logrus.Logger) (Config, error) {
 		}
 		switch r[0] {
 		case "save_interval":
-			logger.Warnf("CSV output argument '%s' will soon be deprecated, please use 'saveInterval' instead.", r[0])
+			logger.Warnf("CSV output argument '%s' is deprecated, please use 'saveInterval' instead.", r[0])
 			fallthrough
 		case "saveInterval":
 			err := c.SaveInterval.UnmarshalText([]byte(r[1]))

--- a/output/csv/config_test.go
+++ b/output/csv/config_test.go
@@ -24,8 +24,11 @@ import (
 	"testing"
 	"time"
 
+	"go.k6.io/k6/lib/testutils"
+
 	"gopkg.in/guregu/null.v3"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"go.k6.io/k6/lib/types"
@@ -91,7 +94,18 @@ func TestParseArg(t *testing.T) {
 				SaveInterval: types.NullDurationFrom(5 * time.Second),
 			},
 		},
+		"saveInterval=5s": {
+			config: Config{
+				SaveInterval: types.NullDurationFrom(5 * time.Second),
+			},
+		},
 		"file_name=test.csv,save_interval=5s": {
+			config: Config{
+				FileName:     null.StringFrom("test.csv"),
+				SaveInterval: types.NullDurationFrom(5 * time.Second),
+			},
+		},
+		"fileName=test.csv,save_interval=5s": {
 			config: Config{
 				FileName:     null.StringFrom("test.csv"),
 				SaveInterval: types.NullDurationFrom(5 * time.Second),
@@ -102,12 +116,15 @@ func TestParseArg(t *testing.T) {
 		},
 	}
 
+	testLog := logrus.New()
+	testLog.SetOutput(testutils.NewTestOutput(t))
+
 	for arg, testCase := range cases {
 		arg := arg
 		testCase := testCase
 
 		t.Run(arg, func(t *testing.T) {
-			config, err := ParseArg(arg)
+			config, err := ParseArg(arg, testLog)
 
 			if testCase.expectedErr {
 				assert.Error(t, err)

--- a/output/csv/config_test.go
+++ b/output/csv/config_test.go
@@ -24,13 +24,12 @@ import (
 	"testing"
 	"time"
 
-	"go.k6.io/k6/lib/testutils"
-
 	"gopkg.in/guregu/null.v3"
 
-	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 
+	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/lib/types"
 )
 
@@ -80,8 +79,9 @@ func TestApply(t *testing.T) {
 
 func TestParseArg(t *testing.T) {
 	cases := map[string]struct {
-		config      Config
-		expectedErr bool
+		config             Config
+		expectedLogEntries []string
+		expectedErr        bool
 	}{
 		"test_file.csv": {
 			config: Config{
@@ -92,6 +92,9 @@ func TestParseArg(t *testing.T) {
 		"save_interval=5s": {
 			config: Config{
 				SaveInterval: types.NullDurationFrom(5 * time.Second),
+			},
+			expectedLogEntries: []string{
+				"CSV output argument 'save_interval' is deprecated, please use 'saveInterval' instead.",
 			},
 		},
 		"saveInterval=5s": {
@@ -104,11 +107,18 @@ func TestParseArg(t *testing.T) {
 				FileName:     null.StringFrom("test.csv"),
 				SaveInterval: types.NullDurationFrom(5 * time.Second),
 			},
+			expectedLogEntries: []string{
+				"CSV output argument 'file_name' is deprecated, please use 'fileName' instead.",
+				"CSV output argument 'save_interval' is deprecated, please use 'saveInterval' instead.",
+			},
 		},
 		"fileName=test.csv,save_interval=5s": {
 			config: Config{
 				FileName:     null.StringFrom("test.csv"),
 				SaveInterval: types.NullDurationFrom(5 * time.Second),
+			},
+			expectedLogEntries: []string{
+				"CSV output argument 'save_interval' is deprecated, please use 'saveInterval' instead.",
 			},
 		},
 		"filename=test.csv,save_interval=5s": {
@@ -116,15 +126,15 @@ func TestParseArg(t *testing.T) {
 		},
 	}
 
-	testLog := logrus.New()
-	testLog.SetOutput(testutils.NewTestOutput(t))
-
 	for arg, testCase := range cases {
 		arg := arg
 		testCase := testCase
 
+		testLogger, hook := test.NewNullLogger()
+		testLogger.SetOutput(testutils.NewTestOutput(t))
+
 		t.Run(arg, func(t *testing.T) {
-			config, err := ParseArg(arg, testLog)
+			config, err := ParseArg(arg, testLogger)
 
 			if testCase.expectedErr {
 				assert.Error(t, err)
@@ -133,6 +143,12 @@ func TestParseArg(t *testing.T) {
 			}
 			assert.Equal(t, testCase.config.FileName.String, config.FileName.String)
 			assert.Equal(t, testCase.config.SaveInterval.String(), config.SaveInterval.String())
+
+			var entries []string
+			for _, v := range hook.AllEntries() {
+				entries = append(entries, v.Message)
+			}
+			assert.ElementsMatch(t, entries, testCase.expectedLogEntries)
 		})
 	}
 }

--- a/output/csv/config_test.go
+++ b/output/csv/config_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"gopkg.in/guregu/null.v3"
 
 	"github.com/sirupsen/logrus/hooks/test"
@@ -146,6 +148,7 @@ func TestParseArg(t *testing.T) {
 
 			var entries []string
 			for _, v := range hook.AllEntries() {
+				assert.Equal(t, v.Level, logrus.WarnLevel)
 				entries = append(entries, v.Message)
 			}
 			assert.ElementsMatch(t, entries, testCase.expectedLogEntries)

--- a/output/csv/output.go
+++ b/output/csv/output.go
@@ -76,7 +76,11 @@ func newOutput(params output.Params) (*Output, error) {
 	sort.Strings(resTags)
 	sort.Strings(ignoredTags)
 
-	config, err := GetConsolidatedConfig(params.JSONConfig, params.Environment, params.ConfigArgument)
+	logger := params.Logger.WithFields(logrus.Fields{
+		"output":   "csv",
+		"filename": params.ConfigArgument,
+	})
+	config, err := GetConsolidatedConfig(params.JSONConfig, params.Environment, params.ConfigArgument, logger.Logger)
 	if err != nil {
 		return nil, err
 	}
@@ -84,10 +88,6 @@ func newOutput(params output.Params) (*Output, error) {
 	saveInterval := time.Duration(config.SaveInterval.Duration)
 	fname := config.FileName.String
 
-	logger := params.Logger.WithFields(logrus.Fields{
-		"output":   "csv",
-		"filename": params.ConfigArgument,
-	})
 	if fname == "" || fname == "-" {
 		stdoutWriter := csv.NewWriter(os.Stdout)
 		return &Output{


### PR DESCRIPTION
This change adds support for camelCased versions of file_name and save_interval CSV output arguments,
writing a warning to the logs informing users the older snake cased argument will be deprecated in time.

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
