### PR TITLE
support compression in websockets #611

### DIFF
--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -163,9 +163,10 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 		HandshakeTimeout: time.Second * 60, // TODO configurable
 		// Pass a custom net.DialContext function to websocket.Dialer that will substitute
 		// the underlying net.Conn with our own tracked netext.Conn
-		NetDialContext:  state.Dialer.DialContext,
-		Proxy:           http.ProxyFromEnvironment,
-		TLSClientConfig: tlsConfig,
+		NetDialContext:    state.Dialer.DialContext,
+		Proxy:             http.ProxyFromEnvironment,
+		TLSClientConfig:   tlsConfig,
+		EnableCompression: true,
 	}
 
 	start := time.Now()


### PR DESCRIPTION
#611

#### Here's my research on compression in Websockets : 

permessage-deflate compression is defined in RFC7692 and gorilla/websockets has implemented this as an experimental feature. 
[read this here](https://pkg.go.dev/github.com/gorilla/websocket#hdr-Compression_EXPERIMENTAL)

permessage-deflate will work only if both client and server supports this extension - and successfully negotiates it through `Sec-Websocket-Extensions` header.

If `EnableCompression` is set to true, gorilla/websocket will automatically try to negotiate compression with peer. 
```
var upgrader = websocket.Upgrader{
    EnableCompression: true,
}
```
Upon successful negotiation any message received in compressed form will be automatically decompressed by gorilla/websocket. So compression/decompression is taken care by gorilla/websocket if its supported.

Also, use of compression is experimental and may result in decreased performance.

the official RFC7692 has only defined deflate algorithm for compression in the specification as of now ( deflate from permessage-deflate). In future, say both a client and server wants to support algorithm 'foo' then this has to be negotiated through extension 'permessage-foo'. Few newer ones being discussed by IETF are 'permessage-bzip2', 'permessage-lz4', 'permessage-snappy'. These have not yet made it into the official RFCs. I'm not sure if any browsers are having experimental support for additional permessage algorithms. 
More about in [this stackoverflow question](https://stackoverflow.com/questions/19298651/how-does-websocket-compress-messages#answer-19300336)


I'd like to propose a PR for enabling `EnableCompression: true` to make compression work wherever it's supported.