### PR TITLE
TLS Auth - Support for encrypted private key

### DIFF
--- a/lib/options.go
+++ b/lib/options.go
@@ -187,7 +187,12 @@ func decryptPrivateKey(privKey, password string) ([]byte, error) {
 	if blockType == "ENCRYPTED PRIVATE KEY" {
 		return nil, fmt.Errorf("encrypted pkcs8 formatted key is not supported")
 	}
-	decryptedKey, err := x509.DecryptPEMBlock(block, []byte(password))
+	/*
+	   Even though `DecryptPEMBlock` has been depecrated since 1.16.x it is still
+	   being used here because there are not alternatives in the standard library
+	   to decrypt PEM encoded files.
+	*/
+	decryptedKey, err := x509.DecryptPEMBlock(block, []byte(password)) // nolint: staticcheck
 	if err != nil {
 		return nil, err
 	}

--- a/lib/options.go
+++ b/lib/options.go
@@ -182,6 +182,9 @@ func parsePrivateKey(privKey, password string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to decode PEM key")
 	}
 	blockType := block.Type
+	if blockType == "ENCRYPTED PRIVATE KEY" {
+		return nil, fmt.Errorf("encrypted pkcs8 formatted key is not supported")
+	}
 	if encrypted := x509.IsEncryptedPEMBlock(block); encrypted {
 		decryptedKey, err := x509.DecryptPEMBlock(block, []byte(password))
 		if err != nil {

--- a/lib/options.go
+++ b/lib/options.go
@@ -187,16 +187,14 @@ func decryptPrivateKey(privKey, password string) ([]byte, error) {
 	if blockType == "ENCRYPTED PRIVATE KEY" {
 		return nil, fmt.Errorf("encrypted pkcs8 formatted key is not supported")
 	}
-	if encrypted := x509.IsEncryptedPEMBlock(block); encrypted {
-		decryptedKey, err := x509.DecryptPEMBlock(block, []byte(password))
-		if err != nil {
-			return nil, err
-		}
-		key = pem.EncodeToMemory(&pem.Block{
-			Type:  blockType,
-			Bytes: decryptedKey,
-		})
+	decryptedKey, err := x509.DecryptPEMBlock(block, []byte(password))
+	if err != nil {
+		return nil, err
 	}
+	key = pem.EncodeToMemory(&pem.Block{
+		Type:  blockType,
+		Bytes: decryptedKey,
+	})
 	return key, nil
 }
 

--- a/lib/options.go
+++ b/lib/options.go
@@ -160,7 +160,7 @@ func (c *TLSAuth) Certificate() (*tls.Certificate, error) {
 	key := []byte(c.Key)
 	var err error
 	if c.Password != "" {
-		key, err = parsePrivateKey(c.Key, c.Password)
+		key, err = decryptPrivateKey(c.Key, c.Password)
 		if err != nil {
 			return nil, err
 		}
@@ -175,12 +175,14 @@ func (c *TLSAuth) Certificate() (*tls.Certificate, error) {
 	return c.certificate, nil
 }
 
-func parsePrivateKey(privKey, password string) ([]byte, error) {
+func decryptPrivateKey(privKey, password string) ([]byte, error) {
 	key := []byte(privKey)
+
 	block, _ := pem.Decode(key)
 	if block == nil {
 		return nil, fmt.Errorf("failed to decode PEM key")
 	}
+
 	blockType := block.Type
 	if blockType == "ENCRYPTED PRIVATE KEY" {
 		return nil, fmt.Errorf("encrypted pkcs8 formatted key is not supported")

--- a/lib/options.go
+++ b/lib/options.go
@@ -188,9 +188,9 @@ func decryptPrivateKey(privKey, password string) ([]byte, error) {
 		return nil, fmt.Errorf("encrypted pkcs8 formatted key is not supported")
 	}
 	/*
-	   Even though `DecryptPEMBlock` has been depecrated since 1.16.x it is still
-	   being used here because there are not alternatives in the standard library
-	   to decrypt PEM encoded files.
+	   Even though `DecryptPEMBlock` has been deprecated since 1.16.x it is still
+	   being used here because it is deprecated due to it not supporting *good* crypography
+	   ultimately though we want to support something so we will be using it for now.
 	*/
 	decryptedKey, err := x509.DecryptPEMBlock(block, []byte(password)) // nolint: staticcheck
 	if err != nil {

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -398,7 +398,7 @@ func TestOptions(t *testing.T) {
 			assert.NoError(t, err)
 
 			var opts2 Options
-			errMsg := "tls: failed to parse private key"
+			errMsg := "encrypted pkcs8 formatted key is not supported"
 			err = json.Unmarshal(optsData, &opts2)
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), errMsg)

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -253,6 +253,7 @@ func TestOptions(t *testing.T) {
 					"AwEHoUQDQgAEF8XzmC7x8Ns0Y2Wyu2c77ge+6I/ghcDTjWOMZzMPmRRDxqKFLuGD\n" +
 					"zW1Kss13WODGSS8+j7dNCPOeLKyK6cbeIg==\n" +
 					"-----END EC PRIVATE KEY-----",
+				Password: "iNGNlsrtnO+4HiQAwRgIhANYDaM18sXAdkjyvuiP4IXA041jdK48Jd6a8aD",
 			}, nil},
 		}
 		opts := Options{}.Apply(Options{TLSAuth: tlsAuth})
@@ -286,6 +287,124 @@ func TestOptions(t *testing.T) {
 			assert.Error(t, json.Unmarshal([]byte(jsonStr), &opts))
 		})
 	})
+
+	t.Run("TLSAuth encrypted key and invalid password", func(t *testing.T) {
+		tlsAuth := []*TLSAuth{
+			{TLSAuthFields{
+				Domains: []string{"example.com", "*.example.com"},
+				Cert: "-----BEGIN CERTIFICATE-----\n" +
+					"MIIBoTCCAUegAwIBAgIUQl0J1Gkd6U2NIMwMDnpfH8c1myEwCgYIKoZIzj0EAwIw\n" +
+					"EDEOMAwGA1UEAxMFTXkgQ0EwHhcNMTcwODE1MTYxODAwWhcNMTgwODE1MTYxODAw\n" +
+					"WjAQMQ4wDAYDVQQDEwV1c2VyMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABLaf\n" +
+					"xEOmBHkzbqd9/0VZX/39qO2yQq2Gz5faRdvy38kuLMCV+9HYrfMx6GYCZzTUIq6h\n" +
+					"8QXOrlgYTixuUVfhJNWjfzB9MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggr\n" +
+					"BgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUxmQiq5K3\n" +
+					"KUnVME945Byt3Ysvkh8wHwYDVR0jBBgwFoAU3qEhcpRgpsqo9V+LFns9a+oZIYww\n" +
+					"CgYIKoZIzj0EAwIDSAAwRQIgSGxnJ+/cLUNTzt7fhr/mjJn7ShsTW33dAdfLM7H2\n" +
+					"z/gCIQDyVf8DePtxlkMBScTxZmIlMQdNc6+6VGZQ4QscruVLmg==\n" +
+					"-----END CERTIFICATE-----",
+				Key: "-----BEGIN EC PRIVATE KEY-----\n" +
+					"Proc-Type: 4,ENCRYPTED\n" +
+					"DEK-Info: AES-256-CBC,DF2445CBFE2E5B112FB2B721063757E5\n" +
+					"o/VKNZjQcRM2hatqUkQ0dTolL7i2i5hJX9XYsl+TMsq8ZkC83uY/JdR986QS+W2c\n" +
+					"EoQGtVGVeL0KGvGpzjTX3YAKXM7Lg5btAeS8GvJ9S7YFd8s0q1pqDdffl2RyjJav\n" +
+					"t1jx6XvLu2nBrOUARvHqjkkJQCTdRf2a34GJdbZqE+4=\n" +
+					"-----END EC PRIVATE KEY-----",
+				Password: "iZfYGcrgFHOg4nweEo7ufT",
+			}, nil},
+		}
+		opts := Options{}.Apply(Options{TLSAuth: tlsAuth})
+		assert.Equal(t, tlsAuth, opts.TLSAuth)
+
+		t.Run("Roundtrip", func(t *testing.T) {
+			optsData, err := json.Marshal(opts)
+			assert.NoError(t, err)
+
+			var opts2 Options
+			errMsg := "x509: decryption password incorrect"
+			err = json.Unmarshal(optsData, &opts2)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), errMsg)
+		})
+	})
+
+	t.Run("TLSAuth encrypted key and valid password", func(t *testing.T) {
+		tlsAuth := []*TLSAuth{
+			{TLSAuthFields{
+				Domains: []string{"example.com", "*.example.com"},
+				Cert: "-----BEGIN CERTIFICATE-----\n" +
+					"MIIBoTCCAUegAwIBAgIUQl0J1Gkd6U2NIMwMDnpfH8c1myEwCgYIKoZIzj0EAwIw\n" +
+					"EDEOMAwGA1UEAxMFTXkgQ0EwHhcNMTcwODE1MTYxODAwWhcNMTgwODE1MTYxODAw\n" +
+					"WjAQMQ4wDAYDVQQDEwV1c2VyMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABLaf\n" +
+					"xEOmBHkzbqd9/0VZX/39qO2yQq2Gz5faRdvy38kuLMCV+9HYrfMx6GYCZzTUIq6h\n" +
+					"8QXOrlgYTixuUVfhJNWjfzB9MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggr\n" +
+					"BgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUxmQiq5K3\n" +
+					"KUnVME945Byt3Ysvkh8wHwYDVR0jBBgwFoAU3qEhcpRgpsqo9V+LFns9a+oZIYww\n" +
+					"CgYIKoZIzj0EAwIDSAAwRQIgSGxnJ+/cLUNTzt7fhr/mjJn7ShsTW33dAdfLM7H2\n" +
+					"z/gCIQDyVf8DePtxlkMBScTxZmIlMQdNc6+6VGZQ4QscruVLmg==\n" +
+					"-----END CERTIFICATE-----",
+				Key: "-----BEGIN EC PRIVATE KEY-----\n" +
+					"Proc-Type: 4,ENCRYPTED\n" +
+					"DEK-Info: AES-256-CBC,DF2445CBFE2E5B112FB2B721063757E5\n" +
+					"o/VKNZjQcRM2hatqUkQ0dTolL7i2i5hJX9XYsl+TMsq8ZkC83uY/JdR986QS+W2c\n" +
+					"EoQGtVGVeL0KGvGpzjTX3YAKXM7Lg5btAeS8GvJ9S7YFd8s0q1pqDdffl2RyjJav\n" +
+					"t1jx6XvLu2nBrOUARvHqjkkJQCTdRf2a34GJdbZqE+4=\n" +
+					"-----END EC PRIVATE KEY-----",
+				Password: "12345",
+			}, nil},
+		}
+		opts := Options{}.Apply(Options{TLSAuth: tlsAuth})
+		assert.Equal(t, tlsAuth, opts.TLSAuth)
+
+		t.Run("Roundtrip", func(t *testing.T) {
+			optsData, err := json.Marshal(opts)
+			assert.NoError(t, err)
+
+			var opts2 Options
+			err = json.Unmarshal(optsData, &opts2)
+			assert.NoError(t, err)
+		})
+	})
+	t.Run("TLSAuth encrypted pks8 format key and valid password", func(t *testing.T) {
+		tlsAuth := []*TLSAuth{
+			{TLSAuthFields{
+				Domains: []string{"example.com", "*.example.com"},
+				Cert: "-----BEGIN CERTIFICATE-----\n" +
+					"MIIBoTCCAUegAwIBAgIUQl0J1Gkd6U2NIMwMDnpfH8c1myEwCgYIKoZIzj0EAwIw\n" +
+					"EDEOMAwGA1UEAxMFTXkgQ0EwHhcNMTcwODE1MTYxODAwWhcNMTgwODE1MTYxODAw\n" +
+					"WjAQMQ4wDAYDVQQDEwV1c2VyMTBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABLaf\n" +
+					"xEOmBHkzbqd9/0VZX/39qO2yQq2Gz5faRdvy38kuLMCV+9HYrfMx6GYCZzTUIq6h\n" +
+					"8QXOrlgYTixuUVfhJNWjfzB9MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggr\n" +
+					"BgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUxmQiq5K3\n" +
+					"KUnVME945Byt3Ysvkh8wHwYDVR0jBBgwFoAU3qEhcpRgpsqo9V+LFns9a+oZIYww\n" +
+					"CgYIKoZIzj0EAwIDSAAwRQIgSGxnJ+/cLUNTzt7fhr/mjJn7ShsTW33dAdfLM7H2\n" +
+					"z/gCIQDyVf8DePtxlkMBScTxZmIlMQdNc6+6VGZQ4QscruVLmg==\n" +
+					"-----END CERTIFICATE-----",
+				Key: "-----BEGIN ENCRYPTED PRIVATE KEY-----\n" +
+					"MIHsMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAjcfarGfrRgUgICCAAw\n" +
+					"DAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEFmtmKEFmThbkbpxmC6iBvoEgZCE\n" +
+					"pDCpH/yCLmSpjdi/PC74I794nzHyCWf/oS0JhM0Q7J+abZP+p5pnreKft1f15Dbw\n" +
+					"QG9alfoM6EffJcVo3gf1tgQrpGGFMwczc4VhQgSGDy0XjZSbd2K0QCFGSmD2ZIR1\n" +
+					"qPG3WepWjKmIsYffGeKZx+FjXHSFeGk7RnssNAyKcPruDQIdWWyXxX1+ugBKuBw=\n" +
+					"-----END ENCRYPTED PRIVATE KEY-----\n",
+				Password: "12345",
+			}, nil},
+		}
+		opts := Options{}.Apply(Options{TLSAuth: tlsAuth})
+		assert.Equal(t, tlsAuth, opts.TLSAuth)
+
+		t.Run("Roundtrip", func(t *testing.T) {
+			optsData, err := json.Marshal(opts)
+			assert.NoError(t, err)
+
+			var opts2 Options
+			errMsg := "tls: failed to parse private key"
+			err = json.Unmarshal(optsData, &opts2)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), errMsg)
+		})
+	})
+
 	t.Run("NoConnectionReuse", func(t *testing.T) {
 		opts := Options{}.Apply(Options{NoConnectionReuse: null.BoolFrom(true)})
 		assert.True(t, opts.NoConnectionReuse.Valid)

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -254,7 +254,6 @@ func TestOptions(t *testing.T) {
 					"AwEHoUQDQgAEF8XzmC7x8Ns0Y2Wyu2c77ge+6I/ghcDTjWOMZzMPmRRDxqKFLuGD\n" +
 					"zW1Kss13WODGSS8+j7dNCPOeLKyK6cbeIg==\n" +
 					"-----END EC PRIVATE KEY-----",
-				Password: "iNGNlsrtnO+4HiQAwRgIhANYDaM18sXAdkjyvuiP4IXA041jdK48Jd6a8aD",
 			}, nil},
 		}
 		opts := Options{}.Apply(Options{TLSAuth: tlsAuth})
@@ -347,6 +346,17 @@ func TestOptions(t *testing.T) {
 				password:     "12345",
 				hasError:     true,
 				errorMessage: "encrypted pkcs8 formatted key is not supported",
+			},
+			{
+				name: "non encrypted key and password",
+				privateKey: "-----BEGIN EC PRIVATE KEY-----\n" +
+					"MHcCAQEEINVilD5qOBkSy+AYfd41X0QPB5N3Z6OzgoBj8FZmSJOFoAoGCCqGSM49\n" +
+					"AwEHoUQDQgAEF8XzmC7x8Ns0Y2Wyu2c77ge+6I/ghcDTjWOMZzMPmRRDxqKFLuGD\n" +
+					"zW1Kss13WODGSS8+j7dNCPOeLKyK6cbeIg==\n" +
+					"-----END EC PRIVATE KEY-----",
+				password:     "12345",
+				hasError:     true,
+				errorMessage: "x509: no DEK-Info header in block",
 			},
 		}
 		for _, tc := range tests {


### PR DESCRIPTION
**Related issue**: #2435 (Also presents the problem)

**Proposal**:
- Allow users to pass an password field which is used to decrypt the private key; If the key is not protected/encrypted, password will be ignored.