### PR TITLE
Revert k6/http.head to not taking body as second argument

### DIFF
--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -92,7 +92,10 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 		args = append([]goja.Value{goja.Undefined()}, args...) // sigh
 		return mi.defaultClient.Request(http.MethodGet, url, args...)
 	})
-	mustExport("head", mi.defaultClient.getMethodClosure(http.MethodHead))
+	mustExport("head", func(url goja.Value, args ...goja.Value) (*Response, error) {
+		args = append([]goja.Value{goja.Undefined()}, args...) // sigh
+		return mi.defaultClient.Request(http.MethodHead, url, args...)
+	})
 	mustExport("post", mi.defaultClient.getMethodClosure(http.MethodPost))
 	mustExport("put", mi.defaultClient.getMethodClosure(http.MethodPut))
 	mustExport("patch", mi.defaultClient.getMethodClosure(http.MethodPatch))

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -89,11 +89,15 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	// wrappers (facades) that convert the old k6 idiosyncratic APIs to the new
 	// proper Client ones that accept Request objects and don't suck
 	mustExport("get", func(url goja.Value, args ...goja.Value) (*Response, error) {
-		args = append([]goja.Value{goja.Undefined()}, args...) // sigh
+		// http.get(url, params) doesn't have a body argument, so we add undefined
+		// as the third argument to http.request(method, url, body, params)
+		args = append([]goja.Value{goja.Undefined()}, args...)
 		return mi.defaultClient.Request(http.MethodGet, url, args...)
 	})
 	mustExport("head", func(url goja.Value, args ...goja.Value) (*Response, error) {
-		args = append([]goja.Value{goja.Undefined()}, args...) // sigh
+		// http.head(url, params) doesn't have a body argument, so we add undefined
+		// as the third argument to http.request(method, url, body, params)
+		args = append([]goja.Value{goja.Undefined()}, args...)
 		return mi.defaultClient.Request(http.MethodHead, url, args...)
 	})
 	mustExport("post", mi.defaultClient.getMethodClosure(http.MethodPost))

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1136,10 +1136,11 @@ func TestRequestAndBatch(t *testing.T) {
 	})
 	t.Run("HEAD", func(t *testing.T) {
 		_, err := rt.RunString(sr(`
-		var res = http.head("HTTPBIN_URL/get?a=1&b=2");
+		var res = http.head("HTTPBIN_URL/get?a=1&b=2", {headers: {"X-We-Want-This": "value"}});
 		if (res.status != 200) { throw new Error("wrong status: " + res.status); }
 		if (res.body.length != 0) { throw new Error("HEAD responses shouldn't have a body"); }
 		if (!res.headers["Content-Length"]) { throw new Error("Missing or invalid Content-Length header!"); }
+		if (res.request.headers["X-We-Want-This"] != "value") { throw new Error("Missing or invalid X-We-Want-This header!"); }
 		`))
 		assert.NoError(t, err)
 		assertRequestMetricsEmitted(t, stats.GetBufferedSamples(samples), "HEAD", sr("HTTPBIN_URL/get?a=1&b=2"), "", 200, "")

--- a/release notes/v0.36.0.md
+++ b/release notes/v0.36.0.md
@@ -131,3 +131,8 @@ export default () => {
 - [#2304](https://github.com/grafana/k6/pull/2304) prepared the removal of external dependencies from k6's JSONAPI compliant REST API, and deprecated the `api.v1`'s `client.Call` method in favor of its newer `client.CallAPI` counterpart. It allows us to both reduce our reliance on external dependencies and improve its maintainability.
 - We have updated our [Goja](https://github.com/dop251/goja) dependency, our JS interpreter, to its latest available version. Unfortunately, some of the new features are not always usable, yet. Namely, Goja now supports the [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) syntax, but the Babel version we use presently does not. Which means that if Babel needs to be used, optional chaining can't be. See [#2317](https://github.com/grafana/k6/pull/2317) and [#2238](https://github.com/grafana/k6/pull/2238).
 - Thanks to @knittl, [#2312](https://github.com/grafana/k6/pull/2312) upgraded [loadimpact/k6](https://hub.docker.com/r/loadimpact/k6) docker image base to Alpine *3.15*.
+
+
+# Known Bugs
+
+- [#2226](https://github.com/grafana/k6/pull/2226) introduced an unintended breaking change to `http.head()`. The signature in k6 v0.35.0 was `http.head(url, [params])` and was inadvertently changed to `http.head(url, [body], [params])` in v0.36.0. That change will be reverted in k6 v0.37.0, but until then, we suggest users use the stable `http.request('HEAD', url, null, params)` API for HTTP HEAD requests that need to specify custom [parameters](https://k6.io/docs/javascript-api/k6-http/params). Thanks, @[grantyoung](https://github.com/grantyoung), for reporting the problem ([#2401](https://github.com/grafana/k6/issues/2401))!


### PR DESCRIPTION
This has been the case forever until v0.36.0.
