### PR TITLE
Simplify execution requirements calculation in `k6 inspect`

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -296,6 +296,13 @@ func (b *Bundle) Instantiate(
 	return bi, instErr
 }
 
+// IsExecutable returns whether the given name is an exported and
+// executable function in the script.
+func (b *Bundle) IsExecutable(name string) bool {
+	_, exists := b.exports[name]
+	return exists
+}
+
 // Instantiates the bundle into an existing runtime. Not public because it also messes with a bunch
 // of other things, will potentially thrash data and makes a mess in it if the operation fails.
 func (b *Bundle) instantiate(logger logrus.FieldLogger, rt *goja.Runtime, init *InitContext, vuID uint64) error {

--- a/js/runner.go
+++ b/js/runner.go
@@ -347,9 +347,10 @@ func (r *Runner) GetOptions() lib.Options {
 
 // IsExecutable returns whether the given name is an exported and
 // executable function in the script.
+//
+// TODO: completely remove this?
 func (r *Runner) IsExecutable(name string) bool {
-	_, exists := r.Bundle.exports[name]
-	return exists
+	return r.Bundle.IsExecutable(name)
 }
 
 // HandleSummary calls the specified summary callback, if supplied.


### PR DESCRIPTION
I tried to read https://github.com/grafana/k6/issues/1048 and honestly got lost in more than a few places... However, I am pretty sure this simplification is safe from reading through the code and thinking logically about it. There is no reason to create a runner and an execution scheduler to get the execution requirements a script. It should be enough to derive the `scenarios` and just use their `GetFullExecutionRequirements()` method, that's exactly what the execution scheduler does, after all... :sweat_smile:  https://github.com/grafana/k6/blob/1e28a3e1c8655d2118c823113e7a90ce44736cfe/core/local/local.go#L69

Anyway, tagged this as v0.38.0 since it doesn't really matter, but we should probably not introduce changes like this right before the release, even if they should not really change anything :sweat_smile: :crossed_fingers: 