### PR TITLE
Fix printing wrong message on remote resolution

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -236,7 +236,7 @@ func Load(
 			return result, nil
 		}
 
-		if moduleSpecifier.Scheme == "" || moduleSpecifier.Opaque == "" {
+		if moduleSpecifier.Scheme == "" && moduleSpecifier.Opaque == "" {
 			// we have an error and we did remote module resolution without a scheme
 			// let's write the coolest error message to try to help the lost soul who got to here
 			return nil, noSchemeRemoteModuleResolutionError{err: err, moduleSpecifier: originalModuleSpecifier}


### PR DESCRIPTION
Previously we will always print the really long message that says we
tried everything. But in reality we only do this if we have something
that:
* is not local (start with ./)
* is not prefixed with `https://`
* is not a magical github or cdnjs URL (which entirely uses the Opaque
  URL property)

But the if changed here basically checks that either we don't have
scheme *or* that it's Opaque. But in reality if it has scheme it never
has Opaque. And Opaque always has no scheme - so all cases enter the if.

The correct is to enter *only* when both are true as in that case it's
not magical and it doesn't have scheme so the schem