### PR TITLE
Set tlsAuth.Password as a nullable string

### DIFF
--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -213,7 +213,7 @@ func TestAbortTest(t *testing.T) { //nolint:tparallel
 func TestOptionsTestFull(t *testing.T) {
 	t.Parallel()
 
-	expected := `{"paused":true,"scenarios":{"const-vus":{"executor":"constant-vus","startTime":"10s","gracefulStop":"30s","env":{"FOO":"bar"},"exec":"default","tags":{"tagkey":"tagvalue"},"vus":50,"duration":"10m0s"}},"executionSegment":"0:1/4","executionSegmentSequence":"0,1/4,1/2,1","noSetup":true,"setupTimeout":"1m0s","noTeardown":true,"teardownTimeout":"5m0s","rps":100,"dns":{"ttl":"1m","select":"roundRobin","policy":"any"},"maxRedirects":3,"userAgent":"k6-user-agent","batch":15,"batchPerHost":5,"httpDebug":"full","insecureSkipTLSVerify":true,"tlsCipherSuites":["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"],"tlsVersion":{"min":"tls1.2","max":"tls1.3"},"tlsAuth":[{"domains":["example.com"],"cert":"mycert.pem","key":"mycert-key.pem"}],"throw":true,"thresholds":{"http_req_duration":[{"threshold":"rate>0.01","abortOnFail":true,"delayAbortEval":"10s"}]},"blacklistIPs":["192.0.2.0/24"],"blockHostnames":["test.k6.io","*.example.com"],"hosts":{"test.k6.io":"1.2.3.4:8443"},"noConnectionReuse":true,"noVUConnectionReuse":true,"minIterationDuration":"10s","ext":{"ext-one":{"rawkey":"rawvalue"}},"summaryTrendStats":["avg","min","max"],"summaryTimeUnit":"ms","systemTags":["iter","vu"],"tags":null,"metricSamplesBufferSize":8,"noCookiesReset":true,"discardResponseBodies":true,"consoleOutput":"loadtest.log","tags":{"runtag-key":"runtag-value"},"localIPs":"192.168.20.12-192.168.20.15,192.168.10.0/27"}`
+	expected := `{"paused":true,"scenarios":{"const-vus":{"executor":"constant-vus","startTime":"10s","gracefulStop":"30s","env":{"FOO":"bar"},"exec":"default","tags":{"tagkey":"tagvalue"},"vus":50,"duration":"10m0s"}},"executionSegment":"0:1/4","executionSegmentSequence":"0,1/4,1/2,1","noSetup":true,"setupTimeout":"1m0s","noTeardown":true,"teardownTimeout":"5m0s","rps":100,"dns":{"ttl":"1m","select":"roundRobin","policy":"any"},"maxRedirects":3,"userAgent":"k6-user-agent","batch":15,"batchPerHost":5,"httpDebug":"full","insecureSkipTLSVerify":true,"tlsCipherSuites":["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"],"tlsVersion":{"min":"tls1.2","max":"tls1.3"},"tlsAuth":[{"domains":["example.com"],"cert":"mycert.pem","key":"mycert-key.pem","password":"mypwd"}],"throw":true,"thresholds":{"http_req_duration":[{"threshold":"rate>0.01","abortOnFail":true,"delayAbortEval":"10s"}]},"blacklistIPs":["192.0.2.0/24"],"blockHostnames":["test.k6.io","*.example.com"],"hosts":{"test.k6.io":"1.2.3.4:8443"},"noConnectionReuse":true,"noVUConnectionReuse":true,"minIterationDuration":"10s","ext":{"ext-one":{"rawkey":"rawvalue"}},"summaryTrendStats":["avg","min","max"],"summaryTimeUnit":"ms","systemTags":["iter","vu"],"tags":null,"metricSamplesBufferSize":8,"noCookiesReset":true,"discardResponseBodies":true,"consoleOutput":"loadtest.log","tags":{"runtag-key":"runtag-value"},"localIPs":"192.168.20.12-192.168.20.15,192.168.10.0/27"}`
 
 	var (
 		rt    = goja.New()
@@ -279,9 +279,10 @@ func TestOptionsTestFull(t *testing.T) {
 				TLSAuth: []*lib.TLSAuth{
 					{
 						TLSAuthFields: lib.TLSAuthFields{
-							Cert:    "mycert.pem",
-							Key:     "mycert-key.pem",
-							Domains: []string{"example.com"},
+							Cert:     "mycert.pem",
+							Key:      "mycert-key.pem",
+							Password: null.StringFrom("mypwd"),
+							Domains:  []string{"example.com"},
 						},
 					},
 				},

--- a/lib/options.go
+++ b/lib/options.go
@@ -132,9 +132,9 @@ func (s *TLSCipherSuites) UnmarshalJSON(data []byte) error {
 // Fields for TLSAuth. Unmarshalling hack.
 type TLSAuthFields struct {
 	// Certificate and key as a PEM-encoded string, including "-----BEGIN CERTIFICATE-----".
-	Cert     string `json:"cert"`
-	Key      string `json:"key"`
-	Password string `json:"password"`
+	Cert     string      `json:"cert"`
+	Key      string      `json:"key"`
+	Password null.String `json:"password"`
 
 	// Domains to present the certificate to. May contain wildcards, eg. "*.example.com".
 	Domains []string `json:"domains"`
@@ -159,8 +159,8 @@ func (c *TLSAuth) UnmarshalJSON(data []byte) error {
 func (c *TLSAuth) Certificate() (*tls.Certificate, error) {
 	key := []byte(c.Key)
 	var err error
-	if c.Password != "" {
-		key, err = decryptPrivateKey(c.Key, c.Password)
+	if c.Password.Valid {
+		key, err = decryptPrivateKey(c.Key, c.Password.String)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -397,7 +397,7 @@ func TestOptions(t *testing.T) {
 						Domains:  domains,
 						Cert:     cert,
 						Key:      tc.privateKey,
-						Password: tc.password,
+						Password: null.StringFrom(tc.password),
 					}, nil},
 				}
 				opts := Options{}.Apply(Options{TLSAuth: tlsAuth})


### PR DESCRIPTION
Optional options should be nullable using a `guregu/null.`-like type for supporting consistently the `exec.test.options`.
Moved the `tlsAuth.password` option to null.String

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
