### PR TITLE
Extend k6 inspect command with additional flag

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -29,13 +29,12 @@ import (
 	"github.com/spf13/pflag"
 
 	"go.k6.io/k6/lib/metrics"
-	"go.k6.io/k6/loader"
 )
 
 var archiveOut = "archive.tar"
 
 func getArchiveCmd(logger *logrus.Logger) *cobra.Command {
-	// archiveCmd represents the pause command
+	// archiveCmd represents the archive command
 	archiveCmd := &cobra.Command{
 		Use:   "archive",
 		Short: "Create an archive",
@@ -50,14 +49,7 @@ An archive is a fully self-contained test run, and can be executed identically e
   k6 run myarchive.tar`[1:],
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// Runner.
-			pwd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			filename := args[0]
-			filesystems := loader.CreateFilesystems()
-			src, err := loader.ReadSource(logger, filename, pwd, filesystems, os.Stdin)
+			src, filesystems, err := readSource(args[0], logger)
 			if err != nil {
 				return err
 			}

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -78,7 +78,7 @@ An archive is a fully self-contained test run, and can be executed identically e
 			if err != nil {
 				return err
 			}
-			conf, err := getConsolidatedConfig(afero.NewOsFs(), Config{Options: cliOpts}, r)
+			conf, err := getConsolidatedConfig(afero.NewOsFs(), Config{Options: cliOpts}, r.GetOptions())
 			if err != nil {
 				return err
 			}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -46,7 +46,6 @@ import (
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/lib/metrics"
-	"go.k6.io/k6/loader"
 	"go.k6.io/k6/ui/pb"
 )
 
@@ -90,14 +89,8 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 			printBar(progressBar)
 
 			// Runner
-			pwd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-
 			filename := args[0]
-			filesystems := loader.CreateFilesystems()
-			src, err := loader.ReadSource(logger, filename, pwd, filesystems, os.Stdin)
+			src, filesystems, err := readSource(filename, logger)
 			if err != nil {
 				return err
 			}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -121,7 +121,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 			if err != nil {
 				return err
 			}
-			conf, err := getConsolidatedConfig(afero.NewOsFs(), Config{Options: cliOpts}, r)
+			conf, err := getConsolidatedConfig(afero.NewOsFs(), Config{Options: cliOpts}, r.GetOptions())
 			if err != nil {
 				return err
 			}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -93,6 +93,8 @@ func exactArgsWithMsg(n int, msg string) cobra.PositionalArgs {
 	}
 }
 
+// readSource is a small wrapper around loader.ReadSource returning
+// result of the load and filesystems map
 func readSource(filename string, logger *logrus.Logger) (*loader.SourceData, map[string]afero.Fs, error) {
 	pwd, err := os.Getwd()
 	if err != nil {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -164,13 +164,13 @@ func readEnvConfig() (Config, error) {
 // Assemble the final consolidated configuration from all of the different sources:
 // - start with the CLI-provided options to get shadowed (non-Valid) defaults in there
 // - add the global file config options
-// - if supplied, add the Runner-provided options
+// - add the Runner-provided options (they may come from Bundle too if applicable)
 // - add the environment variables
 // - merge the user-supplied CLI flags back in on top, to give them the greatest priority
 // - set some defaults if they weren't previously specified
 // TODO: add better validation, more explicit default values and improve consistency between formats
 // TODO: accumulate all errors and differentiate between the layers?
-func getConsolidatedConfig(fs afero.Fs, cliConf Config, runner lib.Runner) (conf Config, err error) {
+func getConsolidatedConfig(fs afero.Fs, cliConf Config, runnerOpts lib.Options) (conf Config, err error) {
 	// TODO: use errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig) where it makes sense?
 
 	fileConf, _, err := readDiskConfig(fs)
@@ -183,9 +183,9 @@ func getConsolidatedConfig(fs afero.Fs, cliConf Config, runner lib.Runner) (conf
 	}
 
 	conf = cliConf.Apply(fileConf)
-	if runner != nil {
-		conf = conf.Apply(Config{Options: runner.GetOptions()})
-	}
+
+	conf = conf.Apply(Config{Options: runnerOpts})
+
 	conf = conf.Apply(envConf).Apply(cliConf)
 	conf = applyDefault(conf)
 

--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -569,16 +569,18 @@ func runTestCase(
 	}
 	require.NoError(t, cliErr)
 
-	var runner lib.Runner
+	var runnerOpts lib.Options
 	if testCase.options.runner != nil {
-		runner = &minirunner.MiniRunner{Options: *testCase.options.runner}
+		runnerOpts = minirunner.MiniRunner{Options: *testCase.options.runner}.GetOptions()
 	}
+	// without runner creation, values in runnerOpts will simply be invalid
+
 	if testCase.options.fs == nil {
 		t.Logf("Creating an empty FS for this test")
 		testCase.options.fs = afero.NewMemMapFs() // create an empty FS if it wasn't supplied
 	}
 
-	consolidatedConfig, err := getConsolidatedConfig(testCase.options.fs, cliConf, runner)
+	consolidatedConfig, err := getConsolidatedConfig(testCase.options.fs, cliConf, runnerOpts)
 	if testCase.expected.consolidationError {
 		require.Error(t, err)
 		return

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -27,15 +27,19 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
+	"go.k6.io/k6/core/local"
 	"go.k6.io/k6/js"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/metrics"
-	"go.k6.io/k6/loader"
+	"go.k6.io/k6/lib/types"
 )
 
-func getInspectCmd(logger logrus.FieldLogger) *cobra.Command {
+func getInspectCmd(logger *logrus.Logger) *cobra.Command {
+	var addExecReqs bool
+
 	// inspectCmd represents the inspect command
 	inspectCmd := &cobra.Command{
 		Use:   "inspect [file]",
@@ -43,19 +47,9 @@ func getInspectCmd(logger logrus.FieldLogger) *cobra.Command {
 		Long:  `Inspect a script or archive.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pwd, err := os.Getwd()
+			src, filesystems, err := readSource(args[0], logger)
 			if err != nil {
 				return err
-			}
-			filesystems := loader.CreateFilesystems()
-			src, err := loader.ReadSource(logger, args[0], pwd, filesystems, os.Stdin)
-			if err != nil {
-				return err
-			}
-
-			typ := runType
-			if typ == "" {
-				typ = detectType(src.Data)
 			}
 
 			runtimeOptions, err := getRuntimeOptions(cmd.Flags(), buildEnvMap(os.Environ()))
@@ -63,13 +57,11 @@ func getInspectCmd(logger logrus.FieldLogger) *cobra.Command {
 				return err
 			}
 			registry := metrics.NewRegistry()
-			_ = metrics.RegisterBuiltinMetrics(registry)
+			builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
 
-			var (
-				opts lib.Options
-				b    *js.Bundle
-			)
-			switch typ {
+			var b *js.Bundle
+			switch getRunType(src) {
+			// this is an exhaustive list
 			case typeArchive:
 				var arc *lib.Archive
 				arc, err = lib.ReadArchive(bytes.NewBuffer(src.Data))
@@ -77,23 +69,30 @@ func getInspectCmd(logger logrus.FieldLogger) *cobra.Command {
 					return err
 				}
 				b, err = js.NewBundleFromArchive(logger, arc, runtimeOptions, registry)
-				if err != nil {
-					return err
-				}
-				opts = b.Options
+
 			case typeJS:
 				b, err = js.NewBundle(logger, src, filesystems, runtimeOptions, registry)
+			}
+			if err != nil {
+				return err
+			}
+
+			// ATM, output can take 2 forms: standard (equal to lib.Options struct) and extended, with additional fields.
+			inspectOutput := interface{}(b.Options)
+
+			if addExecReqs {
+				inspectOutput, err = addExecRequirements(b, builtinMetrics, registry, logger)
 				if err != nil {
 					return err
 				}
-				opts = b.Options
 			}
 
-			data, err := json.MarshalIndent(opts, "", "  ")
+			data, err := json.MarshalIndent(inspectOutput, "", "  ")
 			if err != nil {
 				return err
 			}
 			fmt.Println(string(data))
+
 			return nil
 		},
 	}
@@ -101,6 +100,54 @@ func getInspectCmd(logger logrus.FieldLogger) *cobra.Command {
 	inspectCmd.Flags().SortFlags = false
 	inspectCmd.Flags().AddFlagSet(runtimeOptionFlagSet(false))
 	inspectCmd.Flags().StringVarP(&runType, "type", "t", runType, "override file `type`, \"js\" or \"archive\"")
+	inspectCmd.Flags().BoolVar(&addExecReqs,
+		"execution-requirements",
+		false,
+		"include calculations of execution requirements for the test")
 
 	return inspectCmd
+}
+
+func addExecRequirements(b *js.Bundle,
+	builtinMetrics *metrics.BuiltinMetrics, registry *metrics.Registry,
+	logger *logrus.Logger) (interface{}, error) {
+
+	// TODO: after #1048 issue, consider rewriting this without a Runner:
+	// just creating ExecutionPlan directly from validated options
+
+	runner, err := js.NewFromBundle(logger, b, builtinMetrics, registry)
+	if err != nil {
+		return nil, err
+	}
+
+	conf, err := getConsolidatedConfig(afero.NewOsFs(), Config{}, runner.GetOptions())
+	if err != nil {
+		return nil, err
+	}
+
+	conf, err = deriveAndValidateConfig(conf, runner.IsExecutable)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = runner.SetOptions(conf.Options); err != nil {
+		return nil, err
+	}
+	execScheduler, err := local.NewExecutionScheduler(runner, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	executionPlan := execScheduler.GetExecutionPlan()
+	duration, _ := lib.GetEndOffset(executionPlan)
+
+	return struct {
+		lib.Options
+		TotalDuration types.NullDuration `json:"totalDuration"`
+		MaxVUs        uint64             `json:"maxVUs"`
+	}{
+		conf.Options,
+		types.NewNullDuration(duration, true),
+		lib.GetMaxPossibleVUs(executionPlan),
+	}, nil
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -111,7 +111,6 @@ func getInspectCmd(logger *logrus.Logger) *cobra.Command {
 func addExecRequirements(b *js.Bundle,
 	builtinMetrics *metrics.BuiltinMetrics, registry *metrics.Registry,
 	logger *logrus.Logger) (interface{}, error) {
-
 	// TODO: after #1048 issue, consider rewriting this without a Runner:
 	// just creating ExecutionPlan directly from validated options
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	stdlog "log"
 	"os"
@@ -240,15 +239,6 @@ func (c *rootCommand) rootCmdPersistentFlagSet() *pflag.FlagSet {
 	flags.Lookup("config").DefValue = defaultConfigFilePath
 	must(cobra.MarkFlagFilename(flags, "config"))
 	return flags
-}
-
-// fprintf panics when where's an error writing to the supplied io.Writer
-func fprintf(w io.Writer, format string, a ...interface{}) (n int) {
-	n, err := fmt.Fprintf(w, format, a...)
-	if err != nil {
-		panic(err.Error())
-	}
-	return n
 }
 
 // RawFormatter it does nothing with the message just prints it

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -21,7 +21,6 @@
 package cmd
 
 import (
-	"archive/tar"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -100,13 +99,7 @@ a commandline interface for interacting with it.`,
 			logger.Debug("Initializing the runner...")
 
 			// Create the Runner.
-			pwd, err := os.Getwd()
-			if err != nil {
-				return err
-			}
-			filename := args[0]
-			filesystems := loader.CreateFilesystems()
-			src, err := loader.ReadSource(logger, filename, pwd, filesystems, os.Stdin)
+			src, filesystems, err := readSource(args[0], logger)
 			if err != nil {
 				return err
 			}
@@ -227,7 +220,7 @@ a commandline interface for interacting with it.`,
 			defer engine.StopOutputs()
 
 			printExecutionDescription(
-				"local", filename, "", conf, execScheduler.GetState().ExecutionTuple,
+				"local", args[0], "", conf, execScheduler.GetState().ExecutionTuple,
 				executionPlan, outputs, noColor || !stdoutTTY)
 
 			// Trap Interrupts, SIGINTs and SIGTERMs.
@@ -428,13 +421,6 @@ func newRunner(
 	}
 
 	return runner, err
-}
-
-func detectType(data []byte) string {
-	if _, err := tar.NewReader(bytes.NewReader(data)).Next(); err == nil {
-		return typeArchive
-	}
-	return typeJS
 }
 
 func handleSummaryResult(fs afero.Fs, stdOut, stdErr io.Writer, result map[string]io.Reader) error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -130,7 +130,7 @@ a commandline interface for interacting with it.`,
 			if err != nil {
 				return err
 			}
-			conf, err := getConsolidatedConfig(afero.NewOsFs(), cliConf, initRunner)
+			conf, err := getConsolidatedConfig(afero.NewOsFs(), cliConf, initRunner.GetOptions())
 			if err != nil {
 				return err
 			}

--- a/js/runner.go
+++ b/js/runner.go
@@ -86,7 +86,7 @@ func New(
 		return nil, err
 	}
 
-	return newFromBundle(logger, bundle, builtinMetrics, registry)
+	return NewFromBundle(logger, bundle, builtinMetrics, registry)
 }
 
 // NewFromArchive returns a new Runner from the source in the provided archive
@@ -99,10 +99,11 @@ func NewFromArchive(
 		return nil, err
 	}
 
-	return newFromBundle(logger, bundle, builtinMetrics, registry)
+	return NewFromBundle(logger, bundle, builtinMetrics, registry)
 }
 
-func newFromBundle(
+// NewFromBundle returns a new Runner from the provided Bundle
+func NewFromBundle(
 	logger *logrus.Logger, b *Bundle, builtinMetrics *metrics.BuiltinMetrics, registry *metrics.Registry,
 ) (*Runner, error) {
 	defaultGroup, err := lib.NewGroup("", nil)


### PR DESCRIPTION
This PR adds additional output to `k6 inspect` with `--execution-requirements` CLI option. When switched on, it triggers calculation of execution requirements, substitutes config with the derived one and adds `maxVUs` and `totalDuration` fields to the output.

Signature of `getConsolidatedConfig` was modified: now it doesn't depend on `lib.Runner` but only on `lib.Options`.

Some minor refactoring in `cmd/` was added on the way, but not too much as that'd require additional work and likely a separate PR.

This is part of the work for implementing https://github.com/grafana/k6-operator/issues/9