### PR TITLE
Improve code docs for `ExecutionTuple` and `RampingVUsConfig`

### DIFF
--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -172,14 +172,14 @@ func (vlvc RampingVUsConfig) Validate() []error {
 //
 // VUs  ^
 //    10|          Y
-//     9|         YYY
+//     9|         XXX
 //     8|        YYYYY
-//     7|       YYYYYYY
+//     7|       XXXXXXX
 //     6|      YYYYYYYYY
-//     5|     YYYYXXXYYYY
-//     4|    YYYXXXXXXXYYY
-//     3|   YYXXXXXXXXXXXYY
-//     2|  YXXXXXXXXXXXXXXXY
+//     5|     XXXXXXXXXXX
+//     4|    YYYYYYYYYYYYY
+//     3|   XXXXXXXXXXXXXXX
+//     2|  YYYYYYYYYYYYYYYYY
 //     1| XXXXXXXXXXXXXXXXXXX
 //     0------------------------> time(s)
 //       01234567890123456789012   (t%10)


### PR DESCRIPTION
Some ASCII art was spawned during a call with @inancgumus, so there was no reason not to commit it in the code docs with some more explanations around it... :sweat_smile: 