### PR TITLE
exec.vu.tags: Handle null or undefined values

### DIFF
--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -325,7 +325,11 @@ func (o *tagsDynamicObject) Get(key string) goja.Value {
 // In any other case, if the Throw option is set then an error is raised
 // otherwise just a Warning is written.
 func (o *tagsDynamicObject) Set(key string, val goja.Value) bool {
-	switch val.ExportType().Kind() { //nolint:exhaustive
+	kind := reflect.Invalid
+	if typ := val.ExportType(); typ != nil {
+		kind = typ.Kind()
+	}
+	switch kind {
 	case
 		reflect.String,
 		reflect.Bool,
@@ -335,12 +339,12 @@ func (o *tagsDynamicObject) Set(key string, val goja.Value) bool {
 		o.State.Tags.Set(key, val.String())
 		return true
 	default:
-		err := fmt.Errorf("only String, Boolean and Number types are accepted as a Tag value")
+		reason := "only String, Boolean and Number types are accepted as a Tag value"
 		if o.State.Options.Throw.Bool {
-			common.Throw(o.Runtime, err)
+			common.Throw(o.Runtime, fmt.Errorf(reason))
 			return false
 		}
-		o.State.Logger.Warnf("the execution.vu.tags.Set('%s') operation has been discarded because %s", key, err.Error())
+		o.State.Logger.Warnf("the execution.vu.tags.Set('%s') operation has been discarded because %s", key, reason)
 		return false
 	}
 }

--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -341,8 +341,7 @@ func (o *tagsDynamicObject) Set(key string, val goja.Value) bool {
 	default:
 		reason := "only String, Boolean and Number types are accepted as a Tag value"
 		if o.State.Options.Throw.Bool {
-			common.Throw(o.Runtime, fmt.Errorf(reason))
-			return false
+			panic(o.Runtime.NewTypeError(reason))
 		}
 		o.State.Logger.Warnf("the execution.vu.tags.Set('%s') operation has been discarded because %s", key, reason)
 		return false

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -170,6 +170,21 @@ func TestVUTags(t *testing.T) {
 			require.Len(t, entries, 1)
 			assert.Contains(t, entries[0].Message, "discarded")
 		})
+
+		t.Run("DiscardNullOrUndefined", func(t *testing.T) {
+			t.Parallel()
+
+			cases := []string{"null", "undefined"}
+			tenv := setupTagsExecEnv(t)
+			for _, val := range cases {
+				_, err := tenv.Runtime.RunString(`exec.vu.tags["any"] = ` + val)
+				require.NoError(t, err)
+
+				entries := tenv.LogHook.Drain()
+				require.Len(t, entries, 1)
+				assert.Contains(t, entries[0].Message, "discarded")
+			}
+		})
 	})
 }
 


### PR DESCRIPTION
Setting a property of `vu.tags` as  `null` or `undefined`, like the following example, generates a panic. 

```javascript
import exec from 'k6/execution';

export default function () {
	exec.vu.tags['any'] = null; // or undefined
}
```

- The new logic discards the set operation for `null` and `undefined` values and it prints a warning, instead, in case the `--throw` option is set, then it panics.
- In the case of the `--throw` option set, it's raised a panic passing a TypeError object.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
