### PR TITLE
Add tests covering v0.38.* thresholds regressions

### DIFF
--- a/cmd/testdata/thresholds/empty_sink_no_nan.js
+++ b/cmd/testdata/thresholds/empty_sink_no_nan.js
@@ -1,0 +1,18 @@
+// In scenarios where a threshold would apply to a rate metric
+// that would not receive any samples (settting abortToFail emphasis the issue),
+// division by zero could occur and lead to NaN values being returned.
+//
+// Protects from #2520 regressions.
+import { Rate } from "k6/metrics";
+
+const rate = new Rate("rate");
+
+export const options = {
+	thresholds: {
+		"rate{type:read}": [{ threshold: "rate>0.9", abortOnFail: true }],
+	},
+};
+
+export default function () {
+	console.log("not interacting with rate metric");
+}

--- a/cmd/testdata/thresholds/name_contains_tokens.js
+++ b/cmd/testdata/thresholds/name_contains_tokens.js
@@ -1,0 +1,17 @@
+//  The threshold name contains the '{' and '}' characters, which
+// are used as tokens when parsing the submetric part of a threshold's
+// name. This pattern occurs when following the URL grouping pattern, and
+// should not error.");
+//
+// Protects from #2512 regressions.
+export const options = {
+	thresholds: {
+		"http_req_duration{name:http://${}.com}": ["max < 1000"],
+	},
+};
+
+export default function () {
+	console.log(
+		"asserting a threshold's name containing parsable tokens is valid"
+	);
+}

--- a/cmd/testdata/thresholds/thresholds_on_submetric_without_samples.js
+++ b/cmd/testdata/thresholds/thresholds_on_submetric_without_samples.js
@@ -1,0 +1,19 @@
+// Thresholds over submetrics without any values should still
+// be displayed under their proper parent metrics in the summary.
+//
+// Protects from #2518 regressions.
+import { Counter } from "k6/metrics";
+
+const counter1 = new Counter("one");
+const counter2 = new Counter("two");
+
+export const options = {
+	thresholds: {
+		"one{tag:xyz}": [],
+	},
+};
+
+export default function () {
+	console.log("not submitting metric1");
+	counter2.add(42);
+}


### PR DESCRIPTION
This Pull Request addresses #2525 and adds tests covering the thresholds-related regressions observed in `v0.38.*` versions as a result of further replacement of the thresholds' evaluation logic.

Specifically, this PR adds tests covering #2518, #2512 and #2520.

I've tried different approaches for testing, but adding test scripts illustrating the issue, and writing tests for the `run` command, just like with did for thresholds validation at init ended up being the simplest, clearest and most convenient.

closes #2525 