### PR TITLE
Fix missing metric name in k6 stats (MetricsJSONAPI)

### DIFF
--- a/api/v1/metric_jsonapi.go
+++ b/api/v1/metric_jsonapi.go
@@ -74,7 +74,9 @@ func (m MetricsJSONAPI) Metrics() []Metric {
 	list := make([]Metric, 0, len(m.Data))
 
 	for _, metric := range m.Data {
-		list = append(list, metric.Attributes)
+		m := metric.Attributes
+		m.Name = metric.ID
+		list = append(list, m)
 	}
 
 	return list

--- a/api/v1/metric_routes_test.go
+++ b/api/v1/metric_routes_test.go
@@ -93,6 +93,10 @@ func TestGetMetrics(t *testing.T) {
 		assert.Equal(t, stats.Time, metric.Contains.Type)
 		assert.True(t, metric.Tainted.Valid)
 		assert.True(t, metric.Tainted.Bool)
+
+		resMetrics := envelop.Metrics()
+		assert.Len(t, resMetrics, 1)
+		assert.Equal(t, resMetrics[0].Name, "my_metric")
 	})
 }
 


### PR DESCRIPTION
Fixes https://github.com/grafana/k6/issues/2420

I think this broke in https://github.com/grafana/k6/pull/2304, but nobody noticed since not a lot of people actually use this sub-command... :sweat_smile: 