### PR TITLE
SSLKEYLOGFILE support

### DIFF
--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -117,6 +117,12 @@ func getRuntimeOptions(flags *pflag.FlagSet, environment map[string]string) (lib
 		}
 	}
 
+	if envVar, ok := environment["SSLKEYLOGFILE"]; ok {
+		if !opts.KeyWriter.Valid {
+			opts.KeyWriter = null.StringFrom(envVar)
+		}
+	}
+
 	if opts.IncludeSystemEnvVars.Bool { // If enabled, gather the actual system environment variables
 		opts.Env = environment
 	}

--- a/js/keylogger.go
+++ b/js/keylogger.go
@@ -1,0 +1,17 @@
+package js
+
+import (
+	"os"
+	"sync"
+)
+
+type keyloggerWriter struct {
+	f *os.File
+	m *sync.Mutex
+}
+
+func (k *keyloggerWriter) Write(b []byte) (int, error) {
+	k.m.Lock()
+	defer k.m.Unlock()
+	return k.f.Write(b)
+}

--- a/lib/runtime_options.go
+++ b/lib/runtime_options.go
@@ -60,6 +60,7 @@ type RuntimeOptions struct {
 	NoThresholds  null.Bool   `json:"noThresholds"`
 	NoSummary     null.Bool   `json:"noSummary"`
 	SummaryExport null.String `json:"summaryExport"`
+	KeyWriter     null.String `json:"-"`
 }
 
 // ValidateCompatibilityMode checks if the provided val is a valid compatibility mode


### PR DESCRIPTION
fixes #1043 

During some of the previous discussions we really wanted to close the file at the end of the test. Unfortunately there isn't really a good way for this currently and arguably it will take a lot of time so the solutions (AFAIK) are:
1. don't close the file - in this case we can just open it in `js.Runner` and give it to all `VUs`. The file will be closed when the process exits, possibly not flushing a line ... I guess (although os.File is not buffered by default). 
2. Wait for a rewrite to get us a signal for "k6 is stopping" to close the file. This arguably is connected with way too many other life-time issues in k6 and is unlikely to be easy to fix. 
3. Move this outside of the `js` package and push it in. This in practice will mean more arguments, but may let us do it in `cmd/run.go` for example :shrug:, Which does know when a k6 will stop executing
4. Do some "reference counting" on activation and deactivation of VUs and open/close the file when appropriate - what this PR does.