### PR TITLE
Panic on RegisterCallback result being used more than once

### DIFF
--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -61,11 +61,17 @@ func (e *EventLoop) wakeup() {
 // This function *must* be called from within running on the event loop, but its result can be called from anywhere.
 func (e *EventLoop) RegisterCallback() func(func() error) {
 	e.lock.Lock()
+	var callbackCalled bool
 	e.registeredCallbacks++
 	e.lock.Unlock()
 
 	return func(f func() error) {
 		e.lock.Lock()
+		if callbackCalled { // this is protected by the lock on the event loop
+			e.lock.Unlock() // let not lock up the whole event loop, somebody could recover from the panic
+			panic("RegisterCallback called twice")
+		}
+		callbackCalled = true
 		e.queue = append(e.queue, f)
 		e.registeredCallbacks--
 		e.lock.Unlock()


### PR DESCRIPTION
This should help with actually finding problems with code using it.

I have already seen multiple times code which seems okay but in fact
will call the returned callback twice. This effectively will lead either
to deadlock of the eventloop or earlier exit from a loop.

Given that it's never actually correct to that, panic seems okay.

We also make certain that if the user recovers from the panic we will
not have locked the eventloop either way,

In the future better APIs for most use cases should probably reduce the
need for people to use RegisterCallback and consequently worrying about
this.

