### PR TITLE
Make html.Selection.map return []goja.Value instead of []string

### DIFF
--- a/js/modules/k6/html/html.go
+++ b/js/modules/k6/html/html.go
@@ -426,21 +426,22 @@ func (s Selection) Is(v goja.Value) bool {
 }
 
 // Map implements ES5 Array.prototype.map
-func (s Selection) Map(v goja.Value) []string {
+func (s Selection) Map(v goja.Value) []goja.Value {
 	gojaFn, isFn := goja.AssertFunction(v)
 	if !isFn {
 		common.Throw(s.rt, errors.New("the argument to map() must be a function"))
 	}
 
-	fn := func(idx int, sel *goquery.Selection) string {
+	var values []goja.Value
+	s.sel.Each(func(idx int, sel *goquery.Selection) {
 		selection := &Selection{sel: sel, URL: s.URL, rt: s.rt}
-		if fnRes, fnErr := gojaFn(v, s.rt.ToValue(idx), s.rt.ToValue(selection)); fnErr == nil {
-			return fnRes.String()
-		}
-		return ""
-	}
 
-	return s.sel.Map(fn)
+		if fnRes, fnErr := gojaFn(v, s.rt.ToValue(idx), s.rt.ToValue(selection)); fnErr == nil {
+			values = append(values, fnRes)
+		}
+	})
+
+	return values
 }
 
 func (s Selection) Slice(start int, def ...int) Selection {


### PR DESCRIPTION
This PR attempts to address #2471.

The existing `Html.Selection.map` function would return a `[]string` under the hood. This behavior would result in effectively obfuscating any type that's not a string during the parsing of an HTML or XML document. This PR modifies the behavior and signature of the function to fit what we have [documented](https://k6.io/docs/javascript-api/k6-html/selection/selection-map).  The return value should be an `Array` of values on the JS script side, a `[]goja.Value` in the Go implementation of the library.

The reason why we returned `[]string` in the first place is because goquery, the library we depend on to perform HTML/XML parsing, own map method does so. To work around the limitation, I adopted an approach consisting in serializing the values with map over to JSON, and deserialize them before we return from the `Map` function. 

It works, but I'm open to any other approach that might be simpler or more performant 🙇🏻  