### PR TITLE
Remove calls to context-based utils

### DIFF
--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -820,7 +820,7 @@ func TestExecutionSchedulerStages(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			runner := &minirunner.MiniRunner{
-				Fn: func(ctx context.Context, out chan<- stats.SampleContainer) error {
+				Fn: func(ctx context.Context, _ *lib.State, out chan<- stats.SampleContainer) error {
 					time.Sleep(100 * time.Millisecond)
 					return nil
 				},
@@ -839,7 +839,7 @@ func TestExecutionSchedulerStages(t *testing.T) {
 func TestExecutionSchedulerEndTime(t *testing.T) {
 	t.Parallel()
 	runner := &minirunner.MiniRunner{
-		Fn: func(ctx context.Context, out chan<- stats.SampleContainer) error {
+		Fn: func(ctx context.Context, _ *lib.State, out chan<- stats.SampleContainer) error {
 			time.Sleep(100 * time.Millisecond)
 			return nil
 		},
@@ -866,7 +866,7 @@ func TestExecutionSchedulerEndTime(t *testing.T) {
 func TestExecutionSchedulerRuntimeErrors(t *testing.T) {
 	t.Parallel()
 	runner := &minirunner.MiniRunner{
-		Fn: func(ctx context.Context, out chan<- stats.SampleContainer) error {
+		Fn: func(ctx context.Context, _ *lib.State, out chan<- stats.SampleContainer) error {
 			time.Sleep(10 * time.Millisecond)
 			return errors.New("hi")
 		},
@@ -906,7 +906,7 @@ func TestExecutionSchedulerEndErrors(t *testing.T) {
 	exec.GracefulStop = types.NullDurationFrom(0 * time.Second)
 
 	runner := &minirunner.MiniRunner{
-		Fn: func(ctx context.Context, out chan<- stats.SampleContainer) error {
+		Fn: func(ctx context.Context, _ *lib.State, out chan<- stats.SampleContainer) error {
 			<-ctx.Done()
 			return errors.New("hi")
 		},
@@ -946,7 +946,7 @@ func TestExecutionSchedulerEndIterations(t *testing.T) {
 
 	var i int64
 	runner := &minirunner.MiniRunner{
-		Fn: func(ctx context.Context, out chan<- stats.SampleContainer) error {
+		Fn: func(ctx context.Context, _ *lib.State, out chan<- stats.SampleContainer) error {
 			select {
 			case <-ctx.Done():
 			default:
@@ -987,7 +987,7 @@ func TestExecutionSchedulerEndIterations(t *testing.T) {
 func TestExecutionSchedulerIsRunning(t *testing.T) {
 	t.Parallel()
 	runner := &minirunner.MiniRunner{
-		Fn: func(ctx context.Context, out chan<- stats.SampleContainer) error {
+		Fn: func(ctx context.Context, _ *lib.State, out chan<- stats.SampleContainer) error {
 			<-ctx.Done()
 			return nil
 		},

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -344,6 +344,7 @@ func (b *Bundle) instantiate(logger logrus.FieldLogger, rt *goja.Runtime, init *
 	}
 	unbindInit()
 	*init.moduleVUImpl.ctxPtr = nil
+	init.moduleVUImpl.initEnv = nil
 
 	// If we've already initialized the original VU init context, forbid
 	// any subsequent VUs to open new files

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -38,7 +38,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/lib/metrics"
@@ -413,8 +412,6 @@ func TestRequestWithBinaryFile(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ctx = lib.WithState(ctx, vuImpl.state)
-	ctx = common.WithRuntime(ctx, bi.Runtime)
 	*bi.Context = ctx
 
 	v, err := bi.exports[consts.DefaultFn](goja.Undefined())
@@ -563,8 +560,6 @@ func TestRequestWithMultipleBinaryFiles(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ctx = lib.WithState(ctx, vuImpl.state)
-	ctx = common.WithRuntime(ctx, bi.Runtime)
 	*bi.Context = ctx
 
 	v, err := bi.exports[consts.DefaultFn](goja.Undefined())

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -555,6 +555,14 @@ func TestVURunContext(t *testing.T) {
 			vu.Runtime.Set("fn", func() {
 				fnCalled = true
 
+				// Assert to maintain the retro-compatibility
+				// with the old context-based getters
+				assert.Equal(t, vu.Runtime, common.GetRuntime(*vu.Context), "incorrect runtime in context")
+				assert.Nil(t, common.GetInitEnv(*vu.Context)) // shouldn't get this in the vu context
+
+				require.NotNil(t, vu.moduleVUImpl.Runtime())
+				require.Nil(t, vu.moduleVUImpl.InitEnv())
+
 				state := vu.moduleVUImpl.State()
 				require.NotNil(t, state)
 				assert.Equal(t, null.IntFrom(10), state.Options.VUs)

--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -34,10 +34,10 @@ import (
 	"go.k6.io/k6/stats"
 )
 
-func simpleRunner(vuFn func(context.Context) error) lib.Runner {
+func simpleRunner(vuFn func(context.Context, *lib.State) error) lib.Runner {
 	return &minirunner.MiniRunner{
-		Fn: func(ctx context.Context, _ chan<- stats.SampleContainer) error {
-			return vuFn(ctx)
+		Fn: func(ctx context.Context, state *lib.State, _ chan<- stats.SampleContainer) error {
+			return vuFn(ctx, state)
 		},
 	}
 }

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -74,7 +74,7 @@ func TestConstantArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, logHook := setupExecutor(
 		t, getTestConstantArrivalRateConfig(), es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			time.Sleep(time.Second)
 			return nil
 		}),
@@ -104,7 +104,7 @@ func TestConstantArrivalRateRunCorrectRate(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, logHook := setupExecutor(
 		t, getTestConstantArrivalRateConfig(), es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			atomic.AddInt64(&count, 1)
 			return nil
 		}),
@@ -211,7 +211,7 @@ func TestConstantArrivalRateRunCorrectTiming(t *testing.T) {
 			expectedTimeInt64 := int64(test.start)
 			ctx, cancel, executor, logHook := setupExecutor(
 				t, config, es,
-				simpleRunner(func(ctx context.Context) error {
+				simpleRunner(func(ctx context.Context, _ *lib.State) error {
 					current := atomic.AddInt64(&count, 1)
 
 					expectedTime := test.start
@@ -274,7 +274,7 @@ func TestArrivalRateCancel(t *testing.T) {
 			require.NoError(t, err)
 			es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 			ctx, cancel, executor, logHook := setupExecutor(
-				t, config, es, simpleRunner(func(ctx context.Context) error {
+				t, config, es, simpleRunner(func(ctx context.Context, _ *lib.State) error {
 					select {
 					case <-ch:
 						<-ch
@@ -329,7 +329,7 @@ func TestConstantArrivalRateDroppedIterations(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, logHook := setupExecutor(
 		t, config, es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			atomic.AddInt64(&count, 1)
 			<-ctx.Done()
 			return nil
@@ -389,8 +389,7 @@ func TestConstantArrivalRateGlobalIters(t *testing.T) {
 
 			gotIters := []uint64{}
 			var mx sync.Mutex
-			runner.Fn = func(ctx context.Context, _ chan<- stats.SampleContainer) error {
-				state := lib.GetState(ctx)
+			runner.Fn = func(ctx context.Context, state *lib.State, _ chan<- stats.SampleContainer) error {
 				mx.Lock()
 				gotIters = append(gotIters, state.GetScenarioGlobalVUIter())
 				mx.Unlock()

--- a/lib/executor/constant_vus_test.go
+++ b/lib/executor/constant_vus_test.go
@@ -50,13 +50,12 @@ func TestConstantVUsRun(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, getTestConstantVUsConfig(), es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, state *lib.State) error {
 			select {
 			case <-ctx.Done():
 				return nil
 			default:
 			}
-			state := lib.GetState(ctx)
 			currIter, _ := result.LoadOrStore(state.VUID, uint64(0))
 			result.Store(state.VUID, currIter.(uint64)+1)
 			time.Sleep(210 * time.Millisecond)

--- a/lib/executor/externally_controlled_test.go
+++ b/lib/executor/externally_controlled_test.go
@@ -55,7 +55,7 @@ func TestExternallyControlledRun(t *testing.T) {
 	doneIters := new(uint64)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, getTestExternallyControlledConfig(), es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			time.Sleep(200 * time.Millisecond)
 			atomic.AddUint64(doneIters, 1)
 			return nil

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -55,8 +55,7 @@ func TestPerVUIterationsRun(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, getTestPerVUIterationsConfig(), es,
-		simpleRunner(func(ctx context.Context) error {
-			state := lib.GetState(ctx)
+		simpleRunner(func(ctx context.Context, state *lib.State) error {
 			currIter, _ := result.LoadOrStore(state.VUID, uint64(0))
 			result.Store(state.VUID, currIter.(uint64)+1)
 			return nil
@@ -92,8 +91,7 @@ func TestPerVUIterationsRunVariableVU(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, getTestPerVUIterationsConfig(), es,
-		simpleRunner(func(ctx context.Context) error {
-			state := lib.GetState(ctx)
+		simpleRunner(func(ctx context.Context, state *lib.State) error {
 			if state.VUID == slowVUID {
 				time.Sleep(200 * time.Millisecond)
 			}
@@ -143,7 +141,7 @@ func TestPerVuIterationsEmitDroppedIterations(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, logHook := setupExecutor(
 		t, config, es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			atomic.AddInt64(&count, 1)
 			<-ctx.Done()
 			return nil

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -87,7 +87,7 @@ func TestRampingVUsRun(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, config, es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			// Sleeping for a weird duration somewhat offset from the
 			// executor ticks to hopefully keep race conditions out of
 			// our control from failing the test.
@@ -144,7 +144,7 @@ func TestRampingVUsGracefulStopWaits(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, config, es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			close(started)
 			defer close(stopped)
 			select {
@@ -193,7 +193,7 @@ func TestRampingVUsGracefulStopStops(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, config, es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			close(started)
 			defer close(stopped)
 			select {
@@ -247,8 +247,8 @@ func TestRampingVUsGracefulRampDown(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, config, es,
-		simpleRunner(func(ctx context.Context) error {
-			if lib.GetState(ctx).VUID == 1 { // the first VU will wait here to do stuff
+		simpleRunner(func(ctx context.Context, state *lib.State) error {
+			if state.VUID == 1 { // the first VU will wait here to do stuff
 				close(started)
 				defer close(stopped)
 				select {
@@ -333,7 +333,7 @@ func TestRampingVUsHandleRemainingVUs(t *testing.T) {
 		gotVuInterrupted uint32
 		gotVuFinished    uint32
 	)
-	iteration := func(ctx context.Context) error {
+	iteration := func(ctx context.Context, _ *lib.State) error {
 		select {
 		case <-time.After(vuSleepDuration):
 			atomic.AddUint32(&gotVuFinished, 1)
@@ -385,7 +385,7 @@ func TestRampingVUsRampDownNoWobble(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, config, es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			time.Sleep(500 * time.Millisecond)
 			return nil
 		}),

--- a/lib/executor/shared_iterations_test.go
+++ b/lib/executor/shared_iterations_test.go
@@ -57,7 +57,7 @@ func TestSharedIterationsRun(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, getTestSharedIterationsConfig(), es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			atomic.AddUint64(&doneIters, 1)
 			return nil
 		}),
@@ -83,9 +83,8 @@ func TestSharedIterationsRunVariableVU(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, _ := setupExecutor(
 		t, getTestSharedIterationsConfig(), es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, state *lib.State) error {
 			time.Sleep(10 * time.Millisecond) // small wait to stabilize the test
-			state := lib.GetState(ctx)
 			// Pick one VU randomly and always slow it down.
 			sid := atomic.LoadUint64(&slowVUID)
 			if sid == uint64(0) {
@@ -134,7 +133,7 @@ func TestSharedIterationsEmitDroppedIterations(t *testing.T) {
 	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
 	ctx, cancel, executor, logHook := setupExecutor(
 		t, config, es,
-		simpleRunner(func(ctx context.Context) error {
+		simpleRunner(func(ctx context.Context, _ *lib.State) error {
 			atomic.AddInt64(&count, 1)
 			<-ctx.Done()
 			return nil
@@ -187,8 +186,7 @@ func TestSharedIterationsGlobalIters(t *testing.T) {
 
 			gotIters := []uint64{}
 			var mx sync.Mutex
-			runner.Fn = func(ctx context.Context, _ chan<- stats.SampleContainer) error {
-				state := lib.GetState(ctx)
+			runner.Fn = func(ctx context.Context, state *lib.State, _ chan<- stats.SampleContainer) error {
 				mx.Lock()
 				gotIters = append(gotIters, state.GetScenarioGlobalVUIter())
 				mx.Unlock()

--- a/lib/executor/vu_handle_test.go
+++ b/lib/executor/vu_handle_test.go
@@ -55,7 +55,7 @@ func TestVUHandleRace(t *testing.T) {
 	logEntry := logrus.NewEntry(testLog)
 
 	runner := &minirunner.MiniRunner{}
-	runner.Fn = func(ctx context.Context, out chan<- stats.SampleContainer) error {
+	runner.Fn = func(ctx context.Context, _ *lib.State, out chan<- stats.SampleContainer) error {
 		return nil
 	}
 
@@ -144,7 +144,7 @@ func TestVUHandleStartStopRace(t *testing.T) {
 	logEntry := logrus.NewEntry(testLog)
 
 	runner := &minirunner.MiniRunner{}
-	runner.Fn = func(ctx context.Context, out chan<- stats.SampleContainer) error {
+	runner.Fn = func(ctx context.Context, _ *lib.State, out chan<- stats.SampleContainer) error {
 		return nil
 	}
 
@@ -387,7 +387,7 @@ func BenchmarkVUHandleIterations(b *testing.B) {
 	}
 
 	runner := &minirunner.MiniRunner{}
-	runner.Fn = func(ctx context.Context, out chan<- stats.SampleContainer) error {
+	runner.Fn = func(ctx context.Context, _ *lib.State, out chan<- stats.SampleContainer) error {
 		return nil
 	}
 	getVU := func() (lib.InitializedVU, error) {


### PR DESCRIPTION
Removed all not strictly required calls to the context-based utils functions. The `lib.GetState` required a refactor for the executors' tests and the relative used minirunner Fn.

This is expected to be the latest refactor PR before opening the PR for writing the deprecation comments.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
