### PR TITLE
js/k6/exec: Set VU Tags

### DIFF
--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -406,6 +406,7 @@ func TestRequestWithBinaryFile(t *testing.T) {
 		BPool:          bpool.NewBufferPool(1),
 		Samples:        make(chan stats.SampleContainer, 500),
 		BuiltinMetrics: builtinMetrics,
+		Tags:           lib.NewTagMap(nil),
 	}
 
 	ctx := context.Background()
@@ -553,6 +554,7 @@ func TestRequestWithMultipleBinaryFiles(t *testing.T) {
 		BPool:          bpool.NewBufferPool(1),
 		Samples:        make(chan stats.SampleContainer, 500),
 		BuiltinMetrics: builtinMetrics,
+		Tags:           lib.NewTagMap(nil),
 	}
 
 	ctx := context.Background()

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -1,0 +1,185 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package execution
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/js/modulestest"
+	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/testutils"
+	"go.k6.io/k6/stats"
+	"gopkg.in/guregu/null.v3"
+)
+
+type execEnv struct {
+	Runtime *goja.Runtime
+	Module  *ModuleInstance
+	LogHook *testutils.SimpleLogrusHook
+}
+
+func setupTagsExecEnv(t *testing.T) execEnv {
+	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
+	testLog := logrus.New()
+	testLog.AddHook(logHook)
+	testLog.SetOutput(ioutil.Discard)
+
+	state := &lib.State{
+		Options: lib.Options{
+			SystemTags: stats.NewSystemTagSet(stats.TagVU),
+		},
+		Tags: lib.NewTagMap(map[string]string{
+			"vu": "42",
+		}),
+		Logger: testLog,
+	}
+
+	rt := goja.New()
+	ctx := common.WithRuntime(context.Background(), rt)
+	ctx = lib.WithState(ctx, state)
+	m, ok := New().NewModuleInstance(
+		&modulestest.InstanceCore{
+			Runtime: rt,
+			InitEnv: &common.InitEnvironment{},
+			Ctx:     ctx,
+			State:   state,
+		},
+	).(*ModuleInstance)
+	require.True(t, ok)
+	require.NoError(t, rt.Set("exec", m.GetExports().Default))
+
+	return execEnv{
+		Module:  m,
+		Runtime: rt,
+		LogHook: logHook,
+	}
+}
+
+func TestVUTags(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Get", func(t *testing.T) {
+		t.Parallel()
+
+		tenv := setupTagsExecEnv(t)
+		tag, err := tenv.Runtime.RunString(`exec.vu.tags["vu"]`)
+		require.NoError(t, err)
+		assert.Equal(t, "42", tag.String())
+
+		// not found
+		tag, err = tenv.Runtime.RunString(`exec.vu.tags["not-existing-tag"]`)
+		require.NoError(t, err)
+		assert.Equal(t, "undefined", tag.String())
+	})
+
+	t.Run("JSONEncoding", func(t *testing.T) {
+		t.Parallel()
+
+		tenv := setupTagsExecEnv(t)
+		state := tenv.Module.GetState()
+		state.Tags.Set("custom-tag", "mytag1")
+
+		encoded, err := tenv.Runtime.RunString(`JSON.stringify(exec.vu.tags)`)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"vu":"42","custom-tag":"mytag1"}`, encoded.String())
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("SuccessAccetedTypes", func(t *testing.T) {
+			t.Parallel()
+
+			// bool and numbers are implicitly converted into string
+
+			tests := map[string]struct {
+				v   interface{}
+				exp string
+			}{
+				"string": {v: `"tag1"`, exp: "tag1"},
+				"bool":   {v: true, exp: "true"},
+				"int":    {v: 101, exp: "101"},
+				"float":  {v: 3.14, exp: "3.14"},
+			}
+
+			tenv := setupTagsExecEnv(t)
+
+			for _, tc := range tests {
+				_, err := tenv.Runtime.RunString(fmt.Sprintf(`exec.vu.tags["mytag"] = %v`, tc.v))
+				require.NoError(t, err)
+
+				val, err := tenv.Runtime.RunString(`exec.vu.tags["mytag"]`)
+				require.NoError(t, err)
+
+				assert.Equal(t, tc.exp, val.String())
+			}
+		})
+
+		t.Run("SuccessOverwriteSystemTag", func(t *testing.T) {
+			t.Parallel()
+
+			tenv := setupTagsExecEnv(t)
+
+			_, err := tenv.Runtime.RunString(`exec.vu.tags["vu"] = "vu101"`)
+			require.NoError(t, err)
+			val, err := tenv.Runtime.RunString(`exec.vu.tags["vu"]`)
+			require.NoError(t, err)
+			assert.Equal(t, "vu101", val.String())
+		})
+
+		t.Run("DiscardWrongTypeRaisingError", func(t *testing.T) {
+			t.Parallel()
+
+			tenv := setupTagsExecEnv(t)
+			state := tenv.Module.GetState()
+			state.Options.Throw = null.BoolFrom(true)
+			require.NotNil(t, state)
+
+			// array
+			_, err := tenv.Runtime.RunString(`exec.vu.tags["custom-tag"] = [1, 3, 5]`)
+			require.Contains(t, err.Error(), "only String, Boolean and Number")
+
+			// object
+			_, err = tenv.Runtime.RunString(`exec.vu.tags["custom-tag"] = {f1: "value1", f2: 4}`)
+			require.Contains(t, err.Error(), "only String, Boolean and Number")
+		})
+
+		t.Run("DiscardWrongTypeOnlyWarning", func(t *testing.T) {
+			t.Parallel()
+
+			tenv := setupTagsExecEnv(t)
+			_, err := tenv.Runtime.RunString(`exec.vu.tags["custom-tag"] = [1, 3, 5]`)
+			require.NoError(t, err)
+
+			entries := tenv.LogHook.Drain()
+			require.Len(t, entries, 1)
+			assert.Contains(t, entries[0].Message, "discarded")
+		})
+	})
+}

--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -103,6 +103,7 @@ func TestClient(t *testing.T) {
 			BuiltinMetrics: metrics.RegisterBuiltinMetrics(
 				metrics.NewRegistry(),
 			),
+			Tags: lib.NewTagMap(nil),
 		}
 
 		cwd, err := os.Getwd()

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -156,14 +156,16 @@ func newRuntime(
 	samples := make(chan stats.SampleContainer, 1000)
 
 	state := &lib.State{
-		Options:        options,
-		Logger:         logger,
-		Group:          root,
-		TLSConfig:      tb.TLSClientConfig,
-		Transport:      tb.HTTPTransport,
-		BPool:          bpool.NewBufferPool(1),
-		Samples:        samples,
-		Tags:           map[string]string{"group": root.Path},
+		Options:   options,
+		Logger:    logger,
+		Group:     root,
+		TLSConfig: tb.TLSClientConfig,
+		Transport: tb.HTTPTransport,
+		BPool:     bpool.NewBufferPool(1),
+		Samples:   samples,
+		Tags: lib.NewTagMap(map[string]string{
+			"group": root.Path,
+		}),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 	}
 
@@ -1094,7 +1096,10 @@ func TestRequestAndBatch(t *testing.T) {
 			t.Run("tags-precedence", func(t *testing.T) {
 				oldTags := state.Tags
 				defer func() { state.Tags = oldTags }()
-				state.Tags = map[string]string{"runtag1": "val1", "runtag2": "val2"}
+				state.Tags = lib.NewTagMap(map[string]string{
+					"runtag1": "val1",
+					"runtag2": "val2",
+				})
 
 				_, err := rt.RunString(sr(`
 				var res = http.request("GET", "HTTPBIN_URL/headers", null, { tags: { method: "test", name: "myName", runtag1: "fromreq" } });

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -169,10 +169,10 @@ func TestResponse(t *testing.T) {
 			if assert.NoError(t, err) {
 				old := state.Group
 				state.Group = g
-				state.Tags["group"] = g.Path
+				state.Tags.Set("group", g.Path)
 				defer func() {
 					state.Group = old
-					state.Tags["group"] = old.Path
+					state.Tags.Set("group", old.Path)
 				}()
 			}
 

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -93,12 +93,12 @@ func (*K6) Group(ctx context.Context, name string, fn goja.Callable) (goja.Value
 
 	shouldUpdateTag := state.Options.SystemTags.Has(stats.TagGroup)
 	if shouldUpdateTag {
-		state.Tags["group"] = g.Path
+		state.Tags.Set("group", g.Path)
 	}
 	defer func() {
 		state.Group = old
 		if shouldUpdateTag {
-			state.Tags["group"] = old.Path
+			state.Tags.Set("group", g.Path)
 		}
 	}()
 

--- a/js/modules/k6/k6_test.go
+++ b/js/modules/k6/k6_test.go
@@ -123,7 +123,11 @@ func TestGroup(t *testing.T) {
 		assert.NoError(t, err)
 
 		rt := goja.New()
-		state := &lib.State{Group: root, Samples: make(chan stats.SampleContainer, 1000)}
+		state := &lib.State{
+			Group:   root,
+			Samples: make(chan stats.SampleContainer, 1000),
+			Tags:    lib.NewTagMap(nil),
+		}
 		ctx := context.Background()
 		ctx = lib.WithState(ctx, state)
 		ctx = common.WithRuntime(ctx, rt)
@@ -167,7 +171,9 @@ func checkTestRuntime(t testing.TB, ctxs ...*context.Context) (
 			SystemTags: &stats.DefaultSystemTagSet,
 		},
 		Samples: samples,
-		Tags:    map[string]string{"group": root.Path},
+		Tags: lib.NewTagMap(map[string]string{
+			"group": root.Path,
+		}),
 	}
 	ctx := context.Background()
 	if len(ctxs) == 1 { // hacks

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -133,7 +133,9 @@ func TestMetrics(t *testing.T) {
 					state := &lib.State{
 						Options: lib.Options{},
 						Samples: test.samples,
-						Tags:    map[string]string{"key": "value"},
+						Tags: lib.NewTagMap(map[string]string{
+							"key": "value",
+						}),
 					}
 
 					isTimeString := ""

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -128,6 +128,7 @@ func newTestState(t testing.TB) testState {
 		Samples:        samples,
 		TLSConfig:      tb.TLSClientConfig,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
+		Tags:           lib.NewTagMap(nil),
 	}
 
 	ctx := new(context.Context)
@@ -171,6 +172,7 @@ func TestSession(t *testing.T) {
 		Samples:        samples,
 		TLSConfig:      tb.TLSClientConfig,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
+		Tags:           lib.NewTagMap(nil),
 	}
 
 	ctx := context.Background()
@@ -562,6 +564,7 @@ func TestSocketSendBinary(t *testing.T) { //nolint: tparallel
 		Samples:        samples,
 		TLSConfig:      tb.TLSClientConfig,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
+		Tags:           lib.NewTagMap(nil),
 	}
 
 	ctx := context.Background()
@@ -652,6 +655,7 @@ func TestErrors(t *testing.T) {
 		},
 		Samples:        samples,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
+		Tags:           lib.NewTagMap(nil),
 	}
 
 	ctx := context.Background()
@@ -764,6 +768,7 @@ func TestSystemTags(t *testing.T) {
 		Samples:        samples,
 		TLSConfig:      tb.TLSClientConfig,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
+		Tags:           lib.NewTagMap(nil),
 	}
 
 	ctx := context.Background()
@@ -827,6 +832,7 @@ func TestTLSConfig(t *testing.T) {
 		},
 		Samples:        samples,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
+		Tags:           lib.NewTagMap(nil),
 	}
 
 	ctx := context.Background()
@@ -966,6 +972,7 @@ func TestUserAgent(t *testing.T) {
 		Samples:        samples,
 		TLSConfig:      tb.TLSClientConfig,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
+		Tags:           lib.NewTagMap(nil),
 	}
 
 	ctx := lib.WithState(context.Background(), state)

--- a/js/runner.go
+++ b/js/runner.go
@@ -245,7 +245,7 @@ func (r *Runner) newVU(idLocal, idGlobal uint64, samplesOut chan<- stats.SampleC
 		VUID:           vu.ID,
 		VUIDGlobal:     vu.IDGlobal,
 		Samples:        vu.Samples,
-		Tags:           vu.Runner.Bundle.Options.RunTags.CloneTags(),
+		Tags:           lib.NewTagMap(vu.Runner.Bundle.Options.RunTags.CloneTags()),
 		Group:          r.defaultGroup,
 		BuiltinMetrics: r.builtinMetrics,
 	}
@@ -505,7 +505,7 @@ func (r *Runner) runPart(ctx context.Context, out chan<- stats.SampleContainer, 
 	}
 
 	if r.Bundle.Options.SystemTags.Has(stats.TagGroup) {
-		vu.state.Tags["group"] = group.Path
+		vu.state.Tags.Set("group", group.Path)
 	}
 	vu.state.Group = group
 
@@ -604,21 +604,21 @@ func (u *VU) Activate(params *lib.VUActivationParams) lib.ActiveVU {
 
 	opts := u.Runner.Bundle.Options
 	// TODO: maybe we can cache the original tags only clone them and add (if any) new tags on top ?
-	u.state.Tags = opts.RunTags.CloneTags()
+	u.state.Tags = lib.NewTagMap(opts.RunTags.CloneTags())
 	for k, v := range params.Tags {
-		u.state.Tags[k] = v
+		u.state.Tags.Set(k, v)
 	}
 	if opts.SystemTags.Has(stats.TagVU) {
-		u.state.Tags["vu"] = strconv.FormatUint(u.ID, 10)
+		u.state.Tags.Set("vu", strconv.FormatUint(u.ID, 10))
 	}
 	if opts.SystemTags.Has(stats.TagIter) {
-		u.state.Tags["iter"] = strconv.FormatInt(u.iteration, 10)
+		u.state.Tags.Set("iter", strconv.FormatInt(u.iteration, 10))
 	}
 	if opts.SystemTags.Has(stats.TagGroup) {
-		u.state.Tags["group"] = u.state.Group.Path
+		u.state.Tags.Set("group", u.state.Group.Path)
 	}
 	if opts.SystemTags.Has(stats.TagScenario) {
-		u.state.Tags["scenario"] = params.Scenario
+		u.state.Tags.Set("scenario", params.Scenario)
 	}
 
 	ctx := common.WithRuntime(params.RunContext, u.Runtime)
@@ -731,7 +731,7 @@ func (u *VU) runFn(
 
 	opts := &u.Runner.Bundle.Options
 	if opts.SystemTags.Has(stats.TagIter) {
-		u.state.Tags["iter"] = strconv.FormatInt(u.state.Iteration, 10)
+		u.state.Tags.Set("iter", strconv.FormatInt(u.state.Iteration, 10))
 	}
 
 	defer func() {
@@ -769,8 +769,9 @@ func (u *VU) runFn(
 		u.Transport.CloseIdleConnections()
 	}
 
+	sampleTags := stats.NewSampleTags(u.state.CloneTags())
 	u.state.Samples <- u.Dialer.GetTrail(
-		startTime, endTime, isFullIteration, isDefault, stats.NewSampleTags(u.state.Tags), u.Runner.builtinMetrics)
+		startTime, endTime, isFullIteration, isDefault, sampleTags, u.Runner.builtinMetrics)
 
 	return v, isFullIteration, endTime.Sub(startTime), err
 }

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -2140,6 +2140,7 @@ func TestExecutionInfo(t *testing.T) {
 			}
 			require.NoError(t, err)
 
+			r.Bundle.Options.SystemTags = stats.NewSystemTagSet(stats.DefaultSystemTagSet)
 			samples := make(chan stats.SampleContainer, 100)
 			initVU, err := r.NewVU(1, 10, samples)
 			require.NoError(t, err)

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -139,6 +139,7 @@ func TestMakeRequestError(t *testing.T) {
 			Options:   lib.Options{RunTags: &stats.SampleTags{}},
 			Transport: srv.Client().Transport,
 			Logger:    logger,
+			Tags:      lib.NewTagMap(nil),
 		}
 		ctx = lib.WithState(ctx, state)
 		req, _ := http.NewRequest("GET", srv.URL, nil)
@@ -192,6 +193,7 @@ func TestResponseStatus(t *testing.T) {
 					Logger:         logger,
 					Samples:        samples,
 					BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+					Tags:           lib.NewTagMap(nil),
 				}
 				ctx := lib.WithState(context.Background(), state)
 				req, err := http.NewRequest("GET", server.URL, nil)
@@ -272,6 +274,7 @@ func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 		Logger:         logger,
 		BPool:          bpool.NewBufferPool(100),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+		Tags:           lib.NewTagMap(nil),
 	}
 	ctx = lib.WithState(ctx, state)
 	req, _ := http.NewRequest("GET", srv.URL, nil)
@@ -349,6 +352,7 @@ func TestTrailFailed(t *testing.T) {
 				Logger:         logger,
 				BPool:          bpool.NewBufferPool(2),
 				BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+				Tags:           lib.NewTagMap(nil),
 			}
 			ctx = lib.WithState(ctx, state)
 			req, _ := http.NewRequest("GET", srv.URL, nil)
@@ -415,6 +419,7 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 		Logger:         logger,
 		BPool:          bpool.NewBufferPool(100),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+		Tags:           lib.NewTagMap(nil),
 	}
 
 	ctx = lib.WithState(ctx, state)
@@ -470,6 +475,7 @@ func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 		Logger:         logger,
 		BPool:          bpool.NewBufferPool(100),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+		Tags:           lib.NewTagMap(nil),
 	}
 	ctx = lib.WithState(ctx, state)
 	req, _ := http.NewRequest("GET", srv.URL, nil)

--- a/lib/state.go
+++ b/lib/state.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/cookiejar"
+	"sync"
 
 	"github.com/oxtoacart/bpool"
 	"github.com/sirupsen/logrus"
@@ -70,7 +71,7 @@ type State struct {
 
 	VUID, VUIDGlobal uint64
 	Iteration        int64
-	Tags             map[string]string
+	Tags             *TagMap
 	// These will be assigned on VU activation.
 	// Returns the iteration number of this VU in the current scenario.
 	GetScenarioVUIter func() uint64
@@ -88,8 +89,65 @@ type State struct {
 
 // CloneTags makes a copy of the tags map and returns it.
 func (s *State) CloneTags() map[string]string {
-	tags := make(map[string]string, len(s.Tags))
-	for k, v := range s.Tags {
+	return s.Tags.Clone()
+}
+
+// TagMap is a safe-concurrent Tags lookup.
+type TagMap struct {
+	m     map[string]string
+	mutex sync.RWMutex
+}
+
+// NewTagMap creates a TagMap,
+// if a not-nil map is passed then it will be used as the internal map
+// otherwise a new one will be created.
+func NewTagMap(m map[string]string) *TagMap {
+	if m == nil {
+		m = make(map[string]string)
+	}
+	return &TagMap{
+		m:     m,
+		mutex: sync.RWMutex{},
+	}
+}
+
+// Set sets a Tag.
+func (tg *TagMap) Set(k, v string) {
+	tg.mutex.Lock()
+	defer tg.mutex.Unlock()
+	tg.m[k] = v
+}
+
+// Get returns the Tag value and true
+// if the provided key has been found.
+func (tg *TagMap) Get(k string) (string, bool) {
+	tg.mutex.RLock()
+	defer tg.mutex.RUnlock()
+	v, ok := tg.m[k]
+	return v, ok
+}
+
+// Len returns the number of the set keys.
+func (tg *TagMap) Len() int {
+	tg.mutex.RLock()
+	defer tg.mutex.RUnlock()
+	return len(tg.m)
+}
+
+// Delete deletes a map's item based on the provided key.
+func (tg *TagMap) Delete(k string) {
+	tg.mutex.Lock()
+	defer tg.mutex.Unlock()
+	delete(tg.m, k)
+}
+
+// Clone returns a map with the entire set of items.
+func (tg *TagMap) Clone() map[string]string {
+	tg.mutex.RLock()
+	defer tg.mutex.RUnlock()
+
+	tags := make(map[string]string, len(tg.m))
+	for k, v := range tg.m {
 		tags[k] = v
 	}
 	return tags

--- a/lib/state_test.go
+++ b/lib/state_test.go
@@ -1,0 +1,104 @@
+package lib
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTagMapSet(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Sync", func(t *testing.T) {
+		t.Parallel()
+
+		tm := NewTagMap(nil)
+		tm.Set("mytag", "42")
+		v, found := tm.Get("mytag")
+		assert.True(t, found)
+		assert.Equal(t, "42", v)
+	})
+
+	t.Run("Safe-Concurrent", func(t *testing.T) {
+		t.Parallel()
+		tm := NewTagMap(nil)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		go func() {
+			count := 0
+			for {
+				select {
+				case <-time.Tick(1 * time.Millisecond):
+					count++
+					tm.Set("mytag", strconv.Itoa(count))
+
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+
+		go func() {
+			for {
+				select {
+				case <-time.Tick(1 * time.Millisecond):
+					tm.Get("mytag")
+
+				case <-ctx.Done():
+					return
+				}
+			}
+		}()
+
+		time.Sleep(100 * time.Millisecond)
+	})
+}
+
+func TestTagMapGet(t *testing.T) {
+	t.Parallel()
+	tm := NewTagMap(map[string]string{
+		"key1": "value1",
+	})
+	v, ok := tm.Get("key1")
+	assert.True(t, ok)
+	assert.Equal(t, "value1", v)
+}
+
+func TestTagMapLen(t *testing.T) {
+	t.Parallel()
+	tm := NewTagMap(map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	})
+	assert.Equal(t, 2, tm.Len())
+}
+
+func TestTagMapDelete(t *testing.T) {
+	t.Parallel()
+	m := map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}
+	tm := NewTagMap(m)
+	tm.Delete("key1")
+	_, ok := m["key1"]
+	assert.False(t, ok)
+}
+
+func TestTagMapClone(t *testing.T) {
+	t.Parallel()
+	tm := NewTagMap(map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	})
+	m := tm.Clone()
+	assert.Equal(t, map[string]string{
+		"key1": "value1",
+		"key2": "value2",
+	}, m)
+}


### PR DESCRIPTION
Extended the `k6/execution` API to allow the get or set of a Tag in the VU's state.

This part of the [Stage tagging work](https://github.com/grafana/k6/issues/796), but it can be considered as an independent feature.

```js
import http from 'k6/http';
import exec from 'k6/execution';

export const options = {
  stages: [
    { duration: '1m', target: 10 },
    { duration: '1m', target: 20 },
    { duration: '1m', target: 0 },
  ],
};

export default function () {
  exec.vu.tags['stage'] = 'stage#2'
  console.log(exec.vu.tags['stage']) // returns stage#2
}
```

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
