### PR TITLE
+ TLS key logging to enable Wireshark SSL support

### DIFF
--- a/cmd/options.go
+++ b/cmd/options.go
@@ -99,6 +99,8 @@ func optionFlagSet() *pflag.FlagSet {
 		"Milliseconds are assumed if no unit is provided.\n"+
 		"Possible select values to return a single IP are: 'first', 'random' or 'roundRobin'.\n"+
 		"Possible policy values are: 'preferIPv4', 'preferIPv6', 'onlyIPv4', 'onlyIPv6' or 'any'.\n")
+	flags.Bool("sslkeylog", false, "If enabled, output TLS secrets to env:SSLKEYLOGFILE")
+
 	return flags
 }
 
@@ -129,6 +131,8 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		TeardownTimeout: types.NullDuration{Duration: types.Duration(60 * time.Second), Valid: false},
 
 		MetricSamplesBufferSize: null.NewInt(1000, false),
+
+		SslKeyLog: getNullBool(flags, "sslkeylog"),
 	}
 
 	// Using Changed() because GetStringSlice() doesn't differentiate between empty and no value

--- a/js/runner.go
+++ b/js/runner.go
@@ -216,15 +216,7 @@ func (r *Runner) newVU(idLocal, idGlobal uint64, samplesOut chan<- metrics.Sampl
 		if err != nil {
 			r.Logger.Fatal(err)
 		}
-		tlsConfig = &tls.Config{
-			InsecureSkipVerify: r.Bundle.Options.InsecureSkipTLSVerify.Bool, //nolint:gosec
-			CipherSuites:       cipherSuites,
-			MinVersion:         uint16(tlsVersions.Min),
-			MaxVersion:         uint16(tlsVersions.Max),
-			Certificates:       certs,
-			Renegotiation:      tls.RenegotiateFreelyAsClient,
-			KeyLogWriter:       file,
-		}
+		tlsConfig.KeyLogWriter = file
 	}
 
 	// Follow NameToCertificate in https://pkg.go.dev/crypto/tls@go1.17.6#Config, leave this field nil

--- a/lib/options.go
+++ b/lib/options.go
@@ -389,6 +389,9 @@ type Options struct {
 
 	// Specify client IP ranges and/or CIDR from which VUs will make requests
 	LocalIPs types.NullIPPool `json:"-" envconfig:"K6_LOCAL_IPS"`
+
+	// Enable TLS/SSL key logging
+	SslKeyLog null.Bool `json:"sslkeylog" envconfig:"K6_SSL_KEYLOG"`
 }
 
 // Returns the result of overwriting any fields with any that are set on the argument.


### PR DESCRIPTION
**Related issue**: https://github.com/grafana/k6/issues/2482

**Problem:**
Add SSL decryption support for CAP e.g. Wireshark in the same fashion as Chrome & Firefox do:
if env SSLKEYLOGFILE is set, output keys to it

**Implementation:**
Extend tlsConfig to add KeyLogWriter (https://pkg.go.dev/crypto/tls#Config.KeyLogWriter) if a corresponding debug flag is set