### PR TITLE
Fix threshold over rate metric resulting in `NaN` result

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -436,10 +436,9 @@ func TestEngine_processThresholds(t *testing.T) {
 				thresholds[m] = ths
 			}
 
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
+			runner := &minirunner.MiniRunner{}
 			e, run, wait := newTestEngineWithRegistry(
-				t, ctx, &minirunner.MiniRunner{}, nil, lib.Options{Thresholds: thresholds}, registry,
+				t, nil, runner, nil, lib.Options{Thresholds: thresholds}, registry,
 			)
 
 			e.OutputManager.AddMetricSamples(

--- a/metrics/engine/engine.go
+++ b/metrics/engine/engine.go
@@ -142,14 +142,16 @@ func (me *MetricsEngine) initSubMetricsAndThresholds() error {
 // EvaluateThresholds processes all of the thresholds.
 //
 // TODO: refactor, make private, optimize
-func (me *MetricsEngine) EvaluateThresholds() (thresholdsTainted, shouldAbort bool) {
+func (me *MetricsEngine) EvaluateThresholds(ignoreEmptySinks bool) (thresholdsTainted, shouldAbort bool) {
 	me.MetricsLock.Lock()
 	defer me.MetricsLock.Unlock()
 
 	t := me.executionState.GetCurrentTestRunDuration()
 
 	for _, m := range me.metricsWithThresholds {
-		if len(m.Thresholds.Thresholds) == 0 {
+		// If either the metric has no thresholds defined, or its sinks
+		// are empty, let's ignore its thresholds execution at this point.
+		if len(m.Thresholds.Thresholds) == 0 || (ignoreEmptySinks && m.Sink.IsEmpty()) {
 			continue
 		}
 		m.Tainted = null.BoolFrom(false)

--- a/metrics/sink.go
+++ b/metrics/sink.go
@@ -39,6 +39,7 @@ type Sink interface {
 	Add(s Sample)                              // Add a sample to the sink.
 	Calc()                                     // Make final calculations.
 	Format(t time.Duration) map[string]float64 // Data for thresholds.
+	IsEmpty() bool                             // Check if the Sink is empty.
 }
 
 type CounterSink struct {
@@ -52,6 +53,9 @@ func (c *CounterSink) Add(s Sample) {
 		c.First = s.Time
 	}
 }
+
+// IsEmpty indicates whether the CounterSink is empty.
+func (c *CounterSink) IsEmpty() bool { return c.First.IsZero() }
 
 func (c *CounterSink) Calc() {}
 
@@ -67,6 +71,9 @@ type GaugeSink struct {
 	Max, Min float64
 	minSet   bool
 }
+
+// IsEmpty indicates whether the GaugeSink is empty.
+func (g *GaugeSink) IsEmpty() bool { return !g.minSet }
 
 func (g *GaugeSink) Add(s Sample) {
 	g.Value = s.Value
@@ -94,6 +101,9 @@ type TrendSink struct {
 	Sum, Avg float64
 	Med      float64
 }
+
+// IsEmpty indicates whether the TrendSink is empty.
+func (t *TrendSink) IsEmpty() bool { return t.Count == 0 }
 
 func (t *TrendSink) Add(s Sample) {
 	t.Values = append(t.Values, s.Value)
@@ -164,6 +174,9 @@ type RateSink struct {
 	Total int64
 }
 
+// IsEmpty indicates whether the RateSink is empty.
+func (r *RateSink) IsEmpty() bool { return r.Total == 0 }
+
 func (r *RateSink) Add(s Sample) {
 	r.Total += 1
 	if s.Value != 0 {
@@ -178,6 +191,9 @@ func (r RateSink) Format(t time.Duration) map[string]float64 {
 }
 
 type DummySink map[string]float64
+
+// IsEmpty indicates whether the DummySink is empty.
+func (d DummySink) IsEmpty() bool { return len(d) == 0 }
 
 func (d DummySink) Add(s Sample) {
 	panic(errors.New("you can't add samples to a dummy sink"))

--- a/metrics/thresholds.go
+++ b/metrics/thresholds.go
@@ -58,13 +58,12 @@ func newThreshold(src string, abortOnFail bool, gracePeriod types.NullDuration) 
 
 func (t *Threshold) runNoTaint(sinks map[string]float64) (bool, error) {
 	// Extract the sink value for the aggregation method used in the threshold
-	// expression
+	// expression. Considering we already validated thresholds before starting
+	// the execution, we assume that a missing sink entry means that no samples
+	// are available yet, and that it's safe to ignore this run.
 	lhs, ok := sinks[t.parsed.SinkKey()]
 	if !ok {
-		return false, fmt.Errorf("unable to apply threshold %s over metrics; reason: "+
-			"no metric supporting the %s aggregation method found",
-			t.Source,
-			t.parsed.AggregationMethod)
+		return true, nil
 	}
 
 	// Apply the threshold expression operator to the left and
@@ -221,7 +220,11 @@ func (ts *Thresholds) Run(sink Sink, duration time.Duration) (bool, error) {
 			ts.sinked[key] = sinkImpl.P(threshold.parsed.AggregationValue.Float64 / 100)
 		}
 	case *RateSink:
-		ts.sinked["rate"] = float64(sinkImpl.Trues) / float64(sinkImpl.Total)
+		// We want to avoid division by zero, which
+		// would lead to [#2520](https://github.com/grafana/k6/issues/2520)
+		if sinkImpl.Total > 0 {
+			ts.sinked["rate"] = float64(sinkImpl.Trues) / float64(sinkImpl.Total)
+		}
 	case DummySink:
 		for k, v := range sinkImpl {
 			ts.sinked[k] = v

--- a/metrics/thresholds_test.go
+++ b/metrics/thresholds_test.go
@@ -137,8 +137,8 @@ func TestThreshold_runNoTaint(t *testing.T) {
 			parsed:           &thresholdExpression{tokenRate, null.Float{}, tokenGreater, 0.01},
 			abortGracePeriod: types.NullDurationFrom(0 * time.Second),
 			sinks:            map[string]float64{"med": 27.2},
-			wantOk:           false,
-			wantErr:          true,
+			wantOk:           true,
+			wantErr:          false,
 		},
 		{
 			// The ParseThresholdCondition constructor should ensure that no invalid
@@ -672,22 +672,22 @@ func TestThresholds_Run(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			"Running thresholds of existing sink",
-			args{DummySink{"p(95)": 1234.5}, 0},
-			true,
-			false,
+			name:    "Running thresholds of existing sink",
+			args:    args{DummySink{"p(95)": 1234.5}, 0},
+			want:    true,
+			wantErr: false,
 		},
 		{
-			"Running thresholds of existing sink but failing threshold",
-			args{DummySink{"p(95)": 3000}, 0},
-			false,
-			false,
+			name:    "Running thresholds of existing sink but failing threshold",
+			args:    args{DummySink{"p(95)": 3000}, 0},
+			want:    false,
+			wantErr: false,
 		},
 		{
-			"Running threshold on non existing sink fails",
-			args{DummySink{"dummy": 0}, 0},
-			false,
-			true,
+			name:    "Running threshold on non existing sink does not fail",
+			args:    args{DummySink{"dummy": 0}, 0},
+			want:    true,
+			wantErr: false,
 		},
 	}
 	for _, testCase := range tests {


### PR DESCRIPTION
This Pull Request attempts to address #2520. It was discovered internally by the team that thresholds applied to checks (rate metrics) would immediately fail, and return a `NaN` result.

I've found out that the `NaN` was the result of a division by zero. I assumed it happens because the threshold was run before a single check sample was recorded (I might be wrong there though). I've thus introduced a check in `Thresholds.Run` to perform insert the sink's "rate" value computation only if the right-hand side of the division is not zero. 

Besides, the `Threshold.runNoTaint` function used to make a verification that a sink existed, before actually evaluating the threshold expression. This PR drops this verification, considering the thresholds are now verified at startup. Because of the previously mentioned issue, it would have led to a situation where we know the metric exists, we know the threshold is valid for this metric, but we fail with an error because at a certain point of the execution, our internal storage doesn't have data for it yet. 

I'm not a 100% confident this PR doesn't have unintended side-effects. I have tried it which a bunch of scripts of mine who try to exhibit as much of possible thresholds use cases, and none seem to be broken by this change. But I'd take any more insights if you have. The point of a hotfix being, after all, to fix stuff, not potentially introduce more problems 🤞🏻 

**Learning point**: good to know that `int64(0) / int64(0)` leads to a panic, but `float64(0) / float64(0)` leads to `NaN`.
