### PR TITLE
Close archives after writing them and fix test to not add untracked files to the repo

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -105,7 +105,12 @@ An archive is a fully self-contained test run, and can be executed identically e
 			if err != nil {
 				return err
 			}
-			return arc.Write(f)
+
+			err = arc.Write(f)
+			if cerr := f.Close(); err == nil && cerr != nil {
+				err = cerr
+			}
+			return err
 		},
 	}
 

--- a/cmd/archive_test.go
+++ b/cmd/archive_test.go
@@ -40,10 +40,12 @@ func TestArchiveThresholds(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
+			tmpPath := filepath.Join(t.TempDir(), "archive.tar")
+
 			cmd := getArchiveCmd(testutils.NewLogger(t), newCommandFlags())
 			filename, err := filepath.Abs(testCase.testFilename)
 			require.NoError(t, err)
-			args := []string{filename}
+			args := []string{filename, "--archive-out", tmpPath}
 			if testCase.noThresholds {
 				args = append(args, "--no-thresholds")
 			}


### PR DESCRIPTION
Running `go test` with the current `master` leaves a dangling `cmd/archive.tar` file that "dirties" the repo. 

The proper fix would be to not use the OS filesystem at all, by threading an `afero.Fs` through everything, but that should probably wait for after v0.37.0 is released. I'll check it out and make another PR if it's quick.