### PR TITLE
Remove most direct access to the `os` package, support `NO_COLOR` and `K6_NO_COLOR`

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -25,9 +25,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -91,14 +89,14 @@ func exactArgsWithMsg(n int, msg string) cobra.PositionalArgs {
 
 // readSource is a small wrapper around loader.ReadSource returning
 // result of the load and filesystems map
-func readSource(filename string, logger *logrus.Logger) (*loader.SourceData, map[string]afero.Fs, error) {
-	pwd, err := os.Getwd()
+func readSource(globalState *globalState, filename string) (*loader.SourceData, map[string]afero.Fs, error) {
+	pwd, err := globalState.getwd()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	filesystems := loader.CreateFilesystems()
-	src, err := loader.ReadSource(logger, filename, pwd, filesystems, os.Stdin)
+	filesystems := loader.CreateFilesystems(globalState.fs)
+	src, err := loader.ReadSource(globalState.logger, filename, pwd, filesystems, globalState.stdIn)
 	return src, filesystems, err
 }
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -109,51 +109,42 @@ func getConfig(flags *pflag.FlagSet) (Config, error) {
 	}, nil
 }
 
-// Reads the configuration file from the supplied filesystem and returns it and its path.
-// It will first try to see if the user explicitly specified a custom config file and will
-// try to read that. If there's a custom config specified and it couldn't be read or parsed,
-// an error will be returned.
-// If there's no custom config specified and no file exists in the default config path, it will
-// return an empty config struct, the default config location and *no* error.
-func readDiskConfig(fs afero.Fs, globalFlags *commandFlags) (Config, string, error) {
-	realConfigFilePath := globalFlags.configFilePath
-	if realConfigFilePath == "" {
-		// The user didn't specify K6_CONFIG or --config, use the default path
-		realConfigFilePath = globalFlags.defaultConfigFilePath
-	}
-
+// Reads the configuration file from the supplied filesystem and returns it or
+// an error. The only situation in which an error won't be returned is if the
+// user didn't explicitly specify a config file path and the default config file
+// doesn't exist.
+func readDiskConfig(globalState *globalState) (Config, error) {
 	// Try to see if the file exists in the supplied filesystem
-	if _, err := fs.Stat(realConfigFilePath); err != nil {
-		if os.IsNotExist(err) && globalFlags.configFilePath == "" {
+	if _, err := globalState.fs.Stat(globalState.flags.configFilePath); err != nil {
+		if os.IsNotExist(err) && globalState.flags.configFilePath == globalState.defaultFlags.configFilePath {
 			// If the file doesn't exist, but it was the default config file (i.e. the user
 			// didn't specify anything), silence the error
 			err = nil
 		}
-		return Config{}, realConfigFilePath, err
+		return Config{}, err
 	}
 
-	data, err := afero.ReadFile(fs, realConfigFilePath)
+	data, err := afero.ReadFile(globalState.fs, globalState.flags.configFilePath)
 	if err != nil {
-		return Config{}, realConfigFilePath, err
+		return Config{}, err
 	}
 	var conf Config
-	err = json.Unmarshal(data, &conf)
-	return conf, realConfigFilePath, err
+	return conf, json.Unmarshal(data, &conf)
 }
 
 // Serializes the configuration to a JSON file and writes it in the supplied
 // location on the supplied filesystem
-func writeDiskConfig(fs afero.Fs, configPath string, conf Config) error {
+func writeDiskConfig(globalState *globalState, conf Config) error {
 	data, err := json.MarshalIndent(conf, "", "  ")
 	if err != nil {
 		return err
 	}
 
-	if err := fs.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+	if err := globalState.fs.MkdirAll(filepath.Dir(globalState.flags.configFilePath), 0o755); err != nil {
 		return err
 	}
 
-	return afero.WriteFile(fs, configPath, data, 0o644)
+	return afero.WriteFile(globalState.fs, globalState.flags.configFilePath, data, 0o644)
 }
 
 // Reads configuration variables from the environment.
@@ -176,16 +167,14 @@ func readEnvConfig(envMap map[string]string) (Config, error) {
 // - set some defaults if they weren't previously specified
 // TODO: add better validation, more explicit default values and improve consistency between formats
 // TODO: accumulate all errors and differentiate between the layers?
-func getConsolidatedConfig(
-	fs afero.Fs, cliConf Config, runnerOpts lib.Options, envMap map[string]string, globalFlags *commandFlags,
-) (conf Config, err error) {
+func getConsolidatedConfig(globalState *globalState, cliConf Config, runnerOpts lib.Options) (conf Config, err error) {
 	// TODO: use errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig) where it makes sense?
 
-	fileConf, _, err := readDiskConfig(fs, globalFlags)
+	fileConf, err := readDiskConfig(globalState)
 	if err != nil {
 		return conf, err
 	}
-	envConf, err := readEnvConfig(envMap)
+	envConf, err := readEnvConfig(globalState.envVars)
 	if err != nil {
 		return conf, err
 	}

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -23,8 +23,6 @@ package cmd
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
-	"path/filepath"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -35,7 +33,7 @@ import (
 )
 
 //nolint:funlen,gocognit
-func getConvertCmd(defaultFs afero.Fs, defaultWriter io.Writer) *cobra.Command {
+func getConvertCmd(globalState *globalState) *cobra.Command {
 	var (
 		convertOutput       string
 		optionsFilePath     string
@@ -68,11 +66,7 @@ func getConvertCmd(defaultFs afero.Fs, defaultWriter io.Writer) *cobra.Command {
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Parse the HAR file
-			filePath, err := filepath.Abs(args[0])
-			if err != nil {
-				return err
-			}
-			r, err := defaultFs.Open(filePath)
+			r, err := globalState.fs.Open(args[0])
 			if err != nil {
 				return err
 			}
@@ -88,9 +82,9 @@ func getConvertCmd(defaultFs afero.Fs, defaultWriter io.Writer) *cobra.Command {
 			options := lib.Options{MaxRedirects: null.IntFrom(0)}
 
 			if optionsFilePath != "" {
-				optionsFileContents, err := ioutil.ReadFile(optionsFilePath) //nolint:gosec,govet
-				if err != nil {
-					return err
+				optionsFileContents, readErr := afero.ReadFile(globalState.fs, optionsFilePath)
+				if readErr != nil {
+					return readErr
 				}
 				var injectedOptions lib.Options
 				if err := json.Unmarshal(optionsFileContents, &injectedOptions); err != nil {
@@ -108,11 +102,11 @@ func getConvertCmd(defaultFs afero.Fs, defaultWriter io.Writer) *cobra.Command {
 
 			// Write script content to stdout or file
 			if convertOutput == "" || convertOutput == "-" { //nolint:nestif
-				if _, err := io.WriteString(defaultWriter, script); err != nil {
+				if _, err := io.WriteString(globalState.stdOut, script); err != nil {
 					return err
 				}
 			} else {
-				f, err := defaultFs.Create(convertOutput)
+				f, err := globalState.fs.Create(convertOutput)
 				if err != nil {
 					return err
 				}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -24,10 +24,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"os"
 
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 
 	"go.k6.io/k6/js"
@@ -36,7 +33,7 @@ import (
 	"go.k6.io/k6/lib/types"
 )
 
-func getInspectCmd(logger *logrus.Logger, globalFlags *commandFlags) *cobra.Command {
+func getInspectCmd(globalState *globalState) *cobra.Command {
 	var addExecReqs bool
 
 	// inspectCmd represents the inspect command
@@ -46,19 +43,19 @@ func getInspectCmd(logger *logrus.Logger, globalFlags *commandFlags) *cobra.Comm
 		Long:  `Inspect a script or archive.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			src, filesystems, err := readSource(args[0], logger)
+			src, filesystems, err := readSource(globalState, args[0])
 			if err != nil {
 				return err
 			}
 
-			runtimeOptions, err := getRuntimeOptions(cmd.Flags(), buildEnvMap(os.Environ()))
+			runtimeOptions, err := getRuntimeOptions(cmd.Flags(), globalState.envVars)
 			if err != nil {
 				return err
 			}
 			registry := metrics.NewRegistry()
 
 			var b *js.Bundle
-			typ := globalFlags.runType
+			typ := globalState.flags.runType
 			if typ == "" {
 				typ = detectType(src.Data)
 			}
@@ -70,10 +67,10 @@ func getInspectCmd(logger *logrus.Logger, globalFlags *commandFlags) *cobra.Comm
 				if err != nil {
 					return err
 				}
-				b, err = js.NewBundleFromArchive(logger, arc, runtimeOptions, registry)
+				b, err = js.NewBundleFromArchive(globalState.logger, arc, runtimeOptions, registry)
 
 			case typeJS:
-				b, err = js.NewBundle(logger, src, filesystems, runtimeOptions, registry)
+				b, err = js.NewBundle(globalState.logger, src, filesystems, runtimeOptions, registry)
 			}
 			if err != nil {
 				return err
@@ -83,7 +80,7 @@ func getInspectCmd(logger *logrus.Logger, globalFlags *commandFlags) *cobra.Comm
 			inspectOutput := interface{}(b.Options)
 
 			if addExecReqs {
-				inspectOutput, err = addExecRequirements(b, logger, globalFlags)
+				inspectOutput, err = addExecRequirements(globalState, b)
 				if err != nil {
 					return err
 				}
@@ -101,7 +98,8 @@ func getInspectCmd(logger *logrus.Logger, globalFlags *commandFlags) *cobra.Comm
 
 	inspectCmd.Flags().SortFlags = false
 	inspectCmd.Flags().AddFlagSet(runtimeOptionFlagSet(false))
-	inspectCmd.Flags().StringVarP(&globalFlags.runType, "type", "t", globalFlags.runType, "override file `type`, \"js\" or \"archive\"") //nolint:lll
+	inspectCmd.Flags().StringVarP(&globalState.flags.runType, "type", "t",
+		globalState.flags.runType, "override file `type`, \"js\" or \"archive\"")
 	inspectCmd.Flags().BoolVar(&addExecReqs,
 		"execution-requirements",
 		false,
@@ -110,14 +108,13 @@ func getInspectCmd(logger *logrus.Logger, globalFlags *commandFlags) *cobra.Comm
 	return inspectCmd
 }
 
-func addExecRequirements(b *js.Bundle, logger *logrus.Logger, globalFlags *commandFlags) (interface{}, error) {
-	conf, err := getConsolidatedConfig(
-		afero.NewOsFs(), Config{}, b.Options, buildEnvMap(os.Environ()), globalFlags)
+func addExecRequirements(gs *globalState, b *js.Bundle) (interface{}, error) {
+	conf, err := getConsolidatedConfig(gs, Config{}, b.Options)
 	if err != nil {
 		return nil, err
 	}
 
-	conf, err = deriveAndValidateConfig(conf, b.IsExecutable, logger)
+	conf, err = deriveAndValidateConfig(conf, b.IsExecutable, gs.logger)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -23,12 +23,9 @@ package cmd
 import (
 	"encoding/json"
 	"errors"
-	"os"
 	"syscall"
 
 	"github.com/fatih/color"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 	"gopkg.in/guregu/null.v3"
@@ -39,7 +36,7 @@ import (
 )
 
 //nolint:funlen,gocognit
-func getLoginCloudCommand(logger logrus.FieldLogger, globalFlags *commandFlags) *cobra.Command {
+func getLoginCloudCommand(globalState *globalState) *cobra.Command {
 	// loginCloudCommand represents the 'login cloud' command
 	loginCloudCommand := &cobra.Command{
 		Use:   "cloud",
@@ -58,9 +55,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
   k6 login cloud`[1:],
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fs := afero.NewOsFs()
-
-			currentDiskConf, configPath, err := readDiskConfig(fs, globalFlags)
+			currentDiskConf, err := readDiskConfig(globalState)
 			if err != nil {
 				return err
 			}
@@ -77,7 +72,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 			// We want to use this fully consolidated config for things like
 			// host addresses, so users can overwrite them with env vars.
 			consolidatedCurrentConfig, err := cloudapi.GetConsolidatedConfig(
-				currentJSONConfigRaw, buildEnvMap(os.Environ()), "", nil)
+				currentJSONConfigRaw, globalState.envVars, "", nil)
 			if err != nil {
 				return err
 			}
@@ -91,7 +86,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 			switch {
 			case reset.Valid:
 				newCloudConf.Token = null.StringFromPtr(nil)
-				fprintf(globalFlags.stdout, "  token reset\n")
+				fprintf(globalState.stdOut, "  token reset\n")
 			case show.Bool:
 			case token.Valid:
 				newCloudConf.Token = token
@@ -109,10 +104,10 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 					},
 				}
 				if !term.IsTerminal(int(syscall.Stdin)) { // nolint: unconvert
-					logger.Warn("Stdin is not a terminal, falling back to plain text input")
+					globalState.logger.Warn("Stdin is not a terminal, falling back to plain text input")
 				}
 				var vals map[string]string
-				vals, err = form.Run(os.Stdin, globalFlags.stdout)
+				vals, err = form.Run(globalState.stdIn, globalState.stdOut)
 				if err != nil {
 					return err
 				}
@@ -120,7 +115,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 				password := vals["Password"]
 
 				client := cloudapi.NewClient(
-					logger,
+					globalState.logger,
 					"",
 					consolidatedCurrentConfig.Host.String,
 					consts.Version,
@@ -146,13 +141,13 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 			if err != nil {
 				return err
 			}
-			if err := writeDiskConfig(fs, configPath, currentDiskConf); err != nil {
+			if err := writeDiskConfig(globalState, currentDiskConf); err != nil {
 				return err
 			}
 
 			if newCloudConf.Token.Valid {
-				valueColor := getColor(globalFlags.noColor || !globalFlags.stdoutTTY, color.FgCyan)
-				fprintf(globalFlags.stdout, "  token: %s\n", valueColor.Sprint(newCloudConf.Token.String))
+				valueColor := getColor(globalState.flags.noColor || !globalState.stdOut.isTTY, color.FgCyan)
+				fprintf(globalState.stdOut, "  token: %s\n", valueColor.Sprint(newCloudConf.Token.String))
 			}
 			return nil
 		},

--- a/cmd/login_influxdb.go
+++ b/cmd/login_influxdb.go
@@ -22,12 +22,9 @@ package cmd
 
 import (
 	"encoding/json"
-	"os"
 	"syscall"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 	"gopkg.in/guregu/null.v3"
@@ -37,7 +34,7 @@ import (
 )
 
 //nolint:funlen
-func getLoginInfluxDBCommand(logger logrus.FieldLogger, globalFlags *commandFlags) *cobra.Command {
+func getLoginInfluxDBCommand(globalState *globalState) *cobra.Command {
 	// loginInfluxDBCommand represents the 'login influxdb' command
 	loginInfluxDBCommand := &cobra.Command{
 		Use:   "influxdb [uri]",
@@ -47,8 +44,7 @@ func getLoginInfluxDBCommand(logger logrus.FieldLogger, globalFlags *commandFlag
 This will set the default server used when just "-o influxdb" is passed.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fs := afero.NewOsFs()
-			config, configPath, err := readDiskConfig(fs, globalFlags)
+			config, err := readDiskConfig(globalState)
 			if err != nil {
 				return err
 			}
@@ -94,9 +90,9 @@ This will set the default server used when just "-o influxdb" is passed.`,
 				},
 			}
 			if !term.IsTerminal(int(syscall.Stdin)) { // nolint: unconvert
-				logger.Warn("Stdin is not a terminal, falling back to plain text input")
+				globalState.logger.Warn("Stdin is not a terminal, falling back to plain text input")
 			}
-			vals, err := form.Run(os.Stdin, globalFlags.stdout)
+			vals, err := form.Run(globalState.stdIn, globalState.stdOut)
 			if err != nil {
 				return err
 			}
@@ -121,7 +117,7 @@ This will set the default server used when just "-o influxdb" is passed.`,
 			if err != nil {
 				return err
 			}
-			return writeDiskConfig(fs, configPath, config)
+			return writeDiskConfig(globalState, config)
 		},
 	}
 	return loginInfluxDBCommand

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -21,8 +21,6 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"gopkg.in/guregu/null.v3"
 
@@ -30,7 +28,7 @@ import (
 	"go.k6.io/k6/api/v1/client"
 )
 
-func getPauseCmd(ctx context.Context, globalFlags *commandFlags) *cobra.Command {
+func getPauseCmd(globalState *globalState) *cobra.Command {
 	// pauseCmd represents the pause command
 	pauseCmd := &cobra.Command{
 		Use:   "pause",
@@ -39,17 +37,17 @@ func getPauseCmd(ctx context.Context, globalFlags *commandFlags) *cobra.Command 
 
   Use the global --address flag to specify the URL to the API server.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New(globalFlags.address)
+			c, err := client.New(globalState.flags.address)
 			if err != nil {
 				return err
 			}
-			status, err := c.SetStatus(ctx, v1.Status{
+			status, err := c.SetStatus(globalState.ctx, v1.Status{
 				Paused: null.BoolFrom(true),
 			})
 			if err != nil {
 				return err
 			}
-			return yamlPrint(globalFlags.stdout, status)
+			return yamlPrint(globalState.stdOut, status)
 		},
 	}
 	return pauseCmd

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -21,8 +21,6 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 	"gopkg.in/guregu/null.v3"
 
@@ -30,7 +28,7 @@ import (
 	"go.k6.io/k6/api/v1/client"
 )
 
-func getResumeCmd(ctx context.Context, globalFlags *commandFlags) *cobra.Command {
+func getResumeCmd(globalState *globalState) *cobra.Command {
 	// resumeCmd represents the resume command
 	resumeCmd := &cobra.Command{
 		Use:   "resume",
@@ -39,18 +37,18 @@ func getResumeCmd(ctx context.Context, globalFlags *commandFlags) *cobra.Command
 
   Use the global --address flag to specify the URL to the API server.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New(globalFlags.address)
+			c, err := client.New(globalState.flags.address)
 			if err != nil {
 				return err
 			}
-			status, err := c.SetStatus(ctx, v1.Status{
+			status, err := c.SetStatus(globalState.ctx, v1.Status{
 				Paused: null.BoolFrom(false),
 			})
 			if err != nil {
 				return err
 			}
 
-			return yamlPrint(globalFlags.stdout, status)
+			return yamlPrint(globalState.stdOut, status)
 		},
 	}
 	return resumeCmd

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/signal"
+	"runtime"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/lib/testutils"
+)
+
+type globalTestState struct {
+	*globalState
+	cancel func()
+
+	stdOut, stdErr *bytes.Buffer
+	loggerHook     *testutils.SimpleLogrusHook
+
+	cwd string
+}
+
+func newGlobalTestState(t *testing.T) *globalTestState {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	fs := &afero.MemMapFs{}
+	cwd := "/test/"
+	if runtime.GOOS == "windows" {
+		cwd = "c:\\test\\"
+	}
+	require.NoError(t, fs.MkdirAll(cwd, 0o755))
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.InfoLevel)
+	logger.Out = testutils.NewTestOutput(t)
+	hook := &testutils.SimpleLogrusHook{HookedLevels: logrus.AllLevels}
+	logger.AddHook(hook)
+
+	ts := &globalTestState{
+		cwd:        cwd,
+		cancel:     cancel,
+		loggerHook: hook,
+		stdOut:     new(bytes.Buffer),
+		stdErr:     new(bytes.Buffer),
+	}
+
+	outMutex := &sync.Mutex{}
+	defaultFlags := getDefaultFlags(".config")
+	ts.globalState = &globalState{
+		ctx:            ctx,
+		fs:             fs,
+		getwd:          func() (string, error) { return ts.cwd, nil },
+		args:           []string{},
+		envVars:        map[string]string{},
+		defaultFlags:   defaultFlags,
+		flags:          defaultFlags,
+		outMutex:       outMutex,
+		stdOut:         &consoleWriter{nil, ts.stdOut, false, outMutex, nil},
+		stdErr:         &consoleWriter{nil, ts.stdErr, false, outMutex, nil},
+		stdIn:          os.Stdin, // TODO: spoof?
+		signalNotify:   signal.Notify,
+		signalStop:     signal.Stop,
+		logger:         logger,
+		fallbackLogger: testutils.NewLogger(t).WithField("fallback", true),
+	}
+	return ts
+}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -30,9 +30,9 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -41,6 +41,7 @@ import (
 	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/lib/fsext"
+	"go.k6.io/k6/lib/testutils"
 )
 
 type mockWriter struct {
@@ -212,14 +213,7 @@ func TestRunScriptErrorsAndAbort(t *testing.T) {
 			}
 
 			if tc.expLogOutput != "" {
-				var gotMsg bool
-				for _, entry := range testState.loggerHook.Drain() {
-					if strings.Contains(entry.Message, tc.expLogOutput) {
-						gotMsg = true
-						break
-					}
-				}
-				assert.True(t, gotMsg)
+				assert.True(t, testutils.LogContains(testState.loggerHook.Drain(), logrus.InfoLevel, tc.expLogOutput))
 			}
 		})
 	}

--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/spf13/pflag"
 	"gopkg.in/guregu/null.v3"
@@ -37,22 +36,6 @@ import (
 // self-contained and easily testable now, without any global dependencies...
 
 var userEnvVarName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
-
-func parseEnvKeyValue(kv string) (string, string) {
-	if idx := strings.IndexRune(kv, '='); idx != -1 {
-		return kv[:idx], kv[idx+1:]
-	}
-	return kv, ""
-}
-
-func buildEnvMap(environ []string) map[string]string {
-	env := make(map[string]string, len(environ))
-	for _, kv := range environ {
-		k, v := parseEnvKeyValue(kv)
-		env[k] = v
-	}
-	return env
-}
 
 func runtimeOptionFlagSet(includeSysEnv bool) *pflag.FlagSet {
 	flags := pflag.NewFlagSet("", 0)

--- a/cmd/scale.go
+++ b/cmd/scale.go
@@ -21,7 +21,6 @@
 package cmd
 
 import (
-	"context"
 	"errors"
 
 	"github.com/spf13/cobra"
@@ -30,7 +29,7 @@ import (
 	"go.k6.io/k6/api/v1/client"
 )
 
-func getScaleCmd(ctx context.Context, globalFlags *commandFlags) *cobra.Command {
+func getScaleCmd(globalState *globalState) *cobra.Command {
 	// scaleCmd represents the scale command
 	scaleCmd := &cobra.Command{
 		Use:   "scale",
@@ -45,16 +44,16 @@ func getScaleCmd(ctx context.Context, globalFlags *commandFlags) *cobra.Command 
 				return errors.New("Specify either -u/--vus or -m/--max") //nolint:golint,stylecheck
 			}
 
-			c, err := client.New(globalFlags.address)
+			c, err := client.New(globalState.flags.address)
 			if err != nil {
 				return err
 			}
-			status, err := c.SetStatus(ctx, v1.Status{VUs: vus, VUsMax: max})
+			status, err := c.SetStatus(globalState.ctx, v1.Status{VUs: vus, VUsMax: max})
 			if err != nil {
 				return err
 			}
 
-			return yamlPrint(globalFlags.stdout, status)
+			return yamlPrint(globalState.stdOut, status)
 		},
 	}
 

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -21,14 +21,12 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	"go.k6.io/k6/api/v1/client"
 )
 
-func getStatsCmd(ctx context.Context, globalFlags *commandFlags) *cobra.Command {
+func getStatsCmd(globalState *globalState) *cobra.Command {
 	// statsCmd represents the stats command
 	statsCmd := &cobra.Command{
 		Use:   "stats",
@@ -37,16 +35,16 @@ func getStatsCmd(ctx context.Context, globalFlags *commandFlags) *cobra.Command 
 
   Use the global --address flag to specify the URL to the API server.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New(globalFlags.address)
+			c, err := client.New(globalState.flags.address)
 			if err != nil {
 				return err
 			}
-			metrics, err := c.Metrics(ctx)
+			metrics, err := c.Metrics(globalState.ctx)
 			if err != nil {
 				return err
 			}
 
-			return yamlPrint(globalFlags.stdout, metrics)
+			return yamlPrint(globalState.stdOut, metrics)
 		},
 	}
 	return statsCmd

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -21,14 +21,12 @@
 package cmd
 
 import (
-	"context"
-
 	"github.com/spf13/cobra"
 
 	"go.k6.io/k6/api/v1/client"
 )
 
-func getStatusCmd(ctx context.Context, globalFlags *commandFlags) *cobra.Command {
+func getStatusCmd(globalState *globalState) *cobra.Command {
 	// statusCmd represents the status command
 	statusCmd := &cobra.Command{
 		Use:   "status",
@@ -37,16 +35,16 @@ func getStatusCmd(ctx context.Context, globalFlags *commandFlags) *cobra.Command
 
   Use the global --address flag to specify the URL to the API server.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			c, err := client.New(globalFlags.address)
+			c, err := client.New(globalState.flags.address)
 			if err != nil {
 				return err
 			}
-			status, err := c.Status(ctx)
+			status, err := c.Status(globalState.ctx)
 			if err != nil {
 				return err
 			}
 
-			return yamlPrint(globalFlags.stdout, status)
+			return yamlPrint(globalState.stdOut, status)
 		},
 	}
 	return statusCmd

--- a/cmd/ui_test.go
+++ b/cmd/ui_test.go
@@ -89,7 +89,7 @@ left 2   [   0% ] right 2  000
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			pbs := createTestProgressBars(3, tc.padding, 1)
-			out, longestLine := renderMultipleBars(false, false, 6+tc.padding, 80, tc.widthDelta, pbs, &commandFlags{})
+			out, longestLine := renderMultipleBars(true, false, false, 6+tc.padding, 80, tc.widthDelta, pbs)
 			assert.Equal(t, tc.expOut, out)
 			assert.Equal(t, tc.expLongLine, longestLine)
 		})

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,21 +21,19 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"go.k6.io/k6/lib/consts"
 )
 
-func getVersionCmd() *cobra.Command {
+func getVersionCmd(globalState *globalState) *cobra.Command {
 	// versionCmd represents the version command.
 	versionCmd := &cobra.Command{
 		Use:   "version",
 		Short: "Show application version",
 		Long:  `Show the application version and exit.`,
 		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Println("k6 v" + consts.FullVersion()) //nolint:forbidigo // we probably shouldn't do that though
+			fprintf(globalState.stdOut, "k6 v%s\n", consts.FullVersion())
 		},
 	}
 	return versionCmd

--- a/lib/testutils/logrus_hook.go
+++ b/lib/testutils/logrus_hook.go
@@ -21,6 +21,7 @@
 package testutils
 
 import (
+	"strings"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -57,3 +58,14 @@ func (smh *SimpleLogrusHook) Drain() []logrus.Entry {
 }
 
 var _ logrus.Hook = &SimpleLogrusHook{}
+
+// LogContains is a helper function that checks the provided list of log entries
+// for a message matching the provided level and contents.
+func LogContains(logEntries []logrus.Entry, expLevel logrus.Level, expContents string) bool {
+	for _, entry := range logEntries {
+		if entry.Level == expLevel && strings.Contains(entry.Message, expContents) {
+			return true
+		}
+	}
+	return false
+}

--- a/loader/filesystems.go
+++ b/loader/filesystems.go
@@ -29,12 +29,11 @@ import (
 )
 
 // CreateFilesystems creates the correct filesystem map for the current OS
-func CreateFilesystems() map[string]afero.Fs {
+func CreateFilesystems(osfs afero.Fs) map[string]afero.Fs {
 	// We want to eliminate disk access at runtime, so we set up a memory mapped cache that's
 	// written every time something is read from the real filesystem. This cache is then used for
 	// successive spawns to read from (they have no access to the real disk).
 	// Also initialize the same for `https` but the caching is handled manually in the loader package
-	osfs := afero.NewOsFs()
 	if runtime.GOOS == "windows" {
 		// This is done so that we can continue to use paths with /|"\" through the code but also to
 		// be easier to traverse the cachedFs later as it doesn't work very well if you have windows

--- a/log/file_test.go
+++ b/log/file_test.go
@@ -24,13 +24,12 @@ import (
 	"bufio"
 	"bytes"
 	"context"
-	"fmt"
 	"io"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -62,16 +61,12 @@ func TestFileHookFromConfigLine(t *testing.T) {
 			},
 		},
 		{
-			line: fmt.Sprintf("file=%s/k6.log,level=info", os.TempDir()),
+			line: "file=/k6.log,level=info",
 			err:  false,
 			res: fileHook{
-				path:   fmt.Sprintf("%s/k6.log", os.TempDir()),
+				path:   "/k6.log",
 				levels: logrus.AllLevels[:5],
 			},
-		},
-		{
-			line: "file=./",
-			err:  true,
 		},
 		{
 			line: "file=/a/c/",
@@ -116,7 +111,7 @@ func TestFileHookFromConfigLine(t *testing.T) {
 			t.Parallel()
 
 			res, err := FileHookFromConfigLine(
-				context.Background(), logrus.New(), test.line, make(chan struct{}),
+				context.Background(), afero.NewMemMapFs(), logrus.New(), test.line, make(chan struct{}),
 			)
 
 			if test.err {


### PR DESCRIPTION
This wasn't quite part of the plan, but several hours of yak shaving produced some nice results :sweat_smile: Anyway, `cmd/` looks much nicer and it's now finally safe to test with basically full internal integration tests :tada: 

That said, there is a very high chance of bugs and errors, since we don't yet have full test coverage of `cmd/`... :disappointed: So a careful review and PRs that add more tests are going to be quite welcome :bow: Ideally, we should try to merge this at the beginning of the v0.38.0 cycle, so we also have the maximum time to safely hit any bugs during our manual tests and work...

And I think there were actually some (potential) bugs that were fixed by this refactor. For example, these loggers: https://github.com/grafana/k6/blob/1e28a3e1c8655d2118c823113e7a90ce44736cfe/cmd/root.go#L163-L175
Did not actually use the wrapped `stdout` that is protected by a mutex: https://github.com/grafana/k6/blob/1e28a3e1c8655d2118c823113e7a90ce44736cfe/cmd/root.go#L97

With the last commit, this PR also closes https://github.com/grafana/k6/issues/2091 :tada: 