### PR TITLE
#1289: Error will be displayed that only 1 array is allowed in batch

### DIFF
--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -456,9 +456,6 @@ func (c *Client) Batch(reqsValues ...goja.Value) (interface{}, error) {
 		results   interface{} // either []*Response or map[string]*Response
 	)
 
-	if reqsV == nil {
-		return nil, errors.New("no argument was provided to http.batch()")
-	}
 	switch v := reqsV.Export().(type) {
 	case []interface{}:
 		batchReqs, results, err = c.prepareBatchArray(v)

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -438,18 +438,18 @@ func (c *Client) prepareBatchObject(requests map[string]interface{}) (
 // Batch makes multiple simultaneous HTTP requests. The provideds reqsV should be an array of request
 // objects. Batch returns an array of responses and/or error
 func (c *Client) Batch(reqsValues ...goja.Value) (interface{}, error) {
-	if len(reqsValues) == 0 {
-		return nil, fmt.Errorf("no argument was provided to http.batch()")
-	} else if len(reqsValues) > 1 {
-		return nil, fmt.Errorf("http.batch() must have only one single array as an argument")
-	}
-
-	reqsV := reqsValues[0]
 	state := c.moduleInstance.vu.State()
 	if state == nil {
 		return nil, ErrBatchForbiddenInInitContext
 	}
 
+	if len(reqsValues) == 0 {
+		return nil, fmt.Errorf("no argument was provided to http.batch()")
+	} else if len(reqsValues) > 1 { // Validation for http.batch(["https://validurl"],["https://validurl"])
+		return nil, fmt.Errorf("http.batch() must have only one single array as an argument")
+	}
+
+	reqsV := reqsValues[0]
 	var (
 		err       error
 		batchReqs []httpext.BatchParsedHTTPRequest

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -437,7 +437,14 @@ func (c *Client) prepareBatchObject(requests map[string]interface{}) (
 
 // Batch makes multiple simultaneous HTTP requests. The provideds reqsV should be an array of request
 // objects. Batch returns an array of responses and/or error
-func (c *Client) Batch(reqsV goja.Value) (interface{}, error) {
+func (c *Client) Batch(reqsValues ...goja.Value) (interface{}, error) {
+	if len(reqsValues) == 0 {
+		return nil, fmt.Errorf("no argument was provided to http.batch()")
+	} else if len(reqsValues) > 1 {
+		return nil, fmt.Errorf("http.batch() must have only one single array as an argument")
+	}
+
+	reqsV := reqsValues[0]
 	state := c.moduleInstance.vu.State()
 	if state == nil {
 		return nil, ErrBatchForbiddenInInitContext

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -453,7 +453,7 @@ func (c *Client) Batch(reqsV ...goja.Value) (interface{}, error) {
 		batchReqs []httpext.BatchParsedHTTPRequest
 		results   interface{} // either []*Response or map[string]*Response
 	)
-	
+
 	switch v := reqsV[0].Export().(type) {
 	case []interface{}:
 		batchReqs, results, err = c.prepareBatchArray(v)

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -446,7 +446,7 @@ func (c *Client) Batch(reqsValues ...goja.Value) (interface{}, error) {
 	if len(reqsValues) == 0 {
 		return nil, fmt.Errorf("no argument was provided to http.batch()")
 	} else if len(reqsValues) > 1 {
-		return nil, fmt.Errorf("http.batch() accepts only an array or an object of requests.")
+		return nil, fmt.Errorf("http.batch() accepts only an array or an object of requests")
 	}
 
 	reqsV := reqsValues[0]

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -437,26 +437,24 @@ func (c *Client) prepareBatchObject(requests map[string]interface{}) (
 
 // Batch makes multiple simultaneous HTTP requests. The provideds reqsV should be an array of request
 // objects. Batch returns an array of responses and/or error
-func (c *Client) Batch(reqsValues ...goja.Value) (interface{}, error) {
+func (c *Client) Batch(reqsV ...goja.Value) (interface{}, error) {
 	state := c.moduleInstance.vu.State()
 	if state == nil {
 		return nil, ErrBatchForbiddenInInitContext
 	}
 
-	if len(reqsValues) == 0 {
+	if len(reqsV) == 0 {
 		return nil, fmt.Errorf("no argument was provided to http.batch()")
-	} else if len(reqsValues) > 1 {
+	} else if len(reqsV) > 1 {
 		return nil, fmt.Errorf("http.batch() accepts only an array or an object of requests")
 	}
-
-	reqsV := reqsValues[0]
 	var (
 		err       error
 		batchReqs []httpext.BatchParsedHTTPRequest
 		results   interface{} // either []*Response or map[string]*Response
 	)
-
-	switch v := reqsV.Export().(type) {
+	
+	switch v := reqsV[0].Export().(type) {
 	case []interface{}:
 		batchReqs, results, err = c.prepareBatchArray(v)
 	case map[string]interface{}:

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -445,8 +445,8 @@ func (c *Client) Batch(reqsValues ...goja.Value) (interface{}, error) {
 
 	if len(reqsValues) == 0 {
 		return nil, fmt.Errorf("no argument was provided to http.batch()")
-	} else if len(reqsValues) > 1 { // Validation for http.batch(["https://validurl"],["https://validurl"])
-		return nil, fmt.Errorf("http.batch() must have only one single array as an argument")
+	} else if len(reqsValues) > 1 {
+		return nil, fmt.Errorf("http.batch() accepts only an array or an object of requests.")
 	}
 
 	reqsV := reqsValues[0]

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1308,7 +1308,7 @@ func TestRequestAndBatch(t *testing.T) {
 				},
 				{
 					name: "multiple arguments", code: `["GET", "https://test.k6.io"],["GET", "https://test.k6.io"]`,
-					expErr: `http.batch() accepts only an array or an object of requests.`, throw: true,
+					expErr: `http.batch() accepts only an array or an object of requests`, throw: true,
 				},
 			}
 

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1307,8 +1307,8 @@ func TestRequestAndBatch(t *testing.T) {
 					expErr: `batch request 0 doesn't have a url key`, throw: true,
 				},
 				{
-					name: "multiple array as an argument", code: `["GET", "https://test.k6.io"],["GET", "https://test.k6.io"]`,
-					expErr: `http.batch() must have only one single array as an argument`, throw: true,
+					name: "multiple arguments", code: `["GET", "https://test.k6.io"],["GET", "https://test.k6.io"]`,
+					expErr: `http.batch() accepts only an array or an object of requests.`, throw: true,
 				},
 			}
 

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1306,10 +1306,6 @@ func TestRequestAndBatch(t *testing.T) {
 					name: "object no url key", code: `[ {method: "GET"} ]`,
 					expErr: `batch request 0 doesn't have a url key`, throw: true,
 				},
-				{
-					name: "multiple array as an argument", code: `["GET", "https://test.k6.io"],["GET", "https://test.k6.io"]`,
-					expErr: `http.batch() must have only one single array as an argument`, throw: true,
-				},
 			}
 
 			for _, tc := range testCases {

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1306,6 +1306,10 @@ func TestRequestAndBatch(t *testing.T) {
 					name: "object no url key", code: `[ {method: "GET"} ]`,
 					expErr: `batch request 0 doesn't have a url key`, throw: true,
 				},
+				{
+					name: "multiple array as an argument", code: `["GET", "https://test.k6.io"],["GET", "https://test.k6.io"]`,
+					expErr: `http.batch() must have only one single array as an argument`, throw: true,
+				},
 			}
 
 			for _, tc := range testCases {


### PR DESCRIPTION
Updated Batch method to contain array of goja.Value and if the size is greater than 1 then return and error. Else continue with the data. 