### PR TITLE
statsd output: allow append to name some tags values

### DIFF
--- a/output/statsd/config.go
+++ b/output/statsd/config.go
@@ -38,6 +38,7 @@ type config struct {
 	Namespace    null.String        `json:"namespace,omitempty" envconfig:"K6_STATSD_NAMESPACE"`
 	PushInterval types.NullDuration `json:"pushInterval,omitempty" envconfig:"K6_STATSD_PUSH_INTERVAL"`
 	TagBlocklist stats.TagSet       `json:"tagBlocklist,omitempty" envconfig:"K6_STATSD_TAG_BLOCKLIST"`
+	TagAppend    []string           `json:"tagAppend,omitempty" envconfig:"K6_STATSD_TAG_APPEND"`
 	EnableTags   null.Bool          `json:"enableTags,omitempty" envconfig:"K6_STATSD_ENABLE_TAGS"`
 }
 
@@ -67,6 +68,9 @@ func (c config) Apply(cfg config) config {
 	}
 	if cfg.TagBlocklist != nil {
 		c.TagBlocklist = cfg.TagBlocklist
+	}
+	if cfg.TagAppend != nil {
+		c.TagAppend = cfg.TagAppend
 	}
 	if cfg.EnableTags.Valid {
 		c.EnableTags = cfg.EnableTags

--- a/output/statsd/test_helper.go
+++ b/output/statsd/test_helper.go
@@ -160,3 +160,131 @@ func baseTest(t *testing.T,
 		checkResult(t, test.input, test.output, output)
 	}
 }
+
+//nolint:funlen
+func appendTest(t *testing.T,
+	appended string,
+	getOutput getOutputFn,
+	checkResult func(t *testing.T, samples []stats.SampleContainer, expectedOutput, output string),
+) {
+	t.Helper()
+	testNamespace := "testing.things." // to be dynamic
+
+	addr, err := net.ResolveUDPAddr("udp", "localhost:0")
+	require.NoError(t, err)
+	listener, err := net.ListenUDP("udp", addr) // we want to listen on a random port
+	require.NoError(t, err)
+	ch := make(chan string, 20)
+	end := make(chan struct{})
+	defer close(end)
+
+	go func() {
+		defer close(ch)
+		var buf [4096]byte
+		for {
+			select {
+			case <-end:
+				return
+			default:
+				n, _, err := listener.ReadFromUDP(buf[:])
+				require.NoError(t, err)
+				ch <- string(buf[:n])
+			}
+		}
+	}()
+
+	pushInterval := types.NullDurationFrom(time.Millisecond * 10)
+	collector, err := getOutput(
+		testutils.NewLogger(t),
+		null.StringFrom(listener.LocalAddr().String()),
+		null.StringFrom(testNamespace),
+		null.IntFrom(5),
+		pushInterval,
+	)
+	require.NoError(t, err)
+	require.NoError(t, collector.Start())
+	defer func() {
+		require.NoError(t, collector.Stop())
+	}()
+	newSample := func(m *stats.Metric, value float64, tags map[string]string) stats.Sample {
+		return stats.Sample{
+			Time:   time.Now(),
+			Metric: m, Value: value, Tags: stats.IntoSampleTags(&tags),
+		}
+	}
+
+	myCounter := stats.New("my_counter", stats.Counter)
+	myGauge := stats.New("my_gauge", stats.Gauge)
+	myTrend := stats.New("my_trend", stats.Trend)
+	myRate := stats.New("my_rate", stats.Rate)
+	myCheck := stats.New("my_check", stats.Rate)
+	myNotag := stats.New("my_notag", stats.Counter)
+	testMatrix := []struct {
+		input  []stats.SampleContainer
+		output string
+	}{
+		{
+			input: []stats.SampleContainer{
+				newSample(myCounter, 12, map[string]string{
+					"tag1": "value1",
+					"tag3": "value3",
+				}),
+			},
+			output: "testing.things.my_counter" + appended + ":12|c",
+		},
+		{
+			input: []stats.SampleContainer{
+				newSample(myGauge, 13, map[string]string{
+					"tag1": "value1",
+					"tag3": "value3",
+				}),
+			},
+			output: "testing.things.my_gauge" + appended + ":13.000000|g",
+		},
+		{
+			input: []stats.SampleContainer{
+				newSample(myTrend, 14, map[string]string{
+					"tag1": "value1",
+					"tag3": "value3",
+				}),
+			},
+			output: "testing.things.my_trend" + appended + ":14.000000|ms",
+		},
+		{
+			input: []stats.SampleContainer{
+				newSample(myRate, 15, map[string]string{
+					"tag1": "value1",
+					"tag3": "value3",
+				}),
+			},
+			output: "testing.things.my_rate" + appended + ":15|c",
+		},
+		{
+			input: []stats.SampleContainer{
+				newSample(myCheck, 16, map[string]string{
+					"tag1":  "value1",
+					"tag3":  "value3",
+					"check": "max<100",
+				}),
+				newSample(myCheck, 0, map[string]string{
+					"tag1":  "value1",
+					"tag3":  "value3",
+					"check": "max>100",
+				}),
+			},
+			output: "testing.things.check.max<100.pass:1|c\ntesting.things.check.max>100.fail:1|c",
+		},
+		{
+			input: []stats.SampleContainer{
+				newSample(myNotag, 1, nil),
+			},
+			output: "testing.things.my_notag:1|c",
+		},
+	}
+	for _, test := range testMatrix {
+		collector.AddMetricSamples(test.input)
+		time.Sleep((time.Duration)(pushInterval.Duration))
+		output := <-ch
+		checkResult(t, test.input, test.output, output)
+	}
+}


### PR DESCRIPTION
Allow to append to statsd metric names values of some tag. May be used for separate statistic for group.