### PR TITLE
Support logging as json all kind of goja's objects

### DIFF
--- a/js/console.go
+++ b/js/console.go
@@ -23,7 +23,6 @@ package js
 import (
 	"encoding/json"
 	"os"
-	"reflect"
 	"strings"
 
 	"github.com/dop251/goja"
@@ -97,17 +96,12 @@ func (c console) Error(args ...goja.Value) {
 }
 
 func (c console) valueString(v goja.Value) string {
-	exptype := v.ExportType()
-	if exptype == nil {
+	mv, ok := v.(json.Marshaler)
+	if !ok {
 		return v.String()
 	}
 
-	kind := exptype.Kind()
-	if kind != reflect.Map && kind != reflect.Slice {
-		return v.String()
-	}
-
-	b, err := json.Marshal(v)
+	b, err := json.Marshal(mv)
 	if err != nil {
 		return v.String()
 	}

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -1,23 +1,3 @@
-/*
- *
- * k6 - a next-generation load testing tool
- * Copyright (C) 2016 Load Impact
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
-
 package js
 
 import (
@@ -105,6 +85,33 @@ func extractLogger(fl logrus.FieldLogger) *logrus.Logger {
 		return e
 	}
 	return nil
+}
+
+func TestConsoleLogAndGojaObjectGoReflect(t *testing.T) {
+	t.Parallel()
+
+	type value struct {
+		Text string
+	}
+
+	v := &value{
+		Text: "test1",
+	}
+
+	rt := goja.New()
+	rt.SetFieldNameMapper(common.FieldNameMapper{})
+	obj := rt.ToValue(v)
+
+	logger := testutils.NewLogger(t)
+	hook := logtest.NewLocal(logger)
+
+	c := newConsole(logger)
+	c.Log(obj)
+
+	entry := hook.LastEntry()
+	require.NotNil(t, entry, "nothing logged")
+	assert.Equal(t, `{"text":"test1"}`, entry.Message)
+	assert.Equal(t, logrus.Fields{"source": "console"}, entry.Data)
 }
 
 func TestConsoleLog(t *testing.T) {


### PR DESCRIPTION
Fixes the current implementation that doesn't support all the possible kinds for goja objects.

```javascript
import http from 'k6/http';

export default function () {
    let resp = http.get('https://httpbin.test.k6.io/anything');

    // before: [object Object]
   // after: {"url":"https://httpbin.test.k6.io/anything","status":200, ... }
    console.log(resp);
}
```

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
