### PR TITLE
Fix max duration calculations with multiple 0 vus stages at end

### DIFF
--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -209,8 +209,10 @@ func (vlvc RampingVUsConfig) getRawExecutionSteps(et *lib.ExecutionTuple, zeroEn
 
 		stageVUDiff := stageEndVUs - fromVUs
 		if stageVUDiff == 0 {
+			// skip those as this doesn't change anything
 			if i == len(vlvc.Stages)-1 {
-				// add the last step always
+				// don't skip the last step as we won't add another one after it
+				// unlike in any of the other cases
 				steps = append(steps, lib.ExecutionStep{TimeOffset: timeTillEnd, PlannedVUs: uint64(scaled)})
 			}
 			continue

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -470,14 +470,14 @@ func (vlvc RampingVUsConfig) GetExecutionRequirements(et *lib.ExecutionTuple) []
 		steps = vlvc.reserveVUsForGracefulRampDowns(steps, executorEndOffset)
 	}
 	lastIndex := len(steps)
-	for ; lastIndex >= 0; lastIndex-- {
+	for ; lastIndex > 0; lastIndex-- {
 		if steps[lastIndex-1].PlannedVUs != 0 {
 			break
 		}
 	}
 
-	if len(steps) > lastIndex {
-		executorEndOffset = steps[lastIndex].TimeOffset + vlvc.GracefulStop.TimeDuration()
+	if len(steps) > lastIndex && steps[lastIndex].TimeOffset < executorEndOffset {
+		executorEndOffset = steps[lastIndex].TimeOffset
 	}
 	// add one step for the end of the gracefulStop
 	if steps[len(steps)-1].PlannedVUs != 0 || steps[len(steps)-1].TimeOffset < executorEndOffset {

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -430,14 +430,6 @@ func (vlvc RampingVUsConfig) reserveVUsForGracefulRampDowns( //nolint:funlen
 		})
 		lastPlannedVUs = rawStep.PlannedVUs
 	}
-	/*
-		if newSteps[len(newSteps)-1].TimeOffset < rawSteps[len(rawSteps)-1].TimeOffset {
-			newSteps = append(newSteps, lib.ExecutionStep{
-				TimeOffset: rawSteps[len(rawSteps)-1].TimeOffset,
-				PlannedVUs: rawSteps[len(rawSteps)-1].PlannedVUs,
-			})
-		}
-	*/
 
 	return newSteps
 }

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -438,14 +438,14 @@ func TestRampingVUsConfigExecutionPlanExample(t *testing.T) {
 	conf := NewRampingVUsConfig("test")
 	conf.StartVUs = null.IntFrom(4)
 	conf.Stages = []Stage{
-		{Target: null.IntFrom(6), Duration: types.NullDurationFrom(2 * time.Second)},
-		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(5 * time.Second)},
-		{Target: null.IntFrom(5), Duration: types.NullDurationFrom(4 * time.Second)},
-		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(4 * time.Second)},
-		{Target: null.IntFrom(4), Duration: types.NullDurationFrom(3 * time.Second)},
-		{Target: null.IntFrom(4), Duration: types.NullDurationFrom(2 * time.Second)},
-		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(0 * time.Second)},
-		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(3 * time.Second)},
+		{Target: null.IntFrom(6), Duration: types.NullDurationFrom(2 * time.Second)}, // 2
+		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(5 * time.Second)}, // 7
+		{Target: null.IntFrom(5), Duration: types.NullDurationFrom(4 * time.Second)}, // 11
+		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(4 * time.Second)}, // 15
+		{Target: null.IntFrom(4), Duration: types.NullDurationFrom(3 * time.Second)}, // 18
+		{Target: null.IntFrom(4), Duration: types.NullDurationFrom(2 * time.Second)}, // 20
+		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(0 * time.Second)}, // 20
+		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(3 * time.Second)}, // 23
 	}
 
 	expRawStepsNoZeroEnd := []lib.ExecutionStep{
@@ -469,11 +469,12 @@ func TestRampingVUsConfigExecutionPlanExample(t *testing.T) {
 		{TimeOffset: 17 * time.Second, PlannedVUs: 3},
 		{TimeOffset: 18 * time.Second, PlannedVUs: 4},
 		{TimeOffset: 20 * time.Second, PlannedVUs: 1},
+		{TimeOffset: 23 * time.Second, PlannedVUs: 1},
 	}
 	rawStepsNoZeroEnd := conf.getRawExecutionSteps(et, false)
 	assert.Equal(t, expRawStepsNoZeroEnd, rawStepsNoZeroEnd)
 	endOffset, isFinal := lib.GetEndOffset(rawStepsNoZeroEnd)
-	assert.Equal(t, 20*time.Second, endOffset)
+	assert.Equal(t, 23*time.Second, endOffset)
 	assert.Equal(t, false, isFinal)
 
 	rawStepsZeroEnd := conf.getRawExecutionSteps(et, true)
@@ -559,13 +560,13 @@ func TestRampingVUsConfigExecutionPlanExampleOneThird(t *testing.T) {
 		{TimeOffset: 15 * time.Second, PlannedVUs: 0},
 		{TimeOffset: 16 * time.Second, PlannedVUs: 1},
 		{TimeOffset: 20 * time.Second, PlannedVUs: 0},
+		{TimeOffset: 23 * time.Second, PlannedVUs: 0},
 	}
 	expRawStepsZeroEnd := expRawStepsNoZeroEnd // no need to copy
-	expRawStepsZeroEnd = append(expRawStepsZeroEnd, lib.ExecutionStep{TimeOffset: 23 * time.Second, PlannedVUs: 0})
 	rawStepsNoZeroEnd := conf.getRawExecutionSteps(et, false)
 	assert.Equal(t, expRawStepsNoZeroEnd, rawStepsNoZeroEnd)
 	endOffset, isFinal := lib.GetEndOffset(rawStepsNoZeroEnd)
-	assert.Equal(t, 20*time.Second, endOffset)
+	assert.Equal(t, 23*time.Second, endOffset)
 	assert.Equal(t, true, isFinal)
 
 	rawStepsZeroEnd := conf.getRawExecutionSteps(et, true)
@@ -580,7 +581,7 @@ func TestRampingVUsConfigExecutionPlanExampleOneThird(t *testing.T) {
 		{TimeOffset: 1 * time.Second, PlannedVUs: 2},
 		{TimeOffset: 42 * time.Second, PlannedVUs: 1},
 		{TimeOffset: 50 * time.Second, PlannedVUs: 0},
-		{TimeOffset: 53 * time.Second, PlannedVUs: 0},
+		{TimeOffset: 80 * time.Second, PlannedVUs: 0},
 	}, conf.GetExecutionRequirements(et))
 
 	// Try a longer GracefulStop than the GracefulRampDown
@@ -590,7 +591,7 @@ func TestRampingVUsConfigExecutionPlanExampleOneThird(t *testing.T) {
 		{TimeOffset: 1 * time.Second, PlannedVUs: 2},
 		{TimeOffset: 42 * time.Second, PlannedVUs: 1},
 		{TimeOffset: 50 * time.Second, PlannedVUs: 0},
-		{TimeOffset: 103 * time.Second, PlannedVUs: 0},
+		{TimeOffset: 130 * time.Second, PlannedVUs: 0},
 	}, conf.GetExecutionRequirements(et))
 
 	// Try a much shorter GracefulStop than the GracefulRampDown
@@ -611,7 +612,7 @@ func TestRampingVUsConfigExecutionPlanExampleOneThird(t *testing.T) {
 
 	// Try a zero GracefulStop and GracefulRampDown, i.e. raw steps with 0 end cap
 	conf.GracefulRampDown = types.NullDurationFrom(0 * time.Second)
-	assert.Equal(t, rawStepsZeroEnd, conf.GetExecutionRequirements(et))
+	assert.Equal(t, expRawStepsZeroEnd, conf.GetExecutionRequirements(et))
 }
 
 func TestRampingVUsConfigExecutionPlanZerosAtEnd(t *testing.T) {
@@ -637,13 +638,13 @@ func TestRampingVUsConfigExecutionPlanZerosAtEnd(t *testing.T) {
 		{TimeOffset: 7 * time.Second, PlannedVUs: 2},
 		{TimeOffset: 8 * time.Second, PlannedVUs: 1},
 		{TimeOffset: 9 * time.Second, PlannedVUs: 0},
+		{TimeOffset: 14 * time.Second, PlannedVUs: 0},
 	}
 	expRawStepsZeroEnd := expRawStepsNoZeroEnd // no need to copy
-	expRawStepsZeroEnd = append(expRawStepsZeroEnd, lib.ExecutionStep{TimeOffset: 14 * time.Second, PlannedVUs: 0})
 	rawStepsNoZeroEnd := conf.getRawExecutionSteps(et, false)
 	assert.Equal(t, expRawStepsNoZeroEnd, rawStepsNoZeroEnd)
 	endOffset, isFinal := lib.GetEndOffset(rawStepsNoZeroEnd)
-	assert.Equal(t, 9*time.Second, endOffset)
+	assert.Equal(t, 14*time.Second, endOffset)
 	assert.Equal(t, true, isFinal)
 
 	rawStepsZeroEnd := conf.getRawExecutionSteps(et, true)

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -581,7 +581,6 @@ func TestRampingVUsConfigExecutionPlanExampleOneThird(t *testing.T) {
 		{TimeOffset: 1 * time.Second, PlannedVUs: 2},
 		{TimeOffset: 42 * time.Second, PlannedVUs: 1},
 		{TimeOffset: 50 * time.Second, PlannedVUs: 0},
-		{TimeOffset: 80 * time.Second, PlannedVUs: 0},
 	}, conf.GetExecutionRequirements(et))
 
 	// Try a longer GracefulStop than the GracefulRampDown
@@ -591,7 +590,6 @@ func TestRampingVUsConfigExecutionPlanExampleOneThird(t *testing.T) {
 		{TimeOffset: 1 * time.Second, PlannedVUs: 2},
 		{TimeOffset: 42 * time.Second, PlannedVUs: 1},
 		{TimeOffset: 50 * time.Second, PlannedVUs: 0},
-		{TimeOffset: 130 * time.Second, PlannedVUs: 0},
 	}, conf.GetExecutionRequirements(et))
 
 	// Try a much shorter GracefulStop than the GracefulRampDown

--- a/lib/executors.go
+++ b/lib/executors.go
@@ -303,7 +303,8 @@ func (scs ScenarioConfigs) GetFullExecutionRequirements(et *ExecutionTuple) []Ex
 		stepsLen := len(consolidatedSteps)
 		if stepsLen == 0 ||
 			consolidatedSteps[stepsLen-1].PlannedVUs != newPlannedVUs ||
-			consolidatedSteps[stepsLen-1].MaxUnplannedVUs != newMaxUnplannedVUs {
+			consolidatedSteps[stepsLen-1].MaxUnplannedVUs != newMaxUnplannedVUs ||
+			consolidatedSteps[stepsLen-1].TimeOffset != currentTimeOffset {
 			consolidatedSteps = append(consolidatedSteps, ExecutionStep{
 				TimeOffset:      currentTimeOffset,
 				PlannedVUs:      newPlannedVUs,


### PR DESCRIPTION
In b725f03b we fixed the calculation of the stages, unfortunately we
didn't notice that the max duration for the test was wrongly calculated.

This also tries to fix cases where graceful* will extend the test more
then needed. Previously the code did not take into account that multiple
0 VUs stages can mean that the VUs are long ago stopped before
gracefulStop (for example) needs to be taken into account.

