### PR TITLE
Try to load and parse the sourcemap before returning it

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 // indirect
 	github.com/gedex/inflector v0.0.0-20170307190818-16278e9db813 // indirect
-	github.com/go-sourcemap/sourcemap v2.1.4-0.20211119122758-180fcef48034+incompatible // indirect
+	github.com/go-sourcemap/sourcemap v2.1.4-0.20211119122758-180fcef48034+incompatible
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/mstoykov/envconfig v1.4.1-0.20220114105314-765c6d8c76f1

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -157,7 +157,7 @@ func (c *Compiler) Transform(src, filename string, inputSrcMap []byte) (code str
 
 	// check that babel will likely be able to parse the inputSrcMap
 	if sourceMapEnabled && len(inputSrcMap) != 0 {
-		if err := verifySourceMapForBabel(inputSrcMap); err != nil {
+		if err = verifySourceMapForBabel(inputSrcMap); err != nil {
 			sourceMapEnabled = false
 			inputSrcMap = nil
 			c.logger.WithError(err).Warnf(
@@ -421,25 +421,19 @@ func verifySourceMapForBabel(srcMap []byte) error {
 	if err != nil {
 		return fmt.Errorf("source map is not valid json: %w", err)
 	}
-	if v, ok := m["version"]; !ok {
+	// there are no checks on it's value in babel
+	// we technically only support v3 though
+	if _, ok := m["version"]; !ok {
 		return fmt.Errorf("source map missing required 'version' field")
-	} else {
-		// there are no checks on it's value in babel
-		// we technically only support v3 though
-		_ = v
 	}
 
-	// This actually gets checked by the go implementation
-	if v, ok := m["mappings"]; !ok {
+	// This actually gets checked by the go implementation so it's not really necessary
+	if _, ok := m["mappings"]; !ok {
 		return fmt.Errorf("source map missing required 'mappings' field")
-	} else {
-		_ = v
 	}
-	if v, ok := m["sources"]; !ok {
+	// the go implementation checks the value even if it doesn't require it exists
+	if _, ok := m["sources"]; !ok {
 		return fmt.Errorf("source map missing required 'sources' field")
-	} else {
-		// the go implementation checks the value even if it doesn't require it exists
-		_ = v
 	}
 	return nil
 }

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -161,8 +161,8 @@ func (c *Compiler) Transform(src, filename string, inputSrcMap []byte) (code str
 			sourceMapEnabled = false
 			inputSrcMap = nil
 			c.logger.WithError(err).Warnf(
-				"The source for `%s` needs to go through babel, but it's source map will"+
-					" not be accepted by babel, so it gets disabled", filename)
+				"The source for `%s` needs to be transpiled by Babel, but its source map will"+
+					" not be accepted by Babel, so it was disabled", filename)
 		}
 	}
 	code, srcMap, err = c.babel.transformImpl(c.logger, src, filename, sourceMapEnabled, inputSrcMap)
@@ -416,7 +416,7 @@ func (c *Pool) Put(co *Compiler) {
 
 func verifySourceMapForBabel(srcMap []byte) error {
 	// this function exists to do what babel checks in sourcemap before we give it to it.
-	m := make(map[string]interface{})
+	m := make(map[string]json.RawMessage)
 	err := json.Unmarshal(srcMap, &m)
 	if err != nil {
 		return fmt.Errorf("source map is not valid json: %w", err)

--- a/js/compiler/compiler_test.go
+++ b/js/compiler/compiler_test.go
@@ -235,7 +235,7 @@ func TestCorruptSourceMapOnlyForBabel(t *testing.T) {
 	msg, err := entries[0].String() // we need this in order to get the field error
 	require.NoError(t, err)
 
-	require.Contains(t, msg, `needs to go through babel, but it's source map will not be accepted by babel`)
+	require.Contains(t, msg, `needs to be transpiled by Babel, but its source map will not be accepted by Babel`)
 	require.Contains(t, msg, `source map missing required 'version' field`)
 }
 


### PR DESCRIPTION
This should hopefully fix most of the cases where a source map that
is tried to be loaded but turns out to be gibberish doesn't stop the
whole execution of k6.

edit: this also fixes the error message about source map not being loaded, when goja also has other errors. Previous it would tell you stuff such as 
```
WARN[0000] Couldn't load source map for file:///home/mstoykov/work/k6io/k6/l.js  error="file:///home/mstoykov/work/k6io/k6/l.js: Line 1:1 Unexpected reserved word (and 1 more errors)"
```
when for example the source map wasn't loaded properly but also babel needs to be invoked in order to transpile import/export for example.