### PR TITLE
Disable sourcemaps support in babel if input is big

### DIFF
--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -149,7 +149,7 @@ func (c *Compiler) Transform(src, filename string, inputSrcMap []byte) (code str
 	if sourceMapEnabled && len(src) > maxSrcLenForBabelSourceMap {
 		sourceMapEnabled = false
 		c.logger.Warnf("the source for `%s` needs to go through babel but is over %d bytes. "+
-			"For performance reasons sourcemaps support will be disabled for this particular file.",
+			"For performance reasons source map support will be disabled for this particular file.",
 			filename, maxSrcLenForBabelSourceMap)
 	}
 

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -137,7 +137,7 @@ func (c *Compiler) Transform(src, filename string, inputSrcMap []byte) (code str
 		// TODO: drop this code and everything it's connected to when babel is dropped
 		v := os.Getenv(maxSrcLenForBabelSourceMapVarName)
 		if len(v) > 0 {
-			i, err := strconv.Atoi(v)
+			i, err := strconv.Atoi(v) //nolint:govet // we shadow err on purpose
 			if err != nil {
 				c.logger.Warnf("Tried to parse %q from %s as integer but couldn't %s\n",
 					v, maxSrcLenForBabelSourceMapVarName, err)

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -148,7 +148,7 @@ func (c *Compiler) Transform(src, filename string, inputSrcMap []byte) (code str
 	})
 	if sourceMapEnabled && len(src) > maxSrcLenForBabelSourceMap {
 		sourceMapEnabled = false
-		c.logger.Warnf("the source for `%s` needs to go through babel but is over %d bytes. "+
+		c.logger.Warnf("The source for `%s` needs to go through babel but is over %d bytes. "+
 			"For performance reasons source map support will be disabled for this particular file.",
 			filename, maxSrcLenForBabelSourceMap)
 	}

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -42,7 +42,7 @@ var maxSrcLenForBabelSourceMap = 250 * 1024
 
 const maxSrcLenForBabelSourceMapVarName = "K6_DEBUG_SOURCEMAP_FILESIZE_LIMIT"
 
-//  drop this code and everything it's connected to when goja is dropped
+// TODO: drop this code and everything it's connected to when babel is dropped
 func init() {
 	v := os.Getenv(maxSrcLenForBabelSourceMapVarName)
 	if len(v) > 0 {


### PR DESCRIPTION
This prevents babel from using up a lot of memory (3.5x as much as
before source maps) on really big inputs.
