### PR TITLE
Contain main module within it's own scope as well

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -967,7 +967,7 @@ func TestVuInitException(t *testing.T) {
 
 	var exception errext.Exception
 	require.ErrorAs(t, err, &exception)
-	assert.Equal(t, "Error: oops in 2\n\tat file:///script.js:10:9(31)\n", err.Error())
+	assert.Equal(t, "Error: oops in 2\n\tat file:///script.js:10:9(30)\n\tat native\n", err.Error())
 
 	var errWithHint errext.HasHint
 	require.ErrorAs(t, err, &errWithHint)

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -350,7 +350,7 @@ func (b *Bundle) instantiate(logger logrus.FieldLogger, rt *goja.Runtime, init *
 				}
 				return nil
 			}
-			panic("we shouldn't be able to get here")
+			panic("Somehow a commonjs main module is not wrapped in a function")
 		})
 	})
 

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -67,9 +67,9 @@ type BundleInstance struct {
 	// TODO: maybe just have a reference to the Bundle? or save and pass rtOpts?
 	env map[string]string
 
-	exports map[string]goja.Callable
-
+	exports      map[string]goja.Callable
 	moduleVUImpl *moduleVUImpl
+	pgm          programWithSource
 }
 
 // NewBundle creates a new bundle from a source file and a filesystem.
@@ -90,7 +90,7 @@ func NewBundle(
 		Strict:            true,
 		SourceMapLoader:   generateSourceMapLoader(logger, filesystems),
 	}
-	pgm, _, err := c.Compile(code, src.URL.String(), true)
+	pgm, _, err := c.Compile(code, src.URL.String(), false)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ func NewBundleFromArchive(
 		CompatibilityMode: compatMode,
 		SourceMapLoader:   generateSourceMapLoader(logger, arc.Filesystems),
 	}
-	pgm, _, err := c.Compile(string(arc.Data), arc.FilenameURL.String(), true)
+	pgm, _, err := c.Compile(string(arc.Data), arc.FilenameURL.String(), false)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,8 @@ func (b *Bundle) makeArchive() *lib.Archive {
 
 // getExports validates and extracts exported objects
 func (b *Bundle) getExports(logger logrus.FieldLogger, rt *goja.Runtime, options bool) error {
-	exportsV := rt.Get("exports")
+	pgm := b.BaseInitContext.programs[b.Filename.String()]
+	exportsV := pgm.module.Get("exports")
 	if goja.IsNull(exportsV) || goja.IsUndefined(exportsV) {
 		return errors.New("exports must be an object")
 	}
@@ -262,26 +263,31 @@ func (b *Bundle) Instantiate(logger logrus.FieldLogger, vuID uint64) (*BundleIns
 	}
 
 	rt := vuImpl.runtime
+	pgm := init.programs[b.Filename.String()]
 	bi := &BundleInstance{
 		Runtime:      rt,
 		exports:      make(map[string]goja.Callable),
 		env:          b.RuntimeOptions.Env,
 		moduleVUImpl: vuImpl,
+		pgm:          pgm,
 	}
 
 	// Grab any exported functions that could be executed. These were
 	// already pre-validated in cmd.validateScenarioConfig(), just get them here.
-	exports := rt.Get("exports").ToObject(rt)
+	exports := pgm.module.Get("exports").ToObject(rt)
 	for k := range b.exports {
 		fn, _ := goja.AssertFunction(exports.Get(k))
 		bi.exports[k] = fn
 	}
 
-	jsOptions := rt.Get("options")
+	jsOptions := exports.Get("options")
 	var jsOptionsObj *goja.Object
 	if jsOptions == nil || goja.IsNull(jsOptions) || goja.IsUndefined(jsOptions) {
 		jsOptionsObj = rt.NewObject()
-		rt.Set("options", jsOptionsObj)
+		err := exports.Set("options", jsOptionsObj)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't set exported options with merged values: %w", err)
+		}
 	} else {
 		jsOptionsObj = jsOptions.ToObject(rt)
 	}
@@ -301,12 +307,6 @@ func (b *Bundle) Instantiate(logger logrus.FieldLogger, vuID uint64) (*BundleIns
 func (b *Bundle) instantiate(logger logrus.FieldLogger, rt *goja.Runtime, init *InitContext, vuID uint64) (err error) {
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
 	rt.SetRandSource(common.NewRandSource())
-
-	exports := rt.NewObject()
-	rt.Set("exports", exports)
-	module := rt.NewObject()
-	_ = module.Set("exports", exports)
-	rt.Set("module", module)
 
 	env := make(map[string]string, len(b.RuntimeOptions.Env))
 	for key, value := range b.RuntimeOptions.Env {
@@ -330,10 +330,27 @@ func (b *Bundle) instantiate(logger logrus.FieldLogger, rt *goja.Runtime, init *
 	init.moduleVUImpl.ctx = context.Background()
 	init.moduleVUImpl.initEnv = initenv
 	init.moduleVUImpl.eventLoop = eventloop.New(init.moduleVUImpl)
+	pgm := init.programs[b.Filename.String()] // this just initializes the program
+	pgm.pgm = b.Program
+	pgm.src = b.Source
+	exports := rt.NewObject()
+	pgm.module = rt.NewObject()
+	_ = pgm.module.Set("exports", exports)
+	init.programs[b.Filename.String()] = pgm
+
 	err = common.RunWithPanicCatching(logger, rt, func() error {
 		return init.moduleVUImpl.eventLoop.Start(func() error {
-			_, errRun := rt.RunProgram(b.Program)
-			return errRun
+			f, errRun := rt.RunProgram(b.Program)
+			if errRun != nil {
+				return errRun
+			}
+			if call, ok := goja.AssertFunction(f); ok {
+				if _, errRun = call(exports, pgm.module, exports); errRun != nil {
+					return errRun
+				}
+				return nil
+			}
+			panic("we shouldn't be able to get here")
 		})
 	})
 
@@ -344,6 +361,12 @@ func (b *Bundle) instantiate(logger logrus.FieldLogger, rt *goja.Runtime, init *
 		}
 		return err
 	}
+	exportsV := pgm.module.Get("exports")
+	if goja.IsNull(exportsV) {
+		return errors.New("exports must be an object")
+	}
+	pgm.exports = exportsV.ToObject(rt)
+	init.programs[b.Filename.String()] = pgm
 	unbindInit()
 	init.moduleVUImpl.ctx = nil
 	init.moduleVUImpl.initEnv = nil

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -208,7 +208,7 @@ func (b *Bundle) makeArchive() *lib.Archive {
 
 // getExports validates and extracts exported objects
 func (b *Bundle) getExports(logger logrus.FieldLogger, rt *goja.Runtime, options bool) error {
-	pgm := b.BaseInitContext.programs[b.Filename.String()]
+	pgm := b.BaseInitContext.programs[b.Filename.String()] // this is the main script and it's always present
 	exportsV := pgm.module.Get("exports")
 	if goja.IsNull(exportsV) || goja.IsUndefined(exportsV) {
 		return errors.New("exports must be an object")
@@ -263,7 +263,7 @@ func (b *Bundle) Instantiate(logger logrus.FieldLogger, vuID uint64) (*BundleIns
 	}
 
 	rt := vuImpl.runtime
-	pgm := init.programs[b.Filename.String()]
+	pgm := init.programs[b.Filename.String()] // this is the main script and it's always present
 	bi := &BundleInstance{
 		Runtime:      rt,
 		exports:      make(map[string]goja.Callable),

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -761,28 +761,6 @@ func TestBundleInstantiate(t *testing.T) {
 		require.Equal(t, true, v.Export())
 	})
 
-	t.Run("SetAndRun", func(t *testing.T) {
-		t.Parallel()
-		t.Skip("This makes no sense for a test we are basically testing that we can reset global")
-		b, err := getSimpleBundle(t, "/script.js", `
-		export let options = {
-			vus: 5,
-			teardownTimeout: '1s',
-		};
-		let val = true;
-		export default function() { return val; }
-	`)
-		require.NoError(t, err)
-		logger := testutils.NewLogger(t)
-
-		bi, err := b.Instantiate(logger, 0)
-		require.NoError(t, err)
-		bi.Runtime.Set("val", false)
-		v, err := bi.exports[consts.DefaultFn](goja.Undefined())
-		require.NoError(t, err)
-		require.Equal(t, false, v.Export())
-	})
-
 	t.Run("Options", func(t *testing.T) {
 		t.Parallel()
 		b, err := getSimpleBundle(t, "/script.js", `

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -183,14 +183,15 @@ type compilationState struct {
 	// srcMap is the current full sourceMap that has been generated read so far
 	srcMap      []byte
 	srcMapError error
-	main        bool
+	wrapped     bool // whether the original source is wrapped in a function to make it a commonjs module
 
 	compiler *Compiler
 }
 
 // Compile the program in the given CompatibilityMode, wrapping it between pre and post code
-func (c *Compiler) Compile(src, filename string, main bool) (*goja.Program, string, error) {
-	return c.compileImpl(src, filename, main, c.Options.CompatibilityMode, nil)
+// TODO isESM will be used once goja support ESM modules natively
+func (c *Compiler) Compile(src, filename string, isESM bool) (*goja.Program, string, error) {
+	return c.compileImpl(src, filename, !isESM, c.Options.CompatibilityMode, nil)
 }
 
 // sourceMapLoader is to be used with goja's WithSourceMapLoader
@@ -198,7 +199,10 @@ func (c *Compiler) Compile(src, filename string, main bool) (*goja.Program, stri
 // additioanlly it fixes off by one error in commonjs dependencies due to having to wrap them in a function.
 func (c *compilationState) sourceMapLoader(path string) ([]byte, error) {
 	if path == sourceMapURLFromBabel {
-		return c.increaseMappingsByOne(c.srcMap)
+		if c.wrapped {
+			return c.increaseMappingsByOne(c.srcMap)
+		}
+		return c.srcMap, nil
 	}
 	c.srcMap, c.srcMapError = c.compiler.Options.SourceMapLoader(path)
 	if c.srcMapError != nil {
@@ -211,15 +215,18 @@ func (c *compilationState) sourceMapLoader(path string) ([]byte, error) {
 		c.srcMap = nil
 		return nil, c.srcMapError
 	}
-	return c.increaseMappingsByOne(c.srcMap)
+	if c.wrapped {
+		return c.increaseMappingsByOne(c.srcMap)
+	}
+	return c.srcMap, nil
 }
 
 func (c *Compiler) compileImpl(
-	src, filename string, main bool, compatibilityMode lib.CompatibilityMode, srcMap []byte,
+	src, filename string, wrap bool, compatibilityMode lib.CompatibilityMode, srcMap []byte,
 ) (*goja.Program, string, error) {
 	code := src
-	state := compilationState{srcMap: srcMap, compiler: c, main: main}
-	if !main { // the lines in the sourcemap (if available) will be fixed by increaseMappingsByOne
+	state := compilationState{srcMap: srcMap, compiler: c, wrapped: wrap}
+	if wrap { // the lines in the sourcemap (if available) will be fixed by increaseMappingsByOne
 		code = "(function(module, exports){\n" + code + "\n})\n"
 	}
 	opts := parser.WithDisableSourceMaps
@@ -242,7 +249,7 @@ func (c *Compiler) compileImpl(
 				return nil, code, err
 			}
 			// the compatibility mode "decreases" here as we shouldn't transform twice
-			return c.compileImpl(code, filename, main, lib.CompatibilityModeBase, state.srcMap)
+			return c.compileImpl(code, filename, wrap, lib.CompatibilityModeBase, state.srcMap)
 		}
 		return nil, code, err
 	}

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -198,10 +198,7 @@ func (c *Compiler) Compile(src, filename string, main bool) (*goja.Program, stri
 // additioanlly it fixes off by one error in commonjs dependencies due to having to wrap them in a function.
 func (c *compilationState) sourceMapLoader(path string) ([]byte, error) {
 	if path == sourceMapURLFromBabel {
-		if !c.main {
-			return c.increaseMappingsByOne(c.srcMap)
-		}
-		return c.srcMap, nil
+		return c.increaseMappingsByOne(c.srcMap)
 	}
 	c.srcMap, c.srcMapError = c.compiler.Options.SourceMapLoader(path)
 	if c.srcMapError != nil {
@@ -214,10 +211,7 @@ func (c *compilationState) sourceMapLoader(path string) ([]byte, error) {
 		c.srcMap = nil
 		return nil, c.srcMapError
 	}
-	if !c.main {
-		return c.increaseMappingsByOne(c.srcMap)
-	}
-	return c.srcMap, nil
+	return c.increaseMappingsByOne(c.srcMap)
 }
 
 func (c *Compiler) compileImpl(

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -54,9 +54,10 @@ import (
 )
 
 type programWithSource struct {
-	pgm    *goja.Program
-	src    string
-	module *goja.Object
+	pgm     *goja.Program
+	src     string
+	module  *goja.Object
+	exports *goja.Object
 }
 
 const openCantBeUsedOutsideInitContextMsg = `The "open()" function is only available in the init stage ` +

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -70,13 +70,13 @@ func TestInitContextRequire(t *testing.T) {
 			bi, err := b.Instantiate(logger, 0)
 			assert.NoError(t, err, "instance error")
 
-			exports := bi.Runtime.Get("exports").ToObject(bi.Runtime)
+			exports := bi.pgm.exports
 			require.NotNil(t, exports)
 			_, defaultOk := goja.AssertFunction(exports.Get("default"))
 			assert.True(t, defaultOk, "default export is not a function")
 			assert.Equal(t, "abc123", exports.Get("dummy").String())
 
-			k6 := bi.Runtime.Get("_k6").ToObject(bi.Runtime)
+			k6 := exports.Get("_k6").ToObject(bi.Runtime)
 			require.NotNil(t, k6)
 			_, groupOk := goja.AssertFunction(k6.Get("group"))
 			assert.True(t, groupOk, "k6.group is not a function")
@@ -96,7 +96,7 @@ func TestInitContextRequire(t *testing.T) {
 			bi, err := b.Instantiate(logger, 0)
 			require.NoError(t, err)
 
-			exports := bi.Runtime.Get("exports").ToObject(bi.Runtime)
+			exports := bi.pgm.exports
 			require.NotNil(t, exports)
 			_, defaultOk := goja.AssertFunction(exports.Get("default"))
 			assert.True(t, defaultOk, "default export is not a function")
@@ -130,7 +130,7 @@ func TestInitContextRequire(t *testing.T) {
 			require.NoError(t, afero.WriteFile(fs, "/file.js", []byte(`throw new Error("aaaa")`), 0o755))
 			_, err := getSimpleBundle(t, "/script.js", `import "/file.js"; export default function() {}`, fs)
 			assert.EqualError(t, err,
-				"Error: aaaa\n\tat file:///file.js:2:7(3)\n\tat go.k6.io/k6/js.(*InitContext).Require-fm (native)\n\tat file:///script.js:1:0(14)\n")
+				"Error: aaaa\n\tat file:///file.js:2:7(3)\n\tat go.k6.io/k6/js.(*InitContext).Require-fm (native)\n\tat file:///script.js:1:0(15)\n\tat native\n")
 		})
 
 		imports := map[string]struct {
@@ -282,7 +282,7 @@ func TestInitContextOpen(t *testing.T) {
 			t.Parallel()
 			bi, err := createAndReadFile(t, tc.file, tc.content, tc.length, "")
 			require.NoError(t, err)
-			assert.Equal(t, string(tc.content), bi.Runtime.Get("data").Export())
+			assert.Equal(t, string(tc.content), bi.pgm.exports.Get("data").Export())
 		})
 	}
 
@@ -291,7 +291,7 @@ func TestInitContextOpen(t *testing.T) {
 		bi, err := createAndReadFile(t, "/path/to/file.bin", []byte("hi!\x0f\xff\x01"), 6, "b")
 		require.NoError(t, err)
 		buf := bi.Runtime.NewArrayBuffer([]byte{104, 105, 33, 15, 255, 1})
-		assert.Equal(t, buf, bi.Runtime.Get("data").Export())
+		assert.Equal(t, buf, bi.pgm.exports.Get("data").Export())
 	})
 
 	testdata := map[string]string{

--- a/js/module_loading_test.go
+++ b/js/module_loading_test.go
@@ -314,10 +314,10 @@ func TestLoadCycle(t *testing.T) {
 	// This is mostly the example from https://hacks.mozilla.org/2018/03/es-modules-a-cartoon-deep-dive/
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/counter.js", []byte(`
-			let message = require("./main.js").message;
+			let main = require("./main.js");
 			exports.count = 5;
 			export function a() {
-				return message;
+				return main.message;
 			}
 	`), os.ModePerm))
 
@@ -608,27 +608,36 @@ func TestLoadingSourceMapsDoesntErrorOut(t *testing.T) {
 	}
 }
 
-func TestShowcasingHowOptionsAreGlobalReadable(t *testing.T) {
+func TestOptionsAreGloballyReadable(t *testing.T) {
 	t.Parallel()
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/A.js", []byte(`
-			export function A() {
+        export function A() {
         // we can technically get a field set from outside of js this way
-				return options.someField;
-			}
-		`), os.ModePerm))
+            return options.someField;
+        }`), os.ModePerm))
 	r1, err := getSimpleRunner(t, "/script.js", `
-			import { A } from "./A.js";
-      export let options = {
-        someField: "here is an option",
-      }
+     import { A } from "./A.js";
+     export let options = {
+       someField: "here is an option",
+     }
 
-			export default function(data) {
-        if (A() != "here is an option") {
-          throw "oops"
-        }
-			}
-		`, fs, lib.RuntimeOptions{CompatibilityMode: null.StringFrom("extended")})
+        export default function(data) {
+            var caught = false;
+            try{
+                if (A() == "here is an option") {
+                  throw "oops"
+                }
+            } catch(e) {
+                if (e.message != "options is not defined") {
+                    throw e;
+                }
+                caught = true;
+            }
+            if (!caught) {
+                throw "expected exception"
+            }
+        } `, fs, lib.RuntimeOptions{CompatibilityMode: null.StringFrom("extended")})
 	require.NoError(t, err)
 
 	arc := r1.MakeArchive()
@@ -660,26 +669,36 @@ func TestShowcasingHowOptionsAreGlobalReadable(t *testing.T) {
 	}
 }
 
-func TestShowcasingHowOptionsAreGlobalWritable(t *testing.T) {
+func TestOptionsAreNotGloballyWritable(t *testing.T) {
 	t.Parallel()
 	fs := afero.NewMemMapFs()
 	require.NoError(t, afero.WriteFile(fs, "/A.js", []byte(`
     export function A() {
-      // this requires that this is defined
-      options.minIterationDuration = "1h"
-    }
-		`), os.ModePerm))
+        // this requires that this is defined
+        options.minIterationDuration = "1h"
+    }`), os.ModePerm))
 	r1, err := getSimpleRunner(t, "/script.js", `
     import {A} from "/A.js"
     export let options = {minIterationDuration: "5m"}
 
     export default () =>{}
-    A()
-		`, fs, lib.RuntimeOptions{CompatibilityMode: null.StringFrom("extended")})
+    var caught = false;
+    try{
+        A()
+    } catch(e) {
+        if (e.message != "options is not defined") {
+            throw e;
+        }
+        caught = true;
+    }
+
+    if (!caught) {
+        throw "expected exception"
+    }`, fs, lib.RuntimeOptions{CompatibilityMode: null.StringFrom("extended")})
 	require.NoError(t, err)
 
 	// here it exists
-	require.EqualValues(t, time.Hour, r1.GetOptions().MinIterationDuration.Duration)
+	require.EqualValues(t, time.Minute*5, r1.GetOptions().MinIterationDuration.Duration)
 	arc := r1.MakeArchive()
 	registry := metrics.NewRegistry()
 	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
@@ -690,5 +709,5 @@ func TestShowcasingHowOptionsAreGlobalWritable(t *testing.T) {
 	}, arc)
 	require.NoError(t, err)
 
-	require.EqualValues(t, time.Hour, r2.GetOptions().MinIterationDuration.Duration)
+	require.EqualValues(t, time.Minute*5, r2.GetOptions().MinIterationDuration.Duration)
 }


### PR DESCRIPTION
This is the continuation of #2566 with a fix in which I wrap the main module the same way every other module.

This more or less gets us inline with what will be the behaviour once ESM lands from #2563. 

As you can see I had to also change other tests as they make no sense once the main module doesn't just work in the global scope.


This still needs work if we decide to merge it:
1. I will try to fix the lines for main modules(and not only) with no source maps and/or not going through babel. 
2. More polishing - I likely will want to refactor some of the code a bit more. Like `getExports` seems like of strangely out of place which I also noticed while working on ESM 