### PR TITLE
goja: bump version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.6.1
 	github.com/Soontao/goHttpDigestClient v0.0.0-20170320082612-6d28bb1415c5
 	github.com/andybalholm/brotli v1.0.3
-	github.com/dop251/goja v0.0.0-20211211112501-fb27c91c26ed
+	github.com/dop251/goja v0.0.0-20220104154337-b93494d0c5d9
 	github.com/fatih/color v1.12.0
 	github.com/golang/protobuf v1.4.3
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -57,8 +57,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 h1:Izz0+t1Z5nI16/II7vuEo/nHjodOg0p7+OiDpjX5t1E=
 github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55kozfMjCc=
-github.com/dop251/goja v0.0.0-20211211112501-fb27c91c26ed h1:93Xt1lY7ReTv+7uDM6UHe818CEvLLn5HE1gpB7d3MS8=
-github.com/dop251/goja v0.0.0-20211211112501-fb27c91c26ed/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
+github.com/dop251/goja v0.0.0-20220104154337-b93494d0c5d9 h1:QYh60R7QllMj/JKMtE2hCrwRqDbQq8vsUD63SDdVpHw=
+github.com/dop251/goja v0.0.0-20220104154337-b93494d0c5d9/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/vendor/github.com/dop251/goja/ast/node.go
+++ b/vendor/github.com/dop251/goja/ast/node.go
@@ -118,6 +118,14 @@ type (
 		Identifier Identifier
 	}
 
+	OptionalChain struct {
+		Expression
+	}
+
+	Optional struct {
+		Expression
+	}
+
 	FunctionLiteral struct {
 		Function      file.Idx
 		Name          *Identifier

--- a/vendor/github.com/dop251/goja/compiler.go
+++ b/vendor/github.com/dop251/goja/compiler.go
@@ -21,6 +21,7 @@ const (
 	blockWith
 	blockScope
 	blockIterScope
+	blockOptChain
 )
 
 const (
@@ -382,6 +383,13 @@ func (p *Program) sourceOffset(pc int) int {
 	}
 
 	return 0
+}
+
+func (p *Program) addSrcMap(srcPos int) {
+	if len(p.srcMap) > 0 && p.srcMap[len(p.srcMap)-1].srcPos == srcPos {
+		return
+	}
+	p.srcMap = append(p.srcMap, srcMapItem{pc: len(p.code), srcPos: srcPos})
 }
 
 func (s *scope) lookupName(name unistring.String) (binding *binding, noDynamics bool) {

--- a/vendor/github.com/dop251/goja/compiler_stmt.go
+++ b/vendor/github.com/dop251/goja/compiler_stmt.go
@@ -202,9 +202,13 @@ func (c *compiler) compileTryStatement(v *ast.TryStatement, needResult bool) {
 	c.leaveBlock()
 }
 
+func (c *compiler) addSrcMap(node ast.Node) {
+	c.p.addSrcMap(int(node.Idx0()) - 1)
+}
+
 func (c *compiler) compileThrowStatement(v *ast.ThrowStatement) {
-	//c.p.srcMap = append(c.p.srcMap, srcMapItem{pc: len(c.p.code), srcPos: int(v.Throw) - 1})
 	c.compileExpression(v.Argument).emitGetter(true)
+	c.addSrcMap(v)
 	c.emit(throw)
 }
 
@@ -752,6 +756,7 @@ func (c *compiler) emitVarAssign(name unistring.String, offset int, init compile
 	if init != nil {
 		c.emitVarRef(name, offset)
 		c.emitNamed(init, name)
+		c.p.addSrcMap(offset)
 		c.emit(initValueP)
 	}
 }
@@ -775,6 +780,7 @@ func (c *compiler) emitLexicalAssign(name unistring.String, offset int, init com
 	}
 	if init != nil {
 		c.emitNamed(init, name)
+		c.p.addSrcMap(offset)
 	} else {
 		if isConst {
 			c.throwSyntaxError(offset, "Missing initializer in const declaration")

--- a/vendor/github.com/dop251/goja/parser/lexer.go
+++ b/vendor/github.com/dop251/goja/parser/lexer.go
@@ -405,7 +405,12 @@ func (self *_parser) scan() (tkn token.Token, literal string, parsedLiteral unis
 			case '~':
 				tkn = token.BITWISE_NOT
 			case '?':
-				tkn = token.QUESTION_MARK
+				if self.chr == '.' && !isDecimalDigit(self._peek()) {
+					self.read()
+					tkn = token.QUESTION_DOT
+				} else {
+					tkn = token.QUESTION_MARK
+				}
 			case '"', '\'':
 				insertSemicolon = true
 				tkn = token.STRING

--- a/vendor/github.com/dop251/goja/parser/statement.go
+++ b/vendor/github.com/dop251/goja/parser/statement.go
@@ -269,6 +269,7 @@ func (self *_parser) parseThrowStatement() ast.Statement {
 	}
 
 	node := &ast.ThrowStatement{
+		Throw:    idx,
 		Argument: self.parseExpression(),
 	}
 

--- a/vendor/github.com/dop251/goja/runtime.go
+++ b/vendor/github.com/dop251/goja/runtime.go
@@ -294,9 +294,20 @@ type uncatchableException struct {
 	err error
 }
 
+func (ue *uncatchableException) Unwrap() error {
+	return ue.err
+}
+
 type InterruptedError struct {
 	Exception
 	iface interface{}
+}
+
+func (e *InterruptedError) Unwrap() error {
+	if err, ok := e.iface.(error); ok {
+		return err
+	}
+	return nil
 }
 
 type StackOverflowError struct {

--- a/vendor/github.com/dop251/goja/token/token_const.go
+++ b/vendor/github.com/dop251/goja/token/token_const.go
@@ -67,6 +67,7 @@ const (
 	SEMICOLON         // ;
 	COLON             // :
 	QUESTION_MARK     // ?
+	QUESTION_DOT      // ?.
 	ARROW             // =>
 	ELLIPSIS          // ...
 	BACKTICK          // `
@@ -174,6 +175,7 @@ var token2string = [...]string{
 	SEMICOLON:                   ";",
 	COLON:                       ":",
 	QUESTION_MARK:               "?",
+	QUESTION_DOT:                "?.",
 	ARROW:                       "=>",
 	ELLIPSIS:                    "...",
 	BACKTICK:                    "`",

--- a/vendor/github.com/dop251/goja/vm.go
+++ b/vendor/github.com/dop251/goja/vm.go
@@ -3340,6 +3340,20 @@ func (j jdefP) exec(vm *vm) {
 	vm.sp--
 }
 
+type jopt int32
+
+func (j jopt) exec(vm *vm) {
+	switch vm.stack[vm.sp-1] {
+	case _null:
+		vm.stack[vm.sp-1] = _undefined
+		fallthrough
+	case _undefined:
+		vm.pc += int(j)
+	default:
+		vm.pc++
+	}
+}
+
 type _not struct{}
 
 var not _not

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -23,7 +23,7 @@ github.com/davecgh/go-spew/spew
 ## explicit
 github.com/dlclark/regexp2
 github.com/dlclark/regexp2/syntax
-# github.com/dop251/goja v0.0.0-20211211112501-fb27c91c26ed
+# github.com/dop251/goja v0.0.0-20220104154337-b93494d0c5d9
 ## explicit; go 1.14
 github.com/dop251/goja
 github.com/dop251/goja/ast


### PR DESCRIPTION
It adds the support for:

* optional chaining
* error wrapping for interrupts

and fixes two issues with source maps

Commands executed:

```sh
$ go get github.com/dop251/goja@master
$ go mod tidy
$ go mod vendor
```

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
