### PR TITLE
Add support for shared memory file using the 'r' flag on open.

### DIFF
--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -305,16 +305,44 @@ func (i *InitContext) Open(ctx context.Context, filename string, args ...string)
 	} else if isDir {
 		return nil, fmt.Errorf("open() can't be used with directories, path: %q", filename)
 	}
-	data, err := afero.ReadFile(fs, filename)
+	fileData, err := afero.ReadFile(fs, filename)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(args) > 0 && args[0] == "b" {
-		ab := i.runtime.NewArrayBuffer(data)
+	if len(args) > 0 && contains(args[0], 'b') {
+		dataModule, exists := i.modules["k6/data"]
+		if !exists {
+			return nil, fmt.Errorf(
+				"an internal error occurred; " +
+					"reason: the data module is not loaded in the init context. " +
+					"It looks like you've found a bug, please consider " +
+					"filling an issue on Github: https://github.com/grafana/k6/issues/new/choose",
+			)
+		}
+
+		if contains(args[0], 'r') {
+			// We ask the data module to get or create a shared array buffer entry from
+			// its internal mapping using the provided filename, and data.
+			//
+			// N.B: using mmap in read-only mode could be a better option, rather than
+			// loading all the data in memory; as it's essentially the mmap syscall's
+			// reason to be. However mmap is tricky
+			// in Go: https://valyala.medium.com/mmap-in-go-considered-harmful-d92a25cb161d
+			// Also, mmap is essentially a Unix syscall and we are not sure about the state
+			// of its integration in Windows and MacOS. As of december 2021, https://github.com/edsrzf/mmap-go
+			// would look like the best portable solution if we were to take that route.
+			sharedArrayBuffer := dataModule.(*data.RootModule).GetOrCreateSharedArrayBuffer(filename, fileData)
+			ab := sharedArrayBuffer.Wrap(i.runtime)
+			return i.runtime.ToValue(&ab), nil
+		}
+
+		ab := i.runtime.NewArrayBuffer(fileData)
 		return i.runtime.ToValue(&ab), nil
+		// return i.runtime.ToValue(&ab), nil
 	}
-	return i.runtime.ToValue(string(data)), nil
+
+	return i.runtime.ToValue(string(fileData)), nil
 }
 
 func getInternalJSModules() map[string]interface{} {
@@ -343,4 +371,14 @@ func getJSModules() map[string]interface{} {
 	}
 
 	return result
+}
+
+func contains(str string, c rune) bool {
+	for _, v := range str {
+		if v == c {
+			return true
+		}
+	}
+
+	return false
 }

--- a/js/modules/k6/data/data.go
+++ b/js/modules/k6/data/data.go
@@ -34,17 +34,24 @@ type (
 	// RootModule is the global module instance that will create module
 	// instances for each VU.
 	RootModule struct {
-		shared sharedArrays
+		shared    sharedArrays
+		immutable sharedArrayBuffers
 	}
 
 	// Data represents an instance of the data module.
 	Data struct {
-		vu     modules.VU
-		shared *sharedArrays
+		vu        modules.VU
+		shared    *sharedArrays
+		immutable *sharedArrayBuffers
 	}
 
 	sharedArrays struct {
 		data map[string]sharedArray
+		mu   sync.RWMutex
+	}
+
+	sharedArrayBuffers struct {
+		data map[string]SharedArrayBuffer
 		mu   sync.RWMutex
 	}
 )
@@ -60,6 +67,9 @@ func New() *RootModule {
 		shared: sharedArrays{
 			data: make(map[string]sharedArray),
 		},
+		immutable: sharedArrayBuffers{
+			data: make(map[string]SharedArrayBuffer),
+		},
 	}
 }
 
@@ -67,9 +77,21 @@ func New() *RootModule {
 // a new instance for each VU.
 func (rm *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	return &Data{
-		vu:     vu,
-		shared: &rm.shared,
+		vu:        vu,
+		shared:    &rm.shared,
+		immutable: &rm.immutable,
 	}
+}
+
+// GetOrCreateSharedArrayBuffer fetches a shared array buffer instance with
+// the provided name from the module, if it does not exist yet, it is created
+// from the provided data.
+//
+// This method is for instance used by the init context's open method, when the
+// `b` and `r` options are supplied, in order to ensure we read a binary file
+// from disk only once, but allow repetitive access to its underlying data.
+func (rm *RootModule) GetOrCreateSharedArrayBuffer(filename string, data []byte) SharedArrayBuffer {
+	return rm.immutable.get(filename, data)
 }
 
 // Exports returns the exports of the data module.
@@ -143,4 +165,52 @@ func getShareArrayFromCall(rt *goja.Runtime, call goja.Callable) sharedArray {
 	}
 
 	return sharedArray{arr: arr}
+}
+
+// FIXME: not sure if this is needed. Do we want to expose the sharedArrayBuffer to users?
+// func (d *Data) sharedArrayBuffer(constructor goja.ConstructorCall) goja.Value {
+// 	// runtime := d.vu.Runtime()
+
+// 	// if d.vu.State() != nil {
+// 	// 	common.Throw(runtime, errors.New("new ImmutableArrayBuffer must be called in the init context"))
+// 	// }
+
+// 	// filename := constructor.Argument(0).String()
+// 	// if filename == "" {
+// 	// 	common.Throw(runtime, errors.New("empty filename provided to ImmutableArrayBuffer's constructor"))
+// 	// }
+
+// 	// // TODO: somehow acquire data? It looks like having a constructor just doesn't make sense.
+
+// 	// // FIXME: nil is a leftover, some data should actually make its way here? See previous TODO.
+// 	// array := d.immutable.get(filename, nil)
+// 	// return array.Wrap(runtime).ToObject(runtime)
+// 	// return array.Wrap(runtime).ToObject(runtime)
+// 	return nil
+// }
+
+func (i *sharedArrayBuffers) get(filename string, data []byte) SharedArrayBuffer {
+	i.mu.RLock()
+	array, exists := i.data[filename]
+	i.mu.RUnlock()
+	if !exists {
+		// If the array was not found, we need to try and
+		// create it. Thus, we acquire a read/write lock,
+		// which will be released at the end of this if
+		// statement's scope.
+		i.mu.Lock()
+		defer i.mu.Unlock()
+
+		// To ensure atomicity of our operation, and as we have
+		// reacquired a lock on the data, we should double check
+		// the pre-existence of the array (it might have been created
+		// in the meantime).
+		array, exists = i.data[filename]
+		if !exists {
+			array = SharedArrayBuffer{arr: data}
+			i.data[filename] = array
+		}
+	}
+
+	return array
 }

--- a/js/modules/k6/data/share.go
+++ b/js/modules/k6/data/share.go
@@ -112,3 +112,18 @@ func (s wrappedSharedArray) deepFreeze(rt *goja.Runtime, val goja.Value) error {
 	}
 	return nil
 }
+
+// SharedArrayBuffer holds the bytes of a shared array buffer.
+type SharedArrayBuffer struct {
+	arr []byte
+}
+
+// Wrap wraped a SharedArray buffer with a provided JS runtime
+func (sab SharedArrayBuffer) Wrap(runtime *goja.Runtime) goja.ArrayBuffer {
+	// return rt.NewArrayBuffer(sab.arr)
+	// return rt.NewDynamicArray(WrappedSharedArrayBuffer{
+	// 	SharedArrayBuffer: sab,
+	// 	rt:                rt,
+	// })
+	return runtime.NewArrayBuffer(sab.arr)
+}


### PR DESCRIPTION
## What this PR does

This PR is an attempt at providing some resolution to #1931. It introduces the `r` option to the JS *init context* `open()` function. When used against a binary file as such: `open('myfile', 'br')` it returns an `ArrayBuffer` instance holding the file bytes, that's uniquely mapped and stored in the process. When a file is opened the first time, its content is added to a `filename->content` mapping. Opening the same file multiple times would result in storing its content in memory only once.

It allows to do something along the lines of:

```javascript
// The file is opened, read, and its content's bytes are stored
// and mapped to the filename. It returns its content as an
// ArrayBuffer instance.
const myBinaryFile = open('myfile', 'br');

export default function () {
  const data = {
    field: 'this is a standard form field',
    file: http.file(myBinaryFile, 'myfile'),
  };
  
  http.post('https://example.com/upload', data);
}
```

As of the opening of this PR, this mapping is done directly in the `data` module, and is done against filenames. For a given filename, there exists at any point in time a single copy of its content stored in the `sharedArrayBuffer` attribute of the data `RootModule`.

My understanding is that `ArrayBuffer` isn't stricto sensu immutable, but it's not designed for being modified either. It felt like an acceptable compromise. Let me know if you disagree and/or see issues with this assumption. 

## Scope

This PR doesn't have tests yet. I preferred to wait for your input on the design before adding any. I will add some as soon as we reach a satisfactory 🏗️ agreement on the design.

See Feedback requests and Open Question for more scope related questions.

## Alternatives

An alternative I considered was using `mmap` instead. When a file is opened with the `br` flags, we would open it in read only mode, and `mmap` it in read-only mode. As a reminder, `mmap` is (posix?) a system call that allows a process to map the content of a file directly into its virtual address space: any further operations done to the *mmaped file* are done in memory, and the OS makes sure to sync those to the underlying file storage whenever it judges necessary.

This would have been very convenient, considering that it would be "shared" by design, anyone having the *mmaped file descriptor inside the process can access it, just like it would with any other file. Plus, it supports a similar set of flags as the OS `open` syscall and would easily enforce the "read-only" property.

However, there are in my opinion two main limitations to using `mmap`:
- It apparently performs poorly in Go: https://valyala.medium.com/mmap-in-go-considered-harmful-d92a25cb161d
- It has limited portability. Although libraries exist to cater to that: https://github.com/edsrzf/mmap-go

## Expected feedback and Open Questions

- **Note**: I have experimented with a bunch of alternatives and ended up cutting most of what I've done to limit it to this absolute minimum implementation. The reason is: I really had a hard time gaining any sort of certainty regarding the design. Hence, it would be **really** useful to get feedback from you folks on that front.
- **Question**: this PR makes the `initcontext.go`'s `Open` function call in the `data` module directly like this: `dataModule.(*data.RootModule).GetOrCreateSharedArrayBuffer(filename, fileData)` would you say this is acceptable? If not, what would be an alternative?
- **Feedback needed**: Does this address the #1931 feature request in your opinion? If not, what's missing?
- **Feedback needed**: Would you have designed this feature in another way? If so, how?
- **Feedback needed**: The main reason for using an `ArrayBuffer` and not a `DynamicArray` with paniquing setters, was mostly due to the fact that the `DynamicArray` interface doesn't allow access to its underlying bytes, making `common.ToBytes` ineffective. If you have a better idea, please elaborate 🙏🏻 


## How to review this PR

There really isn't so much code in this PR  as of today. I would recommend starting from the entry point: the modifications made to the `Open` method of the `initcontext.go` file, though. Then it might be interesting to follow what `GetOrCreateSharedArrayBuffer` in `data/data.go` does under the hood.