### PR TITLE
Use require a lot more than assert in js tests

### DIFF
--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -83,53 +83,52 @@ func TestNewBundle(t *testing.T) {
 	t.Run("Blank", func(t *testing.T) {
 		t.Parallel()
 		_, err := getSimpleBundle(t, "/script.js", "")
-		assert.EqualError(t, err, "no exported functions in script")
+		require.EqualError(t, err, "no exported functions in script")
 	})
 	t.Run("Invalid", func(t *testing.T) {
 		t.Parallel()
 		_, err := getSimpleBundle(t, "/script.js", "\x00")
-		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "SyntaxError: file:///script.js: Unexpected character '\x00' (1:0)\n> 1 | \x00\n")
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "SyntaxError: file:///script.js: Unexpected character '\x00' (1:0)\n> 1 | \x00\n")
 	})
 	t.Run("Error", func(t *testing.T) {
 		t.Parallel()
 		_, err := getSimpleBundle(t, "/script.js", `throw new Error("aaaa");`)
 		exception := new(scriptException)
-		assert.ErrorAs(t, err, &exception)
-		assert.EqualError(t, err, "Error: aaaa\n\tat file:///script.js:1:7(2)\n")
+		require.ErrorAs(t, err, &exception)
+		require.EqualError(t, err, "Error: aaaa\n\tat file:///script.js:1:7(2)\n")
 	})
 	t.Run("InvalidExports", func(t *testing.T) {
 		t.Parallel()
 		_, err := getSimpleBundle(t, "/script.js", `exports = null`)
-		assert.EqualError(t, err, "exports must be an object")
+		require.EqualError(t, err, "exports must be an object")
 	})
 	t.Run("DefaultUndefined", func(t *testing.T) {
 		t.Parallel()
 		_, err := getSimpleBundle(t, "/script.js", `export default undefined;`)
-		assert.EqualError(t, err, "no exported functions in script")
+		require.EqualError(t, err, "no exported functions in script")
 	})
 	t.Run("DefaultNull", func(t *testing.T) {
 		t.Parallel()
 		_, err := getSimpleBundle(t, "/script.js", `export default null;`)
-		assert.EqualError(t, err, "no exported functions in script")
+		require.EqualError(t, err, "no exported functions in script")
 	})
 	t.Run("DefaultWrongType", func(t *testing.T) {
 		t.Parallel()
 		_, err := getSimpleBundle(t, "/script.js", `export default 12345;`)
-		assert.EqualError(t, err, "no exported functions in script")
+		require.EqualError(t, err, "no exported functions in script")
 	})
 	t.Run("Minimal", func(t *testing.T) {
 		t.Parallel()
 		_, err := getSimpleBundle(t, "/script.js", `export default function() {};`)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 	t.Run("stdin", func(t *testing.T) {
 		t.Parallel()
 		b, err := getSimpleBundle(t, "-", `export default function() {};`)
-		if assert.NoError(t, err) {
-			assert.Equal(t, "file://-", b.Filename.String())
-			assert.Equal(t, "file:///", b.BaseInitContext.pwd.String())
-		}
+		require.NoError(t, err)
+		assert.Equal(t, "file://-", b.Filename.String())
+		assert.Equal(t, "file:///", b.BaseInitContext.pwd.String())
 	})
 	t.Run("CompatibilityMode", func(t *testing.T) {
 		t.Parallel()
@@ -144,7 +143,7 @@ func TestNewBundle(t *testing.T) {
 					throw new Error("global is not defined");
 				}`, rtOpts)
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 		t.Run("Base/ok/Minimal", func(t *testing.T) {
 			t.Parallel()
@@ -153,7 +152,7 @@ func TestNewBundle(t *testing.T) {
 			}
 			_, err := getSimpleBundle(t, "/script.js",
 				`module.exports.default = function() {};`, rtOpts)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 		t.Run("Base/err", func(t *testing.T) {
 			t.Parallel()
@@ -186,7 +185,7 @@ func TestNewBundle(t *testing.T) {
 					t.Parallel()
 					rtOpts := lib.RuntimeOptions{CompatibilityMode: null.StringFrom(tc.compatMode)}
 					_, err := getSimpleBundle(t, "/script.js", tc.code, rtOpts)
-					assert.EqualError(t, err, tc.expErr)
+					require.EqualError(t, err, tc.expErr)
 				})
 			}
 		})
@@ -199,7 +198,7 @@ func TestNewBundle(t *testing.T) {
 				export let options = {};
 				export default function() {};
 			`)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 		t.Run("Invalid", func(t *testing.T) {
 			t.Parallel()
@@ -215,7 +214,7 @@ func TestNewBundle(t *testing.T) {
 						export let options = %s;
 						export default function() {};
 					`, data.Expr))
-					assert.EqualError(t, err, data.Error)
+					require.EqualError(t, err, data.Error)
 				})
 			}
 		})
@@ -228,9 +227,8 @@ func TestNewBundle(t *testing.T) {
 				};
 				export default function() {};
 			`)
-			if assert.NoError(t, err) {
-				assert.Equal(t, null.BoolFrom(true), b.Options.Paused)
-			}
+			require.NoError(t, err)
+			require.Equal(t, null.BoolFrom(true), b.Options.Paused)
 		})
 		t.Run("VUs", func(t *testing.T) {
 			t.Parallel()
@@ -240,9 +238,8 @@ func TestNewBundle(t *testing.T) {
 				};
 				export default function() {};
 			`)
-			if assert.NoError(t, err) {
-				assert.Equal(t, null.IntFrom(100), b.Options.VUs)
-			}
+			require.NoError(t, err)
+			require.Equal(t, null.IntFrom(100), b.Options.VUs)
 		})
 		t.Run("Duration", func(t *testing.T) {
 			t.Parallel()
@@ -252,9 +249,8 @@ func TestNewBundle(t *testing.T) {
 				};
 				export default function() {};
 			`)
-			if assert.NoError(t, err) {
-				assert.Equal(t, types.NullDurationFrom(10*time.Second), b.Options.Duration)
-			}
+			require.NoError(t, err)
+			require.Equal(t, types.NullDurationFrom(10*time.Second), b.Options.Duration)
 		})
 		t.Run("Iterations", func(t *testing.T) {
 			t.Parallel()
@@ -264,9 +260,8 @@ func TestNewBundle(t *testing.T) {
 				};
 				export default function() {};
 			`)
-			if assert.NoError(t, err) {
-				assert.Equal(t, null.IntFrom(100), b.Options.Iterations)
-			}
+			require.NoError(t, err)
+			require.Equal(t, null.IntFrom(100), b.Options.Iterations)
 		})
 		t.Run("Stages", func(t *testing.T) {
 			t.Parallel()
@@ -276,9 +271,8 @@ func TestNewBundle(t *testing.T) {
 				};
 				export default function() {};
 			`)
-			if assert.NoError(t, err) {
-				assert.Len(t, b.Options.Stages, 0)
-			}
+			require.NoError(t, err)
+			require.Len(t, b.Options.Stages, 0)
 
 			t.Run("Empty", func(t *testing.T) {
 				t.Parallel()
@@ -290,11 +284,9 @@ func TestNewBundle(t *testing.T) {
 					};
 					export default function() {};
 				`)
-				if assert.NoError(t, err) {
-					if assert.Len(t, b.Options.Stages, 1) {
-						assert.Equal(t, lib.Stage{}, b.Options.Stages[0])
-					}
-				}
+				require.NoError(t, err)
+				require.Len(t, b.Options.Stages, 1)
+				require.Equal(t, lib.Stage{}, b.Options.Stages[0])
 			})
 			t.Run("Target", func(t *testing.T) {
 				t.Parallel()
@@ -306,11 +298,9 @@ func TestNewBundle(t *testing.T) {
 					};
 					export default function() {};
 				`)
-				if assert.NoError(t, err) {
-					if assert.Len(t, b.Options.Stages, 1) {
-						assert.Equal(t, lib.Stage{Target: null.IntFrom(10)}, b.Options.Stages[0])
-					}
-				}
+				require.NoError(t, err)
+				require.Len(t, b.Options.Stages, 1)
+				require.Equal(t, lib.Stage{Target: null.IntFrom(10)}, b.Options.Stages[0])
 			})
 			t.Run("Duration", func(t *testing.T) {
 				t.Parallel()
@@ -322,11 +312,9 @@ func TestNewBundle(t *testing.T) {
 					};
 					export default function() {};
 				`)
-				if assert.NoError(t, err) {
-					if assert.Len(t, b.Options.Stages, 1) {
-						assert.Equal(t, lib.Stage{Duration: types.NullDurationFrom(10 * time.Second)}, b.Options.Stages[0])
-					}
-				}
+				require.NoError(t, err)
+				require.Len(t, b.Options.Stages, 1)
+				require.Equal(t, lib.Stage{Duration: types.NullDurationFrom(10 * time.Second)}, b.Options.Stages[0])
 			})
 			t.Run("DurationAndTarget", func(t *testing.T) {
 				t.Parallel()
@@ -338,11 +326,9 @@ func TestNewBundle(t *testing.T) {
 					};
 					export default function() {};
 				`)
-				if assert.NoError(t, err) {
-					if assert.Len(t, b.Options.Stages, 1) {
-						assert.Equal(t, lib.Stage{Duration: types.NullDurationFrom(10 * time.Second), Target: null.IntFrom(10)}, b.Options.Stages[0])
-					}
-				}
+				require.NoError(t, err)
+				require.Len(t, b.Options.Stages, 1)
+				require.Equal(t, lib.Stage{Duration: types.NullDurationFrom(10 * time.Second), Target: null.IntFrom(10)}, b.Options.Stages[0])
 			})
 			t.Run("RampUpAndPlateau", func(t *testing.T) {
 				t.Parallel()
@@ -355,12 +341,10 @@ func TestNewBundle(t *testing.T) {
 					};
 					export default function() {};
 				`)
-				if assert.NoError(t, err) {
-					if assert.Len(t, b.Options.Stages, 2) {
-						assert.Equal(t, lib.Stage{Duration: types.NullDurationFrom(10 * time.Second), Target: null.IntFrom(10)}, b.Options.Stages[0])
-						assert.Equal(t, lib.Stage{Duration: types.NullDurationFrom(5 * time.Second)}, b.Options.Stages[1])
-					}
-				}
+				require.NoError(t, err)
+				require.Len(t, b.Options.Stages, 2)
+				assert.Equal(t, lib.Stage{Duration: types.NullDurationFrom(10 * time.Second), Target: null.IntFrom(10)}, b.Options.Stages[0])
+				assert.Equal(t, lib.Stage{Duration: types.NullDurationFrom(5 * time.Second)}, b.Options.Stages[1])
 			})
 		})
 		t.Run("MaxRedirects", func(t *testing.T) {
@@ -371,9 +355,8 @@ func TestNewBundle(t *testing.T) {
 				};
 				export default function() {};
 			`)
-			if assert.NoError(t, err) {
-				assert.Equal(t, null.IntFrom(10), b.Options.MaxRedirects)
-			}
+			require.NoError(t, err)
+			require.Equal(t, null.IntFrom(10), b.Options.MaxRedirects)
 		})
 		t.Run("InsecureSkipTLSVerify", func(t *testing.T) {
 			t.Parallel()
@@ -383,9 +366,8 @@ func TestNewBundle(t *testing.T) {
 				};
 				export default function() {};
 			`)
-			if assert.NoError(t, err) {
-				assert.Equal(t, null.BoolFrom(true), b.Options.InsecureSkipTLSVerify)
-			}
+			require.NoError(t, err)
+			require.Equal(t, null.BoolFrom(true), b.Options.InsecureSkipTLSVerify)
 		})
 		t.Run("TLSCipherSuites", func(t *testing.T) {
 			t.Parallel()
@@ -401,11 +383,9 @@ func TestNewBundle(t *testing.T) {
 					script = fmt.Sprintf(script, suiteName)
 
 					b, err := getSimpleBundle(t, "/script.js", script)
-					if assert.NoError(t, err) {
-						if assert.Len(t, *b.Options.TLSCipherSuites, 1) {
-							assert.Equal(t, (*b.Options.TLSCipherSuites)[0], suiteID)
-						}
-					}
+					require.NoError(t, err)
+					require.Len(t, *b.Options.TLSCipherSuites, 1)
+					require.Equal(t, (*b.Options.TLSCipherSuites)[0], suiteID)
 				})
 			}
 		})
@@ -422,10 +402,9 @@ func TestNewBundle(t *testing.T) {
 					};
 					export default function() {};
 				`)
-				if assert.NoError(t, err) {
-					assert.Equal(t, b.Options.TLSVersion.Min, lib.TLSVersion(tls.VersionTLS10))
-					assert.Equal(t, b.Options.TLSVersion.Max, lib.TLSVersion(tls.VersionTLS12))
-				}
+				require.NoError(t, err)
+				assert.Equal(t, b.Options.TLSVersion.Min, lib.TLSVersion(tls.VersionTLS10))
+				assert.Equal(t, b.Options.TLSVersion.Max, lib.TLSVersion(tls.VersionTLS12))
 			})
 			t.Run("String", func(t *testing.T) {
 				t.Parallel()
@@ -435,10 +414,9 @@ func TestNewBundle(t *testing.T) {
 					};
 					export default function() {};
 				`)
-				if assert.NoError(t, err) {
-					assert.Equal(t, b.Options.TLSVersion.Min, lib.TLSVersion(tls.VersionTLS10))
-					assert.Equal(t, b.Options.TLSVersion.Max, lib.TLSVersion(tls.VersionTLS10))
-				}
+				require.NoError(t, err)
+				assert.Equal(t, b.Options.TLSVersion.Min, lib.TLSVersion(tls.VersionTLS10))
+				assert.Equal(t, b.Options.TLSVersion.Max, lib.TLSVersion(tls.VersionTLS10))
 			})
 		})
 		t.Run("Thresholds", func(t *testing.T) {
@@ -451,11 +429,9 @@ func TestNewBundle(t *testing.T) {
 				};
 				export default function() {};
 			`)
-			if assert.NoError(t, err) {
-				if assert.Len(t, b.Options.Thresholds["http_req_duration"].Thresholds, 1) {
-					assert.Equal(t, "avg<100", b.Options.Thresholds["http_req_duration"].Thresholds[0].Source)
-				}
-			}
+			require.NoError(t, err)
+			require.Len(t, b.Options.Thresholds["http_req_duration"].Thresholds, 1)
+			require.Equal(t, "avg<100", b.Options.Thresholds["http_req_duration"].Thresholds[0].Source)
 		})
 
 		t.Run("Unknown field", func(t *testing.T) {
@@ -480,8 +456,8 @@ func TestNewBundle(t *testing.T) {
 			entries := hook.Drain()
 			require.Len(t, entries, 1)
 			assert.Equal(t, logrus.WarnLevel, entries[0].Level)
-			require.Contains(t, entries[0].Message, "There were unknown fields")
-			require.Contains(t, entries[0].Data["error"].(error).Error(), "unknown field \"something\"")
+			assert.Contains(t, entries[0].Message, "There were unknown fields")
+			assert.Contains(t, entries[0].Data["error"].(error).Error(), "unknown field \"something\"") //nolint:forcetypeassert
 		})
 	})
 }
@@ -504,19 +480,19 @@ func TestNewBundleFromArchive(t *testing.T) {
 
 	logger := testutils.NewLogger(t)
 	checkBundle := func(t *testing.T, b *Bundle) {
-		assert.Equal(t, lib.Options{VUs: null.IntFrom(12345)}, b.Options)
+		require.Equal(t, lib.Options{VUs: null.IntFrom(12345)}, b.Options)
 		bi, err := b.Instantiate(logger, 0, newModuleVUImpl())
 		require.NoError(t, err)
 		val, err := bi.exports[consts.DefaultFn](goja.Undefined())
 		require.NoError(t, err)
-		assert.Equal(t, "hi!", val.Export())
+		require.Equal(t, "hi!", val.Export())
 	}
 
 	checkArchive := func(t *testing.T, arc *lib.Archive, rtOpts lib.RuntimeOptions, expError string) {
 		b, err := NewBundleFromArchive(logger, arc, rtOpts, metrics.NewRegistry())
 		if expError != "" {
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), expError)
+			require.Contains(t, err.Error(), expError)
 		} else {
 			require.NoError(t, err)
 			checkBundle(t, b)
@@ -602,7 +578,7 @@ func TestNewBundleFromArchive(t *testing.T) {
 		require.NoError(t, err)
 		val, err := bi.exports[consts.DefaultFn](goja.Undefined())
 		require.NoError(t, err)
-		assert.Equal(t, int64(999), val.Export())
+		require.Equal(t, int64(999), val.Export())
 	})
 }
 
@@ -730,7 +706,7 @@ func TestOpen(t *testing.T) {
 
 					sourceBundle, err := getSimpleBundle(t, filepath.ToSlash(filepath.Join(prefix, pwd, "script.js")), data, fs)
 					if tCase.isError {
-						assert.Error(t, err)
+						require.Error(t, err)
 						return
 					}
 					require.NoError(t, err)
@@ -746,7 +722,7 @@ func TestOpen(t *testing.T) {
 							require.NoError(t, err)
 							v, err := bi.exports[consts.DefaultFn](goja.Undefined())
 							require.NoError(t, err)
-							assert.Equal(t, "hi", v.Export())
+							require.Equal(t, "hi", v.Export())
 						})
 					}
 				}
@@ -781,9 +757,8 @@ func TestBundleInstantiate(t *testing.T) {
 		bi, err := b.Instantiate(logger, 0, newModuleVUImpl())
 		require.NoError(t, err)
 		v, err := bi.exports[consts.DefaultFn](goja.Undefined())
-		if assert.NoError(t, err) {
-			assert.Equal(t, true, v.Export())
-		}
+		require.NoError(t, err)
+		require.Equal(t, true, v.Export())
 	})
 
 	t.Run("SetAndRun", func(t *testing.T) {
@@ -803,9 +778,8 @@ func TestBundleInstantiate(t *testing.T) {
 		require.NoError(t, err)
 		bi.Runtime.Set("val", false)
 		v, err := bi.exports[consts.DefaultFn](goja.Undefined())
-		if assert.NoError(t, err) {
-			assert.Equal(t, false, v.Export())
-		}
+		require.NoError(t, err)
+		require.Equal(t, false, v.Export())
 	})
 
 	t.Run("Options", func(t *testing.T) {
@@ -826,18 +800,18 @@ func TestBundleInstantiate(t *testing.T) {
 		// Ensure `options` properties are correctly marshalled
 		jsOptions := bi.Runtime.Get("options").ToObject(bi.Runtime)
 		vus := jsOptions.Get("vus").Export()
-		assert.Equal(t, int64(5), vus)
+		require.Equal(t, int64(5), vus)
 		tdt := jsOptions.Get("teardownTimeout").Export()
-		assert.Equal(t, "1s", tdt)
+		require.Equal(t, "1s", tdt)
 
 		// Ensure options propagate correctly from outside to the script
 		optOrig := b.Options.VUs
 		b.Options.VUs = null.IntFrom(10)
 		bi2, err := b.Instantiate(logger, 0, newModuleVUImpl())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		jsOptions = bi2.Runtime.Get("options").ToObject(bi2.Runtime)
 		vus = jsOptions.Get("vus").Export()
-		assert.Equal(t, int64(10), vus)
+		require.Equal(t, int64(10), vus)
 		b.Options.VUs = optOrig
 	})
 }
@@ -866,14 +840,13 @@ func TestBundleEnv(t *testing.T) {
 		b := b
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, "1", b.RuntimeOptions.Env["TEST_A"])
-			assert.Equal(t, "", b.RuntimeOptions.Env["TEST_B"])
+			require.Equal(t, "1", b.RuntimeOptions.Env["TEST_A"])
+			require.Equal(t, "", b.RuntimeOptions.Env["TEST_B"])
 
 			bi, err := b.Instantiate(logger, 0, newModuleVUImpl())
-			if assert.NoError(t, err) {
-				_, err := bi.exports[consts.DefaultFn](goja.Undefined())
-				assert.NoError(t, err)
-			}
+			require.NoError(t, err)
+			_, err = bi.exports[consts.DefaultFn](goja.Undefined())
+			require.NoError(t, err)
 		})
 	}
 }
@@ -911,7 +884,7 @@ func TestBundleNotSharable(t *testing.T) {
 				for j := 0; j < iters; j++ {
 					bi.Runtime.Set("__ITER", j)
 					_, err := bi.exports[consts.DefaultFn](goja.Undefined())
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 			}
 		})
@@ -954,7 +927,7 @@ func TestBundleMakeArchive(t *testing.T) {
 
 			rtOpts := lib.RuntimeOptions{CompatibilityMode: null.StringFrom(tc.cm.String())}
 			b, err := getSimpleBundle(t, "/path/to/script.js", tc.script, fs, rtOpts)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			arc := b.makeArchive()
 
@@ -965,11 +938,11 @@ func TestBundleMakeArchive(t *testing.T) {
 			assert.Equal(t, "file:///path/to/", arc.PwdURL.String())
 
 			exclaimData, err := afero.ReadFile(arc.Filesystems["file"], "/path/to/exclaim.js")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.exclaim, string(exclaimData))
 
 			fileData, err := afero.ReadFile(arc.Filesystems["file"], "/path/to/file.txt")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, `hi`, string(fileData))
 			assert.Equal(t, consts.Version, arc.K6Version)
 			assert.Equal(t, tc.cm.String(), arc.CompatibilityMode)

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -457,7 +457,7 @@ func TestNewBundle(t *testing.T) {
 			require.Len(t, entries, 1)
 			assert.Equal(t, logrus.WarnLevel, entries[0].Level)
 			assert.Contains(t, entries[0].Message, "There were unknown fields")
-			assert.Contains(t, entries[0].Data["error"].(error).Error(), "unknown field \"something\"") //nolint:forcetypeassert
+			assert.Contains(t, entries[0].Data["error"].(error).Error(), "unknown field \"something\"")
 		})
 	})
 }

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -393,7 +393,7 @@ func TestFileConsole(t *testing.T) {
 							entryStr, err := entry.String()
 							require.NoError(t, err)
 
-							f, err = os.Open(logFilename)
+							f, err = os.Open(logFilename) //nolint:gosec
 							require.NoError(t, err)
 
 							fileContent, err := ioutil.ReadAll(f)

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -32,16 +32,16 @@ func TestConsoleContext(t *testing.T) {
 	_ = rt.Set("console", &console{logger})
 
 	_, err := rt.RunString(`console.log("a")`)
-	assert.NoError(t, err)
-	if entry := hook.LastEntry(); assert.NotNil(t, entry) {
-		assert.Equal(t, "a", entry.Message)
-	}
+	require.NoError(t, err)
+	entry := hook.LastEntry()
+	require.NotNil(t, entry)
+	assert.Equal(t, "a", entry.Message)
 
 	_, err = rt.RunString(`console.log("b")`)
-	assert.NoError(t, err)
-	if entry := hook.LastEntry(); assert.NotNil(t, entry) {
-		assert.Equal(t, "b", entry.Message)
-	}
+	require.NoError(t, err)
+	entry = hook.LastEntry()
+	require.NotNil(t, entry)
+	require.Equal(t, "b", entry.Message)
 }
 
 func getSimpleRunner(tb testing.TB, filename, data string, opts ...interface{}) (*Runner, error) {
@@ -105,7 +105,7 @@ func TestConsoleLogWithGojaNativeObject(t *testing.T) {
 
 	entry := hook.LastEntry()
 	require.NotNil(t, entry, "nothing logged")
-	assert.JSONEq(t, `{"text":"nativeObject"}`, entry.Message)
+	require.JSONEq(t, `{"text":"nativeObject"}`, entry.Message)
 }
 
 func TestConsoleLogObjectsWithGoTypes(t *testing.T) {
@@ -206,7 +206,7 @@ func TestConsoleLog(t *testing.T) {
 
 			samples := make(chan metrics.SampleContainer, 100)
 			initVU, err := r.newVU(1, 1, samples)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -219,7 +219,7 @@ func TestConsoleLog(t *testing.T) {
 			hook := logtest.NewLocal(logger)
 
 			err = vu.RunOnce()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			entry := hook.LastEntry()
 
@@ -259,11 +259,11 @@ func TestConsoleLevels(t *testing.T) {
 						`exports.default = function() { console.%s(%s); }`,
 						name, args,
 					))
-					assert.NoError(t, err)
+					require.NoError(t, err)
 
 					samples := make(chan metrics.SampleContainer, 100)
 					initVU, err := r.newVU(1, 1, samples)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
@@ -276,7 +276,7 @@ func TestConsoleLevels(t *testing.T) {
 					hook := logtest.NewLocal(logger)
 
 					err = vu.RunOnce()
-					assert.NoError(t, err)
+					require.NoError(t, err)
 
 					entry := hook.LastEntry()
 					require.NotNil(t, entry, "nothing logged")
@@ -351,16 +351,16 @@ func TestFileConsole(t *testing.T) {
 									`exports.default = function() { console.%s(%s); }`,
 									name, args,
 								))
-							assert.NoError(t, err)
+							require.NoError(t, err)
 
 							err = r.SetOptions(lib.Options{
 								ConsoleOutput: null.StringFrom(logFilename),
 							})
-							assert.NoError(t, err)
+							require.NoError(t, err)
 
 							samples := make(chan metrics.SampleContainer, 100)
 							initVU, err := r.newVU(1, 1, samples)
-							assert.NoError(t, err)
+							require.NoError(t, err)
 
 							ctx, cancel := context.WithCancel(context.Background())
 							defer cancel()
@@ -371,40 +371,39 @@ func TestFileConsole(t *testing.T) {
 							hook := logtest.NewLocal(logger)
 
 							err = vu.RunOnce()
-							assert.NoError(t, err)
+							require.NoError(t, err)
 
 							// Test if the file was created.
 							_, err = os.Stat(logFilename)
-							assert.NoError(t, err)
+							require.NoError(t, err)
 
 							entry := hook.LastEntry()
-							if assert.NotNil(t, entry, "nothing logged") {
-								assert.Equal(t, level, entry.Level)
-								assert.Equal(t, result.Message, entry.Message)
+							require.NotNil(t, entry, "nothing logged")
+							assert.Equal(t, level, entry.Level)
+							assert.Equal(t, result.Message, entry.Message)
 
-								data := result.Data
-								if data == nil {
-									data = make(logrus.Fields)
-								}
-								assert.Equal(t, data, entry.Data)
-
-								// Test if what we logged to the hook is the same as what we logged
-								// to the file.
-								entryStr, err := entry.String()
-								assert.NoError(t, err)
-
-								f, err := os.Open(logFilename)
-								assert.NoError(t, err)
-
-								fileContent, err := ioutil.ReadAll(f)
-								assert.NoError(t, err)
-
-								expectedStr := entryStr
-								if !deleteFile {
-									expectedStr = preExistingText + expectedStr
-								}
-								assert.Equal(t, expectedStr, string(fileContent))
+							data := result.Data
+							if data == nil {
+								data = make(logrus.Fields)
 							}
+							require.Equal(t, data, entry.Data)
+
+							// Test if what we logged to the hook is the same as what we logged
+							// to the file.
+							entryStr, err := entry.String()
+							require.NoError(t, err)
+
+							f, err = os.Open(logFilename)
+							require.NoError(t, err)
+
+							fileContent, err := ioutil.ReadAll(f)
+							require.NoError(t, err)
+
+							expectedStr := entryStr
+							if !deleteFile {
+								expectedStr = preExistingText + expectedStr
+							}
+							require.Equal(t, expectedStr, string(fileContent))
 						})
 					}
 				})

--- a/js/empty_iterations_bench_test.go
+++ b/js/empty_iterations_bench_test.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/lib"
@@ -35,9 +34,6 @@ func BenchmarkEmptyIteration(b *testing.B) {
 	b.StopTimer()
 
 	r, err := getSimpleRunner(b, "/script.js", `exports.default = function() { }`)
-	if !assert.NoError(b, err) {
-		return
-	}
 	require.NoError(b, err)
 
 	ch := make(chan metrics.SampleContainer, 100)
@@ -47,15 +43,13 @@ func BenchmarkEmptyIteration(b *testing.B) {
 		}
 	}()
 	initVU, err := r.NewVU(1, 1, ch)
-	if !assert.NoError(b, err) {
-		return
-	}
+	require.NoError(b, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		err = vu.RunOnce()
-		assert.NoError(b, err)
+		require.NoError(b, err)
 	}
 }

--- a/js/http_bench_test.go
+++ b/js/http_bench_test.go
@@ -45,9 +45,7 @@ func BenchmarkHTTPRequests(b *testing.B) {
 				if (res.status != 200) { throw new Error("wrong status: " + res.status) }
 			}
 		`), lib.RuntimeOptions{CompatibilityMode: null.StringFrom("extended")})
-	if !assert.NoError(b, err) {
-		return
-	}
+	require.NoError(b, err)
 	err = r.SetOptions(lib.Options{
 		Throw:          null.BoolFrom(true),
 		MaxRedirects:   null.IntFrom(10),
@@ -63,16 +61,13 @@ func BenchmarkHTTPRequests(b *testing.B) {
 		}
 	}()
 	initVU, err := r.NewVU(1, 1, ch)
-	if !assert.NoError(b, err) {
-		return
-	}
+	require.NoError(b, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		err = vu.RunOnce()
-		assert.NoError(b, err)
+		assert.NoError(b, vu.RunOnce())
 	}
 }
 
@@ -88,9 +83,7 @@ func BenchmarkHTTPRequestsBase(b *testing.B) {
 				if (res.status != 200) { throw new Error("wrong status: " + res.status) }
 			}
 		`))
-	if !assert.NoError(b, err) {
-		return
-	}
+	require.NoError(b, err)
 	err = r.SetOptions(lib.Options{
 		Throw:          null.BoolFrom(true),
 		MaxRedirects:   null.IntFrom(10),
@@ -106,15 +99,12 @@ func BenchmarkHTTPRequestsBase(b *testing.B) {
 		}
 	}()
 	initVU, err := r.NewVU(1, 1, ch)
-	if !assert.NoError(b, err) {
-		return
-	}
+	require.NoError(b, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		err = vu.RunOnce()
-		assert.NoError(b, err)
+		assert.NoError(b, vu.RunOnce())
 	}
 }

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -73,14 +73,14 @@ func TestRunnerNew(t *testing.T) {
 			var counter = 0;
 			exports.default = function() { counter++; }
 		`)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		t.Run("NewVU", func(t *testing.T) {
 			t.Parallel()
 			initVU, err := r.NewVU(1, 1, make(chan metrics.SampleContainer, 100))
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			vuc, ok := initVU.(*VU)
-			assert.True(t, ok)
+			require.True(t, ok)
 			assert.Equal(t, int64(0), vuc.Runtime.Get("counter").Export())
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -88,7 +88,7 @@ func TestRunnerNew(t *testing.T) {
 			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 			t.Run("RunOnce", func(t *testing.T) {
 				err = vu.RunOnce()
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, int64(1), vuc.Runtime.Get("counter").Export())
 			})
 		})
@@ -104,9 +104,8 @@ func TestRunnerNew(t *testing.T) {
 func TestRunnerGetDefaultGroup(t *testing.T) {
 	t.Parallel()
 	r1, err := getSimpleRunner(t, "/script.js", `exports.default = function() {};`)
-	if assert.NoError(t, err) {
-		assert.NotNil(t, r1.GetDefaultGroup())
-	}
+	require.NoError(t, err)
+	assert.NotNil(t, r1.GetDefaultGroup())
 
 	registry := metrics.NewRegistry()
 	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
@@ -116,9 +115,8 @@ func TestRunnerGetDefaultGroup(t *testing.T) {
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
 		}, r1.MakeArchive())
-	if assert.NoError(t, err) {
-		assert.NotNil(t, r2.GetDefaultGroup())
-	}
+	require.NoError(t, err)
+	assert.NotNil(t, r2.GetDefaultGroup())
 }
 
 func TestRunnerOptions(t *testing.T) {
@@ -187,13 +185,11 @@ func TestOptionsSettingToScript(t *testing.T) {
 
 			samples := make(chan metrics.SampleContainer, 100)
 			initVU, err := r.NewVU(1, 1, samples)
-			if assert.NoError(t, err) {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
-				err := vu.RunOnce()
-				assert.NoError(t, err)
-			}
+			require.NoError(t, err)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
+			require.NoError(t, vu.RunOnce())
 		})
 	}
 }
@@ -246,13 +242,11 @@ func TestOptionsPropagationToScript(t *testing.T) {
 			samples := make(chan metrics.SampleContainer, 100)
 
 			initVU, err := r.NewVU(1, 1, samples)
-			if assert.NoError(t, err) {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
-				err := vu.RunOnce()
-				assert.NoError(t, err)
-			}
+			require.NoError(t, err)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
+			require.NoError(t, vu.RunOnce())
 		})
 	}
 }
@@ -381,15 +375,11 @@ func testSetupDataHelper(t *testing.T, data string) {
 			defer cancel()
 			samples := make(chan metrics.SampleContainer, 100)
 
-			if !assert.NoError(t, r.Setup(ctx, samples)) {
-				return
-			}
+			require.NoError(t, r.Setup(ctx, samples))
 			initVU, err := r.NewVU(1, 1, samples)
-			if assert.NoError(t, err) {
-				vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
-				err := vu.RunOnce()
-				assert.NoError(t, err)
-			}
+			require.NoError(t, err)
+			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
+			require.NoError(t, vu.RunOnce())
 		})
 	}
 }
@@ -448,13 +438,11 @@ func TestConsoleInInitContext(t *testing.T) {
 			t.Parallel()
 			samples := make(chan metrics.SampleContainer, 100)
 			initVU, err := r.NewVU(1, 1, samples)
-			if assert.NoError(t, err) {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-				vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
-				err := vu.RunOnce()
-				assert.NoError(t, err)
-			}
+			require.NoError(t, err)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
+			require.NoError(t, vu.RunOnce())
 		})
 	}
 }
@@ -493,7 +481,7 @@ func TestRunnerIntegrationImports(t *testing.T) {
 			t.Run(mod, func(t *testing.T) {
 				t.Run("Source", func(t *testing.T) {
 					_, err := getSimpleRunner(t, "/script.js", fmt.Sprintf(`import "%s"; exports.default = function() {}`, mod), rtOpts)
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				})
 			})
 		}
@@ -597,7 +585,7 @@ func TestVURunContext(t *testing.T) {
 			defer cancel()
 			activeVU := vu.Activate(&lib.VUActivationParams{RunContext: ctx})
 			err = activeVU.RunOnce()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.True(t, fnCalled, "fn() not called")
 		})
 	}
@@ -639,7 +627,7 @@ func TestVURunInterrupt(t *testing.T) {
 			defer cancel()
 			activeVU := vu.Activate(&lib.VUActivationParams{RunContext: ctx})
 			err = activeVU.RunOnce()
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Contains(t, err.Error(), "context canceled")
 		})
 	}
@@ -690,7 +678,7 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 				go func() {
 					close(ch)
 					vuErr := vu.RunOnce()
-					assert.Error(t, vuErr)
+					require.Error(t, vuErr)
 					assert.Contains(t, vuErr.Error(), "context canceled")
 				}()
 				<-ch
@@ -760,7 +748,7 @@ func TestVUIntegrationGroups(t *testing.T) {
 			defer cancel()
 			activeVU := vu.Activate(&lib.VUActivationParams{RunContext: ctx})
 			err = activeVU.RunOnce()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.True(t, fnOuterCalled, "fnOuter() not called")
 			assert.True(t, fnInnerCalled, "fnInner() not called")
 			assert.True(t, fnNestedCalled, "fnNested() not called")
@@ -802,7 +790,7 @@ func TestVUIntegrationMetrics(t *testing.T) {
 			defer cancel()
 			activeVU := vu.Activate(&lib.VUActivationParams{RunContext: ctx})
 			err = activeVU.RunOnce()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			sampleCount := 0
 			for i, sampleC := range metrics.GetBufferedSamples(samples) {
 				for j, s := range sampleC.GetSamples() {
@@ -888,7 +876,7 @@ func TestVUIntegrationInsecureRequests(t *testing.T) {
 						require.Error(t, err)
 						assert.Contains(t, err.Error(), data.errMsg)
 					} else {
-						assert.NoError(t, err)
+						require.NoError(t, err)
 					}
 				})
 			}
@@ -1196,7 +1184,7 @@ func TestVUIntegrationTLSConfig(t *testing.T) {
 						require.Error(t, err)
 						assert.Contains(t, err.Error(), data.errMsg)
 					} else {
-						assert.NoError(t, err)
+						require.NoError(t, err)
 					}
 				})
 			}
@@ -1209,15 +1197,15 @@ func TestVUIntegrationOpenFunctionError(t *testing.T) {
 	r, err := getSimpleRunner(t, "/script.js", `
 			exports.default = function() { open("/tmp/foo") }
 		`)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	initVU, err := r.NewVU(1, 1, make(chan metrics.SampleContainer, 100))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 	err = vu.RunOnce()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only available in the init stage")
 }
 
@@ -1227,15 +1215,15 @@ func TestVUIntegrationOpenFunctionErrorWhenSneaky(t *testing.T) {
 			var sneaky = open;
 			exports.default = function() { sneaky("/tmp/foo") }
 		`)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	initVU, err := r.NewVU(1, 1, make(chan metrics.SampleContainer, 100))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 	err = vu.RunOnce()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only available in the init stage")
 }
 
@@ -1260,7 +1248,7 @@ func TestVUDoesOpenUnderV0Condition(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = r.NewVU(1, 1, make(chan metrics.SampleContainer, 100))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 }
 
 func TestVUDoesNotOpenUnderConditions(t *testing.T) {
@@ -1284,7 +1272,7 @@ func TestVUDoesNotOpenUnderConditions(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = r.NewVU(1, 1, make(chan metrics.SampleContainer, 100))
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "open() can't be used with files that weren't previously opened during initialization (__VU==0)")
 }
 
@@ -1308,7 +1296,7 @@ func TestVUDoesNonExistingPathnUnderConditions(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = r.NewVU(1, 1, make(chan metrics.SampleContainer, 100))
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "open() can't be used with files that weren't previously opened during initialization (__VU==0)")
 }
 
@@ -1361,8 +1349,7 @@ func TestVUIntegrationCookiesReset(t *testing.T) {
 			defer cancel()
 			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 			for i := 0; i < 2; i++ {
-				err = vu.RunOnce()
-				assert.NoError(t, err)
+				require.NoError(t, vu.RunOnce())
 			}
 		})
 	}
@@ -1423,10 +1410,10 @@ func TestVUIntegrationCookiesNoReset(t *testing.T) {
 			defer cancel()
 			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 			err = vu.RunOnce()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			err = vu.RunOnce()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -1463,7 +1450,7 @@ func TestVUIntegrationVUID(t *testing.T) {
 			defer cancel()
 			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 			err = vu.RunOnce()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }
@@ -1614,17 +1601,16 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 					t.Parallel()
 					r.Logger, _ = logtest.NewNullLogger()
 					initVU, err := r.NewVU(1, 1, make(chan metrics.SampleContainer, 100))
-					if assert.NoError(t, err) {
-						ctx, cancel := context.WithCancel(context.Background())
-						defer cancel()
-						vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
-						err := vu.RunOnce()
-						if len(data.errMsg) > 0 {
-							require.Error(t, err)
-							assert.Contains(t, err.Error(), data.errMsg)
-						} else {
-							assert.NoError(t, err)
-						}
+					require.NoError(t, err)
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
+					vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
+					err = vu.RunOnce()
+					if len(data.errMsg) > 0 {
+						require.Error(t, err)
+						assert.Contains(t, err.Error(), data.errMsg)
+					} else {
+						require.NoError(t, err)
 					}
 				})
 			}
@@ -1646,12 +1632,11 @@ func TestHTTPRequestInInitContext(t *testing.T) {
 						console.log(test);
 					}
 				`))
-	if assert.Error(t, err) {
-		assert.Contains(
-			t,
-			err.Error(),
-			k6http.ErrHTTPForbiddenInInitContext.Error())
-	}
+	require.Error(t, err)
+	assert.Contains(
+		t,
+		err.Error(),
+		k6http.ErrHTTPForbiddenInInitContext.Error())
 }
 
 func TestInitContextForbidden(t *testing.T) {
@@ -1729,12 +1714,11 @@ func TestInitContextForbidden(t *testing.T) {
 		t.Run(test[0], func(t *testing.T) {
 			t.Parallel()
 			_, err := getSimpleRunner(t, "/script.js", tb.Replacer.Replace(test[1]))
-			if assert.Error(t, err) {
-				assert.Contains(
-					t,
-					err.Error(),
-					test[2])
-			}
+			require.Error(t, err)
+			assert.Contains(
+				t,
+				err.Error(),
+				test[2])
 		})
 	}
 }
@@ -2068,7 +2052,7 @@ func TestVUPanic(t *testing.T) {
 			// require.True(t, strings.HasSuffix(entries[0].Message, "Goja stack:\nfile:///script.js:3:4(12)"))
 
 			err = vu.RunOnce()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			entries = hook.Drain()
 			require.Len(t, entries, 1)
@@ -2483,7 +2467,7 @@ func TestExecutionInfo(t *testing.T) {
 			execState := execScheduler.GetState()
 			execState.ModCurrentlyActiveVUsCount(+1)
 			err = vu.RunOnce()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		})
 	}
 }

--- a/js/share_test.go
+++ b/js/share_test.go
@@ -109,7 +109,7 @@ exports.default = function() {
 			defer cancel()
 			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 			err = vu.RunOnce()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			entries := hook.Drain()
 			assert.Len(t, entries, 0)
 		})


### PR DESCRIPTION
The js tests had a bunch of places where they were using `assert` instead of `require`.

Mostly cases where the test should've not continued such as expecting error or no error. In some places `if assert....` was used which also is completely not needed.

I have kept most usage of `assert` where they will report multiple (and even singular failures sometimes), but I would argue in most cases just using `require` for everything is likely enough. 

There are also a few places where I've added `requires` that were previously missing.

Finally, there are few places that could've been left as `assert` but I decided to go for `require` in order for there to be no `assert.Error` for example. As I would argue this should always be with require.

Some of those lead to *fewer* reported failures as previously an `if assert ...` was followed by more code that could run even if that assert is a failure. But I would argue in all of those cases that is unlikely, and even if that happens this particular failures will likely not help debug the original problem.