### PR TITLE
js/data: ModuleV2 migration

### DIFF
--- a/js/share_test.go
+++ b/js/share_test.go
@@ -99,15 +99,15 @@ exports.default = function() {
 			t.Parallel()
 			samples := make(chan stats.SampleContainer, 100)
 			initVU, err := r.NewVU(1, 1, samples)
-			if assert.NoError(t, err) {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
-				err := vu.RunOnce()
-				assert.NoError(t, err)
-				entries := hook.Drain()
-				require.Len(t, entries, 0)
-			}
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
+			err = vu.RunOnce()
+			assert.NoError(t, err)
+			entries := hook.Drain()
+			assert.Len(t, entries, 0)
 		})
 	}
 }


### PR DESCRIPTION
Migrated `k6/data` to the `modules.Module` (aka `modules.ModuleV2`) interface.