### PR TITLE
Scenario's stage number

### DIFF
--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -130,6 +130,21 @@ func (mi *ModuleInstance) newScenarioInfo() (*goja.Object, error) {
 		"iterationInTest": func() interface{} {
 			return vuState.GetScenarioGlobalVUIter()
 		},
+		"stage": func() interface{} {
+			stage, err := getScenarioState().CurrentStage()
+			if err != nil {
+				common.Throw(rt, err)
+			}
+			si := map[string]func() interface{}{
+				"number": func() interface{} { return stage.Index },
+				"name":   func() interface{} { return stage.Name },
+			}
+			obj, err := newInfoObj(rt, si)
+			if err != nil {
+				common.Throw(rt, err)
+			}
+			return obj
+		},
 	}
 
 	return newInfoObj(rt, si)

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -1,0 +1,74 @@
+/*
+ *
+ * k6 - a next-generation load testing tool
+ * Copyright (C) 2021 Load Impact
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package execution
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/js/modulestest"
+	"go.k6.io/k6/lib"
+)
+
+func TestScenarioStage(t *testing.T) {
+	t.Parallel()
+
+	rt := goja.New()
+	ctx := common.WithRuntime(context.Background(), rt)
+	ctx = lib.WithScenarioState(ctx, &lib.ScenarioState{
+		Stages: []lib.ScenarioStage{
+			{
+				Index:    0,
+				Name:     "ramp up",
+				Duration: 10 * time.Second,
+			},
+			{
+				Index:    1,
+				Name:     "ramp down",
+				Duration: 10 * time.Second,
+			},
+		},
+		StartTime: time.Now().Add(-11 * time.Second),
+	})
+	m, ok := New().NewModuleInstance(
+		&modulestest.InstanceCore{
+			Runtime: rt,
+			InitEnv: &common.InitEnvironment{},
+			State:   &lib.State{},
+			Ctx:     ctx,
+		},
+	).(*ModuleInstance)
+	require.True(t, ok)
+	require.NoError(t, rt.Set("exec", m.GetExports().Default))
+
+	num, err := rt.RunString(`exec.scenario.stage.number`)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), num.ToInteger())
+
+	stage, err := rt.RunString(`exec.scenario.stage.name`)
+	require.NoError(t, err)
+	assert.Equal(t, "ramp down", stage.String())
+}

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -398,6 +398,17 @@ func (varr RampingArrivalRate) Run(
 		Executor:   varr.config.Type,
 		StartTime:  startTime,
 		ProgressFn: progressFn,
+		Stages: func() []lib.ScenarioStage {
+			stages := make([]lib.ScenarioStage, 0, len(varr.config.Stages))
+			for i, s := range varr.config.Stages {
+				stages = append(stages, lib.ScenarioStage{
+					Index:    uint(i),
+					Name:     s.Name.String,
+					Duration: time.Duration(s.Duration.Duration),
+				})
+			}
+			return stages
+		}(),
 	})
 
 	returnVU := func(u lib.InitializedVU) {

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -52,6 +52,7 @@ func init() {
 
 // Stage contains
 type Stage struct {
+	Name     null.String        `json:"name"`
 	Duration types.NullDuration `json:"duration"`
 	Target   null.Int           `json:"target"` // TODO: maybe rename this to endVUs? something else?
 	// TODO: add a progression function?
@@ -572,6 +573,17 @@ func (vlv RampingVUs) Run(
 		Executor:   vlv.config.Type,
 		StartTime:  startTime,
 		ProgressFn: progressFn,
+		Stages: func() []lib.ScenarioStage {
+			stages := make([]lib.ScenarioStage, 0, len(vlv.config.Stages))
+			for i, s := range vlv.config.Stages {
+				stages = append(stages, lib.ScenarioStage{
+					Index:    uint(i),
+					Name:     s.Name.String,
+					Duration: time.Duration(s.Duration.Duration),
+				})
+			}
+			return stages
+		}(),
 	})
 
 	vuHandles := make([]*vuHandle, maxVUs)

--- a/lib/executors_test.go
+++ b/lib/executors_test.go
@@ -1,0 +1,118 @@
+package lib
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScenarioStateCurrentStage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Success", func(t *testing.T) {
+		t.Parallel()
+		// this just asserts that the fields are populated as expected
+		s1 := ScenarioStage{
+			Index:    1,
+			Name:     "stage1",
+			Duration: time.Second,
+		}
+
+		state := ScenarioState{
+			Stages: []ScenarioStage{
+				{
+					Index:    0,
+					Duration: 2 * time.Second,
+				},
+				s1,
+			},
+		}
+		stage, err := state.CurrentStage()
+		require.NoError(t, err)
+		assert.Equal(t, &s1, stage)
+	})
+
+	t.Run("SuccessEdgeCases", func(t *testing.T) {
+		t.Parallel()
+		tests := []struct {
+			name     string
+			stages   []time.Duration
+			elapsed  time.Duration // it fakes the elapsed scenario time
+			expIndex uint
+		}{
+			{
+				name:     "ZeroTime",
+				stages:   []time.Duration{5 * time.Second, 20 * time.Second},
+				elapsed:  0,
+				expIndex: 0,
+			},
+			{
+				name:     "FirstStage",
+				stages:   []time.Duration{5 * time.Second, 20 * time.Second},
+				elapsed:  4 * time.Second,
+				expIndex: 0,
+			},
+			{
+				name:     "MiddleStage",
+				stages:   []time.Duration{5 * time.Second, 20 * time.Second, 10 * time.Second},
+				elapsed:  10 * time.Second,
+				expIndex: 1,
+			},
+			{
+				name:     "StageUpperLimit",
+				stages:   []time.Duration{5 * time.Second, 20 * time.Second, 10 * time.Second},
+				elapsed:  25 * time.Second,
+				expIndex: 2,
+			},
+			{
+				name:     "OverLatestStage",
+				stages:   []time.Duration{5 * time.Second, 20 * time.Second},
+				elapsed:  30 * time.Second,
+				expIndex: 1,
+			},
+		}
+
+		for _, tc := range tests {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				stages := func() []ScenarioStage {
+					stages := make([]ScenarioStage, 0, len(tc.stages))
+					for i, duration := range tc.stages {
+						stage := ScenarioStage{
+							Index:    uint(i),
+							Duration: duration,
+						}
+						if uint(i) == tc.expIndex {
+							stage.Name = tc.name
+						}
+						stages = append(stages, stage)
+					}
+					return stages
+				}
+
+				state := ScenarioState{
+					Stages:    stages(),
+					StartTime: time.Now().Add(-tc.elapsed),
+				}
+
+				stage, err := state.CurrentStage()
+				require.NoError(t, err)
+				assert.Equal(t, tc.expIndex, stage.Index)
+				assert.Equal(t, tc.name, stage.Name)
+			})
+		}
+	})
+
+	t.Run("ErrorOnEmpty", func(t *testing.T) {
+		t.Parallel()
+		state := ScenarioState{}
+		stage, err := state.CurrentStage()
+		require.NotNil(t, err)
+		assert.Contains(t, err.Error(), "any Stage")
+		assert.Nil(t, stage)
+	})
+}


### PR DESCRIPTION
Adding scenario's stage id information.
Export the property `exec.scenario.stage.id` that returns a zero-based value tracking for the current running stage.

An example using it for tracking the stage as a tag:
```js
import http from 'k6/http';
import exec from 'k6/execution';

export const options = {
  stages: [
    { duration: '1m', target: 10 },
    { duration: '1m', target: 20 },
    { duration: '1m', target: 0 },
  ],
};

export default function () {
  exec.vu.tags["stage"] = 'stage#${exec.scenario.stage.id}'
  http.get('http://test.k6.io/');
}
```

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
-->
