### PR TITLE
Remove instructions for bintray migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,27 +104,6 @@ sudo dnf install k6    # use yum install --nogpgcheck k6 for older distros (e.g.
 Note that the `gnupg2` package is required for signature verification.
 
 
-#### Migrating from Bintray
-
-The Bintray repositories were [shut down after May 1st, 2021](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). If you previously added them, you will have to add our repositories following the instructions above and should delete the Bintray ones.
-
-For Debian-based distributions, you can run:
-
-```bash
-sudo sed -i '/dl\.bintray\.com\/loadimpact\/deb/d' /etc/apt/sources.list
-sudo apt-key del 379CE192D401AB61
-sudo apt-get update
-```
-
-Or delete the repository file if you added it to `/etc/apt/sources.list.d/`.
-
-And for rpm-based ones, delete the repository file in `/etc/yum.repos.d/`. If you followed the [official installation instructions](https://k6.io/docs/getting-started/installation/#fedora-centos), this should be:
-
-```bash
-sudo rm /etc/yum.repos.d/bintray-loadimpact-rpm.repo
-```
-
-
 ### Docker
 
 ```bash


### PR DESCRIPTION
Bintray stopped working 1 year ago (May 2021), so these instructions are no longer necessary.

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
