### PR TITLE
cloudapi/logtail: Raise flush wait time for tests

### DIFF
--- a/cloudapi/logs_test.go
+++ b/cloudapi/logs_test.go
@@ -317,14 +317,12 @@ func TestStreamLogsToLogger(t *testing.T) {
 				require.NoError(t, err)
 
 				// wait the flush of the message on the network
-				time.Sleep(5 * time.Millisecond)
+				time.Sleep(20 * time.Millisecond)
 
 				// it generates a failure closing the connection
 				// in a rude way
 				err = conn.Close()
 				require.NoError(t, err)
-
-				time.Sleep(time.Millisecond)
 				return
 			}
 
@@ -338,7 +336,7 @@ func TestStreamLogsToLogger(t *testing.T) {
 			require.NoError(t, err)
 
 			// wait the flush of the message on the network
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 			cancel()
 		})
 
@@ -406,7 +404,7 @@ func TestStreamLogsToLogger(t *testing.T) {
 			require.NoError(t, err)
 
 			// wait the flush of the message on the network
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(20 * time.Millisecond)
 			cancel()
 		})
 


### PR DESCRIPTION
I don't see a way for making the `RestoreConnFromLatestMessage` test more stable using `HTTPMultiBin`. Considering that we already skipped the option to mock the WebSocket connection during the original PR, I just raised the timeout hoping it would be enough for the CI.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
