### PR TITLE
js/k6/exec: test.options object

### DIFF
--- a/js/common/frozen_object.go
+++ b/js/common/frozen_object.go
@@ -1,0 +1,69 @@
+package common
+
+import (
+	"fmt"
+
+	"github.com/dop251/goja"
+)
+
+// FreezeObject replicates the JavaScript Object.freeze function.
+func FreezeObject(rt *goja.Runtime, obj goja.Value) error {
+	global := rt.GlobalObject().Get("Object").ToObject(rt)
+	freeze, ok := goja.AssertFunction(global.Get("freeze"))
+	if !ok {
+		panic("failed to get the Object.freeze function from the runtime")
+	}
+	isFrozen, ok := goja.AssertFunction(global.Get("isFrozen"))
+	if !ok {
+		panic("failed to get the Object.isFrozen function from the runtime")
+	}
+	fobj := &freezing{
+		global:   global,
+		rt:       rt,
+		freeze:   freeze,
+		isFrozen: isFrozen,
+	}
+	return fobj.deepFreeze(obj)
+}
+
+type freezing struct {
+	rt       *goja.Runtime
+	global   goja.Value
+	freeze   goja.Callable
+	isFrozen goja.Callable
+}
+
+func (f *freezing) deepFreeze(val goja.Value) error {
+	if val != nil && goja.IsNull(val) {
+		return nil
+	}
+
+	_, err := f.freeze(goja.Undefined(), val)
+	if err != nil {
+		return fmt.Errorf("object freeze failed: %w", err)
+	}
+
+	o := val.ToObject(f.rt)
+	if o == nil {
+		return nil
+	}
+
+	for _, key := range o.Keys() {
+		prop := o.Get(key)
+		if prop == nil {
+			continue
+		}
+		frozen, err := f.isFrozen(goja.Undefined(), prop)
+		if err != nil {
+			return err
+		}
+		if frozen.ToBoolean() { // prevent cycles
+			continue
+		}
+		if err = f.deepFreeze(prop); err != nil {
+			return fmt.Errorf("deep freezing the property %s failed: %w", key, err)
+		}
+	}
+
+	return nil
+}

--- a/js/common/frozen_object_test.go
+++ b/js/common/frozen_object_test.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrozenObject(t *testing.T) {
+	t.Parallel()
+
+	rt := goja.New()
+	obj := rt.NewObject()
+	require.NoError(t, obj.Set("foo", "bar"))
+	require.NoError(t, rt.Set("obj", obj))
+
+	v, err := rt.RunString(`obj.foo`)
+	require.NoError(t, err)
+	require.Equal(t, "bar", v.String())
+
+	// Set a nested object
+	_, err = rt.RunString(`obj.nested = {propkey: "value1"}`)
+	require.NoError(t, err)
+
+	// Not yet frozen
+	v, err = rt.RunString(`Object.isFrozen(obj)`)
+	require.NoError(t, err)
+	require.False(t, v.ToBoolean())
+
+	require.NoError(t, FreezeObject(rt, obj))
+
+	// It has been frozen
+	v, err = rt.RunString(`Object.isFrozen(obj)`)
+	require.NoError(t, err)
+	require.True(t, v.ToBoolean())
+
+	// It has deeply frozen the properties
+	vfoo, err := rt.RunString(`Object.isFrozen(obj.foo)`)
+	require.NoError(t, err)
+	require.True(t, vfoo.ToBoolean())
+
+	// And deeply frozen the nested objects
+	vnested, err := rt.RunString(`Object.isFrozen(obj.nested)`)
+	require.NoError(t, err)
+	require.True(t, vnested.ToBoolean())
+
+	nestedProp, err := rt.RunString(`Object.isFrozen(obj.nested.propkey)`)
+	require.NoError(t, err)
+	require.True(t, nestedProp.ToBoolean())
+
+	// The assign is silently ignored
+	_, err = rt.RunString(`obj.foo = "bad change"`)
+	require.NoError(t, err)
+
+	v, err = rt.RunString(`obj.foo`)
+	require.NoError(t, err)
+	assert.Equal(t, "bar", v.String())
+
+	// If the strict mode is enabled then it fails
+	v, err = rt.RunString(`'use strict'; obj.foo = "bad change"`)
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Cannot assign to read only property 'foo'")
+	assert.Nil(t, v)
+}

--- a/js/common/util.go
+++ b/js/common/util.go
@@ -18,6 +18,7 @@
  *
  */
 
+// Package common contains helpers for interacting with the JavaScript runtime.
 package common
 
 import (

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -1,30 +1,14 @@
-/*
- *
- * k6 - a next-generation load testing tool
- * Copyright (C) 2021 Load Impact
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
-
 package execution
 
 import (
 	"context"
+	"crypto/tls"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/dop251/goja"
 	"github.com/sirupsen/logrus"
@@ -33,7 +17,9 @@ import (
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modulestest"
 	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/executor"
 	"go.k6.io/k6/lib/testutils"
+	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/metrics"
 	"gopkg.in/guregu/null.v3"
 )
@@ -222,4 +208,192 @@ func TestAbortTest(t *testing.T) { //nolint:tparallel
 	t.Run("custom reason", func(t *testing.T) { //nolint: paralleltest
 		prove(t, `exec.test.abort("mayday")`, fmt.Sprintf("%s: mayday", common.AbortTest))
 	})
+}
+
+func TestOptionsTestFull(t *testing.T) {
+	t.Parallel()
+
+	expected := `{"paused":true,"scenarios":{"const-vus":{"executor":"constant-vus","startTime":"10s","gracefulStop":"30s","env":{"FOO":"bar"},"exec":"default","tags":{"tagkey":"tagvalue"},"vus":50,"duration":"10m0s"}},"executionSegment":"0:1/4","executionSegmentSequence":"0,1/4,1/2,1","noSetup":true,"setupTimeout":"1m0s","noTeardown":true,"teardownTimeout":"5m0s","rps":100,"dns":{"ttl":"1m","select":"roundRobin","policy":"any"},"maxRedirects":3,"userAgent":"k6-user-agent","batch":15,"batchPerHost":5,"httpDebug":"full","insecureSkipTLSVerify":true,"tlsCipherSuites":["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"],"tlsVersion":{"min":"tls1.2","max":"tls1.3"},"tlsAuth":[{"domains":["example.com"],"cert":"mycert.pem","key":"mycert-key.pem"}],"throw":true,"thresholds":{"http_req_duration":[{"threshold":"rate>0.01","abortOnFail":true,"delayAbortEval":"10s"}]},"blacklistIPs":["192.0.2.0/24"],"blockHostnames":["test.k6.io","*.example.com"],"hosts":{"test.k6.io":"1.2.3.4:8443"},"noConnectionReuse":true,"noVUConnectionReuse":true,"minIterationDuration":"10s","ext":{"ext-one":{"rawkey":"rawvalue"}},"summaryTrendStats":["avg","min","max"],"summaryTimeUnit":"ms","systemTags":["iter","vu"],"tags":null,"metricSamplesBufferSize":8,"noCookiesReset":true,"discardResponseBodies":true,"consoleOutput":"loadtest.log","tags":{"runtag-key":"runtag-value"},"localIPs":"192.168.20.12-192.168.20.15,192.168.10.0/27"}`
+
+	var (
+		rt    = goja.New()
+		state = &lib.State{
+			Options: lib.Options{
+				Paused: null.BoolFrom(true),
+				Scenarios: map[string]lib.ExecutorConfig{
+					"const-vus": executor.ConstantVUsConfig{
+						BaseConfig: executor.BaseConfig{
+							Name:         "const-vus",
+							Type:         "constant-vus",
+							StartTime:    types.NullDurationFrom(10 * time.Second),
+							GracefulStop: types.NullDurationFrom(30 * time.Second),
+							Env: map[string]string{
+								"FOO": "bar",
+							},
+							Exec: null.StringFrom("default"),
+							Tags: map[string]string{
+								"tagkey": "tagvalue",
+							},
+						},
+						VUs:      null.IntFrom(50),
+						Duration: types.NullDurationFrom(10 * time.Minute),
+					},
+				},
+				ExecutionSegment: func() *lib.ExecutionSegment {
+					seg, err := lib.NewExecutionSegmentFromString("0:1/4")
+					require.NoError(t, err)
+					return seg
+				}(),
+				ExecutionSegmentSequence: func() *lib.ExecutionSegmentSequence {
+					seq, err := lib.NewExecutionSegmentSequenceFromString("0,1/4,1/2,1")
+					require.NoError(t, err)
+					return &seq
+				}(),
+				NoSetup:               null.BoolFrom(true),
+				NoTeardown:            null.BoolFrom(true),
+				NoConnectionReuse:     null.BoolFrom(true),
+				NoVUConnectionReuse:   null.BoolFrom(true),
+				InsecureSkipTLSVerify: null.BoolFrom(true),
+				Throw:                 null.BoolFrom(true),
+				NoCookiesReset:        null.BoolFrom(true),
+				DiscardResponseBodies: null.BoolFrom(true),
+				RPS:                   null.IntFrom(100),
+				MaxRedirects:          null.IntFrom(3),
+				UserAgent:             null.StringFrom("k6-user-agent"),
+				Batch:                 null.IntFrom(15),
+				BatchPerHost:          null.IntFrom(5),
+				SetupTimeout:          types.NullDurationFrom(1 * time.Minute),
+				TeardownTimeout:       types.NullDurationFrom(5 * time.Minute),
+				MinIterationDuration:  types.NullDurationFrom(10 * time.Second),
+				HTTPDebug:             null.StringFrom("full"),
+				DNS: types.DNSConfig{
+					TTL:    null.StringFrom("1m"),
+					Select: types.NullDNSSelect{DNSSelect: types.DNSroundRobin, Valid: true},
+					Policy: types.NullDNSPolicy{DNSPolicy: types.DNSany, Valid: true},
+					Valid:  true,
+				},
+				TLSVersion: &lib.TLSVersions{
+					Min: tls.VersionTLS12,
+					Max: tls.VersionTLS13,
+				},
+				TLSAuth: []*lib.TLSAuth{
+					{
+						TLSAuthFields: lib.TLSAuthFields{
+							Cert:    "mycert.pem",
+							Key:     "mycert-key.pem",
+							Domains: []string{"example.com"},
+						},
+					},
+				},
+				TLSCipherSuites: &lib.TLSCipherSuites{
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				},
+				BlacklistIPs: []*lib.IPNet{
+					{
+						IPNet: func() net.IPNet {
+							_, ipv4net, err := net.ParseCIDR("192.0.2.1/24")
+							require.NoError(t, err)
+							return *ipv4net
+						}(),
+					},
+				},
+				Thresholds: map[string]metrics.Thresholds{
+					"http_req_duration": {
+						Thresholds: []*metrics.Threshold{
+							{
+								Source:           "rate>0.01",
+								LastFailed:       true,
+								AbortOnFail:      true,
+								AbortGracePeriod: types.NullDurationFrom(10 * time.Second),
+							},
+						},
+					},
+				},
+				BlockedHostnames: func() types.NullHostnameTrie {
+					bh, err := types.NewNullHostnameTrie([]string{"test.k6.io", "*.example.com"})
+					require.NoError(t, err)
+					return bh
+				}(),
+				Hosts: map[string]*lib.HostAddress{
+					"test.k6.io": {
+						IP:   []byte{0x01, 0x02, 0x03, 0x04},
+						Port: 8443,
+					},
+				},
+				External: map[string]json.RawMessage{
+					"ext-one": json.RawMessage(`{"rawkey":"rawvalue"}`),
+				},
+				SummaryTrendStats: []string{"avg", "min", "max"},
+				SummaryTimeUnit:   null.StringFrom("ms"),
+				SystemTags: func() *metrics.SystemTagSet {
+					sysm := metrics.TagIter | metrics.TagVU
+					return &sysm
+				}(),
+				RunTags:                 metrics.NewSampleTags(map[string]string{"runtag-key": "runtag-value"}),
+				MetricSamplesBufferSize: null.IntFrom(8),
+				ConsoleOutput:           null.StringFrom("loadtest.log"),
+				LocalIPs: func() types.NullIPPool {
+					npool := types.NullIPPool{}
+					err := npool.UnmarshalText([]byte("192.168.20.12-192.168.20.15,192.168.10.0/27"))
+					require.NoError(t, err)
+					return npool
+				}(),
+
+				// The following fields are not expected to be
+				// in the final test.options object
+				VUs:        null.IntFrom(50),
+				Iterations: null.IntFrom(100),
+				Duration:   types.NullDurationFrom(10 * time.Second),
+				Stages: []lib.Stage{
+					{
+						Duration: types.NullDurationFrom(2 * time.Second),
+						Target:   null.IntFrom(2),
+					},
+				},
+			},
+		}
+		ctx = context.Background()
+	)
+
+	m, ok := New().NewModuleInstance(
+		&modulestest.VU{
+			RuntimeField: rt,
+			InitEnvField: &common.InitEnvironment{},
+			CtxField:     ctx,
+			StateField:   state,
+		},
+	).(*ModuleInstance)
+	require.True(t, ok)
+	require.NoError(t, rt.Set("exec", m.Exports().Default))
+
+	opts, err := rt.RunString(`JSON.stringify(exec.test.options)`)
+	require.NoError(t, err)
+	require.NotNil(t, opts)
+	assert.JSONEq(t, expected, opts.String())
+}
+
+func TestOptionsTestSetPropertyDenied(t *testing.T) {
+	t.Parallel()
+
+	rt := goja.New()
+	m, ok := New().NewModuleInstance(
+		&modulestest.VU{
+			RuntimeField: rt,
+			InitEnvField: &common.InitEnvironment{},
+			CtxField:     context.Background(),
+			StateField: &lib.State{
+				Options: lib.Options{
+					Paused: null.BoolFrom(true),
+				},
+			},
+		},
+	).(*ModuleInstance)
+	require.True(t, ok)
+	require.NoError(t, rt.Set("exec", m.Exports().Default))
+
+	_, err := rt.RunString(`exec.test.options.paused = false`)
+	require.NoError(t, err)
+	paused, err := rt.RunString(`exec.test.options.paused`)
+	require.NoError(t, err)
+	assert.Equal(t, true, rt.ToValue(paused).ToBoolean())
 }

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -473,17 +473,19 @@ func TestOptions(t *testing.T) {
 	})
 	t.Run("ClientIPRanges", func(t *testing.T) {
 		t.Parallel()
-		clientIPRanges, err := types.NewIPPool("129.112.232.12,123.12.0.0/32")
+		clientIPRanges := types.NullIPPool{}
+		err := clientIPRanges.UnmarshalText([]byte("129.112.232.12,123.12.0.0/32"))
 		require.NoError(t, err)
-		opts := Options{}.Apply(Options{LocalIPs: types.NullIPPool{Pool: clientIPRanges, Valid: true}})
+		opts := Options{}.Apply(Options{LocalIPs: clientIPRanges})
 		assert.NotNil(t, opts.LocalIPs)
 	})
 }
 
 func TestOptionsEnv(t *testing.T) {
 	t.Parallel()
-	mustIPPool := func(s string) *types.IPPool {
-		p, err := types.NewIPPool(s)
+	mustNullIPPool := func(s string) types.NullIPPool {
+		p := types.NullIPPool{}
+		err := p.UnmarshalText([]byte(s))
 		require.NoError(t, err)
 		return p
 	}
@@ -559,8 +561,8 @@ func TestOptionsEnv(t *testing.T) {
 		},
 		{"LocalIPs", "K6_LOCAL_IPS"}: {
 			"":                 types.NullIPPool{},
-			"192.168.220.2":    types.NullIPPool{Pool: mustIPPool("192.168.220.2"), Valid: true},
-			"192.168.220.2/24": types.NullIPPool{Pool: mustIPPool("192.168.220.0/24"), Valid: true},
+			"192.168.220.2":    mustNullIPPool("192.168.220.2"),
+			"192.168.220.0/24": mustNullIPPool("192.168.220.0/24"),
 		},
 		{"Throw", "K6_THROW"}: {
 			"":      null.Bool{},

--- a/lib/types/ipblock.go
+++ b/lib/types/ipblock.go
@@ -182,6 +182,7 @@ func (pool *IPPool) GetIPBig(index *big.Int) net.IP {
 type NullIPPool struct {
 	Pool  *IPPool
 	Valid bool
+	raw   []byte
 }
 
 // UnmarshalText converts text data to a valid NullIPPool
@@ -196,5 +197,11 @@ func (n *NullIPPool) UnmarshalText(data []byte) error {
 		return err
 	}
 	n.Valid = true
+	n.raw = data
 	return nil
+}
+
+// MarshalText returns the IPs pool in text form
+func (n *NullIPPool) MarshalText() ([]byte, error) {
+	return n.raw, nil
 }

--- a/lib/types/ipblock_test.go
+++ b/lib/types/ipblock_test.go
@@ -29,10 +29,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:gochecknoglobals
-var max64 = new(big.Int).Exp(big.NewInt(2), big.NewInt(64), nil)
-
 func get128BigInt(hi, lo int64) *big.Int {
+	max64 := new(big.Int).Exp(big.NewInt(2), big.NewInt(64), nil)
 	h := big.NewInt(hi)
 	h.Mul(h, max64)
 	return h.Add(h, big.NewInt(lo))
@@ -159,4 +157,21 @@ func TestIpBlockError(t *testing.T) {
 			require.Contains(t, err.Error(), data)
 		})
 	}
+}
+
+func TestNullIPPoolMarshalText(t *testing.T) {
+	t.Parallel()
+
+	rangeInput := "192.168.20.12-192.168.20.15,192.168.10.0/27"
+	p, err := NewIPPool(rangeInput)
+	require.NoError(t, err)
+
+	nullpool := NullIPPool{
+		Pool:  p,
+		Valid: true,
+		raw:   []byte(rangeInput),
+	}
+	text, err := nullpool.MarshalText()
+	require.NoError(t, err)
+	assert.Equal(t, "192.168.20.12-192.168.20.15,192.168.10.0/27", string(text))
 }


### PR DESCRIPTION
This PR adds the capability for fetching the consolidated and derived options for tests using the `k6/execution` API. It adds a `test.options` object exporting all the potential set properties.

A simple example of the expected API:

```javascript
import exec from 'k6/execution';

export const options = {
  vus: 10,
  duration : '30s'
};

export default function() {
  console.log(exec.test.options.scenarios.default.vus) // 10
}
```

### Open questions

1. ~We are defining the default values for some objects/arrays as `null`. An example is [Thresholds](https://k6.io/docs/using-k6/options/#thresholds).
Which value do we expect to get if we access properties like Thresholds? `undefined` or `null` or `{}` (empty object)?~ We will use the same value returned from the JSON marshal, at the moment, the k6 options' values are Nullable so the default value will be `null`.

```javascript
import exec from 'k6/execution';

export const options = {
  vus: 10,
  duration : '30s'
};

export default function() {
  console.log(exec.test.options.thresholds) // what do you expect to get?
}
```

2. This point from the original issue is missing:
>A deprecation warning should be added when a set operation on the options object is executed. (Maybe also on getting?)

~~In case of `const`, it seems not possible by spec to set back an eventual wrap/proxy for warning the access. Do we have an alternative?~~ We used a classic JS Object but with the Object.freeze function applied. 

I would define these cases before polishing and addressing edge cases.

Closes https://github.com/grafana/k6/issues/2450
<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
-->
