### PR TITLE
Refactor `k6/http` and `k6/html` to the new JS `Module` API

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,6 +38,8 @@ linters-settings:
     min-confidence: 0
   gocyclo:
     min-complexity: 25
+  cyclop: #TODO: see https://github.com/grafana/k6/issues/2294, leave only one of these?
+    max-complexity: 25
   maligned:
     suggest-new: true
   dupl:

--- a/js/modules/k6/html/element_test.go
+++ b/js/modules/k6/html/element_test.go
@@ -21,13 +21,11 @@
 package html
 
 import (
-	"context"
 	"testing"
 
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
-
-	"go.k6.io/k6/js/common"
+	"github.com/stretchr/testify/require"
 )
 
 const testHTMLElem = `
@@ -55,17 +53,13 @@ const testHTMLElem = `
 `
 
 func TestElement(t *testing.T) {
-	rt := goja.New()
-	rt.SetFieldNameMapper(common.FieldNameMapper{})
-
-	ctx := common.WithRuntime(context.Background(), rt)
-	rt.Set("src", testHTMLElem)
-	rt.Set("html", common.Bind(rt, &HTML{}, &ctx))
-	// compileProtoElem()
+	t.Parallel()
+	rt, _ := getTestModuleInstance(t)
+	require.NoError(t, rt.Set("src", testHTMLElem))
 
 	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("NodeName", func(t *testing.T) {

--- a/js/modules/k6/html/elements_gen_test.go
+++ b/js/modules/k6/html/elements_gen_test.go
@@ -21,13 +21,10 @@
 package html
 
 import (
-	"context"
 	"testing"
 
-	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
-
-	"go.k6.io/k6/js/common"
+	"github.com/stretchr/testify/require"
 )
 
 var textTests = []struct {
@@ -404,16 +401,13 @@ const testGenElems = `<html><body>
 	`
 
 func TestGenElements(t *testing.T) {
-	rt := goja.New()
-	rt.SetFieldNameMapper(common.FieldNameMapper{})
-
-	ctx := common.WithRuntime(context.Background(), rt)
-	rt.Set("src", testGenElems)
-	rt.Set("html", common.Bind(rt, &HTML{}, &ctx))
+	t.Parallel()
+	rt, mi := getTestModuleInstance(t)
+	require.NoError(t, rt.Set("src", testGenElems))
 
 	_, err := rt.RunString("var doc = html.parseHTML(src)")
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("Test text properties", func(t *testing.T) {
@@ -468,8 +462,7 @@ func TestGenElements(t *testing.T) {
 	})
 
 	t.Run("Test url properties", func(t *testing.T) {
-		html := HTML{}
-		sel, parseError := html.ParseHTML(ctx, testGenElems)
+		sel, parseError := mi.parseHTML(testGenElems)
 		if parseError != nil {
 			t.Errorf("Unable to parse html")
 		}

--- a/js/modules/k6/html/elements_test.go
+++ b/js/modules/k6/html/elements_test.go
@@ -21,13 +21,11 @@
 package html
 
 import (
-	"context"
 	"testing"
 
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
-
-	"go.k6.io/k6/js/common"
+	"github.com/stretchr/testify/require"
 )
 
 const testHTMLElems = `
@@ -86,16 +84,13 @@ const testHTMLElems = `
 `
 
 func TestElements(t *testing.T) {
-	rt := goja.New()
-	rt.SetFieldNameMapper(common.FieldNameMapper{})
-
-	ctx := common.WithRuntime(context.Background(), rt)
-	rt.Set("src", testHTMLElems)
-	rt.Set("html", common.Bind(rt, &HTML{}, &ctx))
+	t.Parallel()
+	rt, _ := getTestModuleInstance(t)
+	require.NoError(t, rt.Set("src", testHTMLElems))
 
 	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("AnchorElement", func(t *testing.T) {

--- a/js/modules/k6/html/serialize_test.go
+++ b/js/modules/k6/html/serialize_test.go
@@ -21,13 +21,11 @@
 package html
 
 import (
-	"context"
 	"testing"
 
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
-
-	"go.k6.io/k6/js/common"
+	"github.com/stretchr/testify/require"
 )
 
 const testSerializeHTML = `
@@ -69,14 +67,12 @@ const testSerializeHTML = `
 `
 
 func TestSerialize(t *testing.T) {
-	rt := goja.New()
-	rt.SetFieldNameMapper(common.FieldNameMapper{})
-	ctx := common.WithRuntime(context.Background(), rt)
-	rt.Set("src", testSerializeHTML)
-	rt.Set("html", common.Bind(rt, New(), &ctx))
+	t.Parallel()
+	rt, _ := getTestModuleInstance(t)
+	require.NoError(t, rt.Set("src", testSerializeHTML))
 
 	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("SerializeArray", func(t *testing.T) {

--- a/js/modules/k6/http/file.go
+++ b/js/modules/k6/http/file.go
@@ -21,7 +21,6 @@
 package http
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -42,8 +41,8 @@ func escapeQuotes(s string) string {
 	return quoteEscaper.Replace(s)
 }
 
-// File returns a FileData parameter
-func (h *HTTP) File(ctx context.Context, data interface{}, args ...string) FileData {
+// File returns a FileData object.
+func (mi *ModuleInstance) file(data interface{}, args ...string) FileData {
 	// supply valid default if filename and content-type are not specified
 	fname, ct := fmt.Sprintf("%d", time.Now().UnixNano()), "application/octet-stream"
 
@@ -57,7 +56,7 @@ func (h *HTTP) File(ctx context.Context, data interface{}, args ...string) FileD
 
 	dt, err := common.ToBytes(data)
 	if err != nil {
-		common.Throw(common.GetRuntime(ctx), err)
+		common.Throw(mi.vu.Runtime(), err)
 	}
 
 	return FileData{

--- a/js/modules/k6/http/file_test.go
+++ b/js/modules/k6/http/file_test.go
@@ -21,20 +21,17 @@
 package http
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"go.k6.io/k6/js/common"
 )
 
 func TestHTTPFile(t *testing.T) {
 	t.Parallel()
-	rt := goja.New()
+	rt, mi := getTestModuleInstance(t, nil, nil)
 	input := []byte{104, 101, 108, 108, 111}
 
 	testCases := []struct {
@@ -79,9 +76,7 @@ func TestHTTPFile(t *testing.T) {
 					require.EqualError(t, val.(error), tc.expErr)
 				}()
 			}
-			h := new(GlobalHTTP).NewModuleInstancePerVU().(*HTTP)
-			ctx := common.WithRuntime(context.Background(), rt)
-			out := h.File(ctx, tc.input, tc.args...)
+			out := mi.file(tc.input, tc.args...)
 			assert.Equal(t, tc.expected, out)
 		})
 	}

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -21,101 +21,159 @@
 package http
 
 import (
-	"context"
+	"net/http"
+	"net/http/cookiejar"
 
+	"github.com/dop251/goja"
 	"go.k6.io/k6/js/common"
-	"go.k6.io/k6/lib"
+	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib/netext"
 	"go.k6.io/k6/lib/netext/httpext"
 )
 
-const (
-	HTTP_METHOD_GET     = "GET"
-	HTTP_METHOD_POST    = "POST"
-	HTTP_METHOD_PUT     = "PUT"
-	HTTP_METHOD_DELETE  = "DELETE"
-	HTTP_METHOD_HEAD    = "HEAD"
-	HTTP_METHOD_PATCH   = "PATCH"
-	HTTP_METHOD_OPTIONS = "OPTIONS"
+// RootModule is the global module object type. It is instantiated once per test
+// run and will be used to create HTTP module instances for each VU.
+//
+// TODO: add sync.Once for all of the deprecation warnings we might want to do
+// for the old k6/http APIs here, so they are shown only once in a test run.
+type RootModule struct{}
+
+// ModuleInstance represents an instance of the HTTP module for every VU.
+type ModuleInstance struct {
+	vu            modules.VU
+	rootModule    *RootModule
+	defaultClient *Client
+	exports       *goja.Object
+}
+
+var (
+	_ modules.Module   = &RootModule{}
+	_ modules.Instance = &ModuleInstance{}
 )
 
-// ErrJarForbiddenInInitContext is used when a cookie jar was made in the init context
-var ErrJarForbiddenInInitContext = common.NewInitContextError("Making cookie jars in the init context is not supported")
-
-// New returns a new global module instance
-func New() *GlobalHTTP {
-	return &GlobalHTTP{}
+// New returns a pointer to a new HTTP RootModule.
+func New() *RootModule {
+	return &RootModule{}
 }
 
-// GlobalHTTP is a global HTTP module for a k6 instance/test run
-type GlobalHTTP struct{}
+// NewModuleInstance returns an HTTP module instance for each VU.
+func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
+	rt := vu.Runtime()
+	mi := &ModuleInstance{
+		vu:         vu,
+		rootModule: r,
+		exports:    rt.NewObject(),
+	}
+	mi.defineConstants()
 
-// NewModuleInstancePerVU returns an HTTP instance for each VU
-func (g *GlobalHTTP) NewModuleInstancePerVU() interface{} { // this here needs to return interface{}
-	return &HTTP{ // change the below fields to be not writable or not fields
-		TLS_1_0:                            netext.TLS_1_0,
-		TLS_1_1:                            netext.TLS_1_1,
-		TLS_1_2:                            netext.TLS_1_2,
-		TLS_1_3:                            netext.TLS_1_3,
-		OCSP_STATUS_GOOD:                   netext.OCSP_STATUS_GOOD,
-		OCSP_STATUS_REVOKED:                netext.OCSP_STATUS_REVOKED,
-		OCSP_STATUS_SERVER_FAILED:          netext.OCSP_STATUS_SERVER_FAILED,
-		OCSP_STATUS_UNKNOWN:                netext.OCSP_STATUS_UNKNOWN,
-		OCSP_REASON_UNSPECIFIED:            netext.OCSP_REASON_UNSPECIFIED,
-		OCSP_REASON_KEY_COMPROMISE:         netext.OCSP_REASON_KEY_COMPROMISE,
-		OCSP_REASON_CA_COMPROMISE:          netext.OCSP_REASON_CA_COMPROMISE,
-		OCSP_REASON_AFFILIATION_CHANGED:    netext.OCSP_REASON_AFFILIATION_CHANGED,
-		OCSP_REASON_SUPERSEDED:             netext.OCSP_REASON_SUPERSEDED,
-		OCSP_REASON_CESSATION_OF_OPERATION: netext.OCSP_REASON_CESSATION_OF_OPERATION,
-		OCSP_REASON_CERTIFICATE_HOLD:       netext.OCSP_REASON_CERTIFICATE_HOLD,
-		OCSP_REASON_REMOVE_FROM_CRL:        netext.OCSP_REASON_REMOVE_FROM_CRL,
-		OCSP_REASON_PRIVILEGE_WITHDRAWN:    netext.OCSP_REASON_PRIVILEGE_WITHDRAWN,
-		OCSP_REASON_AA_COMPROMISE:          netext.OCSP_REASON_AA_COMPROMISE,
-
+	mi.defaultClient = &Client{
+		// TODO: configure this from lib.Options and get rid of some of the
+		// things in the VU State struct that should be here. See
+		// https://github.com/grafana/k6/issues/2293
+		moduleInstance:   mi,
 		responseCallback: defaultExpectedStatuses.match,
 	}
-}
 
-//nolint: golint
-type HTTP struct {
-	TLS_1_0                            string `js:"TLS_1_0"`
-	TLS_1_1                            string `js:"TLS_1_1"`
-	TLS_1_2                            string `js:"TLS_1_2"`
-	TLS_1_3                            string `js:"TLS_1_3"`
-	OCSP_STATUS_GOOD                   string `js:"OCSP_STATUS_GOOD"`
-	OCSP_STATUS_REVOKED                string `js:"OCSP_STATUS_REVOKED"`
-	OCSP_STATUS_SERVER_FAILED          string `js:"OCSP_STATUS_SERVER_FAILED"`
-	OCSP_STATUS_UNKNOWN                string `js:"OCSP_STATUS_UNKNOWN"`
-	OCSP_REASON_UNSPECIFIED            string `js:"OCSP_REASON_UNSPECIFIED"`
-	OCSP_REASON_KEY_COMPROMISE         string `js:"OCSP_REASON_KEY_COMPROMISE"`
-	OCSP_REASON_CA_COMPROMISE          string `js:"OCSP_REASON_CA_COMPROMISE"`
-	OCSP_REASON_AFFILIATION_CHANGED    string `js:"OCSP_REASON_AFFILIATION_CHANGED"`
-	OCSP_REASON_SUPERSEDED             string `js:"OCSP_REASON_SUPERSEDED"`
-	OCSP_REASON_CESSATION_OF_OPERATION string `js:"OCSP_REASON_CESSATION_OF_OPERATION"`
-	OCSP_REASON_CERTIFICATE_HOLD       string `js:"OCSP_REASON_CERTIFICATE_HOLD"`
-	OCSP_REASON_REMOVE_FROM_CRL        string `js:"OCSP_REASON_REMOVE_FROM_CRL"`
-	OCSP_REASON_PRIVILEGE_WITHDRAWN    string `js:"OCSP_REASON_PRIVILEGE_WITHDRAWN"`
-	OCSP_REASON_AA_COMPROMISE          string `js:"OCSP_REASON_AA_COMPROMISE"`
-
-	responseCallback func(int) bool
-}
-
-// XCookieJar creates a new cookie jar object.
-func (*HTTP) XCookieJar(ctx *context.Context) *HTTPCookieJar {
-	return newCookieJar(ctx)
-}
-
-// CookieJar returns the active cookie jar for the current VU.
-func (*HTTP) CookieJar(ctx context.Context) (*HTTPCookieJar, error) {
-	state := lib.GetState(ctx)
-	if state == nil {
-		return nil, ErrJarForbiddenInInitContext
+	mustExport := func(name string, value interface{}) {
+		if err := mi.exports.Set(name, value); err != nil {
+			common.Throw(rt, err)
+		}
 	}
-	return &HTTPCookieJar{state.CookieJar, &ctx}, nil
+
+	mustExport("url", mi.URL)
+	mustExport("CookieJar", mi.newCookieJar)
+	mustExport("cookieJar", mi.getVUCookieJar)
+	mustExport("file", mi.file) // TODO: deprecate or refactor?
+
+	// TODO: refactor so the Client actually has better APIs and these are
+	// wrappers (facades) that convert the old k6 idiosyncratic APIs to the new
+	// proper Client ones that accept Request objects and don't suck
+	mustExport("get", func(url goja.Value, args ...goja.Value) (*Response, error) {
+		args = append([]goja.Value{goja.Undefined()}, args...) // sigh
+		return mi.defaultClient.Request(http.MethodGet, url, args...)
+	})
+	mustExport("head", mi.defaultClient.getMethodClosure(http.MethodHead))
+	mustExport("post", mi.defaultClient.getMethodClosure(http.MethodPost))
+	mustExport("put", mi.defaultClient.getMethodClosure(http.MethodPut))
+	mustExport("patch", mi.defaultClient.getMethodClosure(http.MethodPatch))
+	mustExport("del", mi.defaultClient.getMethodClosure(http.MethodDelete))
+	mustExport("options", mi.defaultClient.getMethodClosure(http.MethodOptions))
+	mustExport("request", mi.defaultClient.Request)
+	mustExport("batch", mi.defaultClient.Batch)
+	mustExport("setResponseCallback", mi.defaultClient.SetResponseCallback)
+
+	mustExport("expectedStatuses", mi.expectedStatuses) // TODO: refactor?
+
+	// TODO: actually expose the default client as k6/http.defaultClient when we
+	// have a better HTTP API (e.g. proper Client constructor, an actual Request
+	// object, custom Transport implementations you can pass the Client, etc.).
+	// This will allow us to find solutions to many of the issues with the
+	// current HTTP API that plague us:
+	// https://github.com/grafana/k6/issues?q=is%3Aopen+is%3Aissue+label%3Anew-http
+
+	return mi
 }
 
-// URL creates a new URL from the provided parts
-func (*HTTP) URL(parts []string, pieces ...string) (httpext.URL, error) {
+// Exports returns the JS values this module exports.
+func (mi *ModuleInstance) Exports() modules.Exports {
+	return modules.Exports{
+		Default: mi.exports,
+		// TODO: add new HTTP APIs like Client, Request (see above comment in
+		// NewModuleInstance()), etc. as named exports?
+	}
+}
+
+func (mi *ModuleInstance) defineConstants() {
+	rt := mi.vu.Runtime()
+	mustAddProp := func(name, val string) {
+		err := mi.exports.DefineDataProperty(
+			name, rt.ToValue(val), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE,
+		)
+		if err != nil {
+			common.Throw(rt, err)
+		}
+	}
+	mustAddProp("TLS_1_0", netext.TLS_1_0)
+	mustAddProp("TLS_1_1", netext.TLS_1_1)
+	mustAddProp("TLS_1_2", netext.TLS_1_2)
+	mustAddProp("TLS_1_3", netext.TLS_1_3)
+	mustAddProp("OCSP_STATUS_GOOD", netext.OCSP_STATUS_GOOD)
+	mustAddProp("OCSP_STATUS_REVOKED", netext.OCSP_STATUS_REVOKED)
+	mustAddProp("OCSP_STATUS_SERVER_FAILED", netext.OCSP_STATUS_SERVER_FAILED)
+	mustAddProp("OCSP_STATUS_UNKNOWN", netext.OCSP_STATUS_UNKNOWN)
+	mustAddProp("OCSP_REASON_UNSPECIFIED", netext.OCSP_REASON_UNSPECIFIED)
+	mustAddProp("OCSP_REASON_KEY_COMPROMISE", netext.OCSP_REASON_KEY_COMPROMISE)
+	mustAddProp("OCSP_REASON_CA_COMPROMISE", netext.OCSP_REASON_CA_COMPROMISE)
+	mustAddProp("OCSP_REASON_AFFILIATION_CHANGED", netext.OCSP_REASON_AFFILIATION_CHANGED)
+	mustAddProp("OCSP_REASON_SUPERSEDED", netext.OCSP_REASON_SUPERSEDED)
+	mustAddProp("OCSP_REASON_CESSATION_OF_OPERATION", netext.OCSP_REASON_CESSATION_OF_OPERATION)
+	mustAddProp("OCSP_REASON_CERTIFICATE_HOLD", netext.OCSP_REASON_CERTIFICATE_HOLD)
+	mustAddProp("OCSP_REASON_REMOVE_FROM_CRL", netext.OCSP_REASON_REMOVE_FROM_CRL)
+	mustAddProp("OCSP_REASON_PRIVILEGE_WITHDRAWN", netext.OCSP_REASON_PRIVILEGE_WITHDRAWN)
+	mustAddProp("OCSP_REASON_AA_COMPROMISE", netext.OCSP_REASON_AA_COMPROMISE)
+}
+
+func (mi *ModuleInstance) newCookieJar(call goja.ConstructorCall) *goja.Object {
+	rt := mi.vu.Runtime()
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+	return rt.ToValue(&CookieJar{mi, jar}).ToObject(rt)
+}
+
+// getVUCookieJar returns the active cookie jar for the current VU.
+func (mi *ModuleInstance) getVUCookieJar(call goja.FunctionCall) goja.Value {
+	rt := mi.vu.Runtime()
+	if state := mi.vu.State(); state != nil {
+		return rt.ToValue(&CookieJar{mi, state.CookieJar})
+	}
+	common.Throw(rt, ErrJarForbiddenInInitContext)
+	return nil
+}
+
+// URL creates a new URL wrapper from the provided parts.
+func (mi *ModuleInstance) URL(parts []string, pieces ...string) (httpext.URL, error) {
 	var name, urlstr string
 	for i, part := range parts {
 		name += part
@@ -126,4 +184,12 @@ func (*HTTP) URL(parts []string, pieces ...string) (httpext.URL, error) {
 		}
 	}
 	return httpext.NewURL(urlstr, name)
+}
+
+// Client represents a stand-alone HTTP client.
+//
+// TODO: move to its own file
+type Client struct {
+	moduleInstance   *ModuleInstance
+	responseCallback func(int) bool
 }

--- a/js/modules/k6/http/response.go
+++ b/js/modules/k6/http/response.go
@@ -21,10 +21,10 @@
 package http
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -39,7 +39,7 @@ import (
 // Response is a representation of an HTTP response to be returned to the goja VM
 type Response struct {
 	*httpext.Response `js:"-"`
-	h                 *HTTP
+	client            *Client
 
 	cachedJSON    interface{}
 	validatedJSON bool
@@ -56,36 +56,23 @@ func (j jsonError) Error() string {
 	return fmt.Sprintf("%s %d, character %d , error: %v", errMessage, j.line, j.character, j.err)
 }
 
-// processResponse stores the body as an ArrayBuffer if indicated by
-// respType. This is done here instead of in httpext.readResponseBody to avoid
-// a reverse dependency on js/common or goja.
-func processResponse(ctx context.Context, resp *httpext.Response, respType httpext.ResponseType) {
-	if respType == httpext.ResponseTypeBinary && resp.Body != nil {
-		rt := common.GetRuntime(ctx)
-		resp.Body = rt.NewArrayBuffer(resp.Body.([]byte))
-	}
-}
-
-func (h *HTTP) responseFromHttpext(resp *httpext.Response) *Response {
-	return &Response{Response: resp, h: h, cachedJSON: nil, validatedJSON: false}
-}
-
 // HTML returns the body as an html.Selection
 func (res *Response) HTML(selector ...string) html.Selection {
+	rt := res.client.moduleInstance.vu.Runtime()
 	if res.Body == nil {
 		err := fmt.Errorf("the body is null so we can't transform it to HTML" +
 			" - this likely was because of a request error getting the response")
-		common.Throw(common.GetRuntime(res.GetCtx()), err)
+		common.Throw(rt, err)
 	}
 
 	body, err := common.ToString(res.Body)
 	if err != nil {
-		common.Throw(common.GetRuntime(res.GetCtx()), err)
+		common.Throw(rt, err)
 	}
 
-	sel, err := html.HTML{}.ParseHTML(res.GetCtx(), body)
+	sel, err := html.ParseHTML(rt, body)
 	if err != nil {
-		common.Throw(common.GetRuntime(res.GetCtx()), err)
+		common.Throw(rt, err)
 	}
 	sel.URL = res.URL
 	if len(selector) > 0 {
@@ -96,7 +83,7 @@ func (res *Response) HTML(selector ...string) html.Selection {
 
 // JSON parses the body of a response as JSON and returns it to the goja VM.
 func (res *Response) JSON(selector ...string) goja.Value {
-	rt := common.GetRuntime(res.GetCtx())
+	rt := res.client.moduleInstance.vu.Runtime()
 
 	if res.Body == nil {
 		err := fmt.Errorf("the body is null so we can't transform it to JSON" +
@@ -168,7 +155,7 @@ func checkErrorInJSON(input []byte, offset int, err error) error {
 // SubmitForm parses the body as an html looking for a from and then submitting it
 // TODO: document the actual arguments that can be provided
 func (res *Response) SubmitForm(args ...goja.Value) (*Response, error) {
-	rt := common.GetRuntime(res.GetCtx())
+	rt := res.client.moduleInstance.vu.Runtime()
 
 	formSelector := "form"
 	submitSelector := "[type=\"submit\"]"
@@ -201,7 +188,7 @@ func (res *Response) SubmitForm(args ...goja.Value) (*Response, error) {
 	var requestMethod string
 	if methodAttr == goja.Undefined() {
 		// Use GET by default
-		requestMethod = HTTP_METHOD_GET
+		requestMethod = http.MethodGet
 	} else {
 		requestMethod = strings.ToUpper(methodAttr.String())
 	}
@@ -240,21 +227,24 @@ func (res *Response) SubmitForm(args ...goja.Value) (*Response, error) {
 		values[k] = v
 	}
 
-	if requestMethod == HTTP_METHOD_GET {
+	if requestMethod == http.MethodGet {
 		q := url.Values{}
 		for k, v := range values {
 			q.Add(k, v.String())
 		}
 		requestURL.RawQuery = q.Encode()
-		return res.h.Request(res.GetCtx(), requestMethod, rt.ToValue(requestURL.String()), goja.Null(), requestParams)
+		return res.client.Request(requestMethod, rt.ToValue(requestURL.String()), goja.Null(), requestParams)
 	}
-	return res.h.Request(res.GetCtx(), requestMethod, rt.ToValue(requestURL.String()), rt.ToValue(values), requestParams)
+	return res.client.Request(
+		requestMethod, rt.ToValue(requestURL.String()),
+		rt.ToValue(values), requestParams,
+	)
 }
 
 // ClickLink parses the body as an html, looks for a link and than makes a request as if the link was
 // clicked
 func (res *Response) ClickLink(args ...goja.Value) (*Response, error) {
-	rt := common.GetRuntime(res.GetCtx())
+	rt := res.client.moduleInstance.vu.Runtime()
 
 	selector := "a[href]"
 	requestParams := goja.Null()
@@ -289,5 +279,5 @@ func (res *Response) ClickLink(args ...goja.Value) (*Response, error) {
 	}
 	requestURL := responseURL.ResolveReference(hrefURL)
 
-	return res.h.Get(res.GetCtx(), rt.ToValue(requestURL.String()), requestParams)
+	return res.client.Request(http.MethodGet, rt.ToValue(requestURL.String()), goja.Undefined(), requestParams)
 }

--- a/js/modules/k6/http/response_callback_test.go
+++ b/js/modules/k6/http/response_callback_test.go
@@ -21,7 +21,6 @@
 package http
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"testing"
@@ -29,7 +28,6 @@ import (
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/metrics"
 	"go.k6.io/k6/stats"
@@ -37,12 +35,8 @@ import (
 
 func TestExpectedStatuses(t *testing.T) {
 	t.Parallel()
-	rt := goja.New()
-	rt.SetFieldNameMapper(common.FieldNameMapper{})
-	ctx := context.Background()
+	rt, _ := getTestModuleInstance(t, nil, nil)
 
-	ctx = common.WithRuntime(ctx, rt)
-	rt.Set("http", common.Bind(rt, new(GlobalHTTP).NewModuleInstancePerVU(), &ctx))
 	cases := map[string]struct {
 		code, err string
 		expected  expectedStatuses
@@ -108,10 +102,8 @@ type expectedSample struct {
 
 func TestResponseCallbackInAction(t *testing.T) {
 	t.Parallel()
-	tb, _, samples, rt, ctx := newRuntime(t)
+	tb, _, samples, rt, mii := newRuntime(t)
 	sr := tb.Replacer.Replace
-	httpModule := new(GlobalHTTP).NewModuleInstancePerVU().(*HTTP)
-	rt.Set("http", common.Bind(rt, httpModule, ctx))
 
 	HTTPMetricsWithoutFailed := []string{
 		metrics.HTTPReqsName,
@@ -282,7 +274,7 @@ func TestResponseCallbackInAction(t *testing.T) {
 	for name, testCase := range testCases {
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
-			httpModule.responseCallback = defaultExpectedStatuses.match
+			mii.defaultClient.responseCallback = defaultExpectedStatuses.match
 
 			_, err := rt.RunString(sr(testCase.code))
 			assert.NoError(t, err)
@@ -308,10 +300,8 @@ func TestResponseCallbackInAction(t *testing.T) {
 
 func TestResponseCallbackBatch(t *testing.T) {
 	t.Parallel()
-	tb, _, samples, rt, ctx := newRuntime(t)
+	tb, _, samples, rt, mii := newRuntime(t)
 	sr := tb.Replacer.Replace
-	httpModule := new(GlobalHTTP).NewModuleInstancePerVU().(*HTTP)
-	rt.Set("http", common.Bind(rt, httpModule, ctx))
 
 	HTTPMetricsWithoutFailed := []string{
 		metrics.HTTPReqsName,
@@ -393,7 +383,7 @@ func TestResponseCallbackBatch(t *testing.T) {
 	for name, testCase := range testCases {
 		testCase := testCase
 		t.Run(name, func(t *testing.T) {
-			httpModule.responseCallback = defaultExpectedStatuses.match
+			mii.defaultClient.responseCallback = defaultExpectedStatuses.match
 
 			_, err := rt.RunString(sr(testCase.code))
 			assert.NoError(t, err)
@@ -424,7 +414,7 @@ func TestResponseCallbackBatch(t *testing.T) {
 
 func TestResponseCallbackInActionWithoutPassedTag(t *testing.T) {
 	t.Parallel()
-	tb, state, samples, rt, ctx := newRuntime(t)
+	tb, state, samples, rt, _ := newRuntime(t)
 	sr := tb.Replacer.Replace
 	allHTTPMetrics := []string{
 		metrics.HTTPReqsName,
@@ -438,8 +428,6 @@ func TestResponseCallbackInActionWithoutPassedTag(t *testing.T) {
 		metrics.HTTPReqTLSHandshakingName,
 	}
 	deleteSystemTag(state, stats.TagExpectedResponse.String())
-	httpModule := new(GlobalHTTP).NewModuleInstancePerVU().(*HTTP)
-	rt.Set("http", common.Bind(rt, httpModule, ctx))
 
 	_, err := rt.RunString(sr(`http.request("GET", "HTTPBIN_URL/redirect/1", null, {responseCallback: http.expectedStatuses(200)});`))
 	assert.NoError(t, err)
@@ -481,10 +469,7 @@ func TestResponseCallbackInActionWithoutPassedTag(t *testing.T) {
 
 func TestDigestWithResponseCallback(t *testing.T) {
 	t.Parallel()
-	tb, _, samples, rt, ctx := newRuntime(t)
-
-	httpModule := new(GlobalHTTP).NewModuleInstancePerVU().(*HTTP)
-	rt.Set("http", common.Bind(rt, httpModule, ctx))
+	tb, _, samples, rt, _ := newRuntime(t)
 
 	urlWithCreds := tb.Replacer.Replace(
 		"http://testuser:testpwd@HTTPBIN_IP:HTTPBIN_PORT/digest-auth/auth/testuser/testpwd",

--- a/js/modules/k6/http/tls_test.go
+++ b/js/modules/k6/http/tls_test.go
@@ -1,5 +1,3 @@
-// +build go1.12
-
 /*
  *
  * k6 - a next-generation load testing tool

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -191,7 +191,7 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 				if goja.IsUndefined(jarV) || goja.IsNull(jarV) {
 					continue
 				}
-				if v, ok := jarV.Export().(*httpModule.HTTPCookieJar); ok {
+				if v, ok := jarV.Export().(*httpModule.CookieJar); ok {
 					jar = v.Jar
 				}
 			case "compression":

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -1075,9 +1075,9 @@ func TestCompression(t *testing.T) {
 		}))
 
 		_, err := ts.rt.RunString(sr(`
-		// if client supports compression, it has to send the header 
+		// if client supports compression, it has to send the header
 		// 'Sec-Websocket-Extensions:permessage-deflate; server_no_context_takeover; client_no_context_takeover' to server.
-		// if compression is negotiated successfully, server will reply with header 
+		// if compression is negotiated successfully, server will reply with header
 		// 'Sec-Websocket-Extensions:permessage-deflate; server_no_context_takeover; client_no_context_takeover'
 
 		var params = {
@@ -1274,7 +1274,14 @@ func TestCookieJar(t *testing.T) {
 			t.Logf("error while closing connection in /ws-echo-someheader: %v", err)
 		}
 	}))
-	err := ts.rt.Set("http", common.Bind(ts.rt, httpModule.New().NewModuleInstancePerVU(), ts.ctxPtr))
+
+	mii := &modulestest.VU{
+		RuntimeField: ts.rt,
+		InitEnvField: &common.InitEnvironment{Registry: metrics.NewRegistry()},
+		CtxField:     context.Background(),
+		StateField:   ts.state,
+	}
+	err := ts.rt.Set("http", httpModule.New().NewModuleInstance(mii).Exports().Default)
 	require.NoError(t, err)
 	ts.state.CookieJar, _ = cookiejar.New(nil)
 

--- a/js/modules/modules.go
+++ b/js/modules/modules.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/dop251/goja"
 	"go.k6.io/k6/js/common"
-	"go.k6.io/k6/js/modules/k6/http"
 	"go.k6.io/k6/lib"
 )
 
@@ -71,10 +70,6 @@ type Module interface {
 	// This method will be called for *each* require/import and should return an unique instance for each call
 	NewModuleInstance(VU) Instance
 }
-
-// checks that modules implement HasModuleInstancePerVU
-// this is done here as otherwise there will be a loop if the module imports this package
-var _ HasModuleInstancePerVU = http.New()
 
 // GetJSModules returns a map of all registered js modules
 func GetJSModules() map[string]interface{} {

--- a/lib/netext/httpext/batch.go
+++ b/lib/netext/httpext/batch.go
@@ -45,10 +45,10 @@ type BatchParsedHTTPRequest struct {
 // The processResponse callback can be used to modify the response, e.g.
 // to replace the body.
 func MakeBatchRequests(
-	ctx context.Context,
+	ctx context.Context, state *lib.State,
 	requests []BatchParsedHTTPRequest,
 	reqCount, globalLimit, perHostLimit int,
-	processResponse func(context.Context, *Response, ResponseType),
+	processResponse func(*Response, ResponseType),
 ) <-chan error {
 	workers := globalLimit
 	if reqCount < workers {
@@ -63,9 +63,9 @@ func MakeBatchRequests(
 			defer hl.End()
 		}
 
-		resp, err := MakeRequest(ctx, req.ParsedHTTPRequest)
+		resp, err := MakeRequest(ctx, state, req.ParsedHTTPRequest)
 		if resp != nil {
-			processResponse(ctx, resp, req.ParsedHTTPRequest.ResponseType)
+			processResponse(resp, req.ParsedHTTPRequest.ResponseType)
 			*req.Response = *resp
 		}
 		result <- err

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -127,10 +127,11 @@ func updateK6Response(k6Response *Response, finishedReq *finishedRequest) {
 	}
 }
 
-// MakeRequest makes http request for tor the provided ParsedHTTPRequest
-func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error) {
-	state := lib.GetState(ctx)
-
+// MakeRequest makes http request for tor the provided ParsedHTTPRequest.
+//
+// TODO: split apart...
+// nolint: cyclop, gocyclo, funlen, gocognit
+func MakeRequest(ctx context.Context, state *lib.State, preq *ParsedHTTPRequest) (*Response, error) {
 	respReq := &Request{
 		Method:  preq.Req.Method,
 		URL:     preq.Req.URL.String(),
@@ -249,7 +250,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		transport = ntlmssp.Negotiator{RoundTripper: transport}
 	}
 
-	resp := &Response{ctx: ctx, URL: preq.URL.URL, Request: respReq}
+	resp := &Response{URL: preq.URL.URL, Request: respReq}
 	client := http.Client{
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -118,7 +118,13 @@ func TestMakeRequestError(t *testing.T) {
 			Body:         new(bytes.Buffer),
 			Compressions: []CompressionType{badCompressionType},
 		}
-		_, err = MakeRequest(ctx, preq)
+		state := &lib.State{
+			Options:   lib.Options{RunTags: &stats.SampleTags{}},
+			Transport: http.DefaultTransport,
+			Logger:    logrus.New(),
+			Tags:      lib.NewTagMap(nil),
+		}
+		_, err = MakeRequest(ctx, state, preq)
 		require.Error(t, err)
 		require.Equal(t, err.Error(), "unknown compressionType CompressionType(13)")
 	})
@@ -141,7 +147,6 @@ func TestMakeRequestError(t *testing.T) {
 			Logger:    logger,
 			Tags:      lib.NewTagMap(nil),
 		}
-		ctx = lib.WithState(ctx, state)
 		req, _ := http.NewRequest("GET", srv.URL, nil)
 		preq := &ParsedHTTPRequest{
 			Req:     req,
@@ -150,7 +155,7 @@ func TestMakeRequestError(t *testing.T) {
 			Timeout: 10 * time.Second,
 		}
 
-		res, err := MakeRequest(ctx, preq)
+		res, err := MakeRequest(ctx, state, preq)
 
 		assert.Nil(t, res)
 		assert.EqualError(t, err, "unsupported response status: 101 Switching Protocols")
@@ -195,7 +200,6 @@ func TestResponseStatus(t *testing.T) {
 					BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 					Tags:           lib.NewTagMap(nil),
 				}
-				ctx := lib.WithState(context.Background(), state)
 				req, err := http.NewRequest("GET", server.URL, nil)
 				require.NoError(t, err)
 
@@ -207,7 +211,9 @@ func TestResponseStatus(t *testing.T) {
 					ResponseType: ResponseTypeNone,
 				}
 
-				res, err := MakeRequest(ctx, preq)
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				res, err := MakeRequest(ctx, state, preq)
 				require.NoError(t, err)
 				assert.Equal(t, tc.statusCodeExpected, res.Status)
 				assert.Equal(t, tc.statusCodeStringExpected, res.StatusText)
@@ -276,7 +282,6 @@ func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 		Tags:           lib.NewTagMap(nil),
 	}
-	ctx = lib.WithState(ctx, state)
 	req, _ := http.NewRequest("GET", srv.URL, nil)
 	preq := &ParsedHTTPRequest{
 		Req:              req,
@@ -286,7 +291,7 @@ func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 		ResponseCallback: func(i int) bool { return i == 0 },
 	}
 
-	res, err := MakeRequest(ctx, preq)
+	res, err := MakeRequest(ctx, state, preq)
 	require.NoError(t, err)
 	assert.NotNil(t, res)
 	assert.Len(t, samples, 1)
@@ -354,7 +359,6 @@ func TestTrailFailed(t *testing.T) {
 				BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 				Tags:           lib.NewTagMap(nil),
 			}
-			ctx = lib.WithState(ctx, state)
 			req, _ := http.NewRequest("GET", srv.URL, nil)
 			preq := &ParsedHTTPRequest{
 				Req:              req,
@@ -363,7 +367,7 @@ func TestTrailFailed(t *testing.T) {
 				Timeout:          10 * time.Millisecond,
 				ResponseCallback: responseCallback,
 			}
-			res, err := MakeRequest(ctx, preq)
+			res, err := MakeRequest(ctx, state, preq)
 
 			require.NoError(t, err)
 			require.NotNil(t, res)
@@ -422,7 +426,6 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 		Tags:           lib.NewTagMap(nil),
 	}
 
-	ctx = lib.WithState(ctx, state)
 	req, _ := http.NewRequest("GET", "http://"+addr.String(), nil)
 	preq := &ParsedHTTPRequest{
 		Req:              req,
@@ -432,7 +435,7 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 		ResponseCallback: func(i int) bool { return i == 0 },
 	}
 
-	res, err := MakeRequest(ctx, preq)
+	res, err := MakeRequest(ctx, state, preq)
 	require.NoError(t, err)
 	assert.NotNil(t, res)
 	assert.Len(t, samples, 1)
@@ -477,7 +480,6 @@ func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 		Tags:           lib.NewTagMap(nil),
 	}
-	ctx = lib.WithState(ctx, state)
 	req, _ := http.NewRequest("GET", srv.URL, nil)
 	preq := &ParsedHTTPRequest{
 		Req:              req,
@@ -487,7 +489,7 @@ func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 		ResponseCallback: func(i int) bool { return i == 0 },
 	}
 
-	res, err := MakeRequest(ctx, preq)
+	res, err := MakeRequest(ctx, state, preq)
 	require.NoError(t, err)
 	assert.NotNil(t, res)
 	assert.Len(t, samples, 1)

--- a/lib/netext/httpext/response.go
+++ b/lib/netext/httpext/response.go
@@ -21,7 +21,6 @@
 package httpext
 
 import (
-	"context"
 	"crypto/tls"
 
 	"go.k6.io/k6/lib/netext"
@@ -74,8 +73,6 @@ type HTTPCookie struct {
 
 // Response is a representation of an HTTP response
 type Response struct {
-	ctx context.Context
-
 	RemoteIP       string                   `json:"remote_ip"`
 	RemotePort     int                      `json:"remote_port"`
 	URL            string                   `json:"url"`
@@ -95,9 +92,8 @@ type Response struct {
 }
 
 // NewResponse returns an empty Response instance.
-func NewResponse(ctx context.Context) *Response {
+func NewResponse() *Response {
 	return &Response{
-		ctx:  ctx,
 		Body: []byte{},
 	}
 }
@@ -107,9 +103,4 @@ func (res *Response) setTLSInfo(tlsState *tls.ConnectionState) {
 	res.TLSVersion = tlsInfo.Version
 	res.TLSCipherSuite = tlsInfo.CipherSuite
 	res.OCSP = oscp
-}
-
-// GetCtx return the response context
-func (res *Response) GetCtx() context.Context {
-	return res.ctx
 }

--- a/lib/state.go
+++ b/lib/state.go
@@ -54,8 +54,11 @@ type State struct {
 	Group *Group
 
 	// Networking equipment.
+	Dialer DialContexter
+
+	// TODO: move a lot of the things below to the k6/http ModuleInstance, see
+	// https://github.com/grafana/k6/issues/2293.
 	Transport http.RoundTripper
-	Dialer    DialContexter
 	CookieJar *cookiejar.Jar
 	TLSConfig *tls.Config
 

--- a/samples/http_get.js
+++ b/samples/http_get.js
@@ -1,5 +1,5 @@
 import http from 'k6/http';
 
 export default function () {
-  const response = http.get("https://test-api.k6.io/");
+  http.get('https://test-api.k6.io/');
 };


### PR DESCRIPTION
I thought I needed to refactor both `k6/html` and `k6/http` together, since the latter depends on the former, but turns out that wasn't quite the case and the panic was caused by something else... :sweat_smile: Still, it doesn't hurt and the `k6/html` changes are relatively minor...

I like how this looks like for now, and I'll probably make another PR after this to move some things out of the [`js.Runner.newVu()`](https://github.com/grafana/k6/blob/dae70006ca77767e456acafbdda284d064dbd882/js/runner.go#L149) and `lib.State` and into the `k6/http` module, for example:
- `TLSConfig`, `Transport` and `CookieJar` probably should go in the `Client` and be initialized in a constructor, which will use the global `lib.Options` as the default options for its initialization
- `BPool` can either be in the `Client` or `ModuleInstance`, depends
- `RPSLimit` should probably be in the `RootModule`

As a prerequisite to these though, other built-in modules (and xk6 extensions) should be able to essentially do the equivalent of `require('k6/http')` internally, i.e. get the `ModuleInstance` for their VU. And to do that without Go import loops, we probably have to move some of the logic from [`js/InitContext`](https://github.com/grafana/k6/blob/dae70006ca77767e456acafbdda284d064dbd882/js/initcontext.go#L133) to [`js/common.InitEnvironment`](https://github.com/grafana/k6/blob/dae70006ca77767e456acafbdda284d064dbd882/js/common/initenv.go#L34)