### PR TITLE
Update instructions for building from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,9 @@ In case there isn't an official package for your operating system or architectur
 
 ### Build from source
 
-k6 is written in Go, so it's just a single statically-linked executable and very easy to build and distribute. To build from source you need **[Git](https://git-scm.com/downloads)** and **[Go](https://golang.org/doc/install)** (1.16 or newer). Follow these instructions:
+k6 is written in Go, so it's just a single statically-linked executable and very easy to build and distribute. To build from source you need **[Go](https://go.dev/doc/install)** (1.17 or newer). Follow these instructions:
 
-- Run `go install go.k6.io/k6` which will:
-  - git clone the repo and put the source in `$GOPATH/src/go.k6.io/k6`
-  - build a `k6` binary and put it in `$GOPATH/bin`
+- Run `go install go.k6.io/k6@latest` which will build a `k6` binary and put it in `$GOPATH/bin`.
 - Make sure you have `$GOPATH/bin` in your `PATH` (or copy the `k6` binary somewhere in your `PATH`), so you are able to run k6 from any location.
 - Tada, you can now run k6 using `k6 run script.js`
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ In case there isn't an official package for your operating system or architectur
 
 k6 is written in Go, so it's just a single statically-linked executable and very easy to build and distribute. To build from source you need **[Go](https://go.dev/doc/install)** (1.17 or newer). Follow these instructions:
 
-- Run `go install go.k6.io/k6@latest` which will build a `k6` binary and put it in `$GOPATH/bin`.
+- Run `go install go.k6.io/k6@latest` which will build a `k6` binary and put it in the `$GOBIN` folder (which defaults to `$GOPATH/bin`).
 - Make sure you have `$GOPATH/bin` in your `PATH` (or copy the `k6` binary somewhere in your `PATH`), so you are able to run k6 from any location.
 - Tada, you can now run k6 using `k6 run script.js`
 


### PR DESCRIPTION
Updated the instructions for building from source to reflect the following:

* Git should not be required where modules are proxied via `proxy.golang.org`, which is the default behaviour of Go.
* Go installation instructions are now at `go.dev` instead of `golang.org`.
* Go 1.17 is the minimum required version for k6 as specified in `go.mod`.
* `go install` requires a version to be specified.
* `go install` does not clone sources to `$GOPATH/src`.