### PR TITLE
Add a new GitHub Action to auto-assign PR reviewers

### DIFF
--- a/.github/pr-auto-assign-config.yml
+++ b/.github/pr-auto-assign-config.yml
@@ -1,0 +1,16 @@
+addReviewers: true
+addAssignees: false
+useReviewGroups: true
+useAssigneeGroups: false
+numberOfReviewers: 1
+reviewGroups:
+  old:
+    - na--
+    - MStoykov
+    - imiric
+  new: # TODO: remove a few months from now
+    - codebien
+    - yorugac
+    - inancgumus
+skipKeywords:
+  - wip

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -1,0 +1,13 @@
+name: 'Auto Assign'
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  add-reviews:
+    if: ${{ join(github.event.pull_request.requested_reviewers.*.login, ',') == '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@19c336bfad4fcb61cab8dcb6b6a5fe3e62ac5cd8 #v1.2.0
+        with:
+          configuration-path: ".github/pr-auto-assign-config.yml"


### PR DESCRIPTION
This should hopefully automatically assign reviewers when a PR is opened, though it will probably only work when we merge it in `master`...