### PR TITLE
Support websocket-connect error handler in user scripts

### DIFF
--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -259,13 +259,15 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 		_ = socket.closeConnection(websocket.CloseGoingAway)
 		return nil, wsRespErr
 	}
-	wsResponse.URL = url
+	if wsResponse != nil {
+		wsResponse.URL = url
+	}
 
 	if connErr != nil {
 		// Pass the error to the user script before exiting immediately
 		socket.handleEvent("error", rt.ToValue(connErr))
 
-		if errHandlerFn != nil {
+		if errHandlerFn != nil && wsResponse != nil {
 			if _, err := errHandlerFn(goja.Undefined(), rt.ToValue(wsResponse)); err != nil {
 				return nil, err
 			}
@@ -610,6 +612,9 @@ func (s *Socket) readPump(readChan chan *message, errorChan chan error, closeCha
 
 // Wrap the raw HTTPResponse we received to a WSHTTPResponse we can pass to the user
 func wrapHTTPResponse(httpResponse *http.Response) (*WSHTTPResponse, error) {
+	if httpResponse == nil {
+		return nil, nil
+	}
 	wsResponse := WSHTTPResponse{
 		Status: httpResponse.StatusCode,
 	}

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -113,7 +113,7 @@ func (*WS) Connect(ctx context.Context, url string, args ...goja.Value) (*WSHTTP
 		return nil, errors.New("last argument to ws.connect must be a function")
 	}
 
-	var errHandlerFn goja.Callable = nil
+	var errHandlerFn goja.Callable
 	if secondCallableV != nil {
 		errHandlerFn, isFunc = goja.AssertFunction(secondCallableV)
 		if !isFunc {


### PR DESCRIPTION
Hi there!

I'm writing a websocket loadtest with k6. The websocket server returns 503 errors when it's overloaded or when transient network errors occur. This is intended and fine, our production client retries these errors.

However I couldn't find a way to distinguish 3xx, 4xx, 5xx or problems with the websocket handshake. All of these scenarios result in 'websocket: bad handshake' error, which is returned by Gorilla-websocket.

Gorilla however does return more information. This pull request adds an extra (optional) argument to ws.connect, to handle websocket-connect errors.
In practice this can be used to report the different error codes, and also allow retrying of transient errors.

here's my example code:
(it's typescript, but the compiler emits simple javascript)

```
interface WSHttpResponse {
  url: string,
  status: number,
  headers: { [key: string]: string[] },
  body: ArrayBuffer,
  error: string,
}

ws.connect(wsEndpoint, params, sock => {
  // connect worked, setup socket as usual
  },
  //@ts-ignore  ws-connect error handler. @types/k6 package still need to be updated
  (err: WSHttpResponse) => {
    console.log("ERROR: " + JSON.stringify(err));
  }
);
```

example output:

```
ERROR {"url":"ws://localhost:10555","status":503,"headers":{"Date":"Thu, 18 Nov 2021 17:36:39 GMT","Server":"envoy"},"body":"something went wrong","error":""}
```

update: I simplified the code by using the existing WSHttpResponse instead of a new type