### PR TITLE
Remove global max VUs deprecated option

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/mstoykov/envconfig"
 	"github.com/sirupsen/logrus"
@@ -213,11 +214,11 @@ func getConsolidatedConfig(globalState *globalState, cliConf Config, runnerOpts 
 //
 // Note that if you add option default value here, also add it in command line argument help text.
 func applyDefault(conf Config) Config {
-	if conf.Options.SystemTags == nil {
-		conf.Options.SystemTags = &metrics.DefaultSystemTagSet
+	if conf.SystemTags == nil {
+		conf.SystemTags = &metrics.DefaultSystemTagSet
 	}
-	if conf.Options.SummaryTrendStats == nil {
-		conf.Options.SummaryTrendStats = lib.DefaultSummaryTrendStats
+	if conf.SummaryTrendStats == nil {
+		conf.SummaryTrendStats = lib.DefaultSummaryTrendStats
 	}
 	defDNS := types.DefaultDNSConfig()
 	if !conf.DNS.TTL.Valid {
@@ -229,7 +230,12 @@ func applyDefault(conf Config) Config {
 	if !conf.DNS.Policy.Valid {
 		conf.DNS.Policy = defDNS.Policy
 	}
-
+	if !conf.SetupTimeout.Valid {
+		conf.SetupTimeout.Duration = types.Duration(60 * time.Second)
+	}
+	if !conf.TeardownTimeout.Valid {
+		conf.TeardownTimeout.Duration = types.Duration(60 * time.Second)
+	}
 	return conf
 }
 

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/spf13/pflag"
 	"gopkg.in/guregu/null.v3"
@@ -101,29 +100,24 @@ func optionFlagSet() *pflag.FlagSet {
 //nolint:funlen,gocognit,cyclop // this needs breaking up but probably should wait for croconf
 func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 	opts := lib.Options{
-		VUs:                   getNullInt64(flags, "vus"),
-		Duration:              getNullDuration(flags, "duration"),
-		Iterations:            getNullInt64(flags, "iterations"),
-		Paused:                getNullBool(flags, "paused"),
-		NoSetup:               getNullBool(flags, "no-setup"),
-		NoTeardown:            getNullBool(flags, "no-teardown"),
-		MaxRedirects:          getNullInt64(flags, "max-redirects"),
-		Batch:                 getNullInt64(flags, "batch"),
-		BatchPerHost:          getNullInt64(flags, "batch-per-host"),
-		RPS:                   getNullInt64(flags, "rps"),
-		UserAgent:             getNullString(flags, "user-agent"),
-		HTTPDebug:             getNullString(flags, "http-debug"),
-		InsecureSkipTLSVerify: getNullBool(flags, "insecure-skip-tls-verify"),
-		NoConnectionReuse:     getNullBool(flags, "no-connection-reuse"),
-		NoVUConnectionReuse:   getNullBool(flags, "no-vu-connection-reuse"),
-		MinIterationDuration:  getNullDuration(flags, "min-iteration-duration"),
-		Throw:                 getNullBool(flags, "throw"),
-		DiscardResponseBodies: getNullBool(flags, "discard-response-bodies"),
-		// Default values for options without CLI flags:
-		// TODO: find a saner and more dev-friendly and error-proof way to handle options
-		SetupTimeout:    types.NullDuration{Duration: types.Duration(60 * time.Second), Valid: false},
-		TeardownTimeout: types.NullDuration{Duration: types.Duration(60 * time.Second), Valid: false},
-
+		VUs:                     getNullInt64(flags, "vus"),
+		Duration:                getNullDuration(flags, "duration"),
+		Iterations:              getNullInt64(flags, "iterations"),
+		Paused:                  getNullBool(flags, "paused"),
+		NoSetup:                 getNullBool(flags, "no-setup"),
+		NoTeardown:              getNullBool(flags, "no-teardown"),
+		MaxRedirects:            getNullInt64(flags, "max-redirects"),
+		Batch:                   getNullInt64(flags, "batch"),
+		BatchPerHost:            getNullInt64(flags, "batch-per-host"),
+		RPS:                     getNullInt64(flags, "rps"),
+		UserAgent:               getNullString(flags, "user-agent"),
+		HTTPDebug:               getNullString(flags, "http-debug"),
+		InsecureSkipTLSVerify:   getNullBool(flags, "insecure-skip-tls-verify"),
+		NoConnectionReuse:       getNullBool(flags, "no-connection-reuse"),
+		NoVUConnectionReuse:     getNullBool(flags, "no-vu-connection-reuse"),
+		MinIterationDuration:    getNullDuration(flags, "min-iteration-duration"),
+		Throw:                   getNullBool(flags, "throw"),
+		DiscardResponseBodies:   getNullBool(flags, "discard-response-bodies"),
 		MetricSamplesBufferSize: null.NewInt(1000, false),
 	}
 

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -44,12 +44,8 @@ var (
 func optionFlagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("", 0)
 	flags.SortFlags = false
+
 	flags.Int64P("vus", "u", 1, "number of virtual users")
-
-	// TODO: delete in a few versions
-	flags.Int64P("max", "m", 0, "max available virtual users")
-	_ = flags.MarkDeprecated("max", "the global MaxVUs option is obsolete and doesn't affect the k6 script execution")
-
 	flags.DurationP("duration", "d", 0, "test duration limit")
 	flags.Int64P("iterations", "i", 0, "script total iteration limit (among all VUs)")
 	flags.StringSliceP("stage", "s", nil, "add a `stage`, as `[duration]:[target]`")


### PR DESCRIPTION
<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
-->
