### PR TITLE
Add TLS Issuer to Response

### DIFF
--- a/lib/netext/httpext/response.go
+++ b/lib/netext/httpext/response.go
@@ -85,6 +85,7 @@ type Response struct {
 	Timings        ResponseTimings          `json:"timings"`
 	TLSVersion     string                   `json:"tls_version"`
 	TLSCipherSuite string                   `json:"tls_cipher_suite"`
+	TLSIssuer      string                   `json:"tls_issuer"`
 	OCSP           netext.OCSP              `json:"ocsp"`
 	Error          string                   `json:"error"`
 	ErrorCode      int                      `json:"error_code"`
@@ -102,5 +103,6 @@ func (res *Response) setTLSInfo(tlsState *tls.ConnectionState) {
 	tlsInfo, oscp := netext.ParseTLSConnState(tlsState)
 	res.TLSVersion = tlsInfo.Version
 	res.TLSCipherSuite = tlsInfo.CipherSuite
+	res.TLSIssuer = tlsInfo.Issuer
 	res.OCSP = oscp
 }

--- a/lib/netext/tls.go
+++ b/lib/netext/tls.go
@@ -53,6 +53,7 @@ const (
 type TLSInfo struct {
 	Version     string
 	CipherSuite string
+	Issuer      string
 }
 type OCSP struct {
 	ProducedAt       int64  `json:"produced_at"`
@@ -76,6 +77,7 @@ func ParseTLSConnState(tlsState *tls.ConnectionState) (TLSInfo, OCSP) {
 		tlsInfo.Version = TLS_1_3
 	}
 
+	tlsInfo.Issuer = tlsState.PeerCertificates[0].Issuer.Organization[0]
 	tlsInfo.CipherSuite = lib.SupportedTLSCipherSuitesToString[tlsState.CipherSuite]
 	ocspStapledRes := OCSP{Status: OCSP_STATUS_UNKNOWN}
 


### PR DESCRIPTION
I've added TLS Issuer information to the Response object. In our organization we create Kubernetes Ingresses dynamically for certain pods and we would like to test whether the Ingress has a correct SSL certificate rather than a placeholder one.

The Issuer is extracted from the first peer certificate as per docs:

> The first element is the leaf certificate that the connection is verified against.

I have chosen to use the first organization of the certificate as the issuer, this seems like a reasonable value to me, but I'm open to changing that as I don't know too much about X590 certificates.