### PR TITLE
js/modules: Remove common utils dependency

### DIFF
--- a/js/modules/k6/crypto/crypto_test.go
+++ b/js/modules/k6/crypto/crypto_test.go
@@ -49,14 +49,12 @@ func TestCryptoAlgorithms(t *testing.T) {
 
 	rt := goja.New()
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
-	ctx := context.Background()
-	ctx = common.WithRuntime(ctx, rt)
 
 	m, ok := New().NewModuleInstance(
 		&modulestest.VU{
 			RuntimeField: rt,
 			InitEnvField: &common.InitEnvironment{},
-			CtxField:     ctx,
+			CtxField:     context.Background(),
 			StateField:   nil,
 		},
 	).(*Crypto)
@@ -201,15 +199,13 @@ func TestStreamingApi(t *testing.T) {
 	state := &lib.State{Group: root}
 
 	ctx := context.Background()
-	ctx = lib.WithState(ctx, state)
-	ctx = common.WithRuntime(ctx, rt)
 
 	m, ok := New().NewModuleInstance(
 		&modulestest.VU{
 			RuntimeField: rt,
 			InitEnvField: &common.InitEnvironment{},
 			CtxField:     ctx,
-			StateField:   nil,
+			StateField:   state,
 		},
 	).(*Crypto)
 	require.True(t, ok)
@@ -271,18 +267,11 @@ func TestOutputEncoding(t *testing.T) {
 	rt := goja.New()
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
 
-	root, _ := lib.NewGroup("", nil)
-	state := &lib.State{Group: root}
-
-	ctx := context.Background()
-	ctx = lib.WithState(ctx, state)
-	ctx = common.WithRuntime(ctx, rt)
-
 	m, ok := New().NewModuleInstance(
 		&modulestest.VU{
 			RuntimeField: rt,
 			InitEnvField: &common.InitEnvironment{},
-			CtxField:     ctx,
+			CtxField:     context.Background(),
 			StateField:   nil,
 		},
 	).(*Crypto)
@@ -359,18 +348,11 @@ func TestHMac(t *testing.T) {
 	rt := goja.New()
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
 
-	root, _ := lib.NewGroup("", nil)
-	state := &lib.State{Group: root}
-
-	ctx := context.Background()
-	ctx = lib.WithState(ctx, state)
-	ctx = common.WithRuntime(ctx, rt)
-
 	m, ok := New().NewModuleInstance(
 		&modulestest.VU{
 			RuntimeField: rt,
 			InitEnvField: &common.InitEnvironment{},
-			CtxField:     ctx,
+			CtxField:     context.Background(),
 			StateField:   nil,
 		},
 	).(*Crypto)
@@ -499,13 +481,12 @@ func TestAWSv4(t *testing.T) {
 	// example values from https://docs.aws.amazon.com/general/latest/gr/signature-v4-examples.html
 	rt := goja.New()
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
-	ctx := common.WithRuntime(context.Background(), rt)
 
 	m, ok := New().NewModuleInstance(
 		&modulestest.VU{
 			RuntimeField: rt,
 			InitEnvField: &common.InitEnvironment{},
-			CtxField:     ctx,
+			CtxField:     context.Background(),
 			StateField:   nil,
 		},
 	).(*Crypto)

--- a/js/modules/k6/crypto/x509/x509_test.go
+++ b/js/modules/k6/crypto/x509/x509_test.go
@@ -37,12 +37,11 @@ import (
 func makeRuntime(t *testing.T) *goja.Runtime {
 	rt := goja.New()
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
-	ctx := common.WithRuntime(context.Background(), rt)
 	m, ok := New().NewModuleInstance(
 		&modulestest.VU{
 			RuntimeField: rt,
 			InitEnvField: &common.InitEnvironment{},
-			CtxField:     ctx,
+			CtxField:     context.Background(),
 			StateField:   nil,
 		},
 	).(*X509)

--- a/js/modules/k6/data/share_test.go
+++ b/js/modules/k6/data/share_test.go
@@ -53,7 +53,7 @@ func newConfiguredRuntime() (*goja.Runtime, error) {
 		&modulestest.VU{
 			RuntimeField: rt,
 			InitEnvField: &common.InitEnvironment{},
-			CtxField:     common.WithRuntime(context.Background(), rt),
+			CtxField:     context.Background(),
 			StateField:   nil,
 		},
 	).(*Data)
@@ -173,7 +173,7 @@ func TestSharedArrayAnotherRuntimeWorking(t *testing.T) {
 	vu := &modulestest.VU{
 		RuntimeField: rt,
 		InitEnvField: &common.InitEnvironment{},
-		CtxField:     common.WithRuntime(context.Background(), rt),
+		CtxField:     context.Background(),
 		StateField:   nil,
 	}
 	m, ok := New().NewModuleInstance(vu).(*Data)
@@ -186,7 +186,7 @@ func TestSharedArrayAnotherRuntimeWorking(t *testing.T) {
 	// create another Runtime with new ctx but keep the initEnv
 	rt = goja.New()
 	vu.RuntimeField = rt
-	vu.CtxField = common.WithRuntime(context.Background(), rt)
+	vu.CtxField = context.Background()
 	require.NoError(t, rt.Set("data", m.Exports().Named))
 
 	_, err = rt.RunString(`var array = new data.SharedArray("shared", function() {throw "wat";});`)

--- a/js/modules/k6/encoding/encoding_test.go
+++ b/js/modules/k6/encoding/encoding_test.go
@@ -34,6 +34,7 @@ import (
 
 func TestEncodingAlgorithms(t *testing.T) {
 	t.Parallel()
+
 	if testing.Short() {
 		return
 	}
@@ -42,7 +43,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
 	m, ok := New().NewModuleInstance(
 		&modulestest.VU{
-			CtxField:     common.WithRuntime(context.Background(), rt),
+			CtxField:     context.Background(),
 			RuntimeField: rt,
 			InitEnvField: &common.InitEnvironment{},
 			StateField:   nil,

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -60,9 +60,11 @@ func setupTagsExecEnv(t *testing.T) execEnv {
 		Logger: testLog,
 	}
 
-	rt := goja.New()
-	ctx := common.WithRuntime(context.Background(), rt)
-	ctx = lib.WithState(ctx, state)
+	var (
+		rt  = goja.New()
+		ctx = context.Background()
+	)
+
 	m, ok := New().NewModuleInstance(
 		&modulestest.VU{
 			RuntimeField: rt,
@@ -187,10 +189,11 @@ func TestVUTags(t *testing.T) {
 func TestAbortTest(t *testing.T) { //nolint: tparallel
 	t.Parallel()
 
-	rt := goja.New()
-	ctx := common.WithRuntime(context.Background(), rt)
-	state := &lib.State{}
-	ctx = lib.WithState(ctx, state)
+	var (
+		rt    = goja.New()
+		state = &lib.State{}
+		ctx   = context.Background()
+	)
 
 	m, ok := New().NewModuleInstance(
 		&modulestest.VU{

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -132,11 +132,8 @@ func newTestState(t testing.TB) testState {
 		Tags:           lib.NewTagMap(nil),
 	}
 
-	ctx := lib.WithState(tb.Context, state)
-	ctx = common.WithRuntime(ctx, rt)
-
 	m := New().NewModuleInstance(&modulestest.VU{
-		CtxField:     ctx,
+		CtxField:     tb.Context,
 		InitEnvField: &common.InitEnvironment{},
 		RuntimeField: rt,
 		StateField:   state,
@@ -144,7 +141,6 @@ func newTestState(t testing.TB) testState {
 	require.NoError(t, rt.Set("ws", m.Exports().Default))
 
 	return testState{
-		ctxPtr:  &ctx,
 		rt:      rt,
 		tb:      tb,
 		state:   state,
@@ -181,12 +177,8 @@ func TestSession(t *testing.T) {
 		Tags:           lib.NewTagMap(nil),
 	}
 
-	ctx := context.Background()
-	ctx = lib.WithState(ctx, state)
-	ctx = common.WithRuntime(ctx, rt)
-
 	m := New().NewModuleInstance(&modulestest.VU{
-		CtxField:     ctx,
+		CtxField:     context.Background(),
 		InitEnvField: &common.InitEnvironment{},
 		RuntimeField: rt,
 		StateField:   state,
@@ -579,12 +571,8 @@ func TestSocketSendBinary(t *testing.T) { //nolint: tparallel
 		Tags:           lib.NewTagMap(nil),
 	}
 
-	ctx := context.Background()
-	ctx = lib.WithState(ctx, state)
-	ctx = common.WithRuntime(ctx, rt)
-
 	m := New().NewModuleInstance(&modulestest.VU{
-		CtxField:     ctx,
+		CtxField:     context.Background(),
 		InitEnvField: &common.InitEnvironment{},
 		RuntimeField: rt,
 		StateField:   state,
@@ -675,12 +663,8 @@ func TestErrors(t *testing.T) {
 		Tags:           lib.NewTagMap(nil),
 	}
 
-	ctx := context.Background()
-	ctx = lib.WithState(ctx, state)
-	ctx = common.WithRuntime(ctx, rt)
-
 	m := New().NewModuleInstance(&modulestest.VU{
-		CtxField:     ctx,
+		CtxField:     context.Background(),
 		InitEnvField: &common.InitEnvironment{},
 		RuntimeField: rt,
 		StateField:   state,
@@ -794,12 +778,8 @@ func TestSystemTags(t *testing.T) {
 		Tags:           lib.NewTagMap(nil),
 	}
 
-	ctx := context.Background()
-	ctx = lib.WithState(ctx, state)
-	ctx = common.WithRuntime(ctx, rt)
-
 	m := New().NewModuleInstance(&modulestest.VU{
-		CtxField:     ctx,
+		CtxField:     context.Background(),
 		InitEnvField: &common.InitEnvironment{},
 		RuntimeField: rt,
 		StateField:   state,
@@ -864,12 +844,8 @@ func TestTLSConfig(t *testing.T) {
 		Tags:           lib.NewTagMap(nil),
 	}
 
-	ctx := context.Background()
-	ctx = lib.WithState(ctx, state)
-	ctx = common.WithRuntime(ctx, rt)
-
 	m := New().NewModuleInstance(&modulestest.VU{
-		CtxField:     ctx,
+		CtxField:     context.Background(),
 		InitEnvField: &common.InitEnvironment{},
 		RuntimeField: rt,
 		StateField:   state,
@@ -1010,11 +986,8 @@ func TestUserAgent(t *testing.T) {
 		Tags:           lib.NewTagMap(nil),
 	}
 
-	ctx := lib.WithState(context.Background(), state)
-	ctx = common.WithRuntime(ctx, rt)
-
 	m := New().NewModuleInstance(&modulestest.VU{
-		CtxField:     ctx,
+		CtxField:     context.Background(),
 		InitEnvField: &common.InitEnvironment{},
 		RuntimeField: rt,
 		StateField:   state,


### PR DESCRIPTION
Something was missed from the module migration to the new `modules.Module` API, where the Runtime and the State are now directly accessible without getting them from the context.

This is required for #2344 

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
