### PR TITLE
gh/templates: remove title field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,6 +1,5 @@
 name: Bug report
 description: Use this template for reporting bugs. Please search existing issues first.
-title: ''
 labels: bug
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feat_req.yaml
+++ b/.github/ISSUE_TEMPLATE/feat_req.yaml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Use this template for suggesting new features.
-title: ''
 labels: feature
 body:
   - type: textarea


### PR DESCRIPTION
The gh issues' templates are broken. The `title` field can't be empty so I'm removing it considering that we wouldn't have a fixed prefix for it. 

A preview is available at: https://github.com/grafana/k6/blob/2a1795644024adffb02c0a7c703c0ce1bc85a5a9/.github/ISSUE_TEMPLATE/bug.yaml
<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
