### PR TITLE
bugfix#2036 Websocket connections ignore userAgent setting

### DIFF
--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -108,10 +108,10 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 		return nil, errors.New("last argument to ws.connect must be a function")
 	}
 
-	// Leave header to nil by default so we can pass it directly to the Dialer
-	var header http.Header
-
+	header := make(http.Header)
 	tags := state.CloneTags()
+
+	header.Set("User-Agent", state.Options.UserAgent.String)
 
 	// Parse the optional second argument (params)
 	if !goja.IsUndefined(paramsV) && !goja.IsNull(paramsV) {
@@ -119,7 +119,6 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 		for _, k := range params.Keys() {
 			switch k {
 			case "headers":
-				header = http.Header{}
 				headersV := params.Get(k)
 				if goja.IsUndefined(headersV) || goja.IsNull(headersV) {
 					continue


### PR DESCRIPTION
#### For fixing the Bug https://github.com/grafana/k6/issues/2036

#### Changes I have made:
Initializing `header` variable beforehand to apply the default User-Agent string (example - "k6/0.27.0 (https://k6.io/)") , OR to apply the User-Agent supplied through `Options` if it exists.