### PR TITLE
Fix wrong omitempty for options.scenarios

### DIFF
--- a/lib/options.go
+++ b/lib/options.go
@@ -292,7 +292,7 @@ type Options struct {
 	// We should support specifying execution segments via environment
 	// variables, but we currently can't, because envconfig has this nasty bug
 	// (among others): https://github.com/kelseyhightower/envconfig/issues/113
-	Scenarios                ScenarioConfigs           `json:"scenarios,omitempty" ignored:"true"`
+	Scenarios                ScenarioConfigs           `json:"scenarios" ignored:"true"`
 	ExecutionSegment         *ExecutionSegment         `json:"executionSegment" ignored:"true"`
 	ExecutionSegmentSequence *ExecutionSegmentSequence `json:"executionSegmentSequence" ignored:"true"`
 


### PR DESCRIPTION
With the current code, running this script:
```js
export default function () {
    console.log(JSON.stringify(options, null, 4));
}
```

Will produce something like this:
```js
{
    "scenarios,omitempty": {},
    "summaryTrendStats": [ "avg", "min", "med", "max", "p(90)", "p(95)"],
    "systemTags": ["check","error","error_code","expected_response","group","method","name","proto","scenario","service","status","subproto","tls_version","url"]
}
```

The actual issue is caused by the `lib.Options.ForEachSpecified()` hack: https://github.com/grafana/k6/blob/737dfa7ced6e4f94dbb3d6f2c2837085e783ac09/js/bundle.go#L290
where it doesn't actually properly parse the `json` struct tag and returns its whole value: https://github.com/grafana/k6/blob/737dfa7ced6e4f94dbb3d6f2c2837085e783ac09/lib/options.go#L615-L618

However, getting rid of that whole mess is something that should probably be done as a part of #883. Similarly, not exporting the default values for `summaryTrendStats` and `systemTags` will also be more complicated and out of scope.

This PR seems like a good idea because it seems to fix the issue without any side-effects (:crossed_fingers:), it's simple and it doesn't make sense for `Scenarios` to be the only `lib.Options` property with `omitempty`...