### PR TITLE
Refactor ramping VUs executor

### DIFF
--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -533,7 +533,6 @@ func (vlv *RampingVUs) Run(ctx context.Context, _ chan<- stats.SampleContainer, 
 
 	runState := &rampingVUsRunState{
 		executor:       vlv,
-		wg:             sync.WaitGroup{},
 		vuHandles:      make([]*vuHandle, maxVUs),
 		maxVUs:         maxVUs,
 		activeVUsCount: new(int64),

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -635,7 +635,6 @@ func (rs rampingVUsRunState) handleVUs(ctx context.Context) {
 	}
 }
 
-// TODO: removing this has no effect on tests?
 func (rs rampingVUsRunState) handleRemainingVUs(ctx context.Context) {
 	var (
 		handleNewMaxAllowedVUs = rs.maxAllowedVUsHandlerStrategy()

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -495,32 +495,32 @@ var _ lib.Executor = &RampingVUs{}
 // number of VUs for the specified stages.
 func (vlv RampingVUs) Run(ctx context.Context, _ chan<- stats.SampleContainer, _ *metrics.BuiltinMetrics) error {
 	rawSteps := vlv.config.getRawExecutionSteps(vlv.executionState.ExecutionTuple, true)
-	regDur, finalRaw := lib.GetEndOffset(rawSteps)
-	if !finalRaw {
-		return fmt.Errorf("%s expected raw end offset at %s to be final", vlv.config.GetName(), regDur)
+	regularDuration, isFinal := lib.GetEndOffset(rawSteps)
+	if !isFinal {
+		return fmt.Errorf("%s expected raw end offset at %s to be final", vlv.config.GetName(), regularDuration)
 	}
 	gracefulSteps := vlv.config.GetExecutionRequirements(vlv.executionState.ExecutionTuple)
-	maxDur, finalGraceful := lib.GetEndOffset(gracefulSteps)
-	if !finalGraceful {
-		return fmt.Errorf("%s expected graceful end offset at %s to be final", vlv.config.GetName(), maxDur)
+	maxDuration, isFinal := lib.GetEndOffset(gracefulSteps)
+	if !isFinal {
+		return fmt.Errorf("%s expected graceful end offset at %s to be final", vlv.config.GetName(), maxDuration)
 	}
-	startMaxVUs := lib.GetMaxPlannedVUs(gracefulSteps)
-	startTime, maxDurCtx, regDurCtx, cancel := getDurationContexts(ctx, regDur, maxDur-regDur)
+	maxVUs := lib.GetMaxPlannedVUs(gracefulSteps)
+	startTime, maxDurationCtx, regularDurationCtx, cancel := getDurationContexts(ctx, regularDuration, maxDuration-regularDuration)
 	defer cancel()
 
 	vlv.logger.WithFields(logrus.Fields{
 		"type":      vlv.config.GetType(),
 		"startVUs":  vlv.config.GetStartVUs(vlv.executionState.ExecutionTuple),
-		"maxVUs":    startMaxVUs,
-		"duration":  regDur,
+		"maxVUs":    maxVUs,
+		"duration":  regularDuration,
 		"numStages": len(vlv.config.Stages),
 	}).Debug("Starting executor run...")
 
 	runState := &rampingVUsRunState{
 		executor:       vlv,
 		wg:             new(sync.WaitGroup),
-		vuHandles:      make([]*vuHandle, startMaxVUs),
-		maxVUs:         startMaxVUs,
+		vuHandles:      make([]*vuHandle, maxVUs),
+		maxVUs:         maxVUs,
 		activeVUsCount: new(int64),
 		started:        startTime,
 		rawSteps:       rawSteps,
@@ -528,18 +528,18 @@ func (vlv RampingVUs) Run(ctx context.Context, _ chan<- stats.SampleContainer, _
 		runIteration:   getIterationRunner(vlv.executionState, vlv.logger),
 	}
 
-	progressFn := runState.makeProgressFn(regDur)
-	maxDurCtx = lib.WithScenarioState(maxDurCtx, &lib.ScenarioState{
+	progressFn := runState.makeProgressFn(regularDuration)
+	maxDurationCtx = lib.WithScenarioState(maxDurationCtx, &lib.ScenarioState{
 		Name:       vlv.config.Name,
 		Executor:   vlv.config.Type,
 		StartTime:  runState.started,
 		ProgressFn: progressFn,
 	})
 	vlv.progress.Modify(pb.WithProgress(progressFn))
-	go trackProgress(ctx, maxDurCtx, regDurCtx, vlv, progressFn)
+	go trackProgress(ctx, maxDurationCtx, regularDurationCtx, vlv, progressFn)
 
 	defer runState.wg.Wait()
-	runState.populateVUHandles(maxDurCtx, cancel)
+	runState.populateVUHandles(maxDurationCtx, cancel)
 	for i := uint64(0); i < runState.maxVUs; i++ {
 		go runState.vuHandles[i].runLoopsIfPossible(runState.runIteration)
 	}
@@ -564,19 +564,19 @@ type rampingVUsRunState struct {
 	runIteration func(context.Context, lib.ActiveVU) bool // a helper closure function that runs a single iteration
 }
 
-func (rs rampingVUsRunState) makeProgressFn(total time.Duration) (progressFn func() (float64, []string)) {
+func (rs rampingVUsRunState) makeProgressFn(regular time.Duration) (progressFn func() (float64, []string)) {
 	vusFmt := pb.GetFixedLengthIntFormat(int64(rs.maxVUs))
-	regDuration := pb.GetFixedLengthDuration(total, total)
+	regularDuration := pb.GetFixedLengthDuration(regular, regular)
 
 	return func() (float64, []string) {
 		spent := time.Since(rs.started)
 		cur := atomic.LoadInt64(rs.activeVUsCount)
 		progVUs := fmt.Sprintf(vusFmt+"/"+vusFmt+" VUs", cur, rs.maxVUs)
-		if spent > total {
-			return 1, []string{progVUs, total.String()}
+		if spent > regular {
+			return 1, []string{progVUs, regular.String()}
 		}
-		progDur := pb.GetFixedLengthDuration(spent, total) + "/" + regDuration
-		return float64(spent) / float64(total), []string{progVUs, progDur}
+		status := pb.GetFixedLengthDuration(spent, regular) + "/" + regularDuration
+		return float64(spent) / float64(regular), []string{progVUs, status}
 	}
 }
 
@@ -611,7 +611,7 @@ func (rs rampingVUsRunState) handleVUs(ctx context.Context) {
 	// giving rawSteps precedence.
 	// we stop iterating once rawSteps are over as we need to run the remaining
 	// gracefulSteps concurrently while waiting for VUs to stop in order to not wait until
-	// the end of gracefulStop (= maxDur-regDur) timeouts
+	// the end of gracefulStop (= maxDuration-regularDuration) timeouts
 	var (
 		handleNewMaxAllowedVUs = rs.maxAllowedVUsHandlerStrategy()
 		handleNewScheduledVUs  = rs.scheduledVUsHandlerStrategy()
@@ -676,12 +676,12 @@ func (rs rampingVUsRunState) scheduledVUsHandlerStrategy() func(lib.ExecutionSte
 // waiter returns a function that will sleep/wait for the required time since the startTime and then
 // return. If the context was done before that it will return true otherwise it will return false
 // TODO use elsewhere
-// TODO set startTime here?
+// TODO set start here?
 // TODO move it to a struct type or something and benchmark if that makes a difference
-func waiter(ctx context.Context, startTime time.Time) func(offset time.Duration) bool {
+func waiter(ctx context.Context, start time.Time) func(offset time.Duration) bool {
 	timer := time.NewTimer(time.Hour * 24)
 	return func(offset time.Duration) bool {
-		diff := offset - time.Since(startTime)
+		diff := offset - time.Since(start)
 		if diff > 0 { // wait until time of event arrives // TODO have a mininum
 			timer.Reset(diff)
 			select {

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -700,7 +700,6 @@ func (rs rampingVUsRunState) scheduledVUsHandlerStrategy() func(lib.ExecutionSte
 		for ; pv < cur; cur-- {
 			rs.vuHandles[cur-1].gracefulStop()
 		}
-		cur = pv
 	}
 }
 

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -469,7 +469,7 @@ func (vlvc RampingVUsConfig) GetExecutionRequirements(et *lib.ExecutionTuple) []
 
 // NewExecutor creates a new RampingVUs executor
 func (vlvc RampingVUsConfig) NewExecutor(es *lib.ExecutionState, logger *logrus.Entry) (lib.Executor, error) {
-	return RampingVUs{
+	return &RampingVUs{
 		BaseExecutor: NewBaseExecutor(vlvc, es, logger),
 		config:       vlvc,
 	}, nil
@@ -486,27 +486,42 @@ func (vlvc RampingVUsConfig) HasWork(et *lib.ExecutionTuple) bool {
 type RampingVUs struct {
 	*BaseExecutor
 	config RampingVUsConfig
+
+	rawSteps, gracefulSteps []lib.ExecutionStep
 }
 
 // Make sure we implement the lib.Executor interface.
 var _ lib.Executor = &RampingVUs{}
 
+// Init initializes the rampingVUs executor by precalculating the raw
+// and graceful steps.
+func (vlv *RampingVUs) Init(_ context.Context) error {
+	vlv.rawSteps = vlv.config.getRawExecutionSteps(
+		vlv.executionState.ExecutionTuple, true,
+	)
+	vlv.gracefulSteps = vlv.config.GetExecutionRequirements(
+		vlv.executionState.ExecutionTuple,
+	)
+	return nil
+}
+
 // Run constantly loops through as many iterations as possible on a variable
 // number of VUs for the specified stages.
-func (vlv RampingVUs) Run(ctx context.Context, _ chan<- stats.SampleContainer, _ *metrics.BuiltinMetrics) error {
-	rawSteps := vlv.config.getRawExecutionSteps(vlv.executionState.ExecutionTuple, true)
-	regularDuration, isFinal := lib.GetEndOffset(rawSteps)
+func (vlv *RampingVUs) Run(ctx context.Context, _ chan<- stats.SampleContainer, _ *metrics.BuiltinMetrics) error {
+	regularDuration, isFinal := lib.GetEndOffset(vlv.rawSteps)
 	if !isFinal {
 		return fmt.Errorf("%s expected raw end offset at %s to be final", vlv.config.GetName(), regularDuration)
 	}
-	gracefulSteps := vlv.config.GetExecutionRequirements(vlv.executionState.ExecutionTuple)
-	maxDuration, isFinal := lib.GetEndOffset(gracefulSteps)
+	maxDuration, isFinal := lib.GetEndOffset(vlv.gracefulSteps)
 	if !isFinal {
 		return fmt.Errorf("%s expected graceful end offset at %s to be final", vlv.config.GetName(), maxDuration)
 	}
-	maxVUs := lib.GetMaxPlannedVUs(gracefulSteps)
-	startTime, maxDurationCtx, regularDurationCtx, cancel := getDurationContexts(ctx, regularDuration, maxDuration-regularDuration)
+	startTime, maxDurationCtx, regularDurationCtx, cancel := getDurationContexts(
+		ctx, regularDuration, maxDuration-regularDuration,
+	)
 	defer cancel()
+
+	maxVUs := lib.GetMaxPlannedVUs(vlv.gracefulSteps)
 
 	vlv.logger.WithFields(logrus.Fields{
 		"type":      vlv.config.GetType(),
@@ -523,8 +538,6 @@ func (vlv RampingVUs) Run(ctx context.Context, _ chan<- stats.SampleContainer, _
 		maxVUs:         maxVUs,
 		activeVUsCount: new(int64),
 		started:        startTime,
-		rawSteps:       rawSteps,
-		gracefulSteps:  gracefulSteps,
 		runIteration:   getIterationRunner(vlv.executionState, vlv.logger),
 	}
 
@@ -565,13 +578,12 @@ func (vlv RampingVUs) Run(ctx context.Context, _ chan<- stats.SampleContainer, _
 // of the ramping VUs executor. It is used to track and modify various
 // details of the execution.
 type rampingVUsRunState struct {
-	executor                RampingVUs
-	vuHandles               []*vuHandle // handles for manipulating and tracking all of the VUs
-	maxVUs                  uint64      // the scaled number of initially configured MaxVUs
-	activeVUsCount          *int64      // the current number of active VUs, used only for the progress display
-	started                 time.Time
-	rawSteps, gracefulSteps []lib.ExecutionStep
-	wg                      *sync.WaitGroup
+	executor       *RampingVUs
+	vuHandles      []*vuHandle // handles for manipulating and tracking all of the VUs
+	maxVUs         uint64      // the scaled number of initially configured MaxVUs
+	activeVUsCount *int64      // the current number of active VUs, used only for the progress display
+	started        time.Time
+	wg             *sync.WaitGroup
 
 	runIteration func(context.Context, lib.ActiveVU) bool // a helper closure function that runs a single iteration
 }
@@ -627,8 +639,8 @@ func (rs rampingVUsRunState) handleVUs(
 ) (handledGracefulSteps int) {
 	wait := waiter(ctx, rs.started)
 	i, j := 0, 0
-	for i != len(rs.rawSteps) {
-		r, g := rs.rawSteps[i], rs.gracefulSteps[j]
+	for i != len(rs.executor.rawSteps) {
+		r, g := rs.executor.rawSteps[i], rs.executor.gracefulSteps[j]
 		if g.TimeOffset < r.TimeOffset {
 			if wait(g.TimeOffset) {
 				break
@@ -659,7 +671,7 @@ func (rs rampingVUsRunState) handleRemainingVUs(
 	handledGracefulSteps int,
 ) {
 	wait := waiter(ctx, rs.started)
-	for _, s := range rs.gracefulSteps[handledGracefulSteps:] {
+	for _, s := range rs.executor.gracefulSteps[handledGracefulSteps:] {
 		if wait(s.TimeOffset) {
 			return
 		}

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -680,7 +680,7 @@ func (rs rampingVUsRunState) handleRemainingVUs(
 }
 
 func (rs rampingVUsRunState) maxAllowedVUsHandlerStrategy() func(lib.ExecutionStep) {
-	var cur uint64
+	var cur uint64 // current number of planned graceful VUs
 	return func(graceful lib.ExecutionStep) {
 		pv := graceful.PlannedVUs
 		for ; pv < cur; cur-- {
@@ -691,7 +691,7 @@ func (rs rampingVUsRunState) maxAllowedVUsHandlerStrategy() func(lib.ExecutionSt
 }
 
 func (rs rampingVUsRunState) scheduledVUsHandlerStrategy() func(lib.ExecutionStep) {
-	var cur uint64
+	var cur uint64 // current number of planned raw VUs
 	return func(raw lib.ExecutionStep) {
 		pv := raw.PlannedVUs
 		for ; cur < pv; cur++ {

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -280,6 +280,85 @@ func TestRampingVUsGracefulRampDown(t *testing.T) {
 	}
 }
 
+// This test aims to check whether the ramping VU executor interrupts
+// hanging/remaining VUs after the graceful rampdown period finishes.
+//
+//                   Rampdown         Graceful Rampdown
+//                   Stage (40ms)     (+30ms)
+//                   [               ][              ]
+//         t 0---5---10---20---30---40---50---60---70
+//     VU1       *..................................✔ (40+30=70ms)
+//     VU2           *...................X            (20+30=50ms)
+//
+//     ✔=Finishes,X=Interrupted,.=Sleeps
+func TestRampingVUsHandleRemainingVUs(t *testing.T) {
+	t.Parallel()
+
+	const (
+		maxVus                   = 2
+		vuSleepDuration          = 65 * time.Millisecond // Each VU will sleep 65ms
+		wantVuFinished    uint32 = 1                     // one VU should finish an iteration
+		wantVuInterrupted uint32 = 1                     // one VU should be interrupted
+	)
+
+	cfg := RampingVUsConfig{
+		BaseConfig: BaseConfig{
+			// Extend the total test duration 50ms more
+			//
+			// test duration = sum(stages) + GracefulStop
+			//
+			// This could have been 30ms but increased it to 50ms
+			// to prevent the test to become flaky.
+			GracefulStop: types.NullDurationFrom(50 * time.Millisecond),
+		},
+		// Wait 30ms more for already started iterations
+		// (Happens in the 2nd stage below: Graceful rampdown period)
+		GracefulRampDown: types.NullDurationFrom(30 * time.Millisecond),
+		// Total test duration is 50ms (excluding the GracefulRampdown period)
+		Stages: []Stage{
+			// Activate 2 VUs in 10ms
+			{
+				Duration: types.NullDurationFrom(10 * time.Millisecond),
+				Target:   null.IntFrom(int64(maxVus)),
+			},
+			// Rampdown to 0 VUs in 40ms
+			{
+				Duration: types.NullDurationFrom(40 * time.Millisecond),
+				Target:   null.IntFrom(int64(0)),
+			},
+		},
+	}
+
+	var (
+		gotVuInterrupted uint32
+		gotVuFinished    uint32
+	)
+	iteration := func(ctx context.Context) error {
+		select {
+		case <-time.After(vuSleepDuration):
+			atomic.AddUint32(&gotVuFinished, 1)
+		case <-ctx.Done():
+			atomic.AddUint32(&gotVuInterrupted, 1)
+		}
+		return nil
+	}
+
+	// run the executor: this should finish in ~70ms
+	// sum(stages) + GracefulRampDown
+	et, err := lib.NewExecutionTuple(nil, nil)
+	require.NoError(t, err)
+	ctx, cancel, executor, _ := setupExecutor(
+		t, cfg,
+		lib.NewExecutionState(lib.Options{}, et, maxVus, maxVus),
+		simpleRunner(iteration),
+	)
+	defer cancel()
+	require.NoError(t, executor.Run(ctx, nil, nil))
+
+	assert.Equal(t, wantVuInterrupted, atomic.LoadUint32(&gotVuInterrupted))
+	assert.Equal(t, wantVuFinished, atomic.LoadUint32(&gotVuFinished))
+}
+
 // Ensure there's no wobble of VUs during graceful ramp-down, without segments.
 // See https://github.com/k6io/k6/issues/1296
 func TestRampingVUsRampDownNoWobble(t *testing.T) {


### PR DESCRIPTION
`RampingVUs.Run` method is complex and this PR aims to refactor it.

**Improvements:**

* Makes the `Run` method easier to read and understand.
* Makes it explicit which Goroutines are being fired in the `Run` method.
* Separates responsibilities to other parts like:
  * `rampingVUsRunState` and its methods.
  * Moves `trackProgress` Goroutine from the `makeProgressFn` to the `Run` method.
  * Makes `populateVUHandles` to only handle initializing VU handles (_not firing up a GR_)
  * Uses two strategy functions for code reusability and clarity (_`handleVUs` and `handleRemainingVUs` use them_).
* Makes the `handleVUs` algorithm easier to understand and manage.
* Adds a `handleRemainingVUs` test with explanations  to make newcomers' and new contributors' job easier

_Note: The other PR (#2124) is convoluted and somehow creates problems locally and with Github. I'd like to keep working on it on this separate branch._