### PR TITLE
Wait on the progress of executors before executors return

### DIFF
--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -230,7 +230,12 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 	activeVUsWg := &sync.WaitGroup{}
 
 	returnedVUs := make(chan struct{})
+	waitOnProgressChannel := make(chan struct{})
 	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(parentCtx, duration, gracefulStop)
+	defer func() {
+		cancel()
+		<-waitOnProgressChannel
+	}()
 
 	vusPool := newActiveVUPool()
 	defer func() {
@@ -266,14 +271,17 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 		return math.Min(1, float64(spent)/float64(duration)), right
 	}
 	car.progress.Modify(pb.WithProgress(progressFn))
-	go trackProgress(parentCtx, maxDurationCtx, regDurationCtx, &car, progressFn)
-
 	maxDurationCtx = lib.WithScenarioState(maxDurationCtx, &lib.ScenarioState{
 		Name:       car.config.Name,
 		Executor:   car.config.Type,
 		StartTime:  startTime,
 		ProgressFn: progressFn,
 	})
+
+	go func() {
+		trackProgress(parentCtx, maxDurationCtx, regDurationCtx, &car, progressFn)
+		close(waitOnProgressChannel)
+	}()
 
 	returnVU := func(u lib.InitializedVU) {
 		car.executionState.ReturnVU(u, true)

--- a/lib/executor/constant_vus.go
+++ b/lib/executor/constant_vus.go
@@ -147,8 +147,12 @@ func (clv ConstantVUs) Run(parentCtx context.Context, out chan<- metrics.SampleC
 	duration := clv.config.Duration.TimeDuration()
 	gracefulStop := clv.config.GetGracefulStop()
 
+	waitOnProgressChannel := make(chan struct{})
 	startTime, maxDurationCtx, regDurationCtx, cancel := getDurationContexts(parentCtx, duration, gracefulStop)
-	defer cancel()
+	defer func() {
+		cancel()
+		<-waitOnProgressChannel
+	}()
 
 	// Make sure the log and the progress bar have accurate information
 	clv.logger.WithFields(
@@ -167,7 +171,17 @@ func (clv ConstantVUs) Run(parentCtx context.Context, out chan<- metrics.SampleC
 		return float64(spent) / float64(duration), right
 	}
 	clv.progress.Modify(pb.WithProgress(progressFn))
-	go trackProgress(parentCtx, maxDurationCtx, regDurationCtx, clv, progressFn)
+	maxDurationCtx = lib.WithScenarioState(maxDurationCtx, &lib.ScenarioState{
+		Name:       clv.config.Name,
+		Executor:   clv.config.Type,
+		StartTime:  startTime,
+		ProgressFn: progressFn,
+	})
+
+	go func() {
+		trackProgress(parentCtx, maxDurationCtx, regDurationCtx, clv, progressFn)
+		close(waitOnProgressChannel)
+	}()
 
 	// Actually schedule the VUs and iterations...
 	activeVUs := &sync.WaitGroup{}
@@ -175,13 +189,6 @@ func (clv ConstantVUs) Run(parentCtx context.Context, out chan<- metrics.SampleC
 
 	regDurationDone := regDurationCtx.Done()
 	runIteration := getIterationRunner(clv.executionState, clv.logger)
-
-	maxDurationCtx = lib.WithScenarioState(maxDurationCtx, &lib.ScenarioState{
-		Name:       clv.config.Name,
-		Executor:   clv.config.Type,
-		StartTime:  startTime,
-		ProgressFn: progressFn,
-	})
 
 	returnVU := func(u lib.InitializedVU) {
 		clv.executionState.ReturnVU(u, true)


### PR DESCRIPTION
Also move some code around so that there aren't other very *unlikely*
races around arguments that were changed in two goroutines

fixes #2500

