### PR TITLE
Make redirects without Location still error in go-tip

### DIFF
--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -293,7 +293,7 @@ func MakeRequest(ctx context.Context, state *lib.State, preq *ParsedHTTPRequest)
 	// make it an error to not have Location header on a redirect
 	if res != nil && resErr == nil {
 		switch res.StatusCode {
-		case 301, 302, 303:
+		case http.StatusMovedPermanently, http.StatusFound, http.StatusSeeOther:
 			if res.Header.Get("Location") == "" {
 				resErr = NewK6Error(defaultErrorCode, fmt.Sprintf("%d response missing Location header", res.StatusCode), nil)
 			}


### PR DESCRIPTION
This is probably temporary, but it's probably better to keep this
behaviour for a while, or at least until a version of go with this
change is released.

