### PR TITLE
Update install from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ In case there isn't an official package for your operating system or architectur
 
 k6 is written in Go, so it's just a single statically-linked executable and very easy to build and distribute. To build from source you need **[Git](https://git-scm.com/downloads)** and **[Go](https://golang.org/doc/install)** (1.16 or newer). Follow these instructions:
 
-- Run `go get go.k6.io/k6` which will:
+- Run `go install go.k6.io/k6` which will:
   - git clone the repo and put the source in `$GOPATH/src/go.k6.io/k6`
   - build a `k6` binary and put it in `$GOPATH/bin`
 - Make sure you have `$GOPATH/bin` in your `PATH` (or copy the `k6` binary somewhere in your `PATH`), so you are able to run k6 from any location.


### PR DESCRIPTION
From go 1.18 onwards (https://tip.golang.org/doc/go1.18#tools), to install a package from source, we MUST use `go install`.
Since the command is already available before (from 1.16 onwards) and it's the recommended way to install a package, why not use it?
<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
