### PR TITLE
Restore `options.scenarios`

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -289,6 +289,13 @@ func (b *Bundle) Instantiate(
 		jsOptionsObj = jsOptions.ToObject(rt)
 	}
 	b.Options.ForEachSpecified("json", func(key string, val interface{}) {
+		// goja.ToValue generates an empty Object `{}` for the scenarios's value.
+		// This skips the set preserving the original `options.scenarios` value.
+		//
+		// TODO: rid this part when #883 will be implemented
+		if key == "scenarios" {
+			return
+		}
 		if err := jsOptionsObj.Set(key, val); err != nil {
 			instErr = err
 		}


### PR DESCRIPTION
Using as an example the following script, it prints an unexpected `{}` object using `>v0.37.0`. This change has been introduced by https://github.com/grafana/k6/pull/2392.

```javascript
import exec from 'k6/execution';

export const options = {
	scenarios: {
		contacts: {
			executor: 'shared-iterations',
			iterations: 1,
		},
	},
};

export default function() {
	console.log(JSON.stringify(options.scenarios))
}
```

In v0.36.0 and previous versions, the `scenarios` key wasn't set during the `js.Bundle.Instantiate` because the key used for it was `scenarios,omitempty`.

The current change is an hack for restoring the previous behaviour where the expected output is:

```javascript
INFO[0000] {"contacts":{"executor":"shared-iterations","iterations":1}}  source=console
``` 

### Questions

* Could we rid the entire `b.Options.ForEachSpecified("json",` logic when https://github.com/grafana/k6/issues/2450 will be implemented. If yes, probably we should directly implement 2450 and not merge this.
* Do we have an alternative to make this change less const-string dependent?

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
