### PR TITLE
Fix panic due to error in HasWork

### DIFF
--- a/lib/executor/constant_vus.go
+++ b/lib/executor/constant_vus.go
@@ -73,7 +73,7 @@ var _ lib.ExecutorConfig = &ConstantVUsConfig{}
 
 // GetVUs returns the scaled VUs for the executor.
 func (clvc ConstantVUsConfig) GetVUs(et *lib.ExecutionTuple) int64 {
-	return et.Segment.Scale(clvc.VUs.Int64)
+	return et.ScaleInt64(clvc.VUs.Int64)
 }
 
 // GetDescription returns a human-readable description of the executor options

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -144,8 +144,8 @@ func (mec ExternallyControlledConfig) Validate() []error {
 func (mec ExternallyControlledConfig) GetExecutionRequirements(et *lib.ExecutionTuple) []lib.ExecutionStep {
 	startVUs := lib.ExecutionStep{
 		TimeOffset:      0,
-		PlannedVUs:      uint64(et.Segment.Scale(mec.MaxVUs.Int64)), // user-configured, VUs to be pre-initialized
-		MaxUnplannedVUs: 0,                                          // intentional, see function comment
+		PlannedVUs:      uint64(et.ScaleInt64(mec.MaxVUs.Int64)), // user-configured, VUs to be pre-initialized
+		MaxUnplannedVUs: 0,                                       // intentional, see function comment
 	}
 
 	maxDuration := mec.Duration.TimeDuration()
@@ -434,11 +434,11 @@ func (rs *externallyControlledRunState) progressFn() (float64, []string) {
 
 func (rs *externallyControlledRunState) handleConfigChange(oldCfg, newCfg ExternallyControlledConfigParams) error {
 	executionState := rs.executor.executionState
-	segment := executionState.Options.ExecutionSegment
-	oldActiveVUs := segment.Scale(oldCfg.VUs.Int64)
-	oldMaxVUs := segment.Scale(oldCfg.MaxVUs.Int64)
-	newActiveVUs := segment.Scale(newCfg.VUs.Int64)
-	newMaxVUs := segment.Scale(newCfg.MaxVUs.Int64)
+	et := executionState.ExecutionTuple
+	oldActiveVUs := et.ScaleInt64(oldCfg.VUs.Int64)
+	oldMaxVUs := et.ScaleInt64(oldCfg.MaxVUs.Int64)
+	newActiveVUs := et.ScaleInt64(newCfg.VUs.Int64)
+	newMaxVUs := et.ScaleInt64(newCfg.MaxVUs.Int64)
 
 	rs.executor.logger.WithFields(logrus.Fields{
 		"oldActiveVUs": oldActiveVUs, "oldMaxVUs": oldMaxVUs,
@@ -523,7 +523,7 @@ func (mex *ExternallyControlled) Run(
 		logrus.Fields{"type": externallyControlledType, "duration": duration},
 	).Debug("Starting executor run...")
 
-	startMaxVUs := mex.executionState.Options.ExecutionSegment.Scale(mex.config.MaxVUs.Int64)
+	startMaxVUs := mex.executionState.ExecutionTuple.ScaleInt64(mex.config.MaxVUs.Int64)
 
 	ss := &lib.ScenarioState{
 		Name:      mex.config.Name,

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -70,7 +70,7 @@ var _ lib.ExecutorConfig = &PerVUIterationsConfig{}
 
 // GetVUs returns the scaled VUs for the executor.
 func (pvic PerVUIterationsConfig) GetVUs(et *lib.ExecutionTuple) int64 {
-	return et.Segment.Scale(pvic.VUs.Int64)
+	return et.ScaleInt64(pvic.VUs.Int64)
 }
 
 // GetIterations returns the UNSCALED iteration count for the executor. It's

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -79,7 +79,7 @@ var _ lib.ExecutorConfig = &RampingArrivalRateConfig{}
 
 // GetPreAllocatedVUs is just a helper method that returns the scaled pre-allocated VUs.
 func (varc RampingArrivalRateConfig) GetPreAllocatedVUs(et *lib.ExecutionTuple) int64 {
-	return et.Segment.Scale(varc.PreAllocatedVUs.Int64)
+	return et.ScaleInt64(varc.PreAllocatedVUs.Int64)
 }
 
 // GetMaxVUs is just a helper method that returns the scaled max VUs.
@@ -90,9 +90,9 @@ func (varc RampingArrivalRateConfig) GetMaxVUs(et *lib.ExecutionTuple) int64 {
 // GetDescription returns a human-readable description of the executor options
 func (varc RampingArrivalRateConfig) GetDescription(et *lib.ExecutionTuple) string {
 	// TODO: something better? always show iterations per second?
-	maxVUsRange := fmt.Sprintf("maxVUs: %d", et.Segment.Scale(varc.PreAllocatedVUs.Int64))
+	maxVUsRange := fmt.Sprintf("maxVUs: %d", et.ScaleInt64(varc.PreAllocatedVUs.Int64))
 	if varc.MaxVUs.Int64 > varc.PreAllocatedVUs.Int64 {
-		maxVUsRange += fmt.Sprintf("-%d", et.Segment.Scale(varc.MaxVUs.Int64))
+		maxVUsRange += fmt.Sprintf("-%d", et.ScaleInt64(varc.MaxVUs.Int64))
 	}
 	maxUnscaledRate := getStagesUnscaledMaxTarget(varc.StartRate.Int64, varc.Stages)
 	maxArrRatePerSec, _ := getArrivalRatePerSec(
@@ -143,8 +143,8 @@ func (varc RampingArrivalRateConfig) GetExecutionRequirements(et *lib.ExecutionT
 	return []lib.ExecutionStep{
 		{
 			TimeOffset:      0,
-			PlannedVUs:      uint64(et.Segment.Scale(varc.PreAllocatedVUs.Int64)),
-			MaxUnplannedVUs: uint64(et.Segment.Scale(varc.MaxVUs.Int64 - varc.PreAllocatedVUs.Int64)),
+			PlannedVUs:      uint64(et.ScaleInt64(varc.PreAllocatedVUs.Int64)),
+			MaxUnplannedVUs: uint64(et.ScaleInt64(varc.MaxVUs.Int64 - varc.PreAllocatedVUs.Int64)),
 		},
 		{
 			TimeOffset:      sumStagesDuration(varc.Stages) + varc.GracefulStop.TimeDuration(),

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -84,7 +84,7 @@ func (varc RampingArrivalRateConfig) GetPreAllocatedVUs(et *lib.ExecutionTuple) 
 
 // GetMaxVUs is just a helper method that returns the scaled max VUs.
 func (varc RampingArrivalRateConfig) GetMaxVUs(et *lib.ExecutionTuple) int64 {
-	return et.Segment.Scale(varc.MaxVUs.Int64)
+	return et.ScaleInt64(varc.MaxVUs.Int64)
 }
 
 // GetDescription returns a human-readable description of the executor options

--- a/lib/executor/ramping_arrival_rate_test.go
+++ b/lib/executor/ramping_arrival_rate_test.go
@@ -766,3 +766,27 @@ func TestRampingArrivalRateGlobalIters(t *testing.T) {
 		})
 	}
 }
+
+func TestRampingArrivalRateCornerCase(t *testing.T) {
+	t.Parallel()
+	config := &RampingArrivalRateConfig{
+		TimeUnit:  types.NullDurationFrom(time.Second),
+		StartRate: null.IntFrom(1),
+		Stages: []Stage{
+			{
+				Duration: types.NullDurationFrom(1 * time.Second),
+				Target:   null.IntFrom(1),
+			},
+		},
+		MaxVUs: null.IntFrom(2),
+	}
+
+	et, err := lib.NewExecutionTuple(newExecutionSegmentFromString("1/5:2/5"), newExecutionSegmentSequenceFromString("0,1/5,2/5,1"))
+	require.NoError(t, err)
+	es := lib.NewExecutionState(lib.Options{}, et, 10, 50)
+
+	executor, err := config.NewExecutor(es, nil)
+	require.NoError(t, err)
+
+	require.False(t, executor.GetConfig().HasWork(et))
+}


### PR DESCRIPTION
The panic was happening in the `Init` but it was due to the fact that
HasWork wrongfully returned True when it should've returned false.
