### PR TITLE
Changes error messages. "should" --> "must", "can"

### DIFF
--- a/lib/execution_segment.go
+++ b/lib/execution_segment.go
@@ -68,13 +68,13 @@ var (
 // fully-initialized and usable execution segment.
 func NewExecutionSegment(from, to *big.Rat) (*ExecutionSegment, error) {
 	if from.Cmp(zeroRat) < 0 {
-		return nil, fmt.Errorf("segment start value should be at least 0 but was %s", from.FloatString(2))
+		return nil, fmt.Errorf("segment start value must be at least 0 but was %s", from.FloatString(2))
 	}
 	if from.Cmp(to) >= 0 {
-		return nil, fmt.Errorf("segment start(%s) should be less than its end(%s)", from.FloatString(2), to.FloatString(2))
+		return nil, fmt.Errorf("segment start(%s) must be less than its end(%s)", from.FloatString(2), to.FloatString(2))
 	}
 	if to.Cmp(oneRat) > 0 {
-		return nil, fmt.Errorf("segment end value shouldn't be more than 1 but was %s", to.FloatString(2))
+		return nil, fmt.Errorf("segment end value can't be more than 1 but was %s", to.FloatString(2))
 	}
 	return newExecutionSegment(from, to), nil
 }
@@ -181,7 +181,7 @@ func (es *ExecutionSegment) FloatLength() float64 {
 // equal consecutive execution sub-segments.
 func (es *ExecutionSegment) Split(numParts int64) ([]*ExecutionSegment, error) {
 	if numParts < 1 {
-		return nil, fmt.Errorf("the number of parts should be at least 1, %d received", numParts)
+		return nil, fmt.Errorf("the number of parts must be at least 1, %d received", numParts)
 	}
 
 	from, to := zeroRat, oneRat
@@ -323,7 +323,7 @@ func NewExecutionSegmentSequence(segments ...*ExecutionSegment) (ExecutionSegmen
 		for i, segment := range segments[1:] {
 			if segment.from.Cmp(to) != 0 {
 				return nil, fmt.Errorf(
-					"the start value %s of segment #%d should be equal to the end value of the previous one, but it is %s",
+					"the start value %s of segment #%d must be equal to the end value of the previous one, but it is %s",
 					segment.from, i+1, to,
 				)
 			}

--- a/lib/executor/base_config.go
+++ b/lib/executor/base_config.go
@@ -67,7 +67,7 @@ func (bc BaseConfig) Validate() (errors []error) {
 	// Some just-in-case checks, since those things are likely checked in other places or
 	// even assigned by us:
 	if bc.Name == "" {
-		errors = append(errors, fmt.Errorf("executor name shouldn't be empty"))
+		errors = append(errors, fmt.Errorf("executor name can't be empty"))
 	}
 	if !executorNameWhitelist.MatchString(bc.Name) {
 		errors = append(errors, fmt.Errorf(executorNameErr))

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -114,32 +114,32 @@ func (carc *ConstantArrivalRateConfig) Validate() []error {
 	if !carc.Rate.Valid {
 		errors = append(errors, fmt.Errorf("the iteration rate isn't specified"))
 	} else if carc.Rate.Int64 <= 0 {
-		errors = append(errors, fmt.Errorf("the iteration rate should be more than 0"))
+		errors = append(errors, fmt.Errorf("the iteration rate must be more than 0"))
 	}
 
 	if carc.TimeUnit.TimeDuration() <= 0 {
-		errors = append(errors, fmt.Errorf("the timeUnit should be more than 0"))
+		errors = append(errors, fmt.Errorf("the timeUnit must be more than 0"))
 	}
 
 	if !carc.Duration.Valid {
 		errors = append(errors, fmt.Errorf("the duration is unspecified"))
 	} else if carc.Duration.TimeDuration() < minDuration {
 		errors = append(errors, fmt.Errorf(
-			"the duration should be at least %s, but is %s", minDuration, carc.Duration,
+			"the duration must be at least %s, but is %s", minDuration, carc.Duration,
 		))
 	}
 
 	if !carc.PreAllocatedVUs.Valid {
 		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs isn't specified"))
 	} else if carc.PreAllocatedVUs.Int64 < 0 {
-		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs shouldn't be negative"))
+		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs can't be negative"))
 	}
 
 	if !carc.MaxVUs.Valid {
 		// TODO: don't change the config while validating
 		carc.MaxVUs.Int64 = carc.PreAllocatedVUs.Int64
 	} else if carc.MaxVUs.Int64 < carc.PreAllocatedVUs.Int64 {
-		errors = append(errors, fmt.Errorf("maxVUs shouldn't be less than preAllocatedVUs"))
+		errors = append(errors, fmt.Errorf("maxVUs can't be less than preAllocatedVUs"))
 	}
 
 	return errors

--- a/lib/executor/constant_vus.go
+++ b/lib/executor/constant_vus.go
@@ -86,14 +86,14 @@ func (clvc ConstantVUsConfig) GetDescription(et *lib.ExecutionTuple) string {
 func (clvc ConstantVUsConfig) Validate() []error {
 	errors := clvc.BaseConfig.Validate()
 	if clvc.VUs.Int64 <= 0 {
-		errors = append(errors, fmt.Errorf("the number of VUs should be more than 0"))
+		errors = append(errors, fmt.Errorf("the number of VUs must be more than 0"))
 	}
 
 	if !clvc.Duration.Valid {
 		errors = append(errors, fmt.Errorf("the duration is unspecified"))
 	} else if clvc.Duration.TimeDuration() < minDuration {
 		errors = append(errors, fmt.Errorf(
-			"the duration should be at least %s, but is %s", minDuration, clvc.Duration,
+			"the duration must be at least %s, but is %s", minDuration, clvc.Duration,
 		))
 	}
 

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -69,7 +69,7 @@ type ExternallyControlledConfigParams struct {
 // Validate just checks the control options in isolation.
 func (mecc ExternallyControlledConfigParams) Validate() (errors []error) {
 	if mecc.VUs.Int64 < 0 {
-		errors = append(errors, fmt.Errorf("the number of VUs shouldn't be negative"))
+		errors = append(errors, fmt.Errorf("the number of VUs can't be negative"))
 	}
 
 	if mecc.MaxVUs.Int64 < mecc.VUs.Int64 {
@@ -80,10 +80,10 @@ func (mecc ExternallyControlledConfigParams) Validate() (errors []error) {
 	}
 
 	if !mecc.Duration.Valid {
-		errors = append(errors, fmt.Errorf("the duration should be specified, for infinite duration use 0"))
+		errors = append(errors, fmt.Errorf("the duration must be specified, for infinite duration use 0"))
 	} else if mecc.Duration.TimeDuration() < 0 {
 		errors = append(errors, fmt.Errorf(
-			"the duration shouldn't be negative, for infinite duration use 0",
+			"the duration can't be negative, for infinite duration use 0",
 		))
 	}
 

--- a/lib/executor/externally_controlled_test.go
+++ b/lib/executor/externally_controlled_test.go
@@ -116,7 +116,7 @@ func TestExternallyControlledRun(t *testing.T) {
 						"invalid configuration supplied: the number of active VUs (15)"+
 							" must be less than or equal to the number of maxVUs (10)")
 					updateConfig(-1, 10,
-						"invalid configuration supplied: the number of VUs shouldn't be negative")
+						"invalid configuration supplied: the number of VUs can't be negative")
 				}
 				ticks++
 			case <-doneCh:

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -66,12 +66,12 @@ func validateStages(stages []Stage) []error {
 		if !s.Duration.Valid {
 			errors = append(errors, fmt.Errorf("stage %d doesn't have a duration", stageNum))
 		} else if s.Duration.Duration < 0 {
-			errors = append(errors, fmt.Errorf("the duration for stage %d shouldn't be negative", stageNum))
+			errors = append(errors, fmt.Errorf("the duration for stage %d can't be negative", stageNum))
 		}
 		if !s.Target.Valid {
 			errors = append(errors, fmt.Errorf("stage %d doesn't have a target", stageNum))
 		} else if s.Target.Int64 < 0 {
-			errors = append(errors, fmt.Errorf("the target for stage %d shouldn't be negative", stageNum))
+			errors = append(errors, fmt.Errorf("the target for stage %d can't be negative", stageNum))
 		}
 	}
 	return errors

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -92,16 +92,16 @@ func (pvic PerVUIterationsConfig) GetDescription(et *lib.ExecutionTuple) string 
 func (pvic PerVUIterationsConfig) Validate() []error {
 	errors := pvic.BaseConfig.Validate()
 	if pvic.VUs.Int64 <= 0 {
-		errors = append(errors, fmt.Errorf("the number of VUs should be more than 0"))
+		errors = append(errors, fmt.Errorf("the number of VUs must be more than 0"))
 	}
 
 	if pvic.Iterations.Int64 <= 0 {
-		errors = append(errors, fmt.Errorf("the number of iterations should be more than 0"))
+		errors = append(errors, fmt.Errorf("the number of iterations must be more than 0"))
 	}
 
 	if pvic.MaxDuration.TimeDuration() < minDuration {
 		errors = append(errors, fmt.Errorf(
-			"the maxDuration should be at least %s, but is %s", minDuration, pvic.MaxDuration,
+			"the maxDuration must be at least %s, but is %s", minDuration, pvic.MaxDuration,
 		))
 	}
 

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -109,11 +109,11 @@ func (varc *RampingArrivalRateConfig) Validate() []error {
 	errors := varc.BaseConfig.Validate()
 
 	if varc.StartRate.Int64 < 0 {
-		errors = append(errors, fmt.Errorf("the startRate value shouldn't be negative"))
+		errors = append(errors, fmt.Errorf("the startRate value can't be negative"))
 	}
 
 	if varc.TimeUnit.TimeDuration() < 0 {
-		errors = append(errors, fmt.Errorf("the timeUnit should be more than 0"))
+		errors = append(errors, fmt.Errorf("the timeUnit must be more than 0"))
 	}
 
 	errors = append(errors, validateStages(varc.Stages)...)
@@ -121,14 +121,14 @@ func (varc *RampingArrivalRateConfig) Validate() []error {
 	if !varc.PreAllocatedVUs.Valid {
 		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs isn't specified"))
 	} else if varc.PreAllocatedVUs.Int64 < 0 {
-		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs shouldn't be negative"))
+		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs can't be negative"))
 	}
 
 	if !varc.MaxVUs.Valid {
 		// TODO: don't change the config while validating
 		varc.MaxVUs.Int64 = varc.PreAllocatedVUs.Int64
 	} else if varc.MaxVUs.Int64 < varc.PreAllocatedVUs.Int64 {
-		errors = append(errors, fmt.Errorf("maxVUs shouldn't be less than preAllocatedVUs"))
+		errors = append(errors, fmt.Errorf("maxVUs can't be less than preAllocatedVUs"))
 	}
 
 	return errors

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -100,11 +100,11 @@ func (vlvc RampingVUsConfig) GetDescription(et *lib.ExecutionTuple) string {
 func (vlvc RampingVUsConfig) Validate() []error {
 	errors := vlvc.BaseConfig.Validate()
 	if vlvc.StartVUs.Int64 < 0 {
-		errors = append(errors, fmt.Errorf("the number of start VUs shouldn't be negative"))
+		errors = append(errors, fmt.Errorf("the number of start VUs can't be negative"))
 	}
 
 	if getStagesUnscaledMaxTarget(vlvc.StartVUs.Int64, vlvc.Stages) <= 0 {
-		errors = append(errors, fmt.Errorf("either startVUs or one of the stages' target value should be greater than 0"))
+		errors = append(errors, fmt.Errorf("either startVUs or one of the stages' target values must be greater than 0"))
 	}
 
 	return append(errors, validateStages(vlvc.Stages)...)

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -253,7 +253,7 @@ func TestRampingVUsGracefulRampDown(t *testing.T) {
 				defer close(stopped)
 				select {
 				case <-ctx.Done():
-					t.Fatal("The iterations shouldn't have ended before the context")
+					t.Fatal("The iterations can't have ended before the context")
 				case <-stop:
 				}
 			} else { // all other (1) VUs will just sleep long enough

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -97,19 +97,19 @@ func (sic SharedIterationsConfig) GetDescription(et *lib.ExecutionTuple) string 
 func (sic SharedIterationsConfig) Validate() []error {
 	errors := sic.BaseConfig.Validate()
 	if sic.VUs.Int64 <= 0 {
-		errors = append(errors, fmt.Errorf("the number of VUs should be more than 0"))
+		errors = append(errors, fmt.Errorf("the number of VUs must be more than 0"))
 	}
 
 	if sic.Iterations.Int64 < sic.VUs.Int64 {
 		errors = append(errors, fmt.Errorf(
-			"the number of iterations (%d) shouldn't be less than the number of VUs (%d)",
+			"the number of iterations (%d) can't be less than the number of VUs (%d)",
 			sic.Iterations.Int64, sic.VUs.Int64,
 		))
 	}
 
 	if sic.MaxDuration.TimeDuration() < minDuration {
 		errors = append(errors, fmt.Errorf(
-			"the maxDuration should be at least %s, but is %s", minDuration, sic.MaxDuration,
+			"the maxDuration must be at least %s, but is %s", minDuration, sic.MaxDuration,
 		))
 	}
 

--- a/lib/netext/httpext/response_type_gen.go
+++ b/lib/netext/httpext/response_type_gen.go
@@ -60,7 +60,7 @@ func (i ResponseType) MarshalJSON() ([]byte, error) {
 func (i *ResponseType) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("ResponseType must be a string, got %s", data)
+		return fmt.Errorf("ResponseType should be a string, got %s", data)
 	}
 
 	var err error

--- a/lib/netext/httpext/response_type_gen.go
+++ b/lib/netext/httpext/response_type_gen.go
@@ -60,7 +60,7 @@ func (i ResponseType) MarshalJSON() ([]byte, error) {
 func (i *ResponseType) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
-		return fmt.Errorf("ResponseType should be a string, got %s", data)
+		return fmt.Errorf("ResponseType must be a string, got %s", data)
 	}
 
 	var err error


### PR DESCRIPTION
In a few cases, the CLI application stops running and returns an error, stating that some parameter "should" or "shouldn't" have a certain value.

The word "should," though, generally indicates _strong advice_. In these cases, the application stops running, so it makes more sense to indicate that that the error is stating _a requirement_. For requirements or impossibilities, the helping verbs "must" or "can't" would be more appropriate.

Believe it or not, there's already an RFC that covers almost exactly this topic.
https://datatracker.ietf.org/doc/html/rfc2119#section-4 
