### PR TITLE
Prevent goroutines getting blocked in js tests

### DIFF
--- a/js/console_test.go
+++ b/js/console_test.go
@@ -48,7 +48,10 @@ func TestConsoleContext(t *testing.T) {
 	rt := goja.New()
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
 
-	ctxPtr := new(context.Context)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ctxPtr := &ctx
+
 	logger, hook := logtest.NewNullLogger()
 	rt.Set("console", common.Bind(rt, &console{logger}, ctxPtr))
 
@@ -58,7 +61,7 @@ func TestConsoleContext(t *testing.T) {
 		assert.Equal(t, "a", entry.Message)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel = context.WithCancel(context.Background())
 	*ctxPtr = ctx
 	_, err = rt.RunString(`console.log("b")`)
 	assert.NoError(t, err)

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -409,7 +409,8 @@ func TestRequestWithBinaryFile(t *testing.T) {
 		Tags:           lib.NewTagMap(nil),
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ctx = lib.WithState(ctx, state)
 	ctx = common.WithRuntime(ctx, bi.Runtime)
 	*bi.Context = ctx
@@ -557,7 +558,8 @@ func TestRequestWithMultipleBinaryFiles(t *testing.T) {
 		Tags:           lib.NewTagMap(nil),
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ctx = lib.WithState(ctx, state)
 	ctx = common.WithRuntime(ctx, bi.Runtime)
 	*bi.Context = ctx


### PR DESCRIPTION
The predominant reason was the use of context.Background() for a context, which leads to a goroutine waiting on it ending, to block indefinitely.

The other case were gRPC tests which did *not* close their connections.