### PR TITLE
Wait for file log to drain before k6 exits

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -290,7 +290,7 @@ func (c *rootCommand) setupLoggers() (<-chan struct{}, error) {
 		c.logger.SetOutput(ioutil.Discard)
 
 	case strings.HasPrefix(line, "loki"):
-		ch = make(chan struct{})
+		ch = make(chan struct{}) // TODO: refactor, get it from the constructor
 		hook, err := log.LokiFromConfigLine(c.ctx, c.fallbackLogger, line, ch)
 		if err != nil {
 			return nil, err
@@ -300,7 +300,8 @@ func (c *rootCommand) setupLoggers() (<-chan struct{}, error) {
 		c.logFmt = "raw"
 
 	case strings.HasPrefix(line, "file"):
-		hook, err := log.FileHookFromConfigLine(c.ctx, c.fallbackLogger, line)
+		ch = make(chan struct{}) // TODO: refactor, get it from the constructor
+		hook, err := log.FileHookFromConfigLine(c.ctx, c.fallbackLogger, line, ch)
 		if err != nil {
 			return nil, err
 		}

--- a/log/file_test.go
+++ b/log/file_test.go
@@ -115,7 +115,9 @@ func TestFileHookFromConfigLine(t *testing.T) {
 		t.Run(test.line, func(t *testing.T) {
 			t.Parallel()
 
-			res, err := FileHookFromConfigLine(context.Background(), logrus.New(), test.line)
+			res, err := FileHookFromConfigLine(
+				context.Background(), logrus.New(), test.line, make(chan struct{}),
+			)
 
 			if test.err {
 				require.Error(t, err)
@@ -147,6 +149,7 @@ func TestFileHookFire(t *testing.T) {
 		w:        nc,
 		bw:       bufio.NewWriter(nc),
 		levels:   logrus.AllLevels,
+		done:     make(chan struct{}),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
This closes https://github.com/grafana/k6/issues/2413, a minor deficiency that slipped by in https://github.com/grafana/k6/pull/2285 

The integration test for this is unfortunately will have to wait until https://github.com/grafana/k6/pull/2412 is merged. That is in fact how I found the issue, tried to write an integration for sending logs to a file and it failed because the file didn't contain the expected text at the end of the test :sweat_smile: So we'll have to merge this in v0.37.0 without a test :disappointed: 