### PR TITLE
Expose the Source of the NullHostnameTrie

### DIFF
--- a/lib/types/hostnametrie.go
+++ b/lib/types/hostnametrie.go
@@ -70,6 +70,15 @@ func (d *NullHostnameTrie) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// Source return source hostnames that were used diring the construction
+func (d *NullHostnameTrie) Source() []string {
+	if d.Trie == nil {
+		return []string{}
+	}
+
+	return d.Trie.source
+}
+
 // MarshalJSON implements json.Marshaler interface
 func (d NullHostnameTrie) MarshalJSON() ([]byte, error) {
 	if !d.Valid {
@@ -119,7 +128,7 @@ func NewHostnameTrie(source []string) (*HostnameTrie, error) {
 // Regex description of hostname pattern to enforce blocks by. Global var
 // to avoid compilation penalty at runtime.
 // based on regex from https://stackoverflow.com/a/106223/5427244
-//nolint:gochecknoglobals,lll
+//nolint:lll
 var validHostnamePattern *regexp.Regexp = regexp.MustCompile(`^(\*\.?)?((([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9]))?$`)
 
 func isValidHostnamePattern(s string) error {

--- a/lib/types/hostnametrie_test.go
+++ b/lib/types/hostnametrie_test.go
@@ -28,14 +28,19 @@ import (
 )
 
 func TestHostnameTrieInsert(t *testing.T) {
+	t.Parallel()
+
 	hostnames, err := NewHostnameTrie([]string{"foo.bar"})
 	assert.NoError(t, err)
+
 	assert.NoError(t, hostnames.insert("test.k6.io"))
 	assert.Error(t, hostnames.insert("inval*d.pattern"))
 	assert.NoError(t, hostnames.insert("*valid.pattern"))
 }
 
 func TestHostnameTrieContains(t *testing.T) {
+	t.Parallel()
+
 	trie, err := NewHostnameTrie([]string{"sub.test.k6.io", "test.k6.io", "*valid.pattern", "sub.valid.pattern"})
 	require.NoError(t, err)
 	cases := map[string]string{
@@ -53,6 +58,8 @@ func TestHostnameTrieContains(t *testing.T) {
 	for key, value := range cases {
 		host, pattern := key, value
 		t.Run(host, func(t *testing.T) {
+			t.Parallel()
+
 			match, matches := trie.Contains(host)
 			if pattern == "" {
 				assert.False(t, matches)
@@ -63,4 +70,14 @@ func TestHostnameTrieContains(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNullHostnameTrieSource(t *testing.T) {
+	t.Parallel()
+
+	trie, err := NewNullHostnameTrie([]string{"sub.test.k6.io", "test.k6.io", "*valid.pattern", "sub.valid.pattern"})
+
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"sub.test.k6.io", "test.k6.io", "*valid.pattern", "sub.valid.pattern"}, trie.Source())
 }


### PR DESCRIPTION
## Why?

This change is exposing the source of the `NullHostnameTrie`, otherwise, the only way of getting the access to the underlying array is to use Marshaling, like:

```go
func extractHostnames(list k6types.NullHostnameTrie) ([]string, error) {
	if !list.Valid {
		return []string{}, nil
	}

	tmp, err := list.MarshalJSON()
	if err != nil {
		return []string{}, err
	}

	var extracted []string
	err = json.Unmarshal(tmp, &extracted)
	if err != nil {
		return []string{}, err
	}

	return extracted, nil
}
```

which isn't efficient