### PR TITLE
Fix go get xk6 github action

### DIFF
--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -50,7 +50,7 @@ jobs:
           cd .github/workflows/xk6-tests
           # Temporary hack to ignore the v0.33.0 tag change
           export GONOSUMDB="go.k6.io/k6"
-          go get go.k6.io/xk6/cmd/xk6@master
+          go install go.k6.io/xk6/cmd/xk6@latest
           if [ "${{ github.event_name }}" == "pull_request" -a \
                "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
             export XK6_K6_REPO="github.com/${{ github.event.pull_request.head.repo.full_name }}"

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -50,7 +50,7 @@ jobs:
           cd .github/workflows/xk6-tests
           # Temporary hack to ignore the v0.33.0 tag change
           export GONOSUMDB="go.k6.io/k6"
-          go install go.k6.io/xk6/cmd/xk6@latest
+          go install go.k6.io/xk6/cmd/xk6@master
           if [ "${{ github.event_name }}" == "pull_request" -a \
                "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
             export XK6_K6_REPO="github.com/${{ github.event.pull_request.head.repo.full_name }}"


### PR DESCRIPTION
+ `go get` is now only being used for adding dependencies to a Go module
+ this fix uses `go install` instead to install the xk6 binary (instead of `go get`)