### PR TITLE
Relax assertion in TestConstantArrivalRateRunCorrectTiming

### DIFF
--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -220,7 +220,8 @@ func TestConstantArrivalRateRunCorrectTiming(t *testing.T) {
 							int64(time.Millisecond)*test.steps[(current-2)%int64(len(test.steps))]))
 					}
 
-					// TODO:replace this check with the testing (unit) of the schedule without dependency moment of execution
+					// FIXME: replace this check with a unit test asserting that the scheduling is correct,
+					// without depending on the execution time itself
 					assert.WithinDuration(t,
 						startTime.Add(expectedTime),
 						time.Now(),

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -219,10 +219,12 @@ func TestConstantArrivalRateRunCorrectTiming(t *testing.T) {
 						expectedTime = time.Duration(atomic.AddInt64(&expectedTimeInt64,
 							int64(time.Millisecond)*test.steps[(current-2)%int64(len(test.steps))]))
 					}
+
+					// TODO:replace this check with the testing (unit) of the schedule without dependency moment of execution
 					assert.WithinDuration(t,
 						startTime.Add(expectedTime),
 						time.Now(),
-						time.Millisecond*12,
+						time.Millisecond*24,
 						"%d expectedTime %s", current, expectedTime,
 					)
 


### PR DESCRIPTION
Temporary relax an assertion, while in the meantime we're preparing a proper solution