### PR TITLE
Remove test around redirects without Locations

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -2024,12 +2024,6 @@ func TestErrorCodes(t *testing.T) {
 			script:            `var res = http.request("GET", "HTTPBIN_URL/redirect-to?url=http://dafsgdhfjg.com/");`,
 		},
 		{
-			name:              "Non location redirect",
-			expectedErrorCode: 1000,
-			expectedErrorMsg:  "302 response missing Location header",
-			script:            `var res = http.request("GET", "HTTPBIN_URL/no-location-redirect");`,
-		},
-		{
 			name:              "Bad location redirect",
 			expectedErrorCode: 1000,
 			expectedErrorMsg:  "failed to parse Location header \"h\\t:/\": ",


### PR DESCRIPTION
This no longer passes on gotip as it was fixed in
https://github.com/golang/go/commit/a41763539c7ad09a22720a517a28e6018ca4db0f
