### PR TITLE
More `cmd/` refactoring to simplify test loading and support integration tests

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -42,7 +42,7 @@ An archive is a fully self-contained test run, and can be executed identically e
   k6 run myarchive.tar`[1:],
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			test, err := loadTest(gs, cmd, args, getPartialConfig)
+			test, err := loadAndConfigureTest(gs, cmd, args, getPartialConfig)
 			if err != nil {
 				return err
 			}

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -23,13 +23,9 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-
-	"go.k6.io/k6/errext"
-	"go.k6.io/k6/errext/exitcodes"
-	"go.k6.io/k6/lib/metrics"
 )
 
-func getArchiveCmd(globalState *globalState) *cobra.Command { // nolint: funlen
+func getArchiveCmd(gs *globalState) *cobra.Command {
 	archiveOut := "archive.tar"
 	// archiveCmd represents the archive command
 	archiveCmd := &cobra.Command{
@@ -46,60 +42,24 @@ An archive is a fully self-contained test run, and can be executed identically e
   k6 run myarchive.tar`[1:],
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			src, filesystems, err := readSource(globalState, args[0])
+			test, err := loadTest(gs, cmd, args, getPartialConfig)
 			if err != nil {
 				return err
 			}
 
-			runtimeOptions, err := getRuntimeOptions(cmd.Flags(), globalState.envVars)
-			if err != nil {
-				return err
-			}
-
-			registry := metrics.NewRegistry()
-			builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
-			r, err := newRunner(
-				globalState.logger, src, globalState.flags.runType,
-				filesystems, runtimeOptions, builtinMetrics, registry,
-			)
-			if err != nil {
-				return err
-			}
-
-			cliOpts, err := getOptions(cmd.Flags())
-			if err != nil {
-				return err
-			}
-			conf, err := getConsolidatedConfig(globalState, Config{Options: cliOpts}, r.GetOptions())
-			if err != nil {
-				return err
-			}
-
-			// Parse the thresholds, only if the --no-threshold flag is not set.
-			// If parsing the threshold expressions failed, consider it as an
-			// invalid configuration error.
-			if !runtimeOptions.NoThresholds.Bool {
-				for _, thresholds := range conf.Options.Thresholds {
-					err = thresholds.Parse()
-					if err != nil {
-						return errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
-					}
-				}
-			}
-
-			_, err = deriveAndValidateConfig(conf, r.IsExecutable, globalState.logger)
-			if err != nil {
-				return err
-			}
-
-			err = r.SetOptions(conf.Options)
+			// It's important to NOT set the derived options back to the runner
+			// here, only the consolidated ones. Otherwise, if the script used
+			// an execution shortcut option (e.g. `iterations` or `duration`),
+			// we will have multiple conflicting execution options since the
+			// derivation will set `scenarios` as well.
+			err = test.initRunner.SetOptions(test.consolidatedConfig.Options)
 			if err != nil {
 				return err
 			}
 
 			// Archive.
-			arc := r.MakeArchive()
-			f, err := globalState.fs.Create(archiveOut)
+			arc := test.initRunner.MakeArchive()
+			f, err := gs.fs.Create(archiveOut)
 			if err != nil {
 				return err
 			}

--- a/cmd/archive_test.go
+++ b/cmd/archive_test.go
@@ -6,9 +6,7 @@ import (
 	"testing"
 
 	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.k6.io/k6/errext"
 	"go.k6.io/k6/errext/exitcodes"
 )
 
@@ -51,21 +49,10 @@ func TestArchiveThresholds(t *testing.T) {
 				testState.args = append(testState.args, "--no-thresholds")
 			}
 
-			gotErr := newRootCommand(testState.globalState).cmd.Execute()
-
-			assert.Equal(t,
-				testCase.wantErr,
-				gotErr != nil,
-				"archive command error = %v, wantErr %v", gotErr, testCase.wantErr,
-			)
-
 			if testCase.wantErr {
-				var gotErrExt errext.HasExitCode
-				require.ErrorAs(t, gotErr, &gotErrExt)
-				assert.Equalf(t, exitcodes.InvalidConfig, gotErrExt.ExitCode(),
-					"status code must be %d", exitcodes.InvalidConfig,
-				)
+				testState.expectedExitCode = int(exitcodes.InvalidConfig)
 			}
+			newRootCommand(testState.globalState).execute()
 		})
 	}
 }

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -42,7 +42,6 @@ import (
 	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
-	"go.k6.io/k6/lib/metrics"
 	"go.k6.io/k6/ui/pb"
 )
 
@@ -91,56 +90,23 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 		RunE: func(cmd *cobra.Command, args []string) error {
 			printBanner(globalState)
 
-			logger := globalState.logger
 			progressBar := pb.New(
 				pb.WithConstLeft("Init"),
-				pb.WithConstProgress(0, "Parsing script"),
+				pb.WithConstProgress(0, "Loading test script..."),
 			)
 			printBar(globalState, progressBar)
 
-			// Runner
-			filename := args[0]
-			src, filesystems, err := readSource(globalState, filename)
+			test, err := loadTest(globalState, cmd, args, getPartialConfig)
 			if err != nil {
 				return err
 			}
 
-			runtimeOptions, err := getRuntimeOptions(cmd.Flags(), globalState.envVars)
-			if err != nil {
-				return err
-			}
-
-			modifyAndPrintBar(globalState, progressBar, pb.WithConstProgress(0, "Getting script options"))
-			registry := metrics.NewRegistry()
-			builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
-			r, err := newRunner(logger, src, globalState.flags.runType, filesystems, runtimeOptions, builtinMetrics, registry)
-			if err != nil {
-				return err
-			}
-
-			modifyAndPrintBar(globalState, progressBar, pb.WithConstProgress(0, "Consolidating options"))
-			cliOpts, err := getOptions(cmd.Flags())
-			if err != nil {
-				return err
-			}
-			conf, err := getConsolidatedConfig(globalState, Config{Options: cliOpts}, r.GetOptions())
-			if err != nil {
-				return err
-			}
-
-			// Parse the thresholds, only if the --no-threshold flag is not set.
-			// If parsing the threshold expressions failed, consider it as an
-			// invalid configuration error.
-			if !runtimeOptions.NoThresholds.Bool {
-				for _, thresholds := range conf.Options.Thresholds {
-					err = thresholds.Parse()
-					if err != nil {
-						return errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
-					}
-				}
-			}
-
-			derivedConf, err := deriveAndValidateConfig(conf, r.IsExecutable, logger)
+			// It's important to NOT set the derived options back to the runner
+			// here, only the consolidated ones. Otherwise, if the script used
+			// an execution shortcut option (e.g. `iterations` or `duration`),
+			// we will have multiple conflicting execution options since the
+			// derivation will set `scenarios` as well.
+			err = test.initRunner.SetOptions(test.consolidatedConfig.Options)
 			if err != nil {
 				return err
 			}
@@ -149,13 +115,9 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 			// TODO: validate for externally controlled executor (i.e. executors that aren't distributable)
 			// TODO: move those validations to a separate function and reuse validateConfig()?
 
-			err = r.SetOptions(conf.Options)
-			if err != nil {
-				return err
-			}
+			modifyAndPrintBar(globalState, progressBar, pb.WithConstProgress(0, "Building the archive..."))
+			arc := test.initRunner.MakeArchive()
 
-			modifyAndPrintBar(globalState, progressBar, pb.WithConstProgress(0, "Building the archive"))
-			arc := r.MakeArchive()
 			// TODO: Fix this
 			// We reuse cloud.Config for parsing options.ext.loadimpact, but this probably shouldn't be
 			// done, as the idea of options.ext is that they are extensible without touching k6. But in
@@ -174,7 +136,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 
 			// Cloud config
 			cloudConfig, err := cloudapi.GetConsolidatedConfig(
-				derivedConf.Collectors["cloud"], globalState.envVars, "", arc.Options.External)
+				test.derivedConfig.Collectors["cloud"], globalState.envVars, "", arc.Options.External)
 			if err != nil {
 				return err
 			}
@@ -205,11 +167,13 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 
 			name := cloudConfig.Name.String
 			if !cloudConfig.Name.Valid || cloudConfig.Name.String == "" {
-				name = filepath.Base(filename)
+				name = filepath.Base(test.testPath)
 			}
 
 			globalCtx, globalCancel := context.WithCancel(globalState.ctx)
 			defer globalCancel()
+
+			logger := globalState.logger
 
 			// Start cloud test run
 			modifyAndPrintBar(globalState, progressBar, pb.WithConstProgress(0, "Validating script options"))
@@ -248,14 +212,14 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 				os.Exit(int(exitcodes.ExternalAbort))
 			}()
 
-			et, err := lib.NewExecutionTuple(derivedConf.ExecutionSegment, derivedConf.ExecutionSegmentSequence)
+			et, err := lib.NewExecutionTuple(test.derivedConfig.ExecutionSegment, test.derivedConfig.ExecutionSegmentSequence)
 			if err != nil {
 				return err
 			}
 			testURL := cloudapi.URLForResults(refID, cloudConfig)
-			executionPlan := derivedConf.Scenarios.GetFullExecutionRequirements(et)
+			executionPlan := test.derivedConfig.Scenarios.GetFullExecutionRequirements(et)
 			printExecutionDescription(
-				globalState, "cloud", filename, testURL, derivedConf, et, executionPlan, nil,
+				globalState, "cloud", test.testPath, testURL, test.derivedConfig, et, executionPlan, nil,
 			)
 
 			modifyAndPrintBar(

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -95,7 +95,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 			)
 			printBar(globalState, progressBar)
 
-			test, err := loadTest(globalState, cmd, args, getPartialConfig)
+			test, err := loadAndConfigureTest(globalState, cmd, args, getPartialConfig)
 			if err != nil {
 				return err
 			}
@@ -166,7 +166,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 
 			name := cloudConfig.Name.String
 			if !cloudConfig.Name.Valid || cloudConfig.Name.String == "" {
-				name = filepath.Base(test.testPath)
+				name = filepath.Base(test.sourceRootPath)
 			}
 
 			globalCtx, globalCancel := context.WithCancel(globalState.ctx)
@@ -216,7 +216,7 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 			testURL := cloudapi.URLForResults(refID, cloudConfig)
 			executionPlan := test.derivedConfig.Scenarios.GetFullExecutionRequirements(et)
 			printExecutionDescription(
-				globalState, "cloud", test.testPath, testURL, test.derivedConfig, et, executionPlan, nil,
+				globalState, "cloud", test.sourceRootPath, testURL, test.derivedConfig, et, executionPlan, nil,
 			)
 
 			modifyAndPrintBar(

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -112,7 +112,7 @@ func handleTestAbortSignals(gs *globalState, firstHandler, secondHandler func(os
 			}
 			// If we get a second signal, we immediately exit, so something like
 			// https://github.com/k6io/k6/issues/971 never happens again
-			os.Exit(int(exitcodes.ExternalAbort))
+			gs.osExit(int(exitcodes.ExternalAbort))
 		case <-done:
 			return
 		}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -21,17 +21,13 @@
 package cmd
 
 import (
-	"archive/tar"
-	"bytes"
 	"fmt"
 
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/lib/types"
-	"go.k6.io/k6/loader"
 )
 
 // Panic if the given error is not nil.
@@ -84,26 +80,6 @@ func exactArgsWithMsg(n int, msg string) cobra.PositionalArgs {
 		}
 		return nil
 	}
-}
-
-// readSource is a small wrapper around loader.ReadSource returning
-// result of the load and filesystems map
-func readSource(globalState *globalState, filename string) (*loader.SourceData, map[string]afero.Fs, error) {
-	pwd, err := globalState.getwd()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	filesystems := loader.CreateFilesystems(globalState.fs)
-	src, err := loader.ReadSource(globalState.logger, filename, pwd, filesystems, globalState.stdIn)
-	return src, filesystems, err
-}
-
-func detectType(data []byte) string {
-	if _, err := tar.NewReader(bytes.NewReader(data)).Next(); err == nil {
-		return typeArchive
-	}
-	return typeJS
 }
 
 func printToStdout(gs *globalState, s string) {

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -91,6 +91,16 @@ func (c Config) Apply(cfg Config) Config {
 	return c
 }
 
+// Returns a Config but only parses the Options inside.
+func getPartialConfig(flags *pflag.FlagSet) (Config, error) {
+	opts, err := getOptions(flags)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return Config{Options: opts}, nil
+}
+
 // Gets configuration from CLI flags.
 func getConfig(flags *pflag.FlagSet) (Config, error) {
 	opts, err := getOptions(flags)

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -134,7 +134,7 @@ func TestConvertCmdCorrelate(t *testing.T) {
 		"--enable-status-code-checks=true", "--return-on-failed-check=true", "correlate.har",
 	}
 
-	require.NoError(t, newRootCommand(testState.globalState).cmd.Execute())
+	newRootCommand(testState.globalState).execute()
 
 	result, err := afero.ReadFile(testState.fs, "result.js")
 	require.NoError(t, err)
@@ -166,7 +166,7 @@ func TestConvertCmdStdout(t *testing.T) {
 	require.NoError(t, afero.WriteFile(testState.fs, "stdout.har", []byte(testHAR), 0o644))
 	testState.args = []string{"k6", "convert", "stdout.har"}
 
-	require.NoError(t, newRootCommand(testState.globalState).cmd.Execute())
+	newRootCommand(testState.globalState).execute()
 	assert.Equal(t, testHARConvertResult, testState.stdOut.String())
 }
 
@@ -177,7 +177,7 @@ func TestConvertCmdOutputFile(t *testing.T) {
 	require.NoError(t, afero.WriteFile(testState.fs, "output.har", []byte(testHAR), 0o644))
 	testState.args = []string{"k6", "convert", "--output", "result.js", "output.har"}
 
-	require.NoError(t, newRootCommand(testState.globalState).cmd.Execute())
+	newRootCommand(testState.globalState).execute()
 
 	output, err := afero.ReadFile(testState.fs, "result.js")
 	assert.NoError(t, err)

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -68,8 +68,6 @@ func getInspectCmd(gs *globalState) *cobra.Command {
 
 	inspectCmd.Flags().SortFlags = false
 	inspectCmd.Flags().AddFlagSet(runtimeOptionFlagSet(false))
-	inspectCmd.Flags().StringVarP(&gs.flags.testType, "type", "t",
-		gs.flags.testType, "override file `type`, \"js\" or \"archive\"")
 	inspectCmd.Flags().BoolVar(&addExecReqs,
 		"execution-requirements",
 		false,

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -39,7 +39,7 @@ func getInspectCmd(gs *globalState) *cobra.Command {
 		Long:  `Inspect a script or archive.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			test, err := loadTest(gs, cmd, args, nil)
+			test, err := loadAndConfigureTest(gs, cmd, args, nil)
 			if err != nil {
 				return err
 			}

--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/lib/testutils"
+)
+
+const (
+	noopDefaultFunc   = `export default function() {};`
+	noopHandleSummary = `
+		export function handleSummary(data) {
+			return {}; // silence the end of test summary
+		};
+	`
+)
+
+func TestSimpleTestStdin(t *testing.T) {
+	t.Parallel()
+
+	ts := newGlobalTestState(t)
+	ts.args = []string{"k6", "run", "-"}
+	ts.stdIn = bytes.NewBufferString(noopDefaultFunc)
+	newRootCommand(ts.globalState).execute()
+
+	stdOut := ts.stdOut.String()
+	assert.Contains(t, stdOut, "default: 1 iterations for each of 1 VUs")
+	assert.Contains(t, stdOut, "1 complete and 0 interrupted iterations")
+	assert.Empty(t, ts.stdErr.Bytes())
+	assert.Empty(t, ts.loggerHook.Drain())
+}
+
+func TestStdoutAndStderrAreEmptyWithQuietAndHandleSummary(t *testing.T) {
+	t.Parallel()
+
+	ts := newGlobalTestState(t)
+	ts.args = []string{"k6", "--quiet", "run", "-"}
+	ts.stdIn = bytes.NewBufferString(noopDefaultFunc + noopHandleSummary)
+	newRootCommand(ts.globalState).execute()
+
+	assert.Empty(t, ts.stdErr.Bytes())
+	assert.Empty(t, ts.stdOut.Bytes())
+	assert.Empty(t, ts.loggerHook.Drain())
+}
+
+func TestStdoutAndStderrAreEmptyWithQuietAndLogsForwarded(t *testing.T) {
+	t.Parallel()
+
+	ts := newGlobalTestState(t)
+
+	// TODO: add a test with relative path
+	logFilePath := filepath.Join(ts.cwd, "test.log")
+
+	ts.args = []string{
+		"k6", "--quiet", "--log-output", "file=" + logFilePath,
+		"--log-format", "raw", "run", "--no-summary", "-",
+	}
+	ts.stdIn = bytes.NewBufferString(`export default function() { console.log('foo'); };`)
+	newRootCommand(ts.globalState).execute()
+
+	// The our test state hook still catches this message
+	assert.True(t, testutils.LogContains(ts.loggerHook.Drain(), logrus.InfoLevel, `foo`))
+
+	// But it's not shown on stderr or stdout
+	assert.Empty(t, ts.stdErr.Bytes())
+	assert.Empty(t, ts.stdOut.Bytes())
+
+	// Instead it should be in the log file
+	logContents, err := afero.ReadFile(ts.fs, logFilePath)
+	require.NoError(t, err)
+	assert.Equal(t, "foo\n", string(logContents))
+}
+
+func TestWrongCliFlagIterations(t *testing.T) {
+	t.Parallel()
+
+	ts := newGlobalTestState(t)
+	ts.args = []string{"k6", "run", "--iterations", "foo", "-"}
+	ts.stdIn = bytes.NewBufferString(noopDefaultFunc)
+	// TODO: check for exitcodes.InvalidConfig after https://github.com/loadimpact/k6/issues/883 is done...
+	ts.expectedExitCode = -1
+	newRootCommand(ts.globalState).execute()
+	assert.True(t, testutils.LogContains(ts.loggerHook.Drain(), logrus.ErrorLevel, `invalid argument "foo"`))
+}
+
+func TestWrongEnvVarIterations(t *testing.T) {
+	t.Parallel()
+
+	ts := newGlobalTestState(t)
+	ts.args = []string{"k6", "run", "--vus", "2", "-"}
+	ts.envVars = map[string]string{"K6_ITERATIONS": "4"}
+	ts.stdIn = bytes.NewBufferString(noopDefaultFunc)
+
+	newRootCommand(ts.globalState).execute()
+
+	stdOut := ts.stdOut.String()
+	t.Logf(stdOut)
+	assert.Contains(t, stdOut, "4 iterations shared among 2 VUs")
+	assert.Contains(t, stdOut, "4 complete and 0 interrupted iterations")
+	assert.Empty(t, ts.stdErr.Bytes())
+	assert.Empty(t, ts.loggerHook.Drain())
+}
+
+// TODO: add a hell of a lot more integration tests, including some that spin up
+// a test HTTP server and actually check if k6 hits it
+
+// TODO: also add a test that starts multiple k6 "instances", for example:
+//  - one with `k6 run --paused` and another with `k6 resume`
+//  - one with `k6 run` and another with `k6 stats` or `k6 status`

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -110,11 +110,20 @@ func createOutputs(gs *globalState, test *loadedTest, executionPlan []lib.Execut
 		params.ConfigArgument = outputArg
 		params.JSONConfig = test.derivedConfig.Collectors[outputType]
 
-		output, err := outputConstructor(params)
+		out, err := outputConstructor(params)
 		if err != nil {
 			return nil, fmt.Errorf("could not create the '%s' output: %w", outputType, err)
 		}
-		result = append(result, output)
+
+		if thresholdOut, ok := out.(output.WithThresholds); ok {
+			thresholdOut.SetThresholds(test.derivedConfig.Thresholds)
+		}
+
+		if builtinMetricOut, ok := out.(output.WithBuiltinMetrics); ok {
+			builtinMetricOut.SetBuiltinMetrics(test.builtInMetrics)
+		}
+
+		result = append(result, out)
 	}
 
 	return result, nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -410,7 +410,10 @@ func (c *rootCommand) setupLoggers() (<-chan struct{}, error) {
 
 	case strings.HasPrefix(line, "file"):
 		ch = make(chan struct{}) // TODO: refactor, get it from the constructor
-		hook, err := log.FileHookFromConfigLine(c.globalState.ctx, c.globalState.fs, c.globalState.fallbackLogger, line, ch)
+		hook, err := log.FileHookFromConfigLine(
+			c.globalState.ctx, c.globalState.fs, c.globalState.getwd,
+			c.globalState.fallbackLogger, line, ch,
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,6 @@ const (
 // globalFlags contains global config values that apply for all k6 sub-commands.
 type globalFlags struct {
 	configFilePath string
-	testType       string // TODO: move to RuntimeOptions, it's not trully global
 	quiet          bool
 	noColor        bool
 	address        string
@@ -173,9 +172,6 @@ func getFlags(defaultFlags globalFlags, env map[string]string) globalFlags {
 
 	if val, ok := env["K6_CONFIG"]; ok {
 		result.configFilePath = val
-	}
-	if val, ok := env["K6_TYPE"]; ok {
-		result.testType = val
 	}
 	if val, ok := env["K6_LOG_OUTPUT"]; ok {
 		result.logOutput = val

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ const (
 // globalFlags contains global config values that apply for all k6 sub-commands.
 type globalFlags struct {
 	configFilePath string
-	runType        string
+	testType       string // TODO: move to RuntimeOptions, it's not trully global
 	quiet          bool
 	noColor        bool
 	address        string
@@ -175,7 +175,7 @@ func getFlags(defaultFlags globalFlags, env map[string]string) globalFlags {
 		result.configFilePath = val
 	}
 	if val, ok := env["K6_TYPE"]; ok {
-		result.runType = val
+		result.testType = val
 	}
 	if val, ok := env["K6_LOG_OUTPUT"]; ok {
 		result.logOutput = val

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -23,6 +23,8 @@ type globalTestState struct {
 	loggerHook     *testutils.SimpleLogrusHook
 
 	cwd string
+
+	expectedExitCode int
 }
 
 func newGlobalTestState(t *testing.T) *globalTestState {
@@ -50,8 +52,19 @@ func newGlobalTestState(t *testing.T) *globalTestState {
 		stdErr:     new(bytes.Buffer),
 	}
 
+	defaultOsExitHandle := func(exitCode int) {
+		require.Equal(t, ts.expectedExitCode, exitCode)
+		cancel()
+	}
+
 	outMutex := &sync.Mutex{}
 	defaultFlags := getDefaultFlags(".config")
+
+	// Set an empty REST API address by default so that `k6 run` dosen't try to
+	// bind to it, which will result in parallel integration tests trying to use
+	// the same port and a warning message in every one.
+	defaultFlags.address = ""
+
 	ts.globalState = &globalState{
 		ctx:            ctx,
 		fs:             fs,
@@ -64,6 +77,7 @@ func newGlobalTestState(t *testing.T) *globalTestState {
 		stdOut:         &consoleWriter{nil, ts.stdOut, false, outMutex, nil},
 		stdErr:         &consoleWriter{nil, ts.stdErr, false, outMutex, nil},
 		stdIn:          new(bytes.Buffer),
+		osExit:         defaultOsExitHandle,
 		signalNotify:   signal.Notify,
 		signalStop:     signal.Stop,
 		logger:         logger,
@@ -82,9 +96,7 @@ func TestDeprecatedOptionWarning(t *testing.T) {
 		export default function() { console.log('bar'); };
 	`))
 
-	root := newRootCommand(ts.globalState)
-
-	require.NoError(t, root.cmd.Execute())
+	newRootCommand(ts.globalState).execute()
 
 	logMsgs := ts.loggerHook.Drain()
 	assert.True(t, testutils.LogContains(logMsgs, logrus.InfoLevel, "foo"))

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -160,7 +160,7 @@ a commandline interface for interacting with it.`,
 						// Only exit k6 if the user has explicitly set the REST API address
 						if cmd.Flags().Lookup("address").Changed {
 							logger.WithError(aerr).Error("Error from API server")
-							os.Exit(int(exitcodes.CannotStartRESTAPI))
+							globalState.osExit(int(exitcodes.CannotStartRESTAPI))
 						} else {
 							logger.WithError(aerr).Warn("Error from API server")
 						}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -293,7 +293,7 @@ a commandline interface for interacting with it.`,
 	}
 
 	runCmd.Flags().SortFlags = false
-	runCmd.Flags().AddFlagSet(runCmdFlagSet(globalState))
+	runCmd.Flags().AddFlagSet(runCmdFlagSet())
 
 	return runCmd
 }
@@ -329,23 +329,12 @@ func reportUsage(execScheduler *local.ExecutionScheduler) error {
 	return err
 }
 
-func runCmdFlagSet(globalState *globalState) *pflag.FlagSet {
+func runCmdFlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	flags.SortFlags = false
 	flags.AddFlagSet(optionFlagSet())
 	flags.AddFlagSet(runtimeOptionFlagSet(true))
 	flags.AddFlagSet(configFlagSet())
-
-	// TODO: Figure out a better way to handle the CLI flags:
-	// - the default values are specified in this way so we don't overwrire whatever
-	//   was specified via the environment variables
-	// - but we need to manually specify the DefValue, since that's the default value
-	//   that will be used in the help/usage message - if we don't set it, the environment
-	//   variables will affect the usage message
-	// - and finally, global variables are not very testable... :/
-	flags.StringVarP(&globalState.flags.testType, "type", "t",
-		globalState.flags.testType, "override file `type`, \"js\" or \"archive\"")
-	flags.Lookup("type").DefValue = ""
 	return flags
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -80,7 +80,7 @@ a commandline interface for interacting with it.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			printBanner(globalState)
 
-			test, err := loadTest(globalState, cmd, args, getConfig)
+			test, err := loadAndConfigureTest(globalState, cmd, args, getConfig)
 			if err != nil {
 				return err
 			}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -136,7 +136,7 @@ a commandline interface for interacting with it.`,
 
 			// Create all outputs.
 			executionPlan := execScheduler.GetExecutionPlan()
-			outputs, err := createOutputs(globalState, test.source, conf, test.runtimeOptions, executionPlan)
+			outputs, err := createOutputs(globalState, test, executionPlan)
 			if err != nil {
 				return err
 			}

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -33,7 +33,6 @@ import (
 
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/metrics"
-	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/loader"
 )
 
@@ -78,44 +77,42 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/script.js", jsCode.Bytes(), 0o644))
-	registry := metrics.NewRegistry()
-	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
-	runner, err := newRunner(
-		testutils.NewLogger(t),
-		&loader.SourceData{Data: jsCode.Bytes(), URL: &url.URL{Path: "/script.js", Scheme: "file"}},
-		typeJS,
-		map[string]afero.Fs{"file": fs},
-		rtOpts,
-		builtinMetrics,
-		registry,
-	)
-	require.NoError(t, err)
 
-	archive := runner.MakeArchive()
+	ts := newGlobalTestState(t) // TODO: move upwards, make this into an almost full integration test
+	registry := metrics.NewRegistry()
+	test := &loadedTest{
+		testPath:        "script.js",
+		source:          &loader.SourceData{Data: jsCode.Bytes(), URL: &url.URL{Path: "/script.js", Scheme: "file"}},
+		fileSystems:     map[string]afero.Fs{"file": fs},
+		runtimeOptions:  rtOpts,
+		metricsRegistry: registry,
+		builtInMetrics:  metrics.RegisterBuiltinMetrics(registry),
+	}
+
+	require.NoError(t, test.initializeFirstRunner(ts.globalState))
+
+	archive := test.initRunner.MakeArchive()
 	archiveBuf := &bytes.Buffer{}
 	require.NoError(t, archive.Write(archiveBuf))
 
-	getRunnerErr := func(rtOpts lib.RuntimeOptions) (lib.Runner, error) {
-		return newRunner(
-			testutils.NewLogger(t),
-			&loader.SourceData{
-				Data: archiveBuf.Bytes(),
-				URL:  &url.URL{Path: "/script.js"},
-			},
-			typeArchive,
-			nil,
-			rtOpts,
-			builtinMetrics,
-			registry,
-		)
+	getRunnerErr := func(rtOpts lib.RuntimeOptions) *loadedTest {
+		return &loadedTest{
+			testPath:        "script.tar",
+			source:          &loader.SourceData{Data: archiveBuf.Bytes(), URL: &url.URL{Path: "/script.tar", Scheme: "file"}},
+			fileSystems:     map[string]afero.Fs{"file": fs},
+			runtimeOptions:  rtOpts,
+			metricsRegistry: registry,
+			builtInMetrics:  metrics.RegisterBuiltinMetrics(registry),
+		}
 	}
 
-	_, err = getRunnerErr(lib.RuntimeOptions{})
-	require.NoError(t, err)
+	archTest := getRunnerErr(lib.RuntimeOptions{})
+	require.NoError(t, archTest.initializeFirstRunner(ts.globalState))
+
 	for key, val := range tc.expRTOpts.Env {
-		r, err := getRunnerErr(lib.RuntimeOptions{Env: map[string]string{key: "almost " + val}})
-		assert.NoError(t, err)
-		assert.Equal(t, r.MakeArchive().Env[key], "almost "+val)
+		archTest = getRunnerErr(lib.RuntimeOptions{Env: map[string]string{key: "almost " + val}})
+		require.NoError(t, archTest.initializeFirstRunner(ts.globalState))
+		assert.Equal(t, archTest.initRunner.MakeArchive().Env[key], "almost "+val)
 	}
 }
 

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -81,7 +81,7 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 	ts := newGlobalTestState(t) // TODO: move upwards, make this into an almost full integration test
 	registry := metrics.NewRegistry()
 	test := &loadedTest{
-		testPath:        "script.js",
+		sourceRootPath:  "script.js",
 		source:          &loader.SourceData{Data: jsCode.Bytes(), URL: &url.URL{Path: "/script.js", Scheme: "file"}},
 		fileSystems:     map[string]afero.Fs{"file": fs},
 		runtimeOptions:  rtOpts,
@@ -97,7 +97,7 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 
 	getRunnerErr := func(rtOpts lib.RuntimeOptions) *loadedTest {
 		return &loadedTest{
-			testPath:        "script.tar",
+			sourceRootPath:  "script.tar",
 			source:          &loader.SourceData{Data: archiveBuf.Bytes(), URL: &url.URL{Path: "/script.tar", Scheme: "file"}},
 			fileSystems:     map[string]afero.Fs{"file": fs},
 			runtimeOptions:  rtOpts,

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -89,7 +89,7 @@ func (lt *loadedTest) initializeFirstRunner(gs *globalState) error {
 	testPath := lt.source.URL.String()
 	logger := gs.logger.WithField("test_path", testPath)
 
-	testType := gs.flags.testType
+	testType := lt.runtimeOptions.TestType.String
 	if testType == "" {
 		logger.Debug("Detecting test type for...")
 		testType = detectTestType(lt.source.Data)

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -1,0 +1,199 @@
+package cmd
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+
+	"github.com/spf13/afero"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"go.k6.io/k6/errext"
+	"go.k6.io/k6/errext/exitcodes"
+	"go.k6.io/k6/js"
+	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/metrics"
+	"go.k6.io/k6/loader"
+)
+
+const (
+	testTypeJS      = "js"
+	testTypeArchive = "archive"
+)
+
+type loadedTest struct {
+	testPath        string // contains the raw string the user supplied
+	source          *loader.SourceData
+	fileSystems     map[string]afero.Fs
+	runtimeOptions  lib.RuntimeOptions
+	metricsRegistry *metrics.Registry
+	builtInMetrics  *metrics.BuiltinMetrics
+	initRunner      lib.Runner // TODO: rename to something more appropriate
+
+	// Only set if cliConfigGetter is supplied to loadTest() or if
+	// consolidateDeriveAndValidateConfig() is manually called.
+	consolidatedConfig Config
+	derivedConfig      Config
+}
+
+func loadTest(
+	gs *globalState, cmd *cobra.Command, args []string,
+	// supply this if you want the test config consolidated and validated
+	cliConfigGetter func(flags *pflag.FlagSet) (Config, error), // TODO: obviate
+) (*loadedTest, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("k6 needs at least one argument to load the test")
+	}
+
+	testPath := args[0]
+	gs.logger.Debugf("Resolving and reading test '%s'...", testPath)
+	src, fileSystems, err := readSource(gs, testPath)
+	if err != nil {
+		return nil, err
+	}
+	resolvedPath := src.URL.String()
+	gs.logger.Debugf("'%s' resolved to '%s' and successfully loaded %d bytes!", testPath, resolvedPath, len(src.Data))
+
+	gs.logger.Debugf("Gathering k6 runtime options...")
+	runtimeOptions, err := getRuntimeOptions(cmd.Flags(), gs.envVars)
+	if err != nil {
+		return nil, err
+	}
+
+	registry := metrics.NewRegistry()
+	test := &loadedTest{
+		testPath:        testPath,
+		source:          src,
+		fileSystems:     fileSystems,
+		runtimeOptions:  runtimeOptions,
+		metricsRegistry: registry,
+		builtInMetrics:  metrics.RegisterBuiltinMetrics(registry),
+	}
+
+	gs.logger.Debugf("Initializing k6 runner for '%s' (%s)...", testPath, resolvedPath)
+	if err := test.initializeFirstRunner(gs); err != nil {
+		return nil, fmt.Errorf("could not initialize '%s': %w", testPath, err)
+	}
+	gs.logger.Debug("Runner successfully initialized!")
+
+	if cliConfigGetter != nil {
+		if err := test.consolidateDeriveAndValidateConfig(gs, cmd, cliConfigGetter); err != nil {
+			return nil, err
+		}
+	}
+
+	return test, nil
+}
+
+func (lt *loadedTest) initializeFirstRunner(gs *globalState) error {
+	testPath := lt.source.URL.String()
+	logger := gs.logger.WithField("test_path", testPath)
+
+	testType := gs.flags.testType
+	if testType == "" {
+		logger.Debug("Detecting test type for...")
+		testType = detectTestType(lt.source.Data)
+	}
+
+	switch testType {
+	case testTypeJS:
+		logger.Debug("Trying to load as a JS test...")
+		runner, err := js.New(
+			gs.logger, lt.source, lt.fileSystems, lt.runtimeOptions, lt.builtInMetrics, lt.metricsRegistry,
+		)
+		// TODO: should we use common.UnwrapGojaInterruptedError() here?
+		if err != nil {
+			return fmt.Errorf("could not load JS test '%s': %w", testPath, err)
+		}
+		lt.initRunner = runner
+		return nil
+
+	case testTypeArchive:
+		logger.Debug("Trying to load test as an archive bundle...")
+
+		var arc *lib.Archive
+		arc, err := lib.ReadArchive(bytes.NewReader(lt.source.Data))
+		if err != nil {
+			return fmt.Errorf("could not load test archive bundle '%s': %w", testPath, err)
+		}
+		logger.Debugf("Loaded test as an archive bundle with type '%s'!", arc.Type)
+
+		switch arc.Type {
+		case testTypeJS:
+			logger.Debug("Evaluating JS from archive bundle...")
+			lt.initRunner, err = js.NewFromArchive(gs.logger, arc, lt.runtimeOptions, lt.builtInMetrics, lt.metricsRegistry)
+			if err != nil {
+				return fmt.Errorf("could not load JS from test archive bundle '%s': %w", testPath, err)
+			}
+			return nil
+		default:
+			return fmt.Errorf("archive '%s' has an unsupported test type '%s'", testPath, arc.Type)
+		}
+	default:
+		return fmt.Errorf("unknown or unspecified test type '%s' for '%s'", testType, testPath)
+	}
+}
+
+// readSource is a small wrapper around loader.ReadSource returning
+// result of the load and filesystems map
+func readSource(globalState *globalState, filename string) (*loader.SourceData, map[string]afero.Fs, error) {
+	pwd, err := globalState.getwd()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	filesystems := loader.CreateFilesystems(globalState.fs)
+	src, err := loader.ReadSource(globalState.logger, filename, pwd, filesystems, globalState.stdIn)
+	return src, filesystems, err
+}
+
+func detectTestType(data []byte) string {
+	if _, err := tar.NewReader(bytes.NewReader(data)).Next(); err == nil {
+		return testTypeArchive
+	}
+	return testTypeJS
+}
+
+func (lt *loadedTest) consolidateDeriveAndValidateConfig(
+	gs *globalState, cmd *cobra.Command,
+	cliConfGetter func(flags *pflag.FlagSet) (Config, error), // TODO: obviate
+) error {
+	var cliConfig Config
+	if cliConfGetter != nil {
+		gs.logger.Debug("Parsing CLI flags...")
+		var err error
+		cliConfig, err = cliConfGetter(cmd.Flags())
+		if err != nil {
+			return err
+		}
+	}
+
+	gs.logger.Debug("Consolidating config layers...")
+	consolidatedConfig, err := getConsolidatedConfig(gs, cliConfig, lt.initRunner.GetOptions())
+	if err != nil {
+		return err
+	}
+
+	gs.logger.Debug("Parsing thresholds and validating config...")
+	// Parse the thresholds, only if the --no-threshold flag is not set.
+	// If parsing the threshold expressions failed, consider it as an
+	// invalid configuration error.
+	if !lt.runtimeOptions.NoThresholds.Bool {
+		for _, thresholds := range consolidatedConfig.Options.Thresholds {
+			err = thresholds.Parse()
+			if err != nil {
+				return errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
+			}
+		}
+	}
+
+	derivedConfig, err := deriveAndValidateConfig(consolidatedConfig, lt.initRunner.IsExecutable, gs.logger)
+	if err != nil {
+		return err
+	}
+
+	lt.consolidatedConfig = consolidatedConfig
+	lt.derivedConfig = derivedConfig
+
+	return nil
+}

--- a/core/engine.go
+++ b/core/engine.go
@@ -139,20 +139,12 @@ func NewEngine(
 func (e *Engine) StartOutputs() error {
 	e.logger.Debugf("Starting %d outputs...", len(e.outputs))
 	for i, out := range e.outputs {
-		if thresholdOut, ok := out.(output.WithThresholds); ok {
-			thresholdOut.SetThresholds(e.thresholds)
-		}
-
 		if stopOut, ok := out.(output.WithTestRunStop); ok {
 			stopOut.SetTestRunStopCallback(
 				func(err error) {
 					e.logger.WithError(err).Error("Received error to stop from output")
 					e.Stop()
 				})
-		}
-
-		if builtinMetricOut, ok := out.(output.WithBuiltinMetrics); ok {
-			builtinMetricOut.SetBuiltinMetrics(e.builtinMetrics)
 		}
 
 		if err := out.Start(); err != nil {

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -296,13 +296,6 @@ func (b *Bundle) Instantiate(
 	return bi, instErr
 }
 
-// IsExecutable returns whether the given name is an exported and
-// executable function in the script.
-func (b *Bundle) IsExecutable(name string) bool {
-	_, exists := b.exports[name]
-	return exists
-}
-
 // Instantiates the bundle into an existing runtime. Not public because it also messes with a bunch
 // of other things, will potentially thrash data and makes a mess in it if the operation fails.
 func (b *Bundle) instantiate(logger logrus.FieldLogger, rt *goja.Runtime, init *InitContext, vuID uint64) error {

--- a/js/runner.go
+++ b/js/runner.go
@@ -364,10 +364,9 @@ func (r *Runner) GetOptions() lib.Options {
 
 // IsExecutable returns whether the given name is an exported and
 // executable function in the script.
-//
-// TODO: completely remove this?
 func (r *Runner) IsExecutable(name string) bool {
-	return r.Bundle.IsExecutable(name)
+	_, exists := r.Bundle.exports[name]
+	return exists
 }
 
 // HandleSummary calls the specified summary callback, if supplied.

--- a/lib/runtime_options.go
+++ b/lib/runtime_options.go
@@ -41,6 +41,8 @@ const (
 
 // RuntimeOptions are settings passed onto the goja JS runtime
 type RuntimeOptions struct {
+	TestType null.String `json:"-"`
+
 	// Whether to pass the actual system environment variables to the JS runtime
 	IncludeSystemEnvVars null.Bool `json:"includeSystemEnvVars"`
 

--- a/log/file_test.go
+++ b/log/file_test.go
@@ -110,8 +110,12 @@ func TestFileHookFromConfigLine(t *testing.T) {
 		t.Run(test.line, func(t *testing.T) {
 			t.Parallel()
 
+			getCwd := func() (string, error) {
+				return "/", nil
+			}
+
 			res, err := FileHookFromConfigLine(
-				context.Background(), afero.NewMemMapFs(), logrus.New(), test.line, make(chan struct{}),
+				context.Background(), afero.NewMemMapFs(), getCwd, logrus.New(), test.line, make(chan struct{}),
 			)
 
 			if test.err {


### PR DESCRIPTION
More yak shaving, but after this, some parts of `cmd/` are almost normal looking :sweat_smile: :tada: I particularly like how clean `cmd/archive.go` became :tada: https://github.com/grafana/k6/blob/147e3d1beaf99aef837a3b30142c5728c0a6d17a/cmd/archive.go#L44-L72

Closes https://github.com/grafana/k6/issues/342