### PR TITLE
WIP Fix/1986 mock time in test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.6.1
 	github.com/Soontao/goHttpDigestClient v0.0.0-20170320082612-6d28bb1415c5
 	github.com/andybalholm/brotli v1.0.3
+	github.com/benbjohnson/clock v1.3.0
 	github.com/dop251/goja v0.0.0-20211115154819-26ebff68a7d5
 	github.com/fatih/color v1.12.0
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813 // indirect

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=

--- a/lib/executor/base_config.go
+++ b/lib/executor/base_config.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/lib/consts"
@@ -50,6 +51,13 @@ type BaseConfig struct {
 	Exec         null.String        `json:"exec"` // function name, externally validated
 	Tags         map[string]string  `json:"tags"`
 
+	// clock implements the Clock interface, and is a proxy for every
+	// request relative to time. The Clock interface exposes the standard
+	// time.Time methods, and allows us, for instance, to control the flow
+	// of time in tests by injecting a `clock.Mock`` implementation instance
+	// instead of the standard one.
+	clock clock.Clock
+
 	// TODO: future extensions like distribution, others?
 }
 
@@ -59,6 +67,7 @@ func NewBaseConfig(name, configType string) BaseConfig {
 		Name:         name,
 		Type:         configType,
 		GracefulStop: types.NewNullDuration(DefaultGracefulStopValue, false),
+		clock:        clock.New(),
 	}
 }
 

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,7 +59,10 @@ func newExecutionSegmentSequenceFromString(str string) *lib.ExecutionSegmentSequ
 
 func getTestConstantArrivalRateConfig() *ConstantArrivalRateConfig {
 	return &ConstantArrivalRateConfig{
-		BaseConfig:      BaseConfig{GracefulStop: types.NullDurationFrom(1 * time.Second)},
+		BaseConfig: BaseConfig{
+			GracefulStop: types.NullDurationFrom(1 * time.Second),
+			clock:        clock.NewMock(),
+		},
 		TimeUnit:        types.NullDurationFrom(time.Second),
 		Rate:            null.IntFrom(50),
 		Duration:        types.NullDurationFrom(5 * time.Second),
@@ -385,7 +389,10 @@ func TestConstantArrivalRateGlobalIters(t *testing.T) {
 	t.Parallel()
 
 	config := &ConstantArrivalRateConfig{
-		BaseConfig:      BaseConfig{GracefulStop: types.NullDurationFrom(100 * time.Millisecond)},
+		BaseConfig: BaseConfig{
+			GracefulStop: types.NullDurationFrom(100 * time.Millisecond),
+			clock:        clock.NewMock(),
+		},
 		TimeUnit:        types.NullDurationFrom(950 * time.Millisecond),
 		Rate:            null.IntFrom(20),
 		Duration:        types.NullDurationFrom(1 * time.Second),

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -342,7 +342,10 @@ func TestConstantArrivalRateDroppedIterations(t *testing.T) {
 	require.NoError(t, err)
 
 	config := &ConstantArrivalRateConfig{
-		BaseConfig:      BaseConfig{GracefulStop: types.NullDurationFrom(0 * time.Second)},
+		BaseConfig: BaseConfig{
+			GracefulStop: types.NullDurationFrom(0 * time.Second),
+			clock:        clock.NewMock(),
+		},
 		TimeUnit:        types.NullDurationFrom(time.Second),
 		Rate:            null.IntFrom(10),
 		Duration:        types.NullDurationFrom(950 * time.Millisecond),

--- a/lib/executor/constant_vus.go
+++ b/lib/executor/constant_vus.go
@@ -150,7 +150,12 @@ func (clv ConstantVUs) Run(
 	duration := clv.config.Duration.TimeDuration()
 	gracefulStop := clv.config.GetGracefulStop()
 
-	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(parentCtx, duration, gracefulStop)
+	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(
+		parentCtx,
+		clv.config.clock,
+		duration,
+		gracefulStop,
+	)
 	defer cancel()
 
 	// Make sure the log and the progress bar have accurate information

--- a/lib/executor/constant_vus.go
+++ b/lib/executor/constant_vus.go
@@ -159,7 +159,7 @@ func (clv ConstantVUs) Run(
 	).Debug("Starting executor run...")
 
 	progressFn := func() (float64, []string) {
-		spent := time.Since(startTime)
+		spent := clv.config.clock.Since(startTime)
 		right := []string{fmt.Sprintf("%d VUs", numVUs)}
 		if spent > duration {
 			right = append(right, duration.String())

--- a/lib/executor/constant_vus_test.go
+++ b/lib/executor/constant_vus_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
@@ -36,9 +37,12 @@ import (
 
 func getTestConstantVUsConfig() ConstantVUsConfig {
 	return ConstantVUsConfig{
-		BaseConfig: BaseConfig{GracefulStop: types.NullDurationFrom(100 * time.Millisecond)},
-		VUs:        null.IntFrom(10),
-		Duration:   types.NullDurationFrom(1 * time.Second),
+		BaseConfig: BaseConfig{
+			GracefulStop: types.NullDurationFrom(100 * time.Millisecond),
+			clock:        clock.NewMock(),
+		},
+		VUs:      null.IntFrom(10),
+		Duration: types.NullDurationFrom(1 * time.Second),
 	}
 }
 

--- a/lib/executor/constant_vus_test.go
+++ b/lib/executor/constant_vus_test.go
@@ -65,6 +65,8 @@ func TestConstantVUsRun(t *testing.T) {
 	)
 	defer cancel()
 	err = executor.Run(ctx, nil, nil)
+
+	// Assert
 	require.NoError(t, err)
 
 	var totalIters uint64

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -27,6 +27,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/sirupsen/logrus"
 
 	"go.k6.io/k6/errext"
@@ -140,17 +141,17 @@ func getIterationRunner(
 //  - If the whole test is aborted, the parent context will be cancelled, so
 //    that will also cancel these contexts, thus the "general abort" case is
 //    handled transparently.
-func getDurationContexts(parentCtx context.Context, regularDuration, gracefulStop time.Duration) (
+func getDurationContexts(parentCtx context.Context, clock clock.Clock, regularDuration, gracefulStop time.Duration) (
 	startTime time.Time, maxDurationCtx, regDurationCtx context.Context, maxDurationCancel func(),
 ) {
-	startTime = time.Now()
+	startTime = clock.Now()
 	maxEndTime := startTime.Add(regularDuration + gracefulStop)
 
-	maxDurationCtx, maxDurationCancel = context.WithDeadline(parentCtx, maxEndTime)
+	maxDurationCtx, maxDurationCancel = clock.WithDeadline(parentCtx, maxEndTime)
 	if gracefulStop == 0 {
 		return startTime, maxDurationCtx, maxDurationCtx, maxDurationCancel
 	}
-	regDurationCtx, _ = context.WithDeadline(maxDurationCtx, startTime.Add(regularDuration)) //nolint:govet
+	regDurationCtx, _ = clock.WithDeadline(maxDurationCtx, startTime.Add(regularDuration)) //nolint:govet
 	return startTime, maxDurationCtx, regDurationCtx, maxDurationCancel
 }
 

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -160,6 +160,7 @@ func (pvi PerVUIterations) Run(
 	duration := pvi.config.MaxDuration.TimeDuration()
 	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(
 		parentCtx,
+		pvi.config.clock,
 		duration,
 		pvi.config.GetGracefulStop(),
 	)
@@ -175,6 +176,7 @@ func (pvi PerVUIterations) Run(
 
 	vusFmt := pb.GetFixedLengthIntFormat(numVUs)
 	progressFn := func() (float64, []string) {
+		spent := pvi.config.clock.Since(startTime)
 		progVUs := fmt.Sprintf(vusFmt+" VUs", numVUs)
 		currentDoneIters := atomic.LoadUint64(doneIters)
 		iterationsFmt := pb.GetFixedLengthIntFormat(int64(totalIters))

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -158,9 +158,11 @@ func (pvi PerVUIterations) Run(
 	numVUs := pvi.config.GetVUs(pvi.executionState.ExecutionTuple)
 	iterations := pvi.config.GetIterations()
 	duration := pvi.config.MaxDuration.TimeDuration()
-	gracefulStop := pvi.config.GetGracefulStop()
-
-	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(parentCtx, duration, gracefulStop)
+	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(
+		parentCtx,
+		duration,
+		pvi.config.GetGracefulStop(),
+	)
 	defer cancel()
 
 	// Make sure the log and the progress bar have accurate information
@@ -172,12 +174,12 @@ func (pvi PerVUIterations) Run(
 	doneIters := new(uint64)
 
 	vusFmt := pb.GetFixedLengthIntFormat(numVUs)
-	itersFmt := pb.GetFixedLengthIntFormat(int64(totalIters))
 	progressFn := func() (float64, []string) {
 		spent := time.Since(startTime)
 		progVUs := fmt.Sprintf(vusFmt+" VUs", numVUs)
 		currentDoneIters := atomic.LoadUint64(doneIters)
-		progIters := fmt.Sprintf(itersFmt+"/"+itersFmt+" iters, %d per VU",
+		iterationsFmt := pb.GetFixedLengthIntFormat(int64(totalIters))
+		progIters := fmt.Sprintf(iterationsFmt+"/"+iterationsFmt+" iters, %d per VU",
 			currentDoneIters, totalIters, iterations)
 		right := []string{progVUs, duration.String(), progIters}
 		if spent > duration {

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -175,7 +175,6 @@ func (pvi PerVUIterations) Run(
 
 	vusFmt := pb.GetFixedLengthIntFormat(numVUs)
 	progressFn := func() (float64, []string) {
-		spent := time.Since(startTime)
 		progVUs := fmt.Sprintf(vusFmt+" VUs", numVUs)
 		currentDoneIters := atomic.LoadUint64(doneIters)
 		iterationsFmt := pb.GetFixedLengthIntFormat(int64(totalIters))
@@ -232,7 +231,7 @@ func (pvi PerVUIterations) Run(
 			case <-regDurationDone:
 				stats.PushIfNotDone(parentCtx, out, stats.Sample{
 					Value: float64(iterations - i), Metric: droppedIterationMetric,
-					Tags: pvi.getMetricTags(&vuID), Time: time.Now(),
+					Tags: pvi.getMetricTags(&vuID), Time: pvi.config.clock.Now(),
 				})
 				return // don't make more iterations
 			default:

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
@@ -39,7 +40,10 @@ import (
 
 func getTestPerVUIterationsConfig() PerVUIterationsConfig {
 	return PerVUIterationsConfig{
-		BaseConfig:  BaseConfig{GracefulStop: types.NullDurationFrom(1 * time.Second)},
+		BaseConfig: BaseConfig{
+			GracefulStop: types.NullDurationFrom(1 * time.Second),
+			clock:        clock.NewMock(),
+		},
 		VUs:         null.IntFrom(10),
 		Iterations:  null.IntFrom(100),
 		MaxDuration: types.NullDurationFrom(3 * time.Second),
@@ -153,6 +157,7 @@ func TestPerVuIterationsEmitDroppedIterations(t *testing.T) {
 	require.NoError(t, err)
 
 	config := PerVUIterationsConfig{
+		BaseConfig:  BaseConfig{clock: clock.NewMock()},
 		VUs:         null.IntFrom(5),
 		Iterations:  null.IntFrom(20),
 		MaxDuration: types.NullDurationFrom(1 * time.Second),

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -345,7 +345,12 @@ func (varr RampingArrivalRate) Run(
 	activeVUsWg := &sync.WaitGroup{}
 
 	returnedVUs := make(chan struct{})
-	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(parentCtx, duration, gracefulStop)
+	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(
+		parentCtx,
+		varr.config.clock,
+		duration,
+		gracefulStop,
+	)
 
 	vusPool := newActiveVUPool()
 

--- a/lib/executor/ramping_arrival_rate_test.go
+++ b/lib/executor/ramping_arrival_rate_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/benbjohnson/clock"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,9 +44,12 @@ import (
 
 func getTestRampingArrivalRateConfig() *RampingArrivalRateConfig {
 	return &RampingArrivalRateConfig{
-		BaseConfig: BaseConfig{GracefulStop: types.NullDurationFrom(1 * time.Second)},
-		TimeUnit:   types.NullDurationFrom(time.Second),
-		StartRate:  null.IntFrom(10),
+		BaseConfig: BaseConfig{
+			GracefulStop: types.NullDurationFrom(1 * time.Second),
+			clock:        clock.NewMock(),
+		},
+		TimeUnit:  types.NullDurationFrom(time.Second),
+		StartRate: null.IntFrom(10),
 		Stages: []Stage{
 			{
 				Duration: types.NullDurationFrom(time.Second * 1),

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -517,7 +517,10 @@ func (vlv *RampingVUs) Run(ctx context.Context, _ chan<- stats.SampleContainer, 
 		return fmt.Errorf("%s expected graceful end offset at %s to be final", vlv.config.GetName(), maxDuration)
 	}
 	startTime, maxDurationCtx, regularDurationCtx, cancel := getDurationContexts(
-		ctx, regularDuration, maxDuration-regularDuration,
+		ctx,
+		vlv.config.clock,
+		regularDuration,
+		maxDuration-regularDuration,
 	)
 	defer cancel()
 

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -192,7 +192,12 @@ func (si SharedIterations) Run(
 	duration := si.config.MaxDuration.TimeDuration()
 	gracefulStop := si.config.GetGracefulStop()
 
-	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(parentCtx, duration, gracefulStop)
+	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(
+		parentCtx,
+		si.config.clock,
+		duration,
+		gracefulStop,
+	)
 	defer cancel()
 
 	// Make sure the log and the progress bar have accurate information

--- a/vendor/github.com/benbjohnson/clock/LICENSE
+++ b/vendor/github.com/benbjohnson/clock/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Ben Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/benbjohnson/clock/README.md
+++ b/vendor/github.com/benbjohnson/clock/README.md
@@ -1,0 +1,105 @@
+clock
+=====
+
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/benbjohnson/clock)
+
+Clock is a small library for mocking time in Go. It provides an interface
+around the standard library's [`time`][time] package so that the application
+can use the realtime clock while tests can use the mock clock.
+
+The module is currently maintained by @djmitche.
+
+[time]: https://pkg.go.dev/github.com/benbjohnson/clock
+
+## Usage
+
+### Realtime Clock
+
+Your application can maintain a `Clock` variable that will allow realtime and
+mock clocks to be interchangeable. For example, if you had an `Application` type:
+
+```go
+import "github.com/benbjohnson/clock"
+
+type Application struct {
+	Clock clock.Clock
+}
+```
+
+You could initialize it to use the realtime clock like this:
+
+```go
+var app Application
+app.Clock = clock.New()
+...
+```
+
+Then all timers and time-related functionality should be performed from the
+`Clock` variable.
+
+
+### Mocking time
+
+In your tests, you will want to use a `Mock` clock:
+
+```go
+import (
+	"testing"
+
+	"github.com/benbjohnson/clock"
+)
+
+func TestApplication_DoSomething(t *testing.T) {
+	mock := clock.NewMock()
+	app := Application{Clock: mock}
+	...
+}
+```
+
+Now that you've initialized your application to use the mock clock, you can
+adjust the time programmatically. The mock clock always starts from the Unix
+epoch (midnight UTC on Jan 1, 1970).
+
+
+### Controlling time
+
+The mock clock provides the same functions that the standard library's `time`
+package provides. For example, to find the current time, you use the `Now()`
+function:
+
+```go
+mock := clock.NewMock()
+
+// Find the current time.
+mock.Now().UTC() // 1970-01-01 00:00:00 +0000 UTC
+
+// Move the clock forward.
+mock.Add(2 * time.Hour)
+
+// Check the time again. It's 2 hours later!
+mock.Now().UTC() // 1970-01-01 02:00:00 +0000 UTC
+```
+
+Timers and Tickers are also controlled by this same mock clock. They will only
+execute when the clock is moved forward:
+
+```go
+mock := clock.NewMock()
+count := 0
+
+// Kick off a timer to increment every 1 mock second.
+go func() {
+    ticker := mock.Ticker(1 * time.Second)
+    for {
+        <-ticker.C
+        count++
+    }
+}()
+runtime.Gosched()
+
+// Move the clock forward 10 seconds.
+mock.Add(10 * time.Second)
+
+// This prints 10.
+fmt.Println(count)
+```

--- a/vendor/github.com/benbjohnson/clock/clock.go
+++ b/vendor/github.com/benbjohnson/clock/clock.go
@@ -1,0 +1,378 @@
+package clock
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Re-export of time.Duration
+type Duration = time.Duration
+
+// Clock represents an interface to the functions in the standard library time
+// package. Two implementations are available in the clock package. The first
+// is a real-time clock which simply wraps the time package's functions. The
+// second is a mock clock which will only change when
+// programmatically adjusted.
+type Clock interface {
+	After(d time.Duration) <-chan time.Time
+	AfterFunc(d time.Duration, f func()) *Timer
+	Now() time.Time
+	Since(t time.Time) time.Duration
+	Until(t time.Time) time.Duration
+	Sleep(d time.Duration)
+	Tick(d time.Duration) <-chan time.Time
+	Ticker(d time.Duration) *Ticker
+	Timer(d time.Duration) *Timer
+	WithDeadline(parent context.Context, d time.Time) (context.Context, context.CancelFunc)
+	WithTimeout(parent context.Context, t time.Duration) (context.Context, context.CancelFunc)
+}
+
+// New returns an instance of a real-time clock.
+func New() Clock {
+	return &clock{}
+}
+
+// clock implements a real-time clock by simply wrapping the time package functions.
+type clock struct{}
+
+func (c *clock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+func (c *clock) AfterFunc(d time.Duration, f func()) *Timer {
+	return &Timer{timer: time.AfterFunc(d, f)}
+}
+
+func (c *clock) Now() time.Time { return time.Now() }
+
+func (c *clock) Since(t time.Time) time.Duration { return time.Since(t) }
+
+func (c *clock) Until(t time.Time) time.Duration { return time.Until(t) }
+
+func (c *clock) Sleep(d time.Duration) { time.Sleep(d) }
+
+func (c *clock) Tick(d time.Duration) <-chan time.Time { return time.Tick(d) }
+
+func (c *clock) Ticker(d time.Duration) *Ticker {
+	t := time.NewTicker(d)
+	return &Ticker{C: t.C, ticker: t}
+}
+
+func (c *clock) Timer(d time.Duration) *Timer {
+	t := time.NewTimer(d)
+	return &Timer{C: t.C, timer: t}
+}
+
+func (c *clock) WithDeadline(parent context.Context, d time.Time) (context.Context, context.CancelFunc) {
+	return context.WithDeadline(parent, d)
+}
+
+func (c *clock) WithTimeout(parent context.Context, t time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, t)
+}
+
+// Mock represents a mock clock that only moves forward programmically.
+// It can be preferable to a real-time clock when testing time-based functionality.
+type Mock struct {
+	mu     sync.Mutex
+	now    time.Time   // current time
+	timers clockTimers // tickers & timers
+}
+
+// NewMock returns an instance of a mock clock.
+// The current time of the mock clock on initialization is the Unix epoch.
+func NewMock() *Mock {
+	return &Mock{now: time.Unix(0, 0)}
+}
+
+// Add moves the current time of the mock clock forward by the specified duration.
+// This should only be called from a single goroutine at a time.
+func (m *Mock) Add(d time.Duration) {
+	// Calculate the final current time.
+	t := m.now.Add(d)
+
+	// Continue to execute timers until there are no more before the new time.
+	for {
+		if !m.runNextTimer(t) {
+			break
+		}
+	}
+
+	// Ensure that we end with the new time.
+	m.mu.Lock()
+	m.now = t
+	m.mu.Unlock()
+
+	// Give a small buffer to make sure that other goroutines get handled.
+	gosched()
+}
+
+// Set sets the current time of the mock clock to a specific one.
+// This should only be called from a single goroutine at a time.
+func (m *Mock) Set(t time.Time) {
+	// Continue to execute timers until there are no more before the new time.
+	for {
+		if !m.runNextTimer(t) {
+			break
+		}
+	}
+
+	// Ensure that we end with the new time.
+	m.mu.Lock()
+	m.now = t
+	m.mu.Unlock()
+
+	// Give a small buffer to make sure that other goroutines get handled.
+	gosched()
+}
+
+// runNextTimer executes the next timer in chronological order and moves the
+// current time to the timer's next tick time. The next time is not executed if
+// its next time is after the max time. Returns true if a timer was executed.
+func (m *Mock) runNextTimer(max time.Time) bool {
+	m.mu.Lock()
+
+	// Sort timers by time.
+	sort.Sort(m.timers)
+
+	// If we have no more timers then exit.
+	if len(m.timers) == 0 {
+		m.mu.Unlock()
+		return false
+	}
+
+	// Retrieve next timer. Exit if next tick is after new time.
+	t := m.timers[0]
+	if t.Next().After(max) {
+		m.mu.Unlock()
+		return false
+	}
+
+	// Move "now" forward and unlock clock.
+	m.now = t.Next()
+	m.mu.Unlock()
+
+	// Execute timer.
+	t.Tick(m.now)
+	return true
+}
+
+// After waits for the duration to elapse and then sends the current time on the returned channel.
+func (m *Mock) After(d time.Duration) <-chan time.Time {
+	return m.Timer(d).C
+}
+
+// AfterFunc waits for the duration to elapse and then executes a function.
+// A Timer is returned that can be stopped.
+func (m *Mock) AfterFunc(d time.Duration, f func()) *Timer {
+	t := m.Timer(d)
+	t.C = nil
+	t.fn = f
+	return t
+}
+
+// Now returns the current wall time on the mock clock.
+func (m *Mock) Now() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.now
+}
+
+// Since returns time since `t` using the mock clock's wall time.
+func (m *Mock) Since(t time.Time) time.Duration {
+	return m.Now().Sub(t)
+}
+
+// Until returns time until `t` using the mock clock's wall time.
+func (m *Mock) Until(t time.Time) time.Duration {
+	return t.Sub(m.Now())
+}
+
+// Sleep pauses the goroutine for the given duration on the mock clock.
+// The clock must be moved forward in a separate goroutine.
+func (m *Mock) Sleep(d time.Duration) {
+	<-m.After(d)
+}
+
+// Tick is a convenience function for Ticker().
+// It will return a ticker channel that cannot be stopped.
+func (m *Mock) Tick(d time.Duration) <-chan time.Time {
+	return m.Ticker(d).C
+}
+
+// Ticker creates a new instance of Ticker.
+func (m *Mock) Ticker(d time.Duration) *Ticker {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ch := make(chan time.Time, 1)
+	t := &Ticker{
+		C:    ch,
+		c:    ch,
+		mock: m,
+		d:    d,
+		next: m.now.Add(d),
+	}
+	m.timers = append(m.timers, (*internalTicker)(t))
+	return t
+}
+
+// Timer creates a new instance of Timer.
+func (m *Mock) Timer(d time.Duration) *Timer {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ch := make(chan time.Time, 1)
+	t := &Timer{
+		C:       ch,
+		c:       ch,
+		mock:    m,
+		next:    m.now.Add(d),
+		stopped: false,
+	}
+	m.timers = append(m.timers, (*internalTimer)(t))
+	return t
+}
+
+func (m *Mock) removeClockTimer(t clockTimer) {
+	for i, timer := range m.timers {
+		if timer == t {
+			copy(m.timers[i:], m.timers[i+1:])
+			m.timers[len(m.timers)-1] = nil
+			m.timers = m.timers[:len(m.timers)-1]
+			break
+		}
+	}
+	sort.Sort(m.timers)
+}
+
+// clockTimer represents an object with an associated start time.
+type clockTimer interface {
+	Next() time.Time
+	Tick(time.Time)
+}
+
+// clockTimers represents a list of sortable timers.
+type clockTimers []clockTimer
+
+func (a clockTimers) Len() int           { return len(a) }
+func (a clockTimers) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a clockTimers) Less(i, j int) bool { return a[i].Next().Before(a[j].Next()) }
+
+// Timer represents a single event.
+// The current time will be sent on C, unless the timer was created by AfterFunc.
+type Timer struct {
+	C       <-chan time.Time
+	c       chan time.Time
+	timer   *time.Timer // realtime impl, if set
+	next    time.Time   // next tick time
+	mock    *Mock       // mock clock, if set
+	fn      func()      // AfterFunc function, if set
+	stopped bool        // True if stopped, false if running
+}
+
+// Stop turns off the ticker.
+func (t *Timer) Stop() bool {
+	if t.timer != nil {
+		return t.timer.Stop()
+	}
+
+	t.mock.mu.Lock()
+	registered := !t.stopped
+	t.mock.removeClockTimer((*internalTimer)(t))
+	t.stopped = true
+	t.mock.mu.Unlock()
+	return registered
+}
+
+// Reset changes the expiry time of the timer
+func (t *Timer) Reset(d time.Duration) bool {
+	if t.timer != nil {
+		return t.timer.Reset(d)
+	}
+
+	t.mock.mu.Lock()
+	t.next = t.mock.now.Add(d)
+	defer t.mock.mu.Unlock()
+
+	registered := !t.stopped
+	if t.stopped {
+		t.mock.timers = append(t.mock.timers, (*internalTimer)(t))
+	}
+
+	t.stopped = false
+	return registered
+}
+
+type internalTimer Timer
+
+func (t *internalTimer) Next() time.Time { return t.next }
+func (t *internalTimer) Tick(now time.Time) {
+	// a gosched() after ticking, to allow any consequences of the
+	// tick to complete
+	defer gosched()
+
+	t.mock.mu.Lock()
+	if t.fn != nil {
+		// defer function execution until the lock is released, and
+		defer t.fn()
+	} else {
+		t.c <- now
+	}
+	t.mock.removeClockTimer((*internalTimer)(t))
+	t.stopped = true
+	t.mock.mu.Unlock()
+}
+
+// Ticker holds a channel that receives "ticks" at regular intervals.
+type Ticker struct {
+	C      <-chan time.Time
+	c      chan time.Time
+	ticker *time.Ticker  // realtime impl, if set
+	next   time.Time     // next tick time
+	mock   *Mock         // mock clock, if set
+	d      time.Duration // time between ticks
+}
+
+// Stop turns off the ticker.
+func (t *Ticker) Stop() {
+	if t.ticker != nil {
+		t.ticker.Stop()
+	} else {
+		t.mock.mu.Lock()
+		t.mock.removeClockTimer((*internalTicker)(t))
+		t.mock.mu.Unlock()
+	}
+}
+
+// Reset resets the ticker to a new duration.
+func (t *Ticker) Reset(dur time.Duration) {
+	if t.ticker != nil {
+		t.ticker.Reset(dur)
+		return
+	}
+
+	t.mock.mu.Lock()
+	defer t.mock.mu.Unlock()
+
+	t.d = dur
+	t.next = t.mock.now.Add(dur)
+}
+
+type internalTicker Ticker
+
+func (t *internalTicker) Next() time.Time { return t.next }
+func (t *internalTicker) Tick(now time.Time) {
+	select {
+	case t.c <- now:
+	default:
+	}
+	t.next = now.Add(t.d)
+	gosched()
+}
+
+// Sleep momentarily so that other goroutines can process.
+func gosched() { time.Sleep(1 * time.Millisecond) }
+
+var (
+	// type checking
+	_ Clock = &Mock{}
+)

--- a/vendor/github.com/benbjohnson/clock/context.go
+++ b/vendor/github.com/benbjohnson/clock/context.go
@@ -1,0 +1,86 @@
+package clock
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+func (m *Mock) WithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return m.WithDeadline(parent, m.Now().Add(timeout))
+}
+
+func (m *Mock) WithDeadline(parent context.Context, deadline time.Time) (context.Context, context.CancelFunc) {
+	if cur, ok := parent.Deadline(); ok && cur.Before(deadline) {
+		// The current deadline is already sooner than the new one.
+		return context.WithCancel(parent)
+	}
+	ctx := &timerCtx{clock: m, parent: parent, deadline: deadline, done: make(chan struct{})}
+	propagateCancel(parent, ctx)
+	dur := m.Until(deadline)
+	if dur <= 0 {
+		ctx.cancel(context.DeadlineExceeded) // deadline has already passed
+		return ctx, func() {}
+	}
+	ctx.Lock()
+	defer ctx.Unlock()
+	if ctx.err == nil {
+		ctx.timer = m.AfterFunc(dur, func() {
+			ctx.cancel(context.DeadlineExceeded)
+		})
+	}
+	return ctx, func() { ctx.cancel(context.Canceled) }
+}
+
+// propagateCancel arranges for child to be canceled when parent is.
+func propagateCancel(parent context.Context, child *timerCtx) {
+	if parent.Done() == nil {
+		return // parent is never canceled
+	}
+	go func() {
+		select {
+		case <-parent.Done():
+			child.cancel(parent.Err())
+		case <-child.Done():
+		}
+	}()
+}
+
+type timerCtx struct {
+	sync.Mutex
+
+	clock    Clock
+	parent   context.Context
+	deadline time.Time
+	done     chan struct{}
+
+	err   error
+	timer *Timer
+}
+
+func (c *timerCtx) cancel(err error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.err != nil {
+		return // already canceled
+	}
+	c.err = err
+	close(c.done)
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+func (c *timerCtx) Deadline() (deadline time.Time, ok bool) { return c.deadline, true }
+
+func (c *timerCtx) Done() <-chan struct{} { return c.done }
+
+func (c *timerCtx) Err() error { return c.err }
+
+func (c *timerCtx) Value(key interface{}) interface{} { return c.parent.Value(key) }
+
+func (c *timerCtx) String() string {
+	return fmt.Sprintf("clock.WithDeadline(%s [%s])", c.deadline, c.deadline.Sub(c.clock.Now()))
+}

--- a/vendor/github.com/benbjohnson/clock/go.mod
+++ b/vendor/github.com/benbjohnson/clock/go.mod
@@ -1,0 +1,3 @@
+module github.com/benbjohnson/clock
+
+go 1.15

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -15,6 +15,9 @@ github.com/Soontao/goHttpDigestClient
 github.com/andybalholm/brotli
 # github.com/andybalholm/cascadia v1.1.0
 github.com/andybalholm/cascadia
+# github.com/benbjohnson/clock v1.3.0
+## explicit
+github.com/benbjohnson/clock
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91


### PR DESCRIPTION
This is a draft Pull Request of my attempt to mock time in test #1986 (and to hopefully get to solve #1357 in the process?). I've focused mostly on executors in `lib/executor` as they seemed a good first candidate.

In its current state, the PR adds a dependency to [benbjohnson/clock](https://github.com/benbjohnson/clock), and integrates its `Clock` interface in the `BaseConfig` of the executors. As a default, it ensures the "standard" clock is used (the one that uses the standard library's `time` package under the hood), but it also allows us to use a `clock.Mock` instance  that lets us control the passage of time.

While I was able to integrate the interface in the executors, and replace our usages of `time` with the added `clock` in the code. I've been struggling to get tests to pass using that technique: especially finding out where and when to make the time pass in the tests code. 

If you have ideas, recommendations, or want/can offer some help, this PR is here for that :)

PS: this PR's branch is based upon #2268, and you can safely ignore any commit starting with "Refactor", to focus on commits starting with "WIP" instead.