### PR TITLE
Close the underlying ws connections after 50 millseconds

### DIFF
--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -283,9 +283,6 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 	})
 
 	if connErr != nil {
-		// Pass the error to the user script before exiting immediately
-		socket.handleEvent("error", rt.ToValue(connErr))
-
 		return nil, connErr
 	}
 


### PR DESCRIPTION
Previous to this the event loop can be blocked on slow operation
-read/write, and not actually see that the context has been canceled.

With this change the underlying connection will be closed 5 milliseconds
after the context is which circumvents the whole event loop. This also
means that the other side will likely not get CloseMessage and that
`close` or `error` handlers will not be called. The latter of which
would've likely not ran either way given that the goja VM would've also
probably be interrupted.

