### PR TITLE
Migrate powershell and Go version

### DIFF
--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -182,8 +182,8 @@ jobs:
           goversioninfo -64 \
             -platform-specific=true \
             -charset="1200" \
-            -company="Load Impact AB" \
-            -copyright="© Load Impact AB. Licensed under AGPL." \
+            -company="Raintank Inc. d.b.a. Grafana Labs" \
+            -copyright="© Raintank Inc. d.b.a. Grafana Labs. Licensed under AGPL." \
             -description="A modern load testing tool, using Go and JavaScript" \
             -icon=packaging/k6.ico \
             -internal-name="k6" \

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -25,7 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.16.x]
+        # We are going to keep 1.16.x version until we move the build process to 1.18.x
+        go-version: [1.16.x, 1.17.x]
         platform: [ubuntu-latest, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -80,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.17.x]
+        go-version: [1.18.x]
         platform: [ubuntu-latest, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -154,6 +155,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
+          # We plan to move to 1.18.x after the release of the first patch.
           go-version: 1.17.x
       - name: Install package builders
         env:

--- a/.github/workflows/all.yml
+++ b/.github/workflows/all.yml
@@ -266,7 +266,7 @@ jobs:
     runs-on: windows-2019
     defaults:
       run:
-        shell: powershell
+        shell: pwsh
     needs: [test-current-cov, configure, build]
     if: startsWith(github.ref, 'refs/tags/v')
     env:
@@ -280,9 +280,9 @@ jobs:
           args: install -y pandoc
       - name: Install wix tools
         run: |
-          curl -O wix311-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip
+          curl -Lso wix311-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip
           Expand-Archive -Path .\wix311-binaries.zip -DestinationPath .\wix311\
-          echo "$pwd\wix311" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "$pwd\wix311" | Out-File -FilePath $env:GITHUB_PATH -Append
       - name: Download binaries
         uses: actions/download-artifact@v2
         with:
@@ -294,7 +294,7 @@ jobs:
           move .\packaging\k6-$env:VERSION-windows-amd64\k6.exe .\packaging\
           rmdir .\packaging\k6-$env:VERSION-windows-amd64\
       - name: Add signtool to PATH
-        run: echo "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64" | Out-File -FilePath $env:GITHUB_PATH -Append
       - name: Convert base64 certificate to PFX
         run: |
           $bytes = [Convert]::FromBase64String("${{ secrets.WIN_SIGN_CERT }}")

--- a/.github/workflows/arm-tests.yml
+++ b/.github/workflows/arm-tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.x
+          go-version: 1.17.x
       - name: Run tests
         run: |
           set -x

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -57,8 +57,8 @@ jobs:
           goversioninfo -64 \
             -platform-specific=true \
             -charset="1200" \
-            -company="Grafana Labs AB" \
-            -copyright="© Grafana Labs AB. Licensed under AGPL." \
+            -company="Raintank Inc. d.b.a. Grafana Labs" \
+            -copyright="© Raintank Inc. d.b.a. Grafana Labs. Licensed under AGPL." \
             -description="A modern load testing tool, using Go and JavaScript" \
             -icon=packaging/k6.ico \
             -internal-name="k6" \

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -84,7 +84,7 @@ jobs:
     runs-on: windows-2019
     defaults:
       run:
-        shell: powershell
+        shell: pwsh
     needs: [build]
     env:
       VERSION: ${{ github.event.inputs.k6_version }}
@@ -99,9 +99,9 @@ jobs:
           args: install -y pandoc
       - name: Install wix tools
         run: |
-          curl -O wix311-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip
+          curl -Lso wix311-binaries.zip https://github.com/wixtoolset/wix3/releases/download/wix3112rtm/wix311-binaries.zip
           Expand-Archive -Path .\wix311-binaries.zip -DestinationPath .\wix311\
-          echo "$pwd\wix311" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "$pwd\wix311" | Out-File -FilePath $env:GITHUB_PATH -Append
       - name: Download binaries
         uses: actions/download-artifact@v2
         with:
@@ -113,7 +113,7 @@ jobs:
           move .\packaging\k6-$env:VERSION-windows-amd64\k6.exe .\packaging\
           rmdir .\packaging\k6-$env:VERSION-windows-amd64\
       - name: Add signtool to PATH
-        run: echo "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        run: echo "${env:ProgramFiles(x86)}\Windows Kits\10\bin\x64" | Out-File -FilePath $env:GITHUB_PATH -Append
       - name: Convert base64 certificate to PFX
         run: |
           $bytes = [Convert]::FromBase64String("${{ secrets.WIN_SIGN_CERT }}")

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.x
+          go-version: 1.17.x
       - name: Install Go tip
         if: matrix.go == 'tip'
         run: |


### PR DESCRIPTION
* Move `shell: powershell` to `shell: pwsh` (Powershell Core)  for Windows jobs.
* Set `go1.18` as the version for the current test job. 
* Updated legal entity for Windows build metadata
* Set Go version v1.17.x as stable for ARM and xk6 test 

~~It's blocked by #2465~~ 
<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
