### PR TITLE
HTML package linter fixes

### DIFF
--- a/js/modules/k6/html/element.go
+++ b/js/modules/k6/html/element.go
@@ -449,7 +449,8 @@ func (e Element) NodeValue() goja.Value {
 
 func (e Element) Contains(v goja.Value) bool {
 	if other, ok := v.Export().(Element); ok {
-		// When testing if a node contains itself, jquery's + goquery's version of Contains() return true while the DOM API returns false.
+		// When testing if a node contains itself, jquery's + goquery's version of Contains()
+		// return true while the DOM API returns false.
 		return other.node != e.node && e.sel.sel.Contains(other.node)
 	}
 

--- a/js/modules/k6/html/element_test.go
+++ b/js/modules/k6/html/element_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const testHTMLElem = `
@@ -53,119 +52,166 @@ const testHTMLElem = `
 `
 
 func TestElement(t *testing.T) {
-	t.Parallel()
-	rt, _ := getTestModuleInstance(t)
-	require.NoError(t, rt.Set("src", testHTMLElem))
-
-	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
-
-	require.NoError(t, err)
-	assert.IsType(t, Selection{}, rt.Get("doc").Export())
-
 	t.Run("NodeName", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("#top").get(0).nodeName()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "h1", v.Export())
 		}
 	})
 	t.Run("NodeType", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("#top").get(0).nodeType()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "1", v.String())
 		}
 	})
 	t.Run("NodeValue", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("#top").get(0).firstChild().nodeValue()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "Lorem ipsum", v.String())
 		}
 	})
 	t.Run("InnerHtml", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("span").get(0).innerHTML()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "<b>test content</b>", v.String())
 		}
 	})
 	t.Run("TextContent", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("b").get(0).textContent()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "test content", v.String())
 		}
 	})
 	t.Run("OwnerDocument", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("body").get(0).ownerDocument().nodeName()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "#document", v.String())
 		}
 	})
 	t.Run("Attributes", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).attributes()`)
 		if assert.NoError(t, err) {
-			attrs := v.Export().(map[string]Attribute)
+			attrs, ok := v.Export().(map[string]Attribute)
+
+			assert.True(t, ok)
 			assert.Equal(t, "div_elem", attrs["id"].Value)
 		}
 	})
 	t.Run("FirstChild", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).firstChild().nodeValue()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "innerfirst")
 		}
 	})
 	t.Run("LastChild", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).lastChild().nodeValue()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "innerlast")
 		}
 	})
 	t.Run("ChildElementCount", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("body").get(0).childElementCount()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, int64(6), v.Export())
 		}
 	})
 	t.Run("FirstElementChild", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).firstElementChild().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "Nullam id nisi ")
 		}
 	})
 	t.Run("LastElementChild", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).lastElementChild().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "Maecenas augue ligula")
 		}
 	})
 	t.Run("PreviousSibling", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).previousSibling().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "pretext")
 		}
 	})
 	t.Run("NextSibling", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).nextSibling().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "aftertext")
 		}
 	})
 	t.Run("PreviousElementSibling", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).previousElementSibling().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "consectetur adipiscing elit")
 		}
 	})
 	t.Run("NextElementSibling", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).nextElementSibling().textContent()`)
 		if assert.NoError(t, err) {
 			assert.Contains(t, v.Export(), "This is the footer.")
 		}
 	})
 	t.Run("ParentElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).parentElement().nodeName()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "body", v.String())
 		}
 	})
 	t.Run("ParentNode", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		nodeVal, err1 := rt.RunString(`doc.find("html").get(0).parentNode().nodeName()`)
 		nilVal, err2 := rt.RunString(`doc.find("html").get(0).parentElement()`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
@@ -174,44 +220,68 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("ChildNodes", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).childNodes()`)
 		if assert.NoError(t, err) {
-			nodes := v.Export().([]goja.Value)
+			nodes, ok := v.Export().([]goja.Value)
+
+			assert.True(t, ok)
 			assert.Equal(t, 9, len(nodes))
 			assert.Contains(t, nodes[0].Export().(Element).TextContent(), "innerfirst")
 			assert.Contains(t, nodes[8].Export().(Element).TextContent(), "innerlast")
 		}
 	})
 	t.Run("Children", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).children()`)
 		if assert.NoError(t, err) {
-			nodes := v.Export().([]goja.Value)
+			nodes, ok := v.Export().([]goja.Value)
+
+			assert.True(t, ok)
 			assert.Equal(t, 4, len(nodes))
 			assert.Contains(t, nodes[0].Export().(Element).TextContent(), "Nullam id nisi eget ex")
 			assert.Contains(t, nodes[3].Export().(Element).TextContent(), "Maecenas augue ligula")
 		}
 	})
 	t.Run("ClassList", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).classList()`)
 		if assert.NoError(t, err) {
-			clsNames := v.Export().([]string)
+			clsNames, ok := v.Export().([]string)
+
+			assert.True(t, ok)
 			assert.Equal(t, 2, len(clsNames))
 			assert.Equal(t, []string{"class1", "class2"}, clsNames)
 		}
 	})
 	t.Run("ClassName", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).className()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "class1 class2", v.String())
 		}
 	})
 	t.Run("Lang", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).lang()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "en", v.String())
 		}
 	})
 	t.Run("ToString", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v1, err1 := rt.RunString(`doc.find("div").get(0).toString()`)
 		v2, err2 := rt.RunString(`doc.find("div").get(0).previousSibling().toString()`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
@@ -220,6 +290,9 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("HasAttribute", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v1, err1 := rt.RunString(`doc.find("div").get(0).hasAttribute("id")`)
 		v2, err2 := rt.RunString(`doc.find("div").get(0).hasAttribute("noattr")`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
@@ -228,18 +301,27 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("GetAttribute", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).getAttribute("id")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "div_elem", v.Export())
 		}
 	})
 	t.Run("GetAttributeNode", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).getAttributeNode("id")`)
 		if assert.NoError(t, err) && assert.IsType(t, Attribute{}, v.Export()) {
 			assert.Equal(t, "div_elem", v.Export().(Attribute).Value)
 		}
 	})
 	t.Run("HasAttributes", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v1, err1 := rt.RunString(`doc.find("h1").get(0).hasAttributes()`)
 		v2, err2 := rt.RunString(`doc.find("footer").get(0).hasAttributes()`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
@@ -248,6 +330,9 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("HasChildNodes", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v1, err1 := rt.RunString(`doc.find("p").get(0).hasChildNodes()`)
 		v2, err2 := rt.RunString(`doc.find("empty").get(0).hasChildNodes()`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
@@ -256,6 +341,9 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("IsSameNode", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v1, err1 := rt.RunString(`doc.find("p").get(0).isSameNode(doc.find("p").get(1))`)
 		v2, err2 := rt.RunString(`doc.find("p").get(0).isSameNode(doc.find("p").get(0))`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
@@ -264,6 +352,9 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("IsEqualNode", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v1, err1 := rt.RunString(`doc.find("p").get(0).isEqualNode(doc.find("p").get(1))`)
 		v2, err2 := rt.RunString(`doc.find("p").get(0).isEqualNode(doc.find("p").get(0))`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
@@ -272,35 +363,57 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("GetElementsByClassName", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("body").get(0).getElementsByClassName("class2")`)
 		if assert.NoError(t, err) {
-			elems := v.Export().([]goja.Value)
+			elems, ok := v.Export().([]goja.Value)
+
+			assert.True(t, ok)
 			assert.Equal(t, "div_elem", elems[0].Export().(Element).Id())
 			assert.Equal(t, "h2_elem", elems[1].Export().(Element).Id())
 		}
 	})
 	t.Run("GetElementsByTagName", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("body").get(0).getElementsByTagName("span")`)
 		if assert.NoError(t, err) {
-			elems := v.Export().([]goja.Value)
+			elems, ok := v.Export().([]goja.Value)
+
+			assert.True(t, ok)
 			assert.Equal(t, 2, len(elems))
 		}
 	})
 	t.Run("QuerySelector", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("body").get(0).querySelector("#div_elem").id()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "div_elem", v.Export())
 		}
 	})
 	t.Run("QuerySelectorAll", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("body").get(0).querySelectorAll("span")`)
 		if assert.NoError(t, err) {
-			elems := v.Export().([]goja.Value)
+			elems, ok := v.Export().([]goja.Value)
+
+			assert.True(t, ok)
+			assert.Len(t, elems, 2)
 			assert.Equal(t, "span1", elems[0].Export().(Element).Id())
 			assert.Equal(t, "span2", elems[1].Export().(Element).Id())
 		}
 	})
 	t.Run("Contains", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v1, err1 := rt.RunString(`doc.find("html").get(0).contains(doc.find("body").get(0))`)
 		v2, err2 := rt.RunString(`doc.find("body").get(0).contains(doc.find("body").get(0))`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
@@ -309,18 +422,27 @@ func TestElement(t *testing.T) {
 		}
 	})
 	t.Run("Matches", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("div").get(0).matches("#div_elem")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, true, v.Export())
 		}
 	})
 	t.Run("NamespaceURI", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v, err := rt.RunString(`doc.find("#svg_elem").get(0).namespaceURI()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "http://www.w3.org/2000/svg", v.Export())
 		}
 	})
 	t.Run("IsDefaultNamespace", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElem)
+
 		v1, err1 := rt.RunString(`doc.find("#svg_elem").get(0).isDefaultNamespace()`)
 		v2, err2 := rt.RunString(`doc.find("#div_elem").get(0).isDefaultNamespace()`)
 		if assert.NoError(t, err1) && assert.NoError(t, err2) {
@@ -328,5 +450,4 @@ func TestElement(t *testing.T) {
 			assert.Equal(t, true, v2.ToBoolean())
 		}
 	})
-
 }

--- a/js/modules/k6/html/elements.go
+++ b/js/modules/k6/html/elements.go
@@ -95,64 +95,72 @@ const (
 	methodGet  = "get"
 )
 
-type HrefElement struct{ Element }
-type MediaElement struct{ Element }
-type FormFieldElement struct{ Element }
-type ModElement struct{ Element }
-type TableSectionElement struct{ Element }
-type TableCellElement struct{ Element }
+//revive:disable:exported
 
-type AnchorElement struct{ HrefElement }
-type AreaElement struct{ HrefElement }
-type AudioElement struct{ MediaElement }
-type BaseElement struct{ Element }
-type ButtonElement struct{ FormFieldElement }
-type CanvasElement struct{ Element }
-type DataElement struct{ Element }
-type DataListElement struct{ Element }
-type DelElement struct{ ModElement }
-type InsElement struct{ ModElement }
-type EmbedElement struct{ Element }
-type FieldSetElement struct{ Element }
-type FormElement struct{ Element }
-type IFrameElement struct{ Element }
-type ImageElement struct{ Element }
-type InputElement struct{ FormFieldElement }
-type KeygenElement struct{ Element }
-type LabelElement struct{ Element }
-type LegendElement struct{ Element }
-type LiElement struct{ Element }
-type LinkElement struct{ Element }
-type MapElement struct{ Element }
-type MetaElement struct{ Element }
-type MeterElement struct{ Element }
-type ObjectElement struct{ Element }
-type OListElement struct{ Element }
-type OptGroupElement struct{ Element }
-type OptionElement struct{ Element }
-type OutputElement struct{ Element }
-type ParamElement struct{ Element }
-type PreElement struct{ Element }
-type ProgressElement struct{ Element }
-type QuoteElement struct{ Element }
-type ScriptElement struct{ Element }
-type SelectElement struct{ Element }
-type SourceElement struct{ Element }
-type StyleElement struct{ Element }
-type TableElement struct{ Element }
-type TableHeadElement struct{ TableSectionElement }
-type TableFootElement struct{ TableSectionElement }
-type TableBodyElement struct{ TableSectionElement }
-type TableRowElement struct{ Element }
-type TableColElement struct{ Element }
-type TableDataCellElement struct{ TableCellElement }
-type TableHeaderCellElement struct{ TableCellElement }
-type TextAreaElement struct{ Element }
-type TimeElement struct{ Element }
-type TitleElement struct{ Element }
-type TrackElement struct{ Element }
-type UListElement struct{ Element }
-type VideoElement struct{ MediaElement }
+type (
+	HrefElement         struct{ Element }
+	MediaElement        struct{ Element }
+	FormFieldElement    struct{ Element }
+	ModElement          struct{ Element }
+	TableSectionElement struct{ Element }
+	TableCellElement    struct{ Element }
+)
+
+type (
+	AnchorElement          struct{ HrefElement }
+	AreaElement            struct{ HrefElement }
+	AudioElement           struct{ MediaElement }
+	BaseElement            struct{ Element }
+	ButtonElement          struct{ FormFieldElement }
+	CanvasElement          struct{ Element }
+	DataElement            struct{ Element }
+	DataListElement        struct{ Element }
+	DelElement             struct{ ModElement }
+	InsElement             struct{ ModElement }
+	EmbedElement           struct{ Element }
+	FieldSetElement        struct{ Element }
+	FormElement            struct{ Element }
+	IFrameElement          struct{ Element }
+	ImageElement           struct{ Element }
+	InputElement           struct{ FormFieldElement }
+	KeygenElement          struct{ Element }
+	LabelElement           struct{ Element }
+	LegendElement          struct{ Element }
+	LiElement              struct{ Element }
+	LinkElement            struct{ Element }
+	MapElement             struct{ Element }
+	MetaElement            struct{ Element }
+	MeterElement           struct{ Element }
+	ObjectElement          struct{ Element }
+	OListElement           struct{ Element }
+	OptGroupElement        struct{ Element }
+	OptionElement          struct{ Element }
+	OutputElement          struct{ Element }
+	ParamElement           struct{ Element }
+	PreElement             struct{ Element }
+	ProgressElement        struct{ Element }
+	QuoteElement           struct{ Element }
+	ScriptElement          struct{ Element }
+	SelectElement          struct{ Element }
+	SourceElement          struct{ Element }
+	StyleElement           struct{ Element }
+	TableElement           struct{ Element }
+	TableHeadElement       struct{ TableSectionElement }
+	TableFootElement       struct{ TableSectionElement }
+	TableBodyElement       struct{ TableSectionElement }
+	TableRowElement        struct{ Element }
+	TableColElement        struct{ Element }
+	TableDataCellElement   struct{ TableCellElement }
+	TableHeaderCellElement struct{ TableCellElement }
+	TextAreaElement        struct{ Element }
+	TimeElement            struct{ Element }
+	TitleElement           struct{ Element }
+	TrackElement           struct{ Element }
+	UListElement           struct{ Element }
+	VideoElement           struct{ MediaElement }
+)
+
+//revive:enable:exported
 
 func (h HrefElement) hrefURL() *url.URL {
 	href, exists := h.attrAsURL("href")

--- a/js/modules/k6/html/elements_gen_test.go
+++ b/js/modules/k6/html/elements_gen_test.go
@@ -22,9 +22,6 @@ package html
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 var textTests = []struct {
@@ -402,15 +399,11 @@ const testGenElems = `<html><body>
 
 func TestGenElements(t *testing.T) {
 	t.Parallel()
-	rt, mi := getTestModuleInstance(t)
-	require.NoError(t, rt.Set("src", testGenElems))
-
-	_, err := rt.RunString("var doc = html.parseHTML(src)")
-
-	require.NoError(t, err)
-	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("Test text properties", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testGenElems)
+
 		for _, test := range textTests {
 			v, err := rt.RunString(`doc.find("#` + test.id + `").get(0).` + test.property + `()`)
 			if err != nil {
@@ -422,6 +415,9 @@ func TestGenElements(t *testing.T) {
 	})
 
 	t.Run("Test bool properties", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testGenElems)
+
 		for _, test := range boolTests {
 			vT, errT := rt.RunString(`doc.find("#` + test.idTrue + `").get(0).` + test.property + `()`)
 			if errT != nil {
@@ -440,6 +436,9 @@ func TestGenElements(t *testing.T) {
 	})
 
 	t.Run("Test int64 properties", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testGenElems)
+
 		for _, test := range intTests {
 			v, err := rt.RunString(`doc.find("#` + test.id + `").get(0).` + test.property + `()`)
 			if err != nil {
@@ -451,6 +450,9 @@ func TestGenElements(t *testing.T) {
 	})
 
 	t.Run("Test nullable properties", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testGenElems)
+
 		for _, test := range nullTests {
 			v, err := rt.RunString(`doc.find("#` + test.id + `").get(0).` + test.property + `()`)
 			if err != nil {
@@ -462,6 +464,9 @@ func TestGenElements(t *testing.T) {
 	})
 
 	t.Run("Test url properties", func(t *testing.T) {
+		t.Parallel()
+		rt, mi := getTestRuntimeAndModuleInstanceWithDoc(t, testGenElems)
+
 		sel, parseError := mi.parseHTML(testGenElems)
 		if parseError != nil {
 			t.Errorf("Unable to parse html")

--- a/js/modules/k6/html/elements_test.go
+++ b/js/modules/k6/html/elements_test.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const testHTMLElems = `
@@ -85,16 +84,13 @@ const testHTMLElems = `
 
 func TestElements(t *testing.T) {
 	t.Parallel()
-	rt, _ := getTestModuleInstance(t)
-	require.NoError(t, rt.Set("src", testHTMLElems))
-
-	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
-
-	require.NoError(t, err)
-	assert.IsType(t, Selection{}, rt.Get("doc").Export())
-
 	t.Run("AnchorElement", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("Hash", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(0).hash()`); assert.NoError(t, err) {
 				assert.Equal(t, "#hashtext", v.Export())
 			}
@@ -103,6 +99,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("Host", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(1).host()`); assert.NoError(t, err) {
 				assert.Equal(t, "example.com", v.Export())
 			}
@@ -120,6 +119,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("Hostname", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(1).hostname()`); assert.NoError(t, err) {
 				assert.Equal(t, "example.com", v.Export())
 			}
@@ -128,6 +130,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("Port", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(5).port()`); assert.NoError(t, err) {
 				assert.Equal(t, "80", v.Export())
 			}
@@ -136,6 +141,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("Username", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(5).username()`); assert.NoError(t, err) {
 				assert.Equal(t, "username", v.Export())
 			}
@@ -144,6 +152,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("Password", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(5).password()`); assert.NoError(t, err) {
 				assert.Equal(t, "password", v.Export())
 			}
@@ -152,6 +163,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("Origin", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(5).origin()`); assert.NoError(t, err) {
 				assert.Equal(t, "http://example.com:80", v.Export())
 			}
@@ -160,6 +174,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("Pathname", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(1).pathname()`); assert.NoError(t, err) {
 				assert.Equal(t, "", v.Export())
 			}
@@ -171,6 +188,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("Protocol", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(4).protocol()`); assert.NoError(t, err) {
 				assert.Equal(t, "https", v.Export())
 			}
@@ -179,6 +199,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("RelList", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(6).relList()`); assert.NoError(t, err) {
 				assert.Equal(t, []string{"prev", "next"}, v.Export())
 			}
@@ -187,23 +210,37 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("Search", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(0).search()`); assert.NoError(t, err) {
 				assert.Equal(t, "?querytxt", v.Export())
 			}
 		})
 		t.Run("Text", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("a").get(6).text()`); assert.NoError(t, err) {
 				assert.Equal(t, "6", v.Export())
 			}
 		})
 	})
 	t.Run("AreaElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		if v, err := rt.RunString(`doc.find("area").get(0).toString()`); assert.NoError(t, err) {
 			assert.Equal(t, "web.address.com", v.Export())
 		}
 	})
 	t.Run("ButtonElement", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("form", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("#form_btn").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "form1", v.Export())
 			}
@@ -215,6 +252,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("formaction", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("#form_btn").get(0).formAction()`); assert.NoError(t, err) {
 				assert.Equal(t, "action_url", v.Export())
 			}
@@ -223,6 +263,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("formenctype", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("#form_btn").get(0).formEnctype()`); assert.NoError(t, err) {
 				assert.Equal(t, "text/plain", v.Export())
 			}
@@ -231,6 +274,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("formmethod", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("#form_btn").get(0).formMethod()`); assert.NoError(t, err) {
 				assert.Equal(t, "get", v.Export())
 			}
@@ -239,6 +285,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("formnovalidate", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("#form_btn").get(0).formNoValidate()`); assert.NoError(t, err) {
 				assert.Equal(t, false, v.Export())
 			}
@@ -247,6 +296,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("formtarget", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("#form_btn").get(0).formTarget()`); assert.NoError(t, err) {
 				assert.Equal(t, "_self", v.Export())
 			}
@@ -255,6 +307,9 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("labels", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("#form_btn").get(0).labels()`); assert.NoError(t, err) {
 				assert.Equal(t, 1, len(v.Export().([]goja.Value)))
 				assert.Equal(t, "form_btn_label", v.Export().([]goja.Value)[0].Export().(LabelElement).Id())
@@ -266,29 +321,46 @@ func TestElements(t *testing.T) {
 			}
 		})
 		t.Run("name", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("#form_btn").get(0).name()`); assert.NoError(t, err) {
 				assert.Equal(t, "form_btn", v.Export())
 			}
 		})
 		t.Run("value", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("#form_btn_2").get(0).value()`); assert.NoError(t, err) {
 				assert.Equal(t, "form_btn_2_initval", v.Export())
 			}
 		})
 	})
 	t.Run("CanvasElement", func(t *testing.T) {
+		t.Parallel()
+
 		t.Run("width", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("canvas").get(0).width()`); assert.NoError(t, err) {
 				assert.Equal(t, int64(200), v.Export())
 			}
 		})
 		t.Run("height", func(t *testing.T) {
+			t.Parallel()
+			rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 			if v, err := rt.RunString(`doc.find("canvas").get(0).height()`); assert.NoError(t, err) {
 				assert.Equal(t, int64(150), v.Export())
 			}
 		})
 	})
 	t.Run("DataListElement options", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		if v, err := rt.RunString(`doc.find("datalist").get(0).options()`); assert.NoError(t, err) {
 			assert.Equal(t, 2, len(v.Export().([]goja.Value)))
 			assert.Equal(t, "dl_opt_1", v.Export().([]goja.Value)[0].Export().(OptionElement).Id())
@@ -296,6 +368,9 @@ func TestElements(t *testing.T) {
 		}
 	})
 	t.Run("FieldSetElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("elements", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("fieldset").get(0).elements()`); assert.NoError(t, err) {
 				assert.Equal(t, 5, len(v.Export().([]goja.Value)))
@@ -313,6 +388,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("FormElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("elements", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("#fieldset_form").get(0).elements()`); assert.NoError(t, err) {
 				assert.Equal(t, 6, len(v.Export().([]goja.Value)))
@@ -333,6 +411,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("InputElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("form", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("#test_dl_input").get(0).list().options()`); assert.NoError(t, err) {
 				assert.Equal(t, 2, len(v.Export().([]goja.Value)))
@@ -340,6 +421,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("LabelElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("control", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("#form_btn_2_label").get(0).control().value()`); assert.NoError(t, err) {
 				assert.Equal(t, "form_btn_2_initval", v.Export())
@@ -352,6 +436,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("LegendElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("form", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("#legend_1").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "fieldset_form", v.Export())
@@ -359,6 +446,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("LinkElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("rel list", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("link").get(0).relList()`); assert.NoError(t, err) {
 				assert.Equal(t, []string{"alternate", "next"}, v.Export())
@@ -366,6 +456,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("MapElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("areas", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("#find_this_map").get(0).areas()`); assert.NoError(t, err) {
 				assert.Equal(t, 3, len(v.Export().([]goja.Value)))
@@ -378,6 +471,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("ObjectElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("form", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("#obj_1").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "form1", v.Export())
@@ -385,6 +481,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("OptionElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("disabled", func(t *testing.T) {
 			v1, err1 := rt.RunString(`doc.find("#opt_1").get(0).disabled()`)
 			v2, err2 := rt.RunString(`doc.find("#opt_2").get(0).disabled()`)
@@ -431,6 +530,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("OutputElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("value", func(t *testing.T) {
 			v1, err1 := rt.RunString(`doc.find("#output1").get(0).value()`)
 			v2, err2 := rt.RunString(`doc.find("#output1").get(0).defaultValue()`)
@@ -446,6 +548,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("ProgressElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("max", func(t *testing.T) {
 			v1, err1 := rt.RunString(`doc.find("#progress1").get(0).max()`)
 			v2, err2 := rt.RunString(`doc.find("#progress2").get(0).max()`)
@@ -472,6 +577,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("ScriptElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("text", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("#script1").get(0).text()`); assert.NoError(t, err) {
 				assert.Equal(t, "script text", v.Export())
@@ -479,6 +587,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("SelectElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("form", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("#sel2").get(0).form().id()`); assert.NoError(t, err) {
 				assert.Equal(t, "form3", v.Export())
@@ -516,6 +627,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("StyleElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("text", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("#style1").get(0).type()`); assert.NoError(t, err) {
 				assert.Equal(t, "text/css", v.Export())
@@ -523,6 +637,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("TableElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("caption", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("table").get(0).caption().textContent()`); assert.NoError(t, err) {
 				assert.Equal(t, "caption text", v.Export())
@@ -617,6 +734,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("VideoElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("text tracks", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("#video1").get(0).textTracks()`); assert.NoError(t, err) {
 				assert.Equal(t, 2, len(v.Export().([]goja.Value)))
@@ -626,6 +746,9 @@ func TestElements(t *testing.T) {
 		})
 	})
 	t.Run("TitleElement", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTMLElems)
+
 		t.Run("text tracks", func(t *testing.T) {
 			if v, err := rt.RunString(`doc.find("title").get(0).text()`); assert.NoError(t, err) {
 				assert.Equal(t, "titletest", v.Export())

--- a/js/modules/k6/html/html_test.go
+++ b/js/modules/k6/html/html_test.go
@@ -90,21 +90,35 @@ func getTestModuleInstance(t testing.TB) (*goja.Runtime, *ModuleInstance) {
 	return rt, mi
 }
 
-// TODO: split apart?
-// nolint: cyclop, tparallel
+func getTestRuntimeAndModuleInstanceWithDoc(t testing.TB, html string) (*goja.Runtime, *ModuleInstance) {
+	t.Helper()
+
+	rt, mi := getTestModuleInstance(t)
+	require.NoError(t, rt.Set("src", html))
+
+	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
+
+	require.NoError(t, err)
+	require.IsType(t, Selection{}, rt.Get("doc").Export())
+
+	return rt, mi
+}
+
+func getTestRuntimeWithDoc(t testing.TB, html string) *goja.Runtime {
+	t.Helper()
+
+	rt, _ := getTestRuntimeAndModuleInstanceWithDoc(t, html)
+
+	return rt
+}
+
 func TestParseHTML(t *testing.T) {
 	t.Parallel()
-	rt, _ := getTestModuleInstance(t)
-	require.NoError(t, rt.Set("src", testHTML))
-
-	// TODO: I literally cannot think of a snippet that makes goquery error.
-	// I'm not sure if it's even possible without like, an invalid reader or something, which would
-	// be impossible to cause from the JS side.
-	_, err := rt.RunString(`var doc = html.parseHTML(src)`)
-	require.NoError(t, err)
-	assert.IsType(t, Selection{}, rt.Get("doc").Export())
 
 	t.Run("Find", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("h1")`)
 		if assert.NoError(t, err) && assert.IsType(t, Selection{}, v.Export()) {
 			sel := v.Export().(Selection).sel
@@ -113,6 +127,9 @@ func TestParseHTML(t *testing.T) {
 		}
 	})
 	t.Run("Add", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("Selector", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("h1").add("footer")`)
 			if assert.NoError(t, err) && assert.IsType(t, Selection{}, v.Export()) {
@@ -131,12 +148,18 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Text", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("h1").text()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "Lorem ipsum", v.Export())
 		}
 	})
 	t.Run("Attr", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("h1").attr("id")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "top", v.Export())
@@ -162,12 +185,18 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Html", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("h1").html()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "Lorem ipsum", v.Export())
 		}
 	})
 	t.Run("Val", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("Input", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("#text_input").val()`)
 			if assert.NoError(t, err) {
@@ -209,6 +238,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Children", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("All", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("head").children()`)
 			if assert.NoError(t, err) {
@@ -227,12 +259,18 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Closest", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("textarea").closest("form").attr("id")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "form1", v.Export())
 		}
 	})
 	t.Run("Contents", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("head").contents()`)
 		if assert.NoError(t, err) {
 			sel := v.Export().(Selection).sel
@@ -241,6 +279,9 @@ func TestParseHTML(t *testing.T) {
 		}
 	})
 	t.Run("Each", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("Func arg", func(t *testing.T) {
 			v, err := rt.RunString(`{ var elems = []; doc.find("#select_multi option").each(function(idx, elem) { elems[idx] = elem.innerHTML(); }); elems }`)
 			var elems []string
@@ -259,6 +300,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Is", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("String selector", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("h1").is("h1")`)
 			if assert.NoError(t, err) {
@@ -279,6 +323,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Filter", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("String", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("body").children().filter("p")`)
 			if assert.NoError(t, err) {
@@ -302,6 +349,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("End", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("body").children().filter("p").end()`)
 		if assert.NoError(t, err) {
 			sel := v.Export().(Selection).sel
@@ -309,24 +359,36 @@ func TestParseHTML(t *testing.T) {
 		}
 	})
 	t.Run("Eq", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("body").children().eq(3).attr("id")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "form1", v.Export())
 		}
 	})
 	t.Run("First", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("body").children().first().attr("id")`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "top", v.Export())
 		}
 	})
 	t.Run("Last", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("body").children().last().text()`)
 		if assert.NoError(t, err) {
 			assert.Equal(t, "This is the footer.", v.Export())
 		}
 	})
 	t.Run("Has", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("String selector", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("body").children().has("input").size()`)
 			if assert.NoError(t, err) {
@@ -341,10 +403,14 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Map", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("Valid", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("#select_multi option").map(function(idx, val) { return val.text() })`)
 			if assert.NoError(t, err) {
-				mapped := v.Export().([]string)
+				mapped, ok := v.Export().([]string)
+				assert.True(t, ok)
 				assert.Equal(t, 3, len(mapped))
 				assert.Equal(t, []string{"option 1", "option 2", "option 3"}, mapped)
 			}
@@ -359,13 +425,17 @@ func TestParseHTML(t *testing.T) {
 		t.Run("Map with attr must return string", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("#select_multi").map(function(idx, val) { return val.attr("name") })`)
 			if assert.NoError(t, err) {
-				mapped := v.Export().([]string)
+				mapped, ok := v.Export().([]string)
+				assert.True(t, ok)
 				assert.Equal(t, 1, len(mapped))
 				assert.Equal(t, []string{"select_multi"}, mapped)
 			}
 		})
 	})
 	t.Run("Next", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("No arg", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("h1").next()`)
 			if assert.NoError(t, err) {
@@ -383,6 +453,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("NextAll", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("No arg", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("h1").nextAll()`)
 			if assert.NoError(t, err) {
@@ -399,6 +472,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Prev", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("No arg", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("footer").prev()`)
 			if assert.NoError(t, err) {
@@ -415,6 +491,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("PrevAll", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("No arg", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("form").prevAll()`)
 			if assert.NoError(t, err) {
@@ -431,6 +510,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("PrevUntil", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("String", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("footer").prevUntil("h1").size()`)
 			if assert.NoError(t, err) {
@@ -469,6 +551,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("NextUntil", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("String", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("h1").nextUntil("footer").size()`)
 			if assert.NoError(t, err) {
@@ -507,6 +592,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Parent", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("No filter", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("textarea").parent().attr("id")`)
 			if assert.NoError(t, err) {
@@ -521,6 +609,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Parents", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("No filter", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("textarea").parents().size()`)
 			if assert.NoError(t, err) {
@@ -535,6 +626,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("ParentsUntil", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("String", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("textarea").parentsUntil("html").size()`)
 			if assert.NoError(t, err) {
@@ -573,6 +667,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Not", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("String selector", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("body").children().not("p").size()`)
 			if assert.NoError(t, err) {
@@ -593,6 +690,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Siblings", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("No filter", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("form").siblings().size()`)
 			if assert.NoError(t, err) {
@@ -607,6 +707,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Slice", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("No filter", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("body").children().slice(1, 2)`)
 			if assert.NoError(t, err) {
@@ -626,11 +729,15 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Get", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("No args", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("body").children().get()`)
 			if assert.NoError(t, err) {
-				elems := v.Export().([]goja.Value)
+				elems, ok := v.Export().([]goja.Value)
 
+				assert.True(t, ok)
 				assert.Equal(t, "h1", elems[0].Export().(Element).NodeName())
 				assert.Equal(t, "p", elems[1].Export().(Element).NodeName())
 				assert.Equal(t, "footer", elems[4].Export().(Element).NodeName())
@@ -652,9 +759,14 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("ToArray", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		v, err := rt.RunString(`doc.find("p").toArray()`)
 		if assert.NoError(t, err) {
-			arr := v.Export().([]Selection)
+			arr, ok := v.Export().([]Selection)
+
+			assert.True(t, ok)
 			assert.Equal(t, 2, len(arr))
 			assert.Equal(t, 1, arr[0].sel.Length())
 			assert.Equal(t, 1, arr[1].sel.Length())
@@ -663,6 +775,9 @@ func TestParseHTML(t *testing.T) {
 		}
 	})
 	t.Run("Index", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("No args", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("p").index()`)
 			if assert.NoError(t, err) {
@@ -683,6 +798,9 @@ func TestParseHTML(t *testing.T) {
 		})
 	})
 	t.Run("Data <h1>", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("string attr", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("h1").data("test")`)
 			if assert.NoError(t, err) {
@@ -716,13 +834,18 @@ func TestParseHTML(t *testing.T) {
 		t.Run("dataset", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("h1").data()`)
 			if assert.NoError(t, err) {
-				data := v.Export().(map[string]interface{})
+				data, ok := v.Export().(map[string]interface{})
+
+				assert.True(t, ok)
 				assert.Equal(t, "dataval", data["test"])
 				assert.Equal(t, float64(123), data["numA"])
 			}
 		})
 	})
 	t.Run("Data <p>", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
 		t.Run("boolean attr", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("p").data("test-b")`)
 			if assert.NoError(t, err) {


### PR DESCRIPTION
Fix some linter issues of the HTML package.

This PR is fixing ~340 linter issues.

```bash
golangci-lint run --print-issued-lines=false --out-format tab | sort | uniq | wc -l
1561
```

I'd like from time to time to fix existing linter issues.