### PR TITLE
Add support for cookie jar to k6/ws

### DIFF
--- a/js/modules/k6/http/cookiejar.go
+++ b/js/modules/k6/http/cookiejar.go
@@ -36,7 +36,8 @@ import (
 
 // HTTPCookieJar is cookiejar.Jar wrapper to be used in js scripts
 type HTTPCookieJar struct {
-	jar *cookiejar.Jar
+	// js is to make it not be accessible from inside goja/js, the json is because it's used if we return it from setup
+	Jar *cookiejar.Jar `js:"-" json:"-"`
 	ctx *context.Context
 }
 
@@ -55,7 +56,7 @@ func (j HTTPCookieJar) CookiesForURL(url string) map[string][]string {
 		panic(err)
 	}
 
-	cookies := j.jar.Cookies(u)
+	cookies := j.Jar.Cookies(u)
 	objs := make(map[string][]string, len(cookies))
 	for _, c := range cookies {
 		objs[c.Name] = append(objs[c.Name], c.Value)
@@ -101,6 +102,6 @@ func (j HTTPCookieJar) Set(url, name, value string, opts goja.Value) (bool, erro
 			}
 		}
 	}
-	j.jar.SetCookies(u, []*http.Cookie{&c})
+	j.Jar.SetCookies(u, []*http.Cookie{&c})
 	return true, nil
 }

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -329,7 +329,7 @@ func (h *HTTP) parseRequest(
 				}
 				switch v := jarV.Export().(type) {
 				case *HTTPCookieJar:
-					result.ActiveJar = v.jar
+					result.ActiveJar = v.Jar
 				}
 			case "compression":
 				algosString := strings.TrimSpace(params.Get(k).ToString().String())

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"go.k6.io/k6/js/common"
+	httpModule "go.k6.io/k6/js/modules/k6/http"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/metrics"
 	"go.k6.io/k6/stats"
@@ -114,6 +115,7 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 	enableCompression := false
 
 	tags := state.CloneTags()
+	jar := state.CookieJar
 
 	// Parse the optional second argument (params)
 	if !goja.IsUndefined(paramsV) && !goja.IsNull(paramsV) {
@@ -143,6 +145,14 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 				}
 				for _, key := range tagObj.Keys() {
 					tags[key] = tagObj.Get(key).String()
+				}
+			case "jar":
+				jarV := params.Get(k)
+				if goja.IsUndefined(jarV) || goja.IsNull(jarV) {
+					continue
+				}
+				if v, ok := jarV.Export().(*httpModule.HTTPCookieJar); ok {
+					jar = v.Jar
 				}
 			case "compression":
 				// deflate compression algorithm is supported - as defined in RFC7692
@@ -184,6 +194,10 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 		Proxy:             http.ProxyFromEnvironment,
 		TLSClientConfig:   tlsConfig,
 		EnableCompression: enableCompression,
+		Jar:               jar,
+	}
+	if jar == nil { // this is needed because of how interfaces work and that wsd.Jar is http.Cookiejar
+		wsd.Jar = nil
 	}
 
 	start := time.Now()


### PR DESCRIPTION
This does require the ws module to get access to the http.CookieJar's
jar so we need to make it exported, but through the magic of `js` tags
we can make it not accessible from the js side.