### PR TITLE
fix: proper error exec.scenario.* in not init context

### DIFF
--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -90,7 +90,7 @@ func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{Default: mi.obj}
 }
 
-var errRunInInitContext = errors.New("getting scenario information outside of vu code is not supported")
+var errRunInInitContext = errors.New("getting scenario information outside of the VU context is not supported")
 
 // newScenarioInfo returns a goja.Object with property accessors to retrieve
 // information about the scenario the current VU is running in.

--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -90,7 +90,7 @@ func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{Default: mi.obj}
 }
 
-var errRunInInitContext = errors.New("getting scenario information in the init context is not supported")
+var errRunInInitContext = errors.New("getting scenario information outside of vu code is not supported")
 
 // newScenarioInfo returns a goja.Object with property accessors to retrieve
 // information about the scenario the current VU is running in.

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -418,3 +418,32 @@ func TestOptionsTestSetPropertyDenied(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, true, rt.ToValue(paused).ToBoolean())
 }
+
+func TestScenarioNoAvailableInInitContext(t *testing.T) {
+	t.Parallel()
+
+	rt := goja.New()
+	m, ok := New().NewModuleInstance(
+		&modulestest.VU{
+			RuntimeField: rt,
+			InitEnvField: &common.InitEnvironment{},
+			CtxField:     context.Background(),
+			StateField: &lib.State{
+				Options: lib.Options{
+					Paused: null.BoolFrom(true),
+				},
+			},
+		},
+	).(*ModuleInstance)
+	require.True(t, ok)
+	require.NoError(t, rt.Set("exec", m.Exports().Default))
+
+	scenarioExportedProps := []string{"name", "executor", "startTime", "progress", "iterationInInstance", "iterationInTest"}
+
+	for _, code := range scenarioExportedProps {
+		prop := fmt.Sprintf("exec.scenario.%s", code)
+		_, err := rt.RunString(prop)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "getting scenario information in the init context is not supported")
+	}
+}

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -444,6 +444,6 @@ func TestScenarioNoAvailableInInitContext(t *testing.T) {
 		prop := fmt.Sprintf("exec.scenario.%s", code)
 		_, err := rt.RunString(prop)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "getting scenario information in the init context is not supported")
+		require.ErrorContains(t, err, "getting scenario information outside of vu code is not supported")
 	}
 }

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -444,6 +444,6 @@ func TestScenarioNoAvailableInInitContext(t *testing.T) {
 		prop := fmt.Sprintf("exec.scenario.%s", code)
 		_, err := rt.RunString(prop)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "getting scenario information outside of vu code is not supported")
+		require.ErrorContains(t, err, "getting scenario information outside of the VU context is not supported")
 	}
 }

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -2406,7 +2406,7 @@ func TestExecutionInfo(t *testing.T) {
 		{name: "scenario_err", script: `
 		var exec = require('k6/execution');
 		exec.scenario;
-		`, expErr: "getting scenario information outside of vu code is not supported"},
+		`, expErr: "getting scenario information outside of the VU context is not supported"},
 		{name: "test_ok", script: `
 		var exec = require('k6/execution');
 

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -2406,7 +2406,7 @@ func TestExecutionInfo(t *testing.T) {
 		{name: "scenario_err", script: `
 		var exec = require('k6/execution');
 		exec.scenario;
-		`, expErr: "getting scenario information in the init context is not supported"},
+		`, expErr: "getting scenario information outside of vu code is not supported"},
 		{name: "test_ok", script: `
 		var exec = require('k6/execution');
 


### PR DESCRIPTION
# What?

Always check if `scenarioState` is available for the `execution.scenario`, otherwise erroring.

# Why?

It makes no sense to use this `execution.scenario` not inside the VU context.

Closes: #2545