### PR TITLE
Fix contributing docs test command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ make ci-like-lint
 To exercise the entire test suite, please run the following command
 
 ```bash
-make test
+make tests
 ```
 
 #### Dependencies


### PR DESCRIPTION
This fixes that the `CONTRIBUTING.md` docs specify the command to run tests as `make test` while defined as `tests` in the makefile.
