### PR TITLE
http: Improve Response html()/json() error message if body is null

### DIFF
--- a/js/modules/k6/http/response.go
+++ b/js/modules/k6/http/response.go
@@ -72,6 +72,12 @@ func (h *HTTP) responseFromHttpext(resp *httpext.Response) *Response {
 
 // HTML returns the body as an html.Selection
 func (res *Response) HTML(selector ...string) html.Selection {
+	if res.Body == nil {
+		err := fmt.Errorf("the body is null so we can't transform it to HTML" +
+			" - this likely was because of a request error getting the response")
+		common.Throw(common.GetRuntime(res.GetCtx()), err)
+	}
+
 	body, err := common.ToString(res.Body)
 	if err != nil {
 		common.Throw(common.GetRuntime(res.GetCtx()), err)
@@ -91,6 +97,13 @@ func (res *Response) HTML(selector ...string) html.Selection {
 // JSON parses the body of a response as JSON and returns it to the goja VM.
 func (res *Response) JSON(selector ...string) goja.Value {
 	rt := common.GetRuntime(res.GetCtx())
+
+	if res.Body == nil {
+		err := fmt.Errorf("the body is null so we can't transform it to JSON" +
+			" - this likely was because of a request error getting the response")
+		common.Throw(rt, err)
+	}
+
 	hasSelector := len(selector) > 0
 	if res.cachedJSON == nil || hasSelector { //nolint:nestif
 		var v interface{}

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -124,6 +124,7 @@ func invalidJSONHandler(w http.ResponseWriter, r *http.Request) {
 	_, _ = w.Write(body)
 }
 
+//nolint:paralleltest
 func TestResponse(t *testing.T) {
 	tb, state, samples, rt, _ := newRuntime(t)
 	root := state.Group
@@ -183,6 +184,12 @@ func TestResponse(t *testing.T) {
 			assert.NoError(t, err)
 			assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "GET", sr("HTTPBIN_URL/html"), "", 200, "::my group")
 		})
+
+		t.Run("NoResponseBody", func(t *testing.T) {
+			_, err := rt.RunString(sr(`http.get("HTTPBIN_URL/html", {responseType: 'none'}).html();`))
+			assert.Contains(t, err.Error(), "the body is null so we can't transform it to HTML"+
+				" - this likely was because of a request error getting the response")
+		})
 	})
 	t.Run("Json", func(t *testing.T) {
 		_, err := rt.RunString(sr(`
@@ -204,6 +211,12 @@ func TestResponse(t *testing.T) {
 			_, err := rt.RunString(sr(`http.request("GET", "HTTPBIN_URL/invalidjson").json();`))
 			//nolint:lll
 			assert.Contains(t, err.Error(), "cannot parse json due to an error at line 3, character 9 , error: invalid character 'e' in literal true (expecting 'r')")
+		})
+
+		t.Run("NoResponseBody", func(t *testing.T) {
+			_, err := rt.RunString(sr(`http.get("HTTPBIN_URL/json", {responseType: 'none'}).json();`))
+			assert.Contains(t, err.Error(), "the body is null so we can't transform it to JSON"+
+				" - this likely was because of a request error getting the response")
 		})
 	})
 	t.Run("JsonSelector", func(t *testing.T) {


### PR DESCRIPTION
Closes #2188 

When Response.body is `nil`, instead of displaying the error message `invalid type <nil>, expected string, []byte or ArrayBuffer` (which is being propagated from `util.ToBytes()`/`util.ToString()`), `Response.html()` displays `the body is null so we can't transform it to html - this likely was because of a request error getting the response` while `Response.json()` displays `the body is null so we can't transform it to json - this likely was because of a request error getting the response`.