### PR TITLE
output/influxdb: Warn about not supported v2

### DIFF
--- a/output/influxdb/output.go
+++ b/output/influxdb/output.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -228,7 +229,11 @@ func (o *Output) flushMetrics() {
 		o.logger.WithField("points", len(batch.Points())).Debug("Writing...")
 		startTime := time.Now()
 		if err := o.Client.Write(batch); err != nil {
-			o.logger.WithError(err).Error("Couldn't write stats")
+			msg := "Couldn't write stats"
+			if strings.Contains(err.Error(), "unauthorized access") {
+				msg += ", InfluxDB v2.x isn't supported by this output, if you are using it you may consider to use the extension https://github.com/grafana/xk6-output-influxdb" //nolint:lll
+			}
+			o.logger.WithError(err).Error(msg)
 			return
 		}
 		t := time.Since(startTime)


### PR DESCRIPTION
Return a detailed error suggesting to use the InfluxDB extension in the case a v2 instance is used. With the current library, we don't have a better way than matching the returned error.

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
