### PR TITLE
update iter/s precision from 0 to 2

### DIFF
--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -249,7 +249,7 @@ func (car ConstantArrivalRate) Run(
 
 	vusFmt := pb.GetFixedLengthIntFormat(maxVUs)
 	progIters := fmt.Sprintf(
-		pb.GetFixedLengthFloatFormat(arrivalRatePerSec, 0)+" iters/s", arrivalRatePerSec)
+		pb.GetFixedLengthFloatFormat(arrivalRatePerSec, 2)+" iters/s", arrivalRatePerSec)
 	progressFn := func() (float64, []string) {
 		spent := time.Since(startTime)
 		currActiveVUs := atomic.LoadUint64(&activeVUsCount)

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -362,7 +362,7 @@ func (varr RampingArrivalRate) Run(
 	activeVUsCount := uint64(0)
 	tickerPeriod := int64(startTickerPeriod.Duration)
 	vusFmt := pb.GetFixedLengthIntFormat(maxVUs)
-	itersFmt := pb.GetFixedLengthFloatFormat(maxArrivalRatePerSec, 0) + " iters/s"
+	itersFmt := pb.GetFixedLengthFloatFormat(maxArrivalRatePerSec, 2) + " iters/s"
 
 	progressFn := func() (float64, []string) {
 		currActiveVUs := atomic.LoadUint64(&activeVUsCount)


### PR DESCRIPTION
This Pull Request addresses issue 1753.

If you set up a scenario where the executors run less than one iteration per second, the value is floored to zero while in progress.

By this PR, the behavior changes like at the below.

From:
![image](https://user-images.githubusercontent.com/22320354/144484045-85bedfd9-2a16-49cf-a23c-8f00c35e065f.png)

To:
![image](https://user-images.githubusercontent.com/22320354/144483815-29bce88b-2acc-4576-9917-1ea3c96f0ec1.png)

