### PR TITLE
DockerHub migration to Grafana org

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -15,7 +15,9 @@ defaults:
 
 env:
   APP_NAME: "k6"
-  DOCKER_IMAGE_ID: "loadimpact/k6" # TODO change if we move to a new docker org
+  # We'll push to two DockerHub repos at once; `loadimpact/k6` repo is required for backwards compatibility
+  LI_DOCKER_IMAGE_ID: "loadimpact/k6"
+  DOCKER_IMAGE_ID: "grafana/k6"
   GHCR_IMAGE_ID: ${{ github.repository }}
 
 jobs:
@@ -287,17 +289,21 @@ jobs:
             docker push "ghcr.io/$GHCR_IMAGE_ID:latest"
           fi
 
-          echo "Publish Docker ($DOCKER_IMAGE_ID:$VERSION)"
+          echo "Publish Docker ($DOCKER_IMAGE_ID:$VERSION) and ($LI_DOCKER_IMAGE_ID:$VERSION)"
 
           # Log into Docker Hub Registry
           echo "${{ secrets.DOCKER_PASS }}" | docker login -u "${{ secrets.DOCKER_USER }}" --password-stdin
           docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:$VERSION"
+          docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:$VERSION"
           docker push "$DOCKER_IMAGE_ID:$VERSION"
+          docker push "$LI_DOCKER_IMAGE_ID:$VERSION"
           # We also want to tag the latest stable version as latest
           if [[ "$VERSION" != "master" ]] && [[ ! "$VERSION" =~ (RC|rc) ]]; then
             echo 'Publish Docker (latest)'
             docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:latest"
+            docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:latest"
             docker push "$DOCKER_IMAGE_ID:latest"
+            docker push "$LI_DOCKER_IMAGE_ID:latest"
           fi
 
   package-windows:

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,6 @@ tests :
 check : ci-like-lint tests
 
 container:
-	docker build --rm --pull --no-cache -t loadimpact/k6 .
+	docker build --rm --pull --no-cache -t grafana/k6 .
 
 .PHONY: build format ci-like-lint lint tests check container

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ sudo rm /etc/yum.repos.d/bintray-loadimpact-rpm.repo
 ### Docker
 
 ```bash
-docker pull loadimpact/k6
+docker pull grafana/k6
 ```
 
 ### Pre-built binaries & other platforms
@@ -162,7 +162,7 @@ export default function() {
 
 The script details and how we can extend and configure it will be explained below, but for now, simply save the above snippet as a `script.js` file somewhere on your system. Assuming that you've [installed k6](#install) correctly, on Linux and Mac, you can run the saved script by executing `k6 run script.js` from the same folder. For Windows, the command is almost the same - `k6.exe run script.js`.
 
-If you decide to use the [k6 docker image](https://hub.docker.com/r/loadimpact/k6/), the command will be slightly different. Instead of passing the script filename to k6, a dash is used to instruct k6 to read the script contents directly via the standard input. This allows us to avoid messing with docker volumes for such a simple single-file script, greatly simplifying the docker command: `docker run -i loadimpact/k6 run - <script.js`.
+If you decide to use the [k6 docker image](https://hub.docker.com/r/grafana/k6/), the command will be slightly different. Instead of passing the script filename to k6, a dash is used to instruct k6 to read the script contents directly via the standard input. This allows us to avoid messing with docker volumes for such a simple single-file script, greatly simplifying the docker command: `docker run -i grafana/k6 run - <script.js`.
 
 In some situations, it may also be useful to execute remote scripts. You can do that with HTTP**S** URLs in k6 by [importing them](https://k6.io/docs/using-k6/modules#section-remote-modules) in the script via their URL or simply specifying their URL in the CLI command: `k6 run github.com/k6io/k6/samples/http_2.js` (k6 "knows" a bit about GitHub and cdnjs URLs, so this command is shorthand for `k6 run raw.githubusercontent.com/k6io/k6/master/samples/http_2.js`)
 
@@ -209,7 +209,7 @@ By default, if nothing is specified, k6 runs a script with only 1 VU and for 1 i
 
 Let's say that you want to specify the number of VUs in your script. In order of precedence, you can use any of the following configuration mechanisms to do it:
 1. Command-line flags: `k6 run --vus 10 script.js`, or via the short `-u` flag syntax if we want to save 3 keystrokes (`k6 run -u 10 script.js`).
-2. Environment variables: setting `K6_VUS=20` before you run the script with k6. Especially useful when using the [docker k6 image](https://hub.docker.com/r/loadimpact/k6/) and when running in containerized environments like Kubernetes.
+2. Environment variables: setting `K6_VUS=20` before you run the script with k6. Especially useful when using the [docker k6 image](https://hub.docker.com/r/grafana/k6/) and when running in containerized environments like Kubernetes.
 3. Your script can `export` an `options` object that k6 reads and uses to set any options you want; for example, setting VUs would look like this:
     ```js
     export let options = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - ./grafana:/etc/grafana/provisioning/
 
   k6:
-    image: loadimpact/k6:latest
+    image: grafana/k6:latest
     networks:
       - k6
     ports:


### PR DESCRIPTION
This PR updates CI to push to two DockerHub repositories at once: `loadimpact/k6` and `grafana/k6`, with accompanying small fixes.

Issue: https://github.com/grafana/k6-internal-docs/issues/155