### PR TITLE
chore: relax varnamelen linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,22 @@ linters-settings:
   funlen:
     lines: 80
     statements: 60
+  varnamelen:
+    ignore-type-assert-ok: true
+    ignore-map-index-ok: true
+    ignore-chan-recv-ok: true
+    ignore-names:
+      - i
+      - wg
+      - fn
+      - ch
+      - fs
+      - tc
+      - r
+      - w
+      - rw
+      - vu
+      - rt
   goheader:
     template-path: ".license-template"
     values:


### PR DESCRIPTION
Exclude most common short variables from the `varnamelen` linter.

Other possible (count > 5) short variables that can be added to the whitelist:

```bash
$ golangci-lint run | grep "is too short for the scope of its usage" | cut -d' ' -f4 | sort | uniq -c | sort -rn
     50 'tb'
     36 'r1'
     34 'b'
     33 's'
     32 't'
     27 'm'
     27 'et'
     26 'c'
     22 'sr'
     20 'v'
     16 'ok'
     16 'es'
     15 'ts'
     15 'f'
     13 'e'
     12 'k'
     10 'u'
      9 'cm'
      8 'o'
      8 'h'
      7 'mi'
      7 'l'
      6 'p'
      6 'g'
      5 'j'
      5 'd'
```