### PR TITLE
Make html.Selection.map return []goja.Value instead of []string

### DIFF
--- a/js/modules/k6/html/html_test.go
+++ b/js/modules/k6/html/html_test.go
@@ -409,10 +409,12 @@ func TestParseHTML(t *testing.T) {
 		t.Run("Valid", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("#select_multi option").map(function(idx, val) { return val.text() })`)
 			if assert.NoError(t, err) {
-				mapped, ok := v.Export().([]string)
+				mapped, ok := v.Export().([]goja.Value)
 				assert.True(t, ok)
 				assert.Equal(t, 3, len(mapped))
-				assert.Equal(t, []string{"option 1", "option 2", "option 3"}, mapped)
+				assert.Equal(t, "option 1", mapped[0].String())
+				assert.Equal(t, "option 2", mapped[1].String())
+				assert.Equal(t, "option 3", mapped[2].String())
 			}
 		})
 		t.Run("Invalid arg", func(t *testing.T) {
@@ -425,10 +427,10 @@ func TestParseHTML(t *testing.T) {
 		t.Run("Map with attr must return string", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("#select_multi").map(function(idx, val) { return val.attr("name") })`)
 			if assert.NoError(t, err) {
-				mapped, ok := v.Export().([]string)
+				mapped, ok := v.Export().([]goja.Value)
 				assert.True(t, ok)
 				assert.Equal(t, 1, len(mapped))
-				assert.Equal(t, []string{"select_multi"}, mapped)
+				assert.Equal(t, "select_multi", mapped[0].String())
 			}
 		})
 	})


### PR DESCRIPTION
This PR attempts to address #2471.

The existing `Html.Selection.map` function would return a `[]string` under the hood. This behavior would result in effectively obfuscating any type that's not a string during the parsing of an HTML or XML document. This PR modifies the behavior and signature of the function to fit what we have [documented](https://k6.io/docs/javascript-api/k6-html/selection/selection-map).  The return value should be an `Array` of values on the JS script side, a `[]goja.Value` in the Go implementation of the library.

The reason why we returned `[]string` in the first place is because goquery, the library we depend on to perform HTML/XML parsing, own map method does so. To work around the limitation, I adopted an approach consisting in serializing the values with map over to JSON, and deserialize them before we return from the `Map` function. 

It works, but I'm open to any other approach that might be simpler or more performant 🙇🏻  