### PR TITLE
fix: Implementing a limitation for the open()

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -334,6 +334,10 @@ func (b *Bundle) instantiate(logger logrus.FieldLogger, rt *goja.Runtime, init *
 	unbindInit()
 	*init.ctxPtr = nil
 
+	if vuID == 0 {
+		init.allowOnlyOpenedFiles()
+	}
+
 	rt.SetRandSource(common.NewRandSource())
 
 	return nil

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -319,7 +319,7 @@ func readFile(fileSystem afero.Fs, filename string) (data []byte, err error) {
 			// loading different files per VU is not supported, so all files should are going
 			// to be used inside the scenario should be opened during the init step (without any conditions)
 			err = fmt.Errorf(
-				"open() can't be used under with files that weren't opened during initialization (__VU==0), path: %q",
+				"open() can't be used with files that weren't previously opened during initialization (__VU==0), path: %q",
 				filename,
 			)
 		}
@@ -339,12 +339,12 @@ func readFile(fileSystem afero.Fs, filename string) (data []byte, err error) {
 func (i *InitContext) allowOnlyOpenedFiles() {
 	fs := i.filesystems["file"]
 
-	alreadyOpenedFS, ok := fs.(fsext.OnlyOpenedEnabler)
+	alreadyOpenedFS, ok := fs.(fsext.OnlyCachedEnabler)
 	if !ok {
 		return
 	}
 
-	alreadyOpenedFS.AllowOnlyOpened()
+	alreadyOpenedFS.AllowOnlyCached()
 }
 
 func getInternalJSModules() map[string]interface{} {

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -48,6 +48,7 @@ import (
 	"go.k6.io/k6/js/modules/k6/metrics"
 	"go.k6.io/k6/js/modules/k6/ws"
 	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/loader"
 )
 
@@ -299,13 +300,8 @@ func (i *InitContext) Open(ctx context.Context, filename string, args ...string)
 	if filename[0:1] != afero.FilePathSeparator {
 		filename = afero.FilePathSeparator + filename
 	}
-	// Workaround for https://github.com/spf13/afero/issues/201
-	if isDir, err := afero.IsDir(fs, filename); err != nil {
-		return nil, err
-	} else if isDir {
-		return nil, fmt.Errorf("open() can't be used with directories, path: %q", filename)
-	}
-	data, err := afero.ReadFile(fs, filename)
+
+	data, err := readFile(fs, filename)
 	if err != nil {
 		return nil, err
 	}
@@ -315,6 +311,40 @@ func (i *InitContext) Open(ctx context.Context, filename string, args ...string)
 		return i.runtime.ToValue(&ab), nil
 	}
 	return i.runtime.ToValue(string(data)), nil
+}
+
+func readFile(fileSystem afero.Fs, filename string) ([]byte, error) {
+	// Workaround for https://github.com/spf13/afero/issues/201
+	if isDir, err := afero.IsDir(fileSystem, filename); err != nil {
+		return nil, err
+	} else if isDir {
+		return nil, fmt.Errorf("open() can't be used with directories, path: %q", filename)
+	}
+
+	data, err := afero.ReadFile(fileSystem, filename)
+	if err == nil {
+		return data, nil
+	}
+
+	// loading different files per VU is not supported, so all files should are going
+	// to be used inside the scenario should be opened during the init step (without any conditions)
+	if errors.Is(err, fsext.ErrFileNeverOpenedBefore) {
+		return nil, fmt.Errorf("open() can't be used under the conditions, path: %q", filename)
+	}
+
+	return nil, err
+}
+
+// allowOnlyOpenedFiles enables seen only files
+func (i *InitContext) allowOnlyOpenedFiles() {
+	fs := i.filesystems["file"]
+
+	alreadyOpenedFS, ok := fs.(fsext.OnlyOpenedEnabler)
+	if !ok {
+		return
+	}
+
+	alreadyOpenedFS.AllowOnlyOpened()
 }
 
 func getInternalJSModules() map[string]interface{} {

--- a/lib/archive.go
+++ b/lib/archive.go
@@ -251,7 +251,7 @@ func (arc *Archive) Write(out io.Writer) error {
 	normalizeAndAnonymizeURL(metaArc.PwdURL)
 	metaArc.Filename = getURLtoString(metaArc.FilenameURL)
 	metaArc.Pwd = getURLtoString(metaArc.PwdURL)
-	var actualDataPath, err = url.PathUnescape(path.Join(getURLPathOnFs(metaArc.FilenameURL)))
+	actualDataPath, err := url.PathUnescape(path.Join(getURLPathOnFs(metaArc.FilenameURL)))
 	if err != nil {
 		return err
 	}
@@ -286,7 +286,7 @@ func (arc *Archive) Write(out io.Writer) error {
 		if !ok {
 			continue
 		}
-		if cachedfs, ok := filesystem.(fsext.CacheOnReadFs); ok {
+		if cachedfs, ok := filesystem.(fsext.CacheLayerGetter); ok {
 			filesystem = cachedfs.GetCachingFs()
 		}
 
@@ -344,7 +344,7 @@ func (arc *Archive) Write(out io.Writer) error {
 		}
 
 		for _, filePath := range paths {
-			var fullFilePath = path.Clean(path.Join(name, filePath))
+			fullFilePath := path.Clean(path.Join(name, filePath))
 			// we either have opaque
 			if fullFilePath == actualDataPath {
 				madeLinkToData = true

--- a/lib/fsext/cacheonread.go
+++ b/lib/fsext/cacheonread.go
@@ -30,7 +30,7 @@ import (
 )
 
 // ErrPathNeverRequestedBefore represent an error when path never opened/requested before
-var ErrPathNeverRequestedBefore = errors.New("path nevere requested before")
+var ErrPathNeverRequestedBefore = errors.New("path never requested before")
 
 // CacheOnReadFs is wrapper around afero.CacheOnReadFs with the ability to return the filesystem
 // that is used as cache

--- a/loader/readsource.go
+++ b/loader/readsource.go
@@ -44,7 +44,7 @@ func ReadSource(
 			return nil, err
 		}
 		// TODO: don't do it in this way ...
-		err = afero.WriteFile(filesystems["file"].(fsext.CacheOnReadFs).GetCachingFs(), "/-", data, 0644)
+		err = afero.WriteFile(filesystems["file"].(fsext.CacheLayerGetter).GetCachingFs(), "/-", data, 0o644)
 		if err != nil {
 			return nil, fmt.Errorf("caching data read from -: %w", err)
 		}


### PR DESCRIPTION
Implementing a limitation for the open() that limits opening files
by the list of the files that were opened during the initialization
step (__VU == 0).

For example, a code like:

```js
if (__VU >0) {
   JSON.parse(open("./arr.json"));
}
```

Should return an error.

Closes #1771
