### PR TITLE
output/json: Metric data race

### DIFF
--- a/output/json/json.go
+++ b/output/json/json.go
@@ -183,13 +183,6 @@ func (o *Output) handleMetric(m *metrics.Metric, jw *jwriter.Writer) {
 		wrapped.Data.Thresholds = ts
 	}
 
-	// TODO: refactor after the other refactors
-	// in the metrics area will be completed.
-	//
-	// This parts can be racy because
-	// they are controlled and written from the metrics.Engine.
-	wrapped.Data.Tainted = m.Tainted
-
 	wrapped.MarshalEasyJSON(jw)
 	jw.RawByte('\n')
 }

--- a/output/json/json_easyjson.go
+++ b/output/json/json_easyjson.go
@@ -8,6 +8,7 @@ import (
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
 	metrics "go.k6.io/k6/metrics"
+	null_v3 "gopkg.in/guregu/null.v3"
 	time "time"
 )
 
@@ -187,15 +188,7 @@ func easyjson42239ddeDecodeGoK6IoK6OutputJson1(in *jlexer.Lexer, out *metricEnve
 		case "type":
 			out.Type = string(in.String())
 		case "data":
-			if in.IsNull() {
-				in.Skip()
-				out.Data = nil
-			} else {
-				if out.Data == nil {
-					out.Data = new(metrics.Metric)
-				}
-				easyjson42239ddeDecodeGoK6IoK6Metrics(in, out.Data)
-			}
+			easyjson42239ddeDecode1(in, &out.Data)
 		case "metric":
 			out.Metric = string(in.String())
 		default:
@@ -220,11 +213,7 @@ func easyjson42239ddeEncodeGoK6IoK6OutputJson1(out *jwriter.Writer, in metricEnv
 	{
 		const prefix string = ",\"data\":"
 		out.RawString(prefix)
-		if in.Data == nil {
-			out.RawString("null")
-		} else {
-			easyjson42239ddeEncodeGoK6IoK6Metrics(out, *in.Data)
-		}
+		easyjson42239ddeEncode1(out, in.Data)
 	}
 	{
 		const prefix string = ",\"metric\":"
@@ -243,7 +232,14 @@ func (v metricEnvelope) MarshalEasyJSON(w *jwriter.Writer) {
 func (v *metricEnvelope) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson42239ddeDecodeGoK6IoK6OutputJson1(l, v)
 }
-func easyjson42239ddeDecodeGoK6IoK6Metrics(in *jlexer.Lexer, out *metrics.Metric) {
+func easyjson42239ddeDecode1(in *jlexer.Lexer, out *struct {
+	Name       string               `json:"name"`
+	Type       metrics.MetricType   `json:"type"`
+	Contains   metrics.ValueType    `json:"contains"`
+	Tainted    null_v3.Bool         `json:"tainted"`
+	Thresholds metrics.Thresholds   `json:"thresholds"`
+	Submetrics []*metrics.Submetric `json:"submetrics"`
+}) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -304,7 +300,7 @@ func easyjson42239ddeDecodeGoK6IoK6Metrics(in *jlexer.Lexer, out *metrics.Metric
 						if v1 == nil {
 							v1 = new(metrics.Submetric)
 						}
-						easyjson42239ddeDecodeGoK6IoK6Metrics1(in, v1)
+						easyjson42239ddeDecodeGoK6IoK6Metrics(in, v1)
 					}
 					out.Submetrics = append(out.Submetrics, v1)
 					in.WantComma()
@@ -321,7 +317,14 @@ func easyjson42239ddeDecodeGoK6IoK6Metrics(in *jlexer.Lexer, out *metrics.Metric
 		in.Consumed()
 	}
 }
-func easyjson42239ddeEncodeGoK6IoK6Metrics(out *jwriter.Writer, in metrics.Metric) {
+func easyjson42239ddeEncode1(out *jwriter.Writer, in struct {
+	Name       string               `json:"name"`
+	Type       metrics.MetricType   `json:"type"`
+	Contains   metrics.ValueType    `json:"contains"`
+	Tainted    null_v3.Bool         `json:"tainted"`
+	Thresholds metrics.Thresholds   `json:"thresholds"`
+	Submetrics []*metrics.Submetric `json:"submetrics"`
+}) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -364,7 +367,7 @@ func easyjson42239ddeEncodeGoK6IoK6Metrics(out *jwriter.Writer, in metrics.Metri
 				if v3 == nil {
 					out.RawString("null")
 				} else {
-					easyjson42239ddeEncodeGoK6IoK6Metrics1(out, *v3)
+					easyjson42239ddeEncodeGoK6IoK6Metrics(out, *v3)
 				}
 			}
 			out.RawByte(']')
@@ -372,7 +375,7 @@ func easyjson42239ddeEncodeGoK6IoK6Metrics(out *jwriter.Writer, in metrics.Metri
 	}
 	out.RawByte('}')
 }
-func easyjson42239ddeDecodeGoK6IoK6Metrics1(in *jlexer.Lexer, out *metrics.Submetric) {
+func easyjson42239ddeDecodeGoK6IoK6Metrics(in *jlexer.Lexer, out *metrics.Submetric) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -417,7 +420,7 @@ func easyjson42239ddeDecodeGoK6IoK6Metrics1(in *jlexer.Lexer, out *metrics.Subme
 		in.Consumed()
 	}
 }
-func easyjson42239ddeEncodeGoK6IoK6Metrics1(out *jwriter.Writer, in metrics.Submetric) {
+func easyjson42239ddeEncodeGoK6IoK6Metrics(out *jwriter.Writer, in metrics.Submetric) {
 	out.RawByte('{')
 	first := true
 	_ = first

--- a/output/json/json_easyjson.go
+++ b/output/json/json_easyjson.go
@@ -8,7 +8,6 @@ import (
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
 	metrics "go.k6.io/k6/metrics"
-	null_v3 "gopkg.in/guregu/null.v3"
 	time "time"
 )
 
@@ -236,7 +235,6 @@ func easyjson42239ddeDecode1(in *jlexer.Lexer, out *struct {
 	Name       string               `json:"name"`
 	Type       metrics.MetricType   `json:"type"`
 	Contains   metrics.ValueType    `json:"contains"`
-	Tainted    null_v3.Bool         `json:"tainted"`
 	Thresholds metrics.Thresholds   `json:"thresholds"`
 	Submetrics []*metrics.Submetric `json:"submetrics"`
 }) {
@@ -267,10 +265,6 @@ func easyjson42239ddeDecode1(in *jlexer.Lexer, out *struct {
 		case "contains":
 			if data := in.UnsafeBytes(); in.Ok() {
 				in.AddError((out.Contains).UnmarshalText(data))
-			}
-		case "tainted":
-			if data := in.Raw(); in.Ok() {
-				in.AddError((out.Tainted).UnmarshalJSON(data))
 			}
 		case "thresholds":
 			if data := in.Raw(); in.Ok() {
@@ -321,7 +315,6 @@ func easyjson42239ddeEncode1(out *jwriter.Writer, in struct {
 	Name       string               `json:"name"`
 	Type       metrics.MetricType   `json:"type"`
 	Contains   metrics.ValueType    `json:"contains"`
-	Tainted    null_v3.Bool         `json:"tainted"`
 	Thresholds metrics.Thresholds   `json:"thresholds"`
 	Submetrics []*metrics.Submetric `json:"submetrics"`
 }) {
@@ -342,11 +335,6 @@ func easyjson42239ddeEncode1(out *jwriter.Writer, in struct {
 		const prefix string = ",\"contains\":"
 		out.RawString(prefix)
 		out.Raw((in.Contains).MarshalJSON())
-	}
-	{
-		const prefix string = ",\"tainted\":"
-		out.RawString(prefix)
-		out.Raw((in.Tainted).MarshalJSON())
 	}
 	{
 		const prefix string = ",\"thresholds\":"

--- a/output/json/json_test.go
+++ b/output/json/json_test.go
@@ -82,10 +82,10 @@ func generateTestMetricSamples(t testing.TB) ([]metrics.SampleContainer, func(io
 		metrics.Sample{Time: time3, Metric: metric2, Value: float64(5), Tags: metrics.NewSampleTags(map[string]string{"tag3": "val3"})},
 	}
 	expected := []string{
-		`{"type":"Metric","data":{"name":"my_metric1","type":"gauge","contains":"default","tainted":null,"thresholds":["rate<0.01","p(99)<250"],"submetrics":[{"name":"my_metric1{a:1,b:2}","suffix":"a:1,b:2","tags":{"a":"1","b":"2"}}]},"metric":"my_metric1"}`,
+		`{"type":"Metric","data":{"name":"my_metric1","type":"gauge","contains":"default","thresholds":["rate<0.01","p(99)<250"],"submetrics":[{"name":"my_metric1{a:1,b:2}","suffix":"a:1,b:2","tags":{"a":"1","b":"2"}}]},"metric":"my_metric1"}`,
 		`{"type":"Point","data":{"time":"2021-02-24T13:37:10Z","value":1,"tags":{"tag1":"val1"}},"metric":"my_metric1"}`,
 		`{"type":"Point","data":{"time":"2021-02-24T13:37:10Z","value":2,"tags":{"tag2":"val2"}},"metric":"my_metric1"}`,
-		`{"type":"Metric","data":{"name":"my_metric2","type":"counter","contains":"data","tainted":null,"thresholds":[],"submetrics":null},"metric":"my_metric2"}`,
+		`{"type":"Metric","data":{"name":"my_metric2","type":"counter","contains":"data","thresholds":[],"submetrics":null},"metric":"my_metric2"}`,
 		`{"type":"Point","data":{"time":"2021-02-24T13:37:20Z","value":3,"tags":{"key":"val"}},"metric":"my_metric2"}`,
 		`{"type":"Point","data":{"time":"2021-02-24T13:37:20Z","value":4,"tags":{"key":"val"}},"metric":"my_metric1"}`,
 		`{"type":"Point","data":{"time":"2021-02-24T13:37:30Z","value":5,"tags":{"tag3":"val3"}},"metric":"my_metric2"}`,

--- a/output/json/wrapper.go
+++ b/output/json/wrapper.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"go.k6.io/k6/metrics"
+	"gopkg.in/guregu/null.v3"
 )
 
 //go:generate easyjson -pkg -no_std_marshalers -gen_build_flags -mod=mod .
@@ -32,8 +33,8 @@ import (
 type sampleEnvelope struct {
 	Type string `json:"type"`
 	Data struct {
-		Time  time.Time         `json:"time"`
-		Value float64           `json:"value"`
+		Time  time.Time           `json:"time"`
+		Value float64             `json:"value"`
 		Tags  *metrics.SampleTags `json:"tags"`
 	} `json:"data"`
 	Metric string `json:"metric"`
@@ -54,15 +55,14 @@ func wrapSample(sample metrics.Sample) sampleEnvelope {
 
 //easyjson:json
 type metricEnvelope struct {
-	Type   string        `json:"type"`
-	Data   *metrics.Metric `json:"data"`
-	Metric string        `json:"metric"`
-}
-
-func wrapMetric(metric *metrics.Metric) metricEnvelope {
-	return metricEnvelope{
-		Type:   "Metric",
-		Metric: metric.Name,
-		Data:   metric,
-	}
+	Type string `json:"type"`
+	Data struct {
+		Name       string               `json:"name"`
+		Type       metrics.MetricType   `json:"type"`
+		Contains   metrics.ValueType    `json:"contains"`
+		Tainted    null.Bool            `json:"tainted"`
+		Thresholds metrics.Thresholds   `json:"thresholds"`
+		Submetrics []*metrics.Submetric `json:"submetrics"`
+	} `json:"data"`
+	Metric string `json:"metric"`
 }

--- a/output/json/wrapper.go
+++ b/output/json/wrapper.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"go.k6.io/k6/metrics"
-	"gopkg.in/guregu/null.v3"
 )
 
 //go:generate easyjson -pkg -no_std_marshalers -gen_build_flags -mod=mod .
@@ -60,7 +59,6 @@ type metricEnvelope struct {
 		Name       string               `json:"name"`
 		Type       metrics.MetricType   `json:"type"`
 		Contains   metrics.ValueType    `json:"contains"`
-		Tainted    null.Bool            `json:"tainted"`
 		Thresholds metrics.Thresholds   `json:"thresholds"`
 		Submetrics []*metrics.Submetric `json:"submetrics"`
 	} `json:"data"`

--- a/samples/thresholds.js
+++ b/samples/thresholds.js
@@ -21,7 +21,7 @@ export let options = {
         // Declare a threshold over HTTP response times for all data points
         // where the URL tag is equal to "http://httpbin.org/post",
         // the max should not cross 1000ms
-        "http_req_duration{url:http://httpbin.org/post}": ["max<1000"],
+        "http_req_duration{name:http://httpbin.org/post}": ["max<1000"],
     }
 };
 


### PR DESCRIPTION
:warning: [**Breaking Change**] The `tainted` field has been removed from the flushed fields for a metric type.

The previous implementation [makes a copy](https://github.com/grafana/k6/blob/bfa415c5fdfa6084f49b02877540cf6c05e23605/output/json/json_easyjson.go#L226) of the Metric struct where it generates a data race on the Observed field that [is written](https://github.com/grafana/k6/blob/bfa415c5fdfa6084f49b02877540cf6c05e23605/metrics/engine/engine.go#L133)
from the metrics.Engine.

The current implementation reduces the fields copied resolving the simplest race on Observed. The Observed field is not useful for the JSON output.

`metrics.Thresholds` shouldn't be racy because the output [mostly read "immutable"](https://github.com/grafana/k6/blob/bfa415c5fdfa6084f49b02877540cf6c05e23605/metrics/thresholds.go#L126-L133) values.

The performance seems not impacted, it is aligned with the results from https://github.com/grafana/k6/commit/a5146cf7099cfc5b4ec8938c667c507ce373aff9.

```
BenchmarkFlushMetrics-8   	      61	  16767247 ns/op	 2526610 B/op	   20067 allocs/op
```

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
