### PR TITLE
Make netext httpext Response's Request a pointer

### DIFF
--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -249,7 +249,7 @@ func MakeRequest(ctx context.Context, preq *ParsedHTTPRequest) (*Response, error
 		transport = ntlmssp.Negotiator{RoundTripper: transport}
 	}
 
-	resp := &Response{ctx: ctx, URL: preq.URL.URL, Request: *respReq}
+	resp := &Response{ctx: ctx, URL: preq.URL.URL, Request: respReq}
 	client := http.Client{
 		Transport: transport,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/lib/netext/httpext/response.go
+++ b/lib/netext/httpext/response.go
@@ -91,7 +91,7 @@ type Response struct {
 	OCSP           netext.OCSP              `json:"ocsp"`
 	Error          string                   `json:"error"`
 	ErrorCode      int                      `json:"error_code"`
-	Request        Request                  `json:"request"`
+	Request        *Request                 `json:"request"`
 }
 
 // NewResponse returns an empty Response instance.


### PR DESCRIPTION
A tiny PR making the `Request` attribute of `netext/httpext/Response` struct a pointer. This should avoid copies of said Request objects (as they can be rather big) to be made every time we instantiate a Response. This is in line with Go's standard library.

This is a tiny change, which, as far as I can tell, does not break tests. I've also verified that it does not break the JSON serialization of requests (pointers can be tricksters on that front). 

ref #1931 

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
