### PR TITLE
Add a deprecation warning for thresholds on tags we'll make non-indexable

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -282,6 +282,42 @@ func TestSSLKEYLOGFILE(t *testing.T) {
 	require.Regexp(t, "^CLIENT_[A-Z_]+ [0-9a-f]+ [0-9a-f]+\n", string(sslloglines))
 }
 
+func TestThresholdDeprecationWarnings(t *testing.T) {
+	t.Parallel()
+
+	// TODO: adjust this test after we actually make url, error, iter and vu non-indexable
+
+	ts := newGlobalTestState(t)
+	ts.args = []string{"k6", "run", "--system-tags", "url,error,vu,iter", "-"}
+	ts.stdIn = bytes.NewReader([]byte(`
+		export const options = {
+			thresholds: {
+				'http_req_duration{url:https://test.k6.io}': ['p(95)<500', 'p(99)<1000'],
+				'http_req_duration{error:foo}': ['p(99)<1000'],
+				'iterations{vu:1,iter:0}': ['count == 1'],
+			},
+		};
+
+		export default function () { }`,
+	))
+
+	newRootCommand(ts.globalState).execute()
+
+	logs := ts.loggerHook.Drain()
+	assert.True(t, testutils.LogContains(logs, logrus.WarnLevel,
+		"Thresholds like 'http_req_duration{url:https://test.k6.io}', based on the high-cardinality 'url' metric tag, are deprecated",
+	))
+	assert.True(t, testutils.LogContains(logs, logrus.WarnLevel,
+		"Thresholds like 'http_req_duration{error:foo}', based on the high-cardinality 'error' metric tag, are deprecated",
+	))
+	assert.True(t, testutils.LogContains(logs, logrus.WarnLevel,
+		"Thresholds like 'iterations{vu:1,iter:0}', based on the high-cardinality 'vu' metric tag, are deprecated",
+	))
+	assert.True(t, testutils.LogContains(logs, logrus.WarnLevel,
+		"Thresholds like 'iterations{vu:1,iter:0}', based on the high-cardinality 'iter' metric tag, are deprecated",
+	))
+}
+
 // TODO: add a hell of a lot more integration tests, including some that spin up
 // a test HTTP server and actually check if k6 hits it
 

--- a/metrics/engine/engine.go
+++ b/metrics/engine/engine.go
@@ -90,6 +90,41 @@ func (me *MetricsEngine) getThresholdMetricOrSubmetric(name string) (*metrics.Me
 	if err != nil {
 		return nil, err
 	}
+
+	if sm.Metric.Observed {
+		// Do not repeat warnings for the same sub-metrics
+		return sm.Metric, nil
+	}
+
+	// TODO: reword these from "will be deprecated" to "were deprecated" and
+	// maybe make them errors, not warnings, when we introduce un-indexable tags
+
+	if _, ok := sm.Tags.Get("url"); ok {
+		me.logger.Warnf("Thresholds like '%s', based on the high-cardinality 'url' metric tag, "+
+			"are deprecated and will not be supported in future k6 releases. "+
+			"To prevent breaking changes and reduce bugs, use the 'name' metric tag instead, see"+
+			"URL grouping (https://k6.io/docs/using-k6/http-requests/#url-grouping) for more information.", name,
+		)
+	}
+
+	if _, ok := sm.Tags.Get("error"); ok {
+		me.logger.Warnf("Thresholds like '%s', based on the high-cardinality 'error' metric tag, "+
+			"are deprecated and will not be supported in future k6 releases. "+
+			"To prevent breaking changes and reduce bugs, use the 'error_code' metric tag instead", name,
+		)
+	}
+	if _, ok := sm.Tags.Get("vu"); ok {
+		me.logger.Warnf("Thresholds like '%s', based on the high-cardinality 'vu' metric tag, "+
+			"are deprecated and will not be supported in future k6 releases.", name,
+		)
+	}
+
+	if _, ok := sm.Tags.Get("iter"); ok {
+		me.logger.Warnf("Thresholds like '%s', based on the high-cardinality 'iter' metric tag, "+
+			"are deprecated and will not be supported in future k6 releases.", name,
+		)
+	}
+
 	return sm.Metric, nil
 }
 


### PR DESCRIPTION
This is connected to the future deprecations that are described at the end of the release notes (https://github.com/grafana/k6/pull/2581/files). The earlier we mention them, the better.