### PR TITLE
NTLM dependency package update to solve a duplicate headers bug upon NTLM authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module go.k6.io/k6
 go 1.16
 
 require (
-	github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c
+	github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e
 	github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a
 	github.com/PuerkitoBio/goquery v1.6.1
 	github.com/Soontao/goHttpDigestClient v0.0.0-20170320082612-6d28bb1415c5

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c h1:/IBSNwUN8+eKzUzbJPqhK839ygXJ82sde8x3ogr6R28=
-github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e h1:ZU22z/2YRFLyf/P4ZwUYSdNCWsMEI0VeyrFoI2rAhJQ=
+github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a h1:zpQSzEApXM0qkXcpdjeJ4OpnBWhD/X8zT/iT1wYLiVU=

--- a/vendor/github.com/Azure/go-ntlmssp/authenticate_message.go
+++ b/vendor/github.com/Azure/go-ntlmssp/authenticate_message.go
@@ -42,7 +42,7 @@ func (m authenicateMessage) MarshalBinary() ([]byte, error) {
 	}
 
 	target, user := toUnicode(m.TargetName), toUnicode(m.UserName)
-	workstation := toUnicode("go-ntlmssp")
+	workstation := toUnicode("")
 
 	ptr := binary.Size(&authenticateMessageFields{})
 	f := authenticateMessageFields{

--- a/vendor/github.com/Azure/go-ntlmssp/authheader.go
+++ b/vendor/github.com/Azure/go-ntlmssp/authheader.go
@@ -5,26 +5,55 @@ import (
 	"strings"
 )
 
-type authheader string
+type authheader []string
 
 func (h authheader) IsBasic() bool {
-	return strings.HasPrefix(string(h), "Basic ")
+	for _, s := range h {
+		if strings.HasPrefix(string(s), "Basic ") {
+			return true
+		}
+	}
+	return false
+}
+
+func (h authheader) Basic() string {
+	for _, s := range h {
+		if strings.HasPrefix(string(s), "Basic ") {
+			return s
+		}
+	}
+	return ""
 }
 
 func (h authheader) IsNegotiate() bool {
-	return strings.HasPrefix(string(h), "Negotiate")
+	for _, s := range h {
+		if strings.HasPrefix(string(s), "Negotiate") {
+			return true
+		}
+	}
+	return false
 }
 
 func (h authheader) IsNTLM() bool {
-	return strings.HasPrefix(string(h), "NTLM")
+	for _, s := range h {
+		if strings.HasPrefix(string(s), "NTLM") {
+			return true
+		}
+	}
+	return false
 }
 
 func (h authheader) GetData() ([]byte, error) {
-	p := strings.Split(string(h), " ")
-	if len(p) < 2 {
-		return nil, nil
+	for _, s := range h {
+		if strings.HasPrefix(string(s), "NTLM") || strings.HasPrefix(string(s), "Negotiate") || strings.HasPrefix(string(s), "Basic ") {
+			p := strings.Split(string(s), " ")
+			if len(p) < 2 {
+				return nil, nil
+			}
+			return base64.StdEncoding.DecodeString(string(p[1]))
+		}
 	}
-	return base64.StdEncoding.DecodeString(string(p[1]))
+	return nil, nil
 }
 
 func (h authheader) GetBasicCreds() (username, password string, err error) {

--- a/vendor/github.com/Azure/go-ntlmssp/negotiator.go
+++ b/vendor/github.com/Azure/go-ntlmssp/negotiator.go
@@ -34,10 +34,11 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 		rt = http.DefaultTransport
 	}
 	// If it is not basic auth, just round trip the request as usual
-	reqauth := authheader(req.Header.Get("Authorization"))
+	reqauth := authheader(req.Header.Values("Authorization"))
 	if !reqauth.IsBasic() {
 		return rt.RoundTrip(req)
 	}
+	reqauthBasic := reqauth.Basic()
 	// Save request body
 	body := bytes.Buffer{}
 	if req.Body != nil {
@@ -59,11 +60,10 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 	if res.StatusCode != http.StatusUnauthorized {
 		return res, err
 	}
-
-	resauth := authheader(res.Header.Get("Www-Authenticate"))
+	resauth := authheader(res.Header.Values("Www-Authenticate"))
 	if !resauth.IsNegotiate() && !resauth.IsNTLM() {
 		// Unauthorized, Negotiate not requested, let's try with basic auth
-		req.Header.Set("Authorization", string(reqauth))
+		req.Header.Set("Authorization", string(reqauthBasic))
 		io.Copy(ioutil.Discard, res.Body)
 		res.Body.Close()
 		req.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
@@ -75,7 +75,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 		if res.StatusCode != http.StatusUnauthorized {
 			return res, err
 		}
-		resauth = authheader(res.Header.Get("Www-Authenticate"))
+		resauth = authheader(res.Header.Values("Www-Authenticate"))
 	}
 
 	if resauth.IsNegotiate() || resauth.IsNTLM() {
@@ -112,7 +112,7 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 		}
 
 		// receive challenge?
-		resauth = authheader(res.Header.Get("Www-Authenticate"))
+		resauth = authheader(res.Header.Values("Www-Authenticate"))
 		challengeMessage, err := resauth.GetData()
 		if err != nil {
 			return nil, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/Azure/go-ntlmssp v0.0.0-20200615164410-66371956d46c
+# github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e
 ## explicit
 github.com/Azure/go-ntlmssp
 # github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a


### PR DESCRIPTION
Hello,

A new version of go-ntlmssp has been released following a PR I did, to solve a bug.
The bug is : NTLM authentication doesn't work when two Authorization/WWW-Authenticate headers are returned by the back-end server.
With the new version of the go-ntlmssp package, the number of header doesn't matter, and the most accurate will be taken.