### PR TITLE
More multi message tests for WebSockets

### DIFF
--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -383,7 +383,7 @@ func TestSession(t *testing.T) {
 			var msg2 = "test2"
 			var msg3 = "test3"
 			var allMsgsRecvd = false
-			var res = ws.connect("WSBIN_URL/ws-echo-multi", function(socket){
+			var res = ws.connect("WSBIN_URL/ws-echo-multi", (socket) => {
 				socket.on("open", () => {
 					socket.send(msg1)
 				})
@@ -418,7 +418,7 @@ func TestSession(t *testing.T) {
 			var msg1 = "test1"
 			var msg2 = "test2"
 			var secondMsgReceived = false
-			var res = ws.connect("WSSBIN_URL/ws-echo-multi", function(socket){
+			var res = ws.connect("WSSBIN_URL/ws-echo-multi", (socket) => {
 				socket.on("open", () => {
 					socket.send(msg1)
 				})
@@ -450,7 +450,7 @@ func TestSession(t *testing.T) {
 			var msg1 = "test1"
 			var msg2 = new Uint8Array([116, 101, 115, 116, 50]); // 'test2'
 			var secondMsgReceived = false
-			var res = ws.connect("WSBIN_URL/ws-echo-multi", function(socket){
+			var res = ws.connect("WSBIN_URL/ws-echo-multi", (socket) => {
 				socket.on("open", () => {
 					socket.send(msg1)
 				})


### PR DESCRIPTION
In relation to #1152 
#### Explanation : 

Didn't modify the ws-echo handler in  httpmultibin, instead I extended httpmultibin with a tb.Mux.HandleFunc(...)

Here are the few tests I could add: 
1. **send_receive_multiple_ws**
    send and receive messages 'test1', 'test2', 'test3' in sequence then close.
2. **send_receive_multiple_wss**
    send and receive messages 'test1', and then 'test2', then close on a wss connection
3. **send_receive_text_binary**
    I thought of this scenario where multiple kind of messages (text and binary) are exchanged over the same socket. So, here's a test that sends a text message and a binary message in sequence.

Other than that, I'm a bit concerned about whether running these tests parallely using same runtime will cause a race condition, for test to fail. (randomly, only if some race succeeds)

And, please let me know if any of these tests needs to be modified, or if you'd like me to add more scenarios, or remove.

ALso, I've added a funtion `assertMetricEmittedCount()` for asserting the count of `ws_msgs_sent` and `ws_msgs_received` collected. I made the number of messages sent '3' in send_receive_multiple_ws because of unparam linter complaining about passing same value to assertMetricEmittedCount() always :/ but that extra param `count` could be useful later.