### PR TITLE
FEAT: Issue 2211 : Add Documentation Template as per new Github Issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: k6 Community Forum
     url: https://community.k6.io/
     about: Please ask and answer questions here.
+  - name: k6 Documentation
+    url: https://github.com/grafana/k6-docs
+    about: Please add any documentation related issues here.


### PR DESCRIPTION
# Linked Issue
It fixes https://github.com/grafana/k6/issues/2211

# Description
This PR adds a section in the `config.yaml` that would navigate to K6 Docs for any issue requests.
