### PR TITLE
Deprecate context-based utils

### DIFF
--- a/api/common/context.go
+++ b/api/common/context.go
@@ -30,10 +30,16 @@ type ContextKey int
 
 const ctxKeyEngine = ContextKey(1)
 
+// WithEngine sets the k6 running Engine in the under the hood context.
+//
+// Deprecated: Use directly the Engine as dependency.
 func WithEngine(ctx context.Context, engine *core.Engine) context.Context {
 	return context.WithValue(ctx, ctxKeyEngine, engine)
 }
 
+// GetEngine returns the k6 running Engine fetching it from the context.
+//
+// Deprecated: Use directly the Engine as dependency.
 func GetEngine(ctx context.Context) *core.Engine {
 	return ctx.Value(ctxKeyEngine).(*core.Engine)
 }

--- a/js/common/bridge.go
+++ b/js/common/bridge.go
@@ -134,6 +134,9 @@ func BindToGlobal(rt *goja.Runtime, data map[string]interface{}) func() {
 }
 
 // Bind the provided value v to the provided runtime
+//
+// Deprecated: JS modules can implement the modules.VU interface for getting the context,
+// goja runtime and the VU State, so the goja.Runtime.Set method can be used for data binding.
 func Bind(rt *goja.Runtime, v interface{}, ctxPtr *context.Context) map[string]interface{} {
 	exports := make(map[string]interface{})
 

--- a/js/common/context.go
+++ b/js/common/context.go
@@ -26,6 +26,9 @@ import (
 	"github.com/dop251/goja"
 )
 
+// TODO: https://github.com/grafana/k6/issues/2385
+// Rid all the context-based utils functions
+
 type ctxKey int
 
 const (
@@ -34,11 +37,15 @@ const (
 )
 
 // WithRuntime attaches the given goja runtime to the context.
+//
+// Deprecated: Implement the modules.VU interface for sharing the Runtime.
 func WithRuntime(ctx context.Context, rt *goja.Runtime) context.Context {
 	return context.WithValue(ctx, ctxKeyRuntime, rt)
 }
 
 // GetRuntime retrieves the attached goja runtime from the given context.
+//
+// Deprecated: Use modules.VU for get the Runtime.
 func GetRuntime(ctx context.Context) *goja.Runtime {
 	v := ctx.Value(ctxKeyRuntime)
 	if v == nil {
@@ -48,11 +55,15 @@ func GetRuntime(ctx context.Context) *goja.Runtime {
 }
 
 // WithInitEnv attaches the given init environment to the context.
+//
+// Deprecated: Implement the modules.VU interface for sharing the init environment.
 func WithInitEnv(ctx context.Context, initEnv *InitEnvironment) context.Context {
 	return context.WithValue(ctx, ctxKeyInitEnv, initEnv)
 }
 
 // GetInitEnv retrieves the attached init environment struct from the given context.
+//
+// Deprecated: Use modules.VU for get the init environment.
 func GetInitEnv(ctx context.Context) *InitEnvironment {
 	v := ctx.Value(ctxKeyInitEnv)
 	if v == nil {

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -214,9 +214,6 @@ func (i *InitContext) requireModule(name string) (goja.Value, error) {
 		instance := m.NewModuleInstance(i.moduleVUImpl)
 		return i.moduleVUImpl.runtime.ToValue(toESModuleExports(instance.Exports())), nil
 	}
-	if perInstance, ok := mod.(modules.HasModuleInstancePerVU); ok {
-		mod = perInstance.NewModuleInstancePerVU()
-	}
 
 	onceBindWarning.Do(func() {
 		i.logger.Warnf(`Module '%s' is using deprecated APIs that will be removed in k6 v0.38.0,`+

--- a/js/modules/modules.go
+++ b/js/modules/modules.go
@@ -57,13 +57,6 @@ func Register(name string, mod interface{}) {
 	modules[name] = mod
 }
 
-// HasModuleInstancePerVU should be implemented by all native Golang modules that
-// would require per-VU state. k6 will call their NewModuleInstancePerVU() methods
-// every time a VU imports the module and use its result as the returned object.
-type HasModuleInstancePerVU interface {
-	NewModuleInstancePerVU() interface{}
-}
-
 // Module is the interface js modules should implement in order to get access to the VU
 type Module interface {
 	// NewModuleInstance will get modules.VU that should provide the module with a way to interact with the VU

--- a/lib/context.go
+++ b/lib/context.go
@@ -20,7 +20,9 @@
 
 package lib
 
-import "context"
+import (
+	"context"
+)
 
 type ctxKey int
 
@@ -30,12 +32,19 @@ const (
 	ctxKeyScenario
 )
 
+// TODO: https://github.com/grafana/k6/issues/2385
+// Rid the State's context-based utils functions
+
 // WithState embeds a State in ctx.
+//
+// Deprecated: Implement the modules.VU interface for sharing the State.
 func WithState(ctx context.Context, state *State) context.Context {
 	return context.WithValue(ctx, ctxKeyState, state)
 }
 
 // GetState returns a State from ctx.
+//
+// Deprecated: Use modules.VU for get the State.
 func GetState(ctx context.Context) *State {
 	v := ctx.Value(ctxKeyState)
 	if v == nil {


### PR DESCRIPTION
Deprecating the context-based utils functions. They are anticipating the next step where we could remove all of them from the `k6` public API.

Closes https://github.com/grafana/k6/issues/2344

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
