### PR TITLE
Make ChangePathFs compatible with new afero.Fs without updating

### DIFF
--- a/lib/fsext/changepathfs.go
+++ b/lib/fsext/changepathfs.go
@@ -21,6 +21,7 @@
 package fsext
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,7 +71,12 @@ func (f *ChangePathFile) Name() string {
 	return f.originalName
 }
 
-//Chtimes changes the access and modification times of the named file
+// Chown changes the uid and gid of the named file.
+func (b *ChangePathFs) Chown(name string, uid, gid int) error {
+	return errors.New("unimplemented Chown")
+}
+
+// Chtimes changes the access and modification times of the named file
 func (b *ChangePathFs) Chtimes(name string, atime, mtime time.Time) (err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {


### PR DESCRIPTION
Given that we won't be using this method I don't think we need to have
actual real implementation for it which will require us to update
aforo.Fs, so I just returned an error.

This is predominantly motivated by the fact that an extension having a
dependency on a newer afero.Fs ( through another dependency for example)
will not compile as the interface afero.Fs was extended in v1.5.0.
