### PR TITLE
CI: move deps and lint jobs only on pull requests

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -21,48 +21,6 @@ env:
   GHCR_IMAGE_ID: ${{ github.repository }}
 
 jobs:
-  deps:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17.x
-      - name: Check dependencies
-        run: |
-            go version
-            test -z "$(go mod tidy && go mod vendor && git status --porcelain)"
-            go mod verify
-      - name: Check code generation
-        run: |
-          go install github.com/alvaroloes/enumer@v1.1.2
-          go install github.com/mailru/easyjson/easyjson@v0.7.7
-          test -z "$(go generate ./... && git status --porcelain)"
-
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.17.x
-      - name: Retrieve golangci-lint version
-        run: |
-          echo "::set-output name=Version::$(head -n 1 "${GITHUB_WORKSPACE}/.golangci.yml" | tr -d '# ')"
-        id: version
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: ${{ steps.version.outputs.Version }}
-          only-new-issues: true
-
   test-prev:
     strategy:
       fail-fast: false

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -144,7 +144,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    needs: [configure, deps, lint, test-current-cov]
+    needs: [configure, test-current-cov]
     if: startsWith(github.ref, 'refs/tags/v')
     env:
       VERSION: ${{ needs.configure.outputs.version }}
@@ -205,7 +205,7 @@ jobs:
 
   build-docker:
     runs-on: ubuntu-latest
-    needs: [deps, lint, test-current-cov, configure]
+    needs: [test-current-cov, configure]
     env:
       VERSION: ${{ needs.configure.outputs.version }}
     steps:
@@ -267,7 +267,7 @@ jobs:
     defaults:
       run:
         shell: powershell
-    needs: [deps, lint, test-current-cov, configure, build]
+    needs: [test-current-cov, configure, build]
     if: startsWith(github.ref, 'refs/tags/v')
     env:
       VERSION: ${{ needs.configure.outputs.version }}
@@ -354,7 +354,7 @@ jobs:
 
   publish-github:
     runs-on: ubuntu-latest
-    needs: [configure, deps, lint, test-current-cov, build, package-windows]
+    needs: [configure, test-current-cov, build, package-windows]
     if: startsWith(github.ref, 'refs/tags/v')
     env:
       VERSION: ${{ needs.configure.outputs.version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,54 @@
+name: Lint
+on:
+  # Enable manually triggering this workflow via the API or web UI
+  workflow_dispatch:
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - name: Check dependencies
+        run: |
+            go version
+            test -z "$(go mod tidy && go mod vendor && git status --porcelain)"
+            go mod verify
+      - name: Check code generation
+        run: |
+          go install github.com/alvaroloes/enumer@v1.1.2
+          go install github.com/mailru/easyjson/easyjson@v0.7.7
+          test -z "$(go generate ./... && git status --porcelain)"
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - name: Retrieve golangci-lint version
+        run: |
+          echo "::set-output name=Version::$(head -n 1 "${GITHUB_WORKSPACE}/.golangci.yml" | tr -d '# ')"
+        id: version
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
+          version: ${{ steps.version.outputs.Version }}
+          only-new-issues: true


### PR DESCRIPTION
This was provoked as the new use of golangci-lint action fails on master
with all the lint errors there. But in reality it's probably not needed
to run those tasks on master - they are mostly about new code

