### PR TITLE
chore: remove dead code reported by linters

### DIFF
--- a/js/common/bridge.go
+++ b/js/common/bridge.go
@@ -1,26 +1,10 @@
 package common
 
 import (
-	"context"
 	"reflect"
 	"strings"
 
-	"github.com/dop251/goja"
 	"github.com/serenize/snaker"
-)
-
-var (
-	ctxPtrT = reflect.TypeOf((*context.Context)(nil))
-	ctxT    = reflect.TypeOf((*context.Context)(nil)).Elem()
-	errorT  = reflect.TypeOf((*error)(nil)).Elem()
-	jsValT  = reflect.TypeOf((*goja.Value)(nil)).Elem()
-	fnCallT = reflect.TypeOf((*goja.FunctionCall)(nil)).Elem()
-
-	constructWrap = goja.MustCompile(
-		"__constructor__",
-		`(function(impl) { return function() { return impl.apply(this, arguments); } })`,
-		true,
-	)
 )
 
 // if a fieldName is the key of this map exactly than the value for the given key should be used as

--- a/js/common/bridge_test.go
+++ b/js/common/bridge_test.go
@@ -59,66 +59,6 @@ type bridgeTestErrorType struct{}
 
 func (bridgeTestErrorType) Error() error { return errors.New("error") }
 
-type bridgeTestJSValueType struct{}
-
-func (bridgeTestJSValueType) Func(arg goja.Value) goja.Value { return arg }
-
-type bridgeTestJSValueErrorType struct{}
-
-func (bridgeTestJSValueErrorType) Func(arg goja.Value) (goja.Value, error) {
-	if goja.IsUndefined(arg) {
-		return goja.Undefined(), errors.New("missing argument")
-	}
-	return arg, nil
-}
-
-type bridgeTestJSValueContextType struct{}
-
-func (bridgeTestJSValueContextType) Func(ctx context.Context, arg goja.Value) goja.Value {
-	return arg
-}
-
-type bridgeTestJSValueContextErrorType struct{}
-
-func (bridgeTestJSValueContextErrorType) Func(ctx context.Context, arg goja.Value) (goja.Value, error) {
-	if goja.IsUndefined(arg) {
-		return goja.Undefined(), errors.New("missing argument")
-	}
-	return arg, nil
-}
-
-type bridgeTestNativeFunctionType struct{}
-
-func (bridgeTestNativeFunctionType) Func(call goja.FunctionCall) goja.Value {
-	return call.Argument(0)
-}
-
-type bridgeTestNativeFunctionErrorType struct{}
-
-func (bridgeTestNativeFunctionErrorType) Func(call goja.FunctionCall) (goja.Value, error) {
-	arg := call.Argument(0)
-	if goja.IsUndefined(arg) {
-		return goja.Undefined(), errors.New("missing argument")
-	}
-	return arg, nil
-}
-
-type bridgeTestNativeFunctionContextType struct{}
-
-func (bridgeTestNativeFunctionContextType) Func(ctx context.Context, call goja.FunctionCall) goja.Value {
-	return call.Argument(0)
-}
-
-type bridgeTestNativeFunctionContextErrorType struct{}
-
-func (bridgeTestNativeFunctionContextErrorType) Func(ctx context.Context, call goja.FunctionCall) (goja.Value, error) {
-	arg := call.Argument(0)
-	if goja.IsUndefined(arg) {
-		return goja.Undefined(), errors.New("missing argument")
-	}
-	return arg, nil
-}
-
 type bridgeTestAddType struct{}
 
 func (bridgeTestAddType) Add(a, b int) int { return a + b }
@@ -152,18 +92,6 @@ func (bridgeTestContextAddWithErrorType) ContextAddWithError(ctx context.Context
 	}
 	return res, nil
 }
-
-type bridgeTestContextInjectType struct {
-	ctx context.Context
-}
-
-func (t *bridgeTestContextInjectType) ContextInject(ctx context.Context) { t.ctx = ctx }
-
-type bridgeTestContextInjectPtrType struct {
-	ctxPtr *context.Context
-}
-
-func (t *bridgeTestContextInjectPtrType) ContextInjectPtr(ctxPtr *context.Context) { t.ctxPtr = ctxPtr }
 
 type bridgeTestSumType struct{}
 
@@ -209,15 +137,6 @@ func (m bridgeTestSumWithContextAndErrorType) SumWithContextAndError(ctx context
 		return 0, errors.New("answer is negative")
 	}
 	return sum, nil
-}
-
-type bridgeTestCounterType struct {
-	Counter int
-}
-
-func (m *bridgeTestCounterType) Count() int {
-	m.Counter++
-	return m.Counter
 }
 
 type bridgeTestConstructorType struct{}

--- a/js/modules/modules.go
+++ b/js/modules/modules.go
@@ -23,7 +23,6 @@ package modules
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strings"
 	"sync"
 
@@ -80,18 +79,6 @@ func GetJSModules() map[string]interface{} {
 // Instance is what a module needs to return
 type Instance interface {
 	Exports() Exports
-}
-
-func getInterfaceMethods() []string {
-	var t Instance
-	T := reflect.TypeOf(&t).Elem()
-	result := make([]string, T.NumMethod())
-
-	for i := range result {
-		result[i] = T.Method(i).Name
-	}
-
-	return result
 }
 
 // VU gives access to the currently executing VU to a module Instance


### PR DESCRIPTION
# What?

Removing the dead code reported by linters:

```sh
golangci-lint run --print-issued-lines=false --out-format tab | grep unused 
js/common/bridge.go:13:2                       deadcode          `ctxPtrT` is unused
js/common/bridge.go:14:2                       deadcode          `ctxT` is unused
js/common/bridge.go:15:2                       deadcode          `errorT` is unused
js/common/bridge.go:16:2                       deadcode          `jsValT` is unused
js/common/bridge.go:17:2                       deadcode          `fnCallT` is unused
js/common/bridge.go:19:2                       deadcode          `constructWrap` is unused
js/common/bridge_test.go:106:6                 unused            type `bridgeTestNativeFunctionContextType` is unused
js/common/bridge_test.go:218:33                unused            func `(*bridgeTestCounterType).Count` is unused
js/common/bridge_test.go:75:6                  unused            type `bridgeTestJSValueContextType` is unused
js/common/bridge_test.go:96:6                  unused            type `bridgeTestNativeFunctionErrorType` is unused
js/common/bridge_test.go:162:6                 unused            type `bridgeTestContextInjectPtrType` is unused
js/common/bridge_test.go:92:37                 unused            func `bridgeTestNativeFunctionType.Func` is unused
js/common/bridge_test.go:64:30                 unused            func `bridgeTestJSValueType.Func` is unused
js/common/bridge_test.go:68:35                 unused            func `bridgeTestJSValueErrorType.Func` is unused
js/common/bridge_test.go:77:37                 unused            func `bridgeTestJSValueContextType.Func` is unused
js/common/bridge_test.go:83:42                 unused            func `bridgeTestJSValueContextErrorType.Func` is unused
js/common/bridge_test.go:160:39                unused            func `(*bridgeTestContextInjectType).ContextInject` is unused
js/common/bridge_test.go:90:6                  unused            type `bridgeTestNativeFunctionType` is unused
js/common/bridge_test.go:62:6                  unused            type `bridgeTestJSValueType` is unused
js/common/bridge_test.go:112:6                 unused            type `bridgeTestNativeFunctionContextErrorType` is unused
js/common/bridge_test.go:214:6                 unused            type `bridgeTestCounterType` is unused
js/common/bridge_test.go:166:42                unused            func `(*bridgeTestContextInjectPtrType).ContextInjectPtr` is unused
js/common/bridge_test.go:108:44                unused            func `bridgeTestNativeFunctionContextType.Func` is unused
js/common/bridge_test.go:66:6                  unused            type `bridgeTestJSValueErrorType` is unused
js/common/bridge_test.go:156:6                 unused            type `bridgeTestContextInjectType` is unused
js/common/bridge_test.go:98:42                 unused            func `bridgeTestNativeFunctionErrorType.Func` is unused
js/common/bridge_test.go:114:49                unused            func `bridgeTestNativeFunctionContextErrorType.Func` is unused
js/common/bridge_test.go:81:6                  unused            type `bridgeTestJSValueContextErrorType` is unused
js/modules/modules.go:85:6            deadcode         `getInterfaceMethods` is unused
```

# Why?

In order to keep the codebase clean.