### PR TITLE
Fix all linter errors in loader package

### DIFF
--- a/loader/cdnjs_test.go
+++ b/loader/cdnjs_test.go
@@ -34,6 +34,7 @@ import (
 
 func TestCDNJS(t *testing.T) {
 	t.Skip("skipped to avoid inconsistent API responses")
+	t.Parallel()
 
 	paths := map[string]struct {
 		parts []string
@@ -69,12 +70,13 @@ func TestCDNJS(t *testing.T) {
 		},
 	}
 
-	var root = &url.URL{Scheme: "https", Host: "example.com", Path: "/something/"}
+	root := &url.URL{Scheme: "https", Host: "example.com", Path: "/something/"}
 	logger := logrus.New()
 	logger.SetOutput(testutils.NewTestOutput(t))
 	for path, expected := range paths {
 		path, expected := path, expected
 		t.Run(path, func(t *testing.T) {
+			t.Parallel()
 			name, loader, parts := pickLoader(path)
 			assert.Equal(t, "cdnjs", name)
 			assert.Equal(t, expected.parts, parts)
@@ -96,6 +98,7 @@ func TestCDNJS(t *testing.T) {
 	}
 
 	t.Run("cdnjs.com/libraries/nonexistent", func(t *testing.T) {
+		t.Parallel()
 		path := "cdnjs.com/libraries/nonexistent"
 		name, loader, parts := pickLoader(path)
 		assert.Equal(t, "cdnjs", name)
@@ -105,6 +108,7 @@ func TestCDNJS(t *testing.T) {
 	})
 
 	t.Run("cdnjs.com/libraries/Faker/3.1.0/nonexistent.js", func(t *testing.T) {
+		t.Parallel()
 		path := "cdnjs.com/libraries/Faker/3.1.0/nonexistent.js"
 		name, loader, parts := pickLoader(path)
 		assert.Equal(t, "cdnjs", name)

--- a/loader/github_test.go
+++ b/loader/github_test.go
@@ -33,6 +33,7 @@ import (
 )
 
 func TestGithub(t *testing.T) {
+	t.Parallel()
 	logger := logrus.New()
 	logger.SetOutput(testutils.NewTestOutput(t))
 	path := "github.com/github/gitignore/Go.gitignore"
@@ -44,12 +45,13 @@ func TestGithub(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEndSrc, src)
 
-	var root = &url.URL{Scheme: "https", Host: "example.com", Path: "/something/"}
+	root := &url.URL{Scheme: "https", Host: "example.com", Path: "/something/"}
 	resolvedURL, err := Resolve(root, path)
 	require.NoError(t, err)
 	require.Empty(t, resolvedURL.Scheme)
 	require.Equal(t, path, resolvedURL.Opaque)
 	t.Run("not cached", func(t *testing.T) {
+		t.Parallel()
 		data, err := Load(logger, map[string]afero.Fs{"https": afero.NewMemMapFs()}, resolvedURL, path)
 		require.NoError(t, err)
 		assert.Equal(t, data.URL, resolvedURL)
@@ -58,10 +60,11 @@ func TestGithub(t *testing.T) {
 	})
 
 	t.Run("cached", func(t *testing.T) {
+		t.Parallel()
 		fs := afero.NewMemMapFs()
 		testData := []byte("test data")
 
-		err := afero.WriteFile(fs, "/github.com/github/gitignore/Go.gitignore", testData, 0644)
+		err := afero.WriteFile(fs, "/github.com/github/gitignore/Go.gitignore", testData, 0o644)
 		require.NoError(t, err)
 
 		data, err := Load(logger, map[string]afero.Fs{"https": fs}, resolvedURL, path)
@@ -71,7 +74,8 @@ func TestGithub(t *testing.T) {
 	})
 
 	t.Run("relative", func(t *testing.T) {
-		var tests = map[string]string{
+		t.Parallel()
+		tests := map[string]string{
 			"./something.else":  "github.com/github/gitignore/something.else",
 			"../something.else": "github.com/github/something.else",
 			"/something.else":   "github.com/something.else",
@@ -84,6 +88,7 @@ func TestGithub(t *testing.T) {
 	})
 
 	t.Run("dir", func(t *testing.T) {
+		t.Parallel()
 		require.Equal(t, &url.URL{Opaque: "github.com/github/gitignore"}, Dir(resolvedURL))
 	})
 }


### PR DESCRIPTION
This removes 67 linter errors, does not (seem) to introduce any races in
the tests and it also seems to not improve their runtime as well :(

The changes were done with the idea of "as little change as possible" so
that there should be no bugs introduced.
