### PR TITLE
Strict nolint format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,6 +29,9 @@ issues:
      text: "does not use range value in test Run"
 
 linters-settings:
+  nolintlint:
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    allow-leading-space: false
   exhaustive:
     default-signifies-exhaustive: true
   govet:

--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -31,7 +31,7 @@ import (
 )
 
 // Config holds all the necessary data and options for sending metrics to the Load Impact cloud.
-//nolint: lll
+//nolint:lll
 type Config struct {
 	// TODO: refactor common stuff between cloud execution and output
 	Token     null.String `json:"token" envconfig:"K6_CLOUD_TOKEN"`

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -82,7 +82,7 @@ func (c *cmdCloud) preRun(cmd *cobra.Command, args []string) error {
 }
 
 // TODO: split apart some more
-//nolint: funlen,gocognit,cyclop
+//nolint:funlen,gocognit,cyclop
 func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	printBanner(c.gs)
 

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -82,7 +82,7 @@ func (c *cmdCloud) preRun(cmd *cobra.Command, args []string) error {
 }
 
 // TODO: split apart some more
-// nolint: funlen,gocognit,cyclop
+//nolint: funlen,gocognit,cyclop
 func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	printBanner(c.gs)
 

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -104,7 +104,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 						},
 					},
 				}
-				if !term.IsTerminal(int(syscall.Stdin)) { // nolint: unconvert
+				if !term.IsTerminal(int(syscall.Stdin)) { //nolint: unconvert
 					globalState.logger.Warn("Stdin is not a terminal, falling back to plain text input")
 				}
 				var vals map[string]string

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -104,7 +104,7 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 						},
 					},
 				}
-				if !term.IsTerminal(int(syscall.Stdin)) { //nolint: unconvert
+				if !term.IsTerminal(int(syscall.Stdin)) { //nolint:unconvert
 					globalState.logger.Warn("Stdin is not a terminal, falling back to plain text input")
 				}
 				var vals map[string]string

--- a/cmd/login_influxdb.go
+++ b/cmd/login_influxdb.go
@@ -89,7 +89,7 @@ This will set the default server used when just "-o influxdb" is passed.`,
 					},
 				},
 			}
-			if !term.IsTerminal(int(syscall.Stdin)) { //nolint: unconvert
+			if !term.IsTerminal(int(syscall.Stdin)) { //nolint:unconvert
 				globalState.logger.Warn("Stdin is not a terminal, falling back to plain text input")
 			}
 			vals, err := form.Run(globalState.stdIn, globalState.stdOut)

--- a/cmd/login_influxdb.go
+++ b/cmd/login_influxdb.go
@@ -89,7 +89,7 @@ This will set the default server used when just "-o influxdb" is passed.`,
 					},
 				},
 			}
-			if !term.IsTerminal(int(syscall.Stdin)) { // nolint: unconvert
+			if !term.IsTerminal(int(syscall.Stdin)) { //nolint: unconvert
 				globalState.logger.Warn("Stdin is not a terminal, falling back to plain text input")
 			}
 			vals, err := form.Run(globalState.stdIn, globalState.stdOut)

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -198,7 +198,7 @@ func printExecutionDescription(
 	}
 }
 
-//nolint: funlen
+//nolint:funlen
 func renderMultipleBars(
 	nocolor, isTTY, goBack bool, maxLeft, termWidth, widthDelta int, pbs []*pb.ProgressBar,
 ) (string, int) {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -291,7 +291,7 @@ func renderMultipleBars(
 // TODO: show other information here?
 // TODO: add a no-progress option that will disable these
 // TODO: don't use global variables...
-// nolint:funlen,gocognit
+//nolint:funlen,gocognit
 func showProgress(ctx context.Context, gs *globalState, pbs []*pb.ProgressBar, logger *logrus.Logger) {
 	if gs.flags.quiet {
 		return

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -254,7 +254,7 @@ func TestEngineOutput(t *testing.T) {
 	}
 	metric := test.engine.MetricsEngine.ObservedMetrics["test_metric"]
 	if assert.NotNil(t, metric) {
-		sink := metric.Sink.(*metrics.TrendSink) //nolint: forcetypeassert
+		sink := metric.Sink.(*metrics.TrendSink) //nolint:forcetypeassert
 		if assert.NotNil(t, sink) {
 			numOutputSamples := len(cSamples)
 			numEngineSamples := len(sink.Values)
@@ -1153,7 +1153,6 @@ func TestMetricsEmission(t *testing.T) {
 	}
 }
 
-//nolint: funlen
 func TestMinIterationDurationInSetupTeardownStage(t *testing.T) {
 	t.Parallel()
 	setupScript := `

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -254,7 +254,7 @@ func TestEngineOutput(t *testing.T) {
 	}
 	metric := test.engine.MetricsEngine.ObservedMetrics["test_metric"]
 	if assert.NotNil(t, metric) {
-		sink := metric.Sink.(*metrics.TrendSink) // nolint: forcetypeassert
+		sink := metric.Sink.(*metrics.TrendSink) //nolint: forcetypeassert
 		if assert.NotNil(t, sink) {
 			numOutputSamples := len(cSamples)
 			numEngineSamples := len(sink.Values)

--- a/errext/exitcodes/codes.go
+++ b/errext/exitcodes/codes.go
@@ -19,7 +19,7 @@
  */
 
 // Package exitcodes contains the constants representing possible k6 exit error codes.
-//nolint: golint
+//nolint:golint
 package exitcodes
 
 // ExitCode is just a type representing a process exit code for k6

--- a/js/common/bridge.go
+++ b/js/common/bridge.go
@@ -9,7 +9,7 @@ import (
 
 // if a fieldName is the key of this map exactly than the value for the given key should be used as
 // the name of the field in js
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var fieldNameExceptions = map[string]string{
 	"OCSP": "ocsp",
 }
@@ -41,7 +41,7 @@ func FieldName(t reflect.Type, f reflect.StructField) string {
 
 // if a methodName is the key of this map exactly than the value for the given key should be used as
 // the name of the method in js
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var methodNameExceptions = map[string]string{
 	"JSON": "json",
 	"HTML": "html",

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -88,11 +88,11 @@ var (
 	maxSrcLenForBabelSourceMap     = 250 * 1024 //nolint:gochecknoglobals
 	maxSrcLenForBabelSourceMapOnce sync.Once    //nolint:gochecknoglobals
 
-	onceBabelCode      sync.Once     // nolint:gochecknoglobals
-	globalBabelCode    *goja.Program // nolint:gochecknoglobals
-	globalBabelCodeErr error         // nolint:gochecknoglobals
-	onceBabel          sync.Once     // nolint:gochecknoglobals
-	globalBabel        *babel        // nolint:gochecknoglobals
+	onceBabelCode      sync.Once     //nolint:gochecknoglobals
+	globalBabelCode    *goja.Program //nolint:gochecknoglobals
+	globalBabelCodeErr error         //nolint:gochecknoglobals
+	onceBabel          sync.Once     //nolint:gochecknoglobals
+	globalBabel        *babel        //nolint:gochecknoglobals
 )
 
 const (

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -90,7 +90,7 @@ var (
 
 	onceBabelCode      sync.Once     //nolint:gochecknoglobals
 	globalBabelCode    *goja.Program //nolint:gochecknoglobals
-	globalBabelCodeErr error         //nolint:gochecknoglobals
+	errGlobalBabelCode error         //nolint:gochecknoglobals
 	onceBabel          sync.Once     //nolint:gochecknoglobals
 	globalBabel        *babel        //nolint:gochecknoglobals
 )
@@ -265,10 +265,10 @@ type babel struct {
 
 func newBabel() (*babel, error) {
 	onceBabelCode.Do(func() {
-		globalBabelCode, globalBabelCodeErr = goja.Compile("<internal/k6/compiler/lib/babel.min.js>", babelSrc, false)
+		globalBabelCode, errGlobalBabelCode = goja.Compile("<internal/k6/compiler/lib/babel.min.js>", babelSrc, false)
 	})
-	if globalBabelCodeErr != nil {
-		return nil, globalBabelCodeErr
+	if errGlobalBabelCode != nil {
+		return nil, errGlobalBabelCode
 	}
 	vm := goja.New()
 	_, err := vm.RunProgram(globalBabelCode)

--- a/js/module_loading_test.go
+++ b/js/module_loading_test.go
@@ -444,7 +444,6 @@ func TestLoadCycleBinding(t *testing.T) {
 func TestBrowserified(t *testing.T) {
 	t.Parallel()
 	fs := afero.NewMemMapFs()
-	//nolint: lll
 	require.NoError(t, afero.WriteFile(fs, "/browserified.js", []byte(`
 		(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.npmlibs = f()}})(function(){var define,module,exports;return (function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
 		module.exports.A = function () {

--- a/js/modules/k6/encoding/encoding_test.go
+++ b/js/modules/k6/encoding/encoding_test.go
@@ -84,7 +84,7 @@ func TestEncodingAlgorithms(t *testing.T) {
 			}`)
 			assert.NoError(t, err)
 		})
-		t.Run("DefaultArrayBufferDec", func(t *testing.T) { //nolint: paralleltest // weird that it triggers here, and these tests can't be parallel
+		t.Run("DefaultArrayBufferDec", func(t *testing.T) { //nolint:paralleltest // weird that it triggers here, and these tests can't be parallel
 			_, err := rt.RunString(`
 			var exp = "hello";
 			var decBin = encoding.b64decode("aGVsbG8=");

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -222,10 +222,10 @@ func TestAbortTest(t *testing.T) { //nolint:tparallel
 		require.Equal(t, v.Reason, reason)
 	}
 
-	t.Run("default reason", func(t *testing.T) { //nolint: paralleltest
+	t.Run("default reason", func(t *testing.T) { //nolint:paralleltest
 		prove(t, "exec.test.abort()", errext.AbortTest)
 	})
-	t.Run("custom reason", func(t *testing.T) { //nolint: paralleltest
+	t.Run("custom reason", func(t *testing.T) { //nolint:paralleltest
 		prove(t, `exec.test.abort("mayday")`, fmt.Sprintf("%s: mayday", errext.AbortTest))
 	})
 }

--- a/js/modules/k6/http/http_test.go
+++ b/js/modules/k6/http/http_test.go
@@ -35,7 +35,7 @@ import (
 	"go.k6.io/k6/metrics"
 )
 
-//nolint: golint, revive
+//nolint:golint, revive
 func getTestModuleInstance(
 	t testing.TB, ctx context.Context, state *lib.State,
 ) (*goja.Runtime, *ModuleInstance) {

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -107,7 +107,7 @@ func (c *Client) responseFromHTTPext(resp *httpext.Response) *Response {
 }
 
 // TODO: break this function up
-//nolint: gocyclo, cyclop, funlen, gocognit
+//nolint:gocyclo, cyclop, funlen, gocognit
 func (c *Client) parseRequest(
 	method string, reqURL, body interface{}, params goja.Value,
 ) (*httpext.ParsedHTTPRequest, error) {

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1638,7 +1638,7 @@ func TestRequestCancellation(t *testing.T) {
 
 func TestRequestArrayBufferBody(t *testing.T) {
 	t.Parallel()
-	tb, _, _, rt, _ := newRuntime(t) //nolint: dogsled
+	tb, _, _, rt, _ := newRuntime(t) //nolint:dogsled
 	sr := tb.Replacer.Replace
 
 	tb.Mux.HandleFunc("/post-arraybuffer", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -122,7 +122,7 @@ func (mi *WS) Exports() modules.Exports {
 
 // Connect establishes a WebSocket connection based on the parameters provided.
 // TODO: refactor to reduce the method complexity
-//nolint: funlen,gocognit,gocyclo,cyclop
+//nolint:funlen,gocognit,gocyclo
 func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 	ctx := mi.vu.Context()
 	rt := mi.vu.Runtime()
@@ -594,7 +594,7 @@ func (s *Socket) closeConnection(code int) error {
 }
 
 // Wraps conn.ReadMessage in a channel
-func (s *Socket) readPump(readChan chan *message, errorChan chan error, closeChan chan int) { //nolint: cyclop
+func (s *Socket) readPump(readChan chan *message, errorChan chan error, closeChan chan int) {
 	for {
 		messageType, data, err := s.conn.ReadMessage()
 		if err != nil {

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -541,7 +541,7 @@ func TestSession(t *testing.T) {
 	})
 }
 
-func TestSocketSendBinary(t *testing.T) { //nolint: tparallel
+func TestSocketSendBinary(t *testing.T) { //nolint:tparallel
 	t.Parallel()
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	sr := tb.Replacer.Replace
@@ -552,10 +552,10 @@ func TestSocketSendBinary(t *testing.T) { //nolint: tparallel
 	rt := goja.New()
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
 	samples := make(chan metrics.SampleContainer, 1000)
-	state := &lib.State{ //nolint: exhaustivestruct
+	state := &lib.State{ //nolint:exhaustivestruct
 		Group:  root,
 		Dialer: tb.Dialer,
-		Options: lib.Options{ //nolint: exhaustivestruct
+		Options: lib.Options{ //nolint:exhaustivestruct
 			SystemTags: metrics.NewSystemTagSet(
 				metrics.TagURL,
 				metrics.TagProto,
@@ -619,7 +619,7 @@ func TestSocketSendBinary(t *testing.T) { //nolint: tparallel
 		{"function() {}", "Function"},
 	}
 
-	for _, tc := range errTestCases { //nolint: paralleltest
+	for _, tc := range errTestCases { //nolint:paralleltest
 		tc := tc
 		t.Run(fmt.Sprintf("err_%s", tc.expErrType), func(t *testing.T) {
 			_, err = rt.RunString(fmt.Sprintf(sr(`

--- a/js/runner.go
+++ b/js/runner.go
@@ -61,7 +61,7 @@ var _ lib.Runner = &Runner{}
 // TODO: https://github.com/grafana/k6/issues/2186
 // An advanced TLS support should cover the rid of the warning
 //
-// nolint:gochecknoglobals
+//nolint:gochecknoglobals
 var nameToCertWarning sync.Once
 
 type Runner struct {
@@ -149,7 +149,7 @@ func (r *Runner) NewVU(idLocal, idGlobal uint64, samplesOut chan<- metrics.Sampl
 	return lib.InitializedVU(vu), nil
 }
 
-// nolint:funlen
+//nolint:funlen
 func (r *Runner) newVU(idLocal, idGlobal uint64, samplesOut chan<- metrics.SampleContainer) (*VU, error) {
 	// Instantiate a new bundle, make a VU out of it.
 	bi, err := r.Bundle.Instantiate(r.Logger, idLocal)
@@ -213,7 +213,7 @@ func (r *Runner) newVU(idLocal, idGlobal uint64, samplesOut chan<- metrics.Sampl
 				"and let k6 automatically detect from the provided certificate. It follows the Go's NameToCertificate " +
 				"deprecation - https://pkg.go.dev/crypto/tls@go1.17#Config.")
 		})
-		// nolint:staticcheck // ignore SA1019 we can deprecate it but we have to continue to support the previous code.
+		//nolint:staticcheck // ignore SA1019 we can deprecate it but we have to continue to support the previous code.
 		tlsConfig.NameToCertificate = nameToCert
 	}
 	transport := &http.Transport{

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -2283,7 +2283,7 @@ func TestMinIterationDurationIsCancellable(t *testing.T) {
 	}
 }
 
-// nolint:paralleltest
+//nolint:paralleltest
 func TestForceHTTP1Feature(t *testing.T) {
 	cases := map[string]struct {
 		godebug               string

--- a/lib/archive.go
+++ b/lib/archive.go
@@ -42,7 +42,6 @@ import (
 	"go.k6.io/k6/loader"
 )
 
-//nolint: gochecknoglobals, lll
 var (
 	volumeRE  = regexp.MustCompile(`^[/\\]?([a-zA-Z]):(.*)`)
 	sharedRE  = regexp.MustCompile(`^\\\\([^\\]+)`) // matches a shared folder in Windows before backslack replacement. i.e \\VMBOXSVR\k6\script.js

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -31,7 +31,7 @@ import (
 const Version = "0.39.0"
 
 // VersionDetails can be set externally as part of the build process
-var VersionDetails = "" // nolint:gochecknoglobals
+var VersionDetails = "" //nolint:gochecknoglobals
 
 // FullVersion returns the maximally full version and build information for
 // the currently running k6 executable.

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -498,7 +498,7 @@ func (rs *externallyControlledRunState) handleConfigChange(oldCfg, newCfg Extern
 // Run constantly loops through as many iterations as possible on a variable
 // dynamically controlled number of VUs either for the specified duration, or
 // until the test is manually stopped.
-//nolint:funlen,gocognit,cyclop
+//nolint:funlen,gocognit
 func (mex *ExternallyControlled) Run(parentCtx context.Context, out chan<- metrics.SampleContainer) (err error) {
 	mex.configLock.RLock()
 	// Safely get the current config - it's important that the close of the

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -498,7 +498,7 @@ func (rs *externallyControlledRunState) handleConfigChange(oldCfg, newCfg Extern
 // Run constantly loops through as many iterations as possible on a variable
 // dynamically controlled number of VUs either for the specified duration, or
 // until the test is manually stopped.
-// nolint:funlen,gocognit,cyclop
+//nolint:funlen,gocognit,cyclop
 func (mex *ExternallyControlled) Run(parentCtx context.Context, out chan<- metrics.SampleContainer) (err error) {
 	mex.configLock.RLock()
 	// Safely get the current config - it's important that the close of the

--- a/lib/executor/helpers_test.go
+++ b/lib/executor/helpers_test.go
@@ -22,7 +22,7 @@ package executor
 
 import "go.k6.io/k6/metrics"
 
-func sumMetricValues(samples chan metrics.SampleContainer, metricName string) (sum float64) { // nolint: unparam
+func sumMetricValues(samples chan metrics.SampleContainer, metricName string) (sum float64) { //nolint: unparam
 	for _, sc := range metrics.GetBufferedSamples(samples) {
 		samples := sc.GetSamples()
 		for _, s := range samples {

--- a/lib/executor/helpers_test.go
+++ b/lib/executor/helpers_test.go
@@ -22,7 +22,7 @@ package executor
 
 import "go.k6.io/k6/metrics"
 
-func sumMetricValues(samples chan metrics.SampleContainer, metricName string) (sum float64) { //nolint: unparam
+func sumMetricValues(samples chan metrics.SampleContainer, metricName string) (sum float64) { //nolint:unparam
 	for _, sc := range metrics.GetBufferedSamples(samples) {
 		samples := sc.GetSamples()
 		for _, s := range samples {

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -150,7 +150,7 @@ type PerVUIterations struct {
 var _ lib.Executor = &PerVUIterations{}
 
 // Run executes a specific number of iterations with each configured VU.
-// nolint:funlen
+//nolint:funlen
 func (pvi PerVUIterations) Run(parentCtx context.Context, out chan<- metrics.SampleContainer) (err error) {
 	numVUs := pvi.config.GetVUs(pvi.executionState.ExecutionTuple)
 	iterations := pvi.config.GetIterations()

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -188,7 +188,7 @@ func (varr *RampingArrivalRate) Init(ctx context.Context) error {
 	varr.et = et
 	varr.iterSegIndex = lib.NewSegmentedIndex(et)
 
-	return err //nolint: wrapcheck
+	return err //nolint:wrapcheck
 }
 
 // cal calculates the  transtitions between stages and gives the next full value produced by the

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -182,7 +182,7 @@ func (si *SharedIterations) Init(ctx context.Context) error {
 
 // Run executes a specific total number of iterations, which are all shared by
 // the configured VUs.
-// nolint:funlen
+//nolint:funlen
 func (si SharedIterations) Run(parentCtx context.Context, out chan<- metrics.SampleContainer) (err error) {
 	numVUs := si.config.GetVUs(si.executionState.ExecutionTuple)
 	iterations := si.et.ScaleInt64(si.config.Iterations.Int64)

--- a/lib/netext/httpext/compression.go
+++ b/lib/netext/httpext/compression.go
@@ -39,7 +39,6 @@ import (
 // CompressionType is used to specify what compression is to be used to compress the body of a
 // request
 // The conversion and validation methods are auto-generated with https://github.com/alvaroloes/enumer:
-//nolint: lll
 //go:generate enumer -type=CompressionType -transform=snake -trimprefix CompressionType -output compression_type_gen.go
 type CompressionType uint
 

--- a/lib/netext/httpext/error_codes.go
+++ b/lib/netext/httpext/error_codes.go
@@ -112,7 +112,7 @@ func http2ErrCodeOffset(code http2.ErrCode) errCode {
 	return 1 + errCode(code)
 }
 
-//nolint: errorlint,cyclop
+//nolint:errorlint
 func errorCodeForNetOpError(err *net.OpError) (errCode, string) {
 	// TODO: refactor this further - a big switch would be more readable, maybe
 	// we should even check for *os.SyscallError in the main switch body in the
@@ -172,7 +172,7 @@ func errorCodeForNetOpError(err *net.OpError) (errCode, string) {
 }
 
 // errorCodeForError returns the errorCode and a specific error message for given error.
-//nolint: errorlint, cyclop
+//nolint:errorlint
 func errorCodeForError(err error) (errCode, string) {
 	// We explicitly check for `Unwrap()` in the default switch branch, but
 	// checking for the concrete error types first gives us the opportunity to

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -130,7 +130,7 @@ func updateK6Response(k6Response *Response, finishedReq *finishedRequest) {
 // MakeRequest makes http request for tor the provided ParsedHTTPRequest.
 //
 // TODO: split apart...
-//nolint: cyclop, gocyclo, funlen, gocognit
+//nolint:cyclop, gocyclo, funlen, gocognit
 func MakeRequest(ctx context.Context, state *lib.State, preq *ParsedHTTPRequest) (*Response, error) {
 	respReq := &Request{
 		Method:  preq.Req.Method,

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -130,7 +130,7 @@ func updateK6Response(k6Response *Response, finishedReq *finishedRequest) {
 // MakeRequest makes http request for tor the provided ParsedHTTPRequest.
 //
 // TODO: split apart...
-// nolint: cyclop, gocyclo, funlen, gocognit
+//nolint: cyclop, gocyclo, funlen, gocognit
 func MakeRequest(ctx context.Context, state *lib.State, preq *ParsedHTTPRequest) (*Response, error) {
 	respReq := &Request{
 		Method:  preq.Req.Method,

--- a/lib/netext/httpext/response.go
+++ b/lib/netext/httpext/response.go
@@ -28,7 +28,7 @@ import (
 
 // ResponseType is used in the request to specify how the response body should be treated
 // The conversion and validation methods are auto-generated with https://github.com/alvaroloes/enumer:
-//nolint: lll
+//nolint:lll
 //go:generate enumer -type=ResponseType -transform=snake -json -text -trimprefix ResponseType -output response_type_gen.go
 type ResponseType uint
 

--- a/lib/netext/resolver.go
+++ b/lib/netext/resolver.go
@@ -64,7 +64,7 @@ type cacheResolver struct {
 func NewResolver(
 	actRes MultiResolver, ttl time.Duration, sel types.DNSSelect, pol types.DNSPolicy,
 ) Resolver {
-	r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint: gosec
+	r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec
 	res := resolver{
 		resolve:     actRes,
 		selectIndex: sel,

--- a/lib/netext/resolver.go
+++ b/lib/netext/resolver.go
@@ -64,7 +64,7 @@ type cacheResolver struct {
 func NewResolver(
 	actRes MultiResolver, ttl time.Duration, sel types.DNSSelect, pol types.DNSPolicy,
 ) Resolver {
-	r := rand.New(rand.NewSource(time.Now().UnixNano())) // nolint: gosec
+	r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint: gosec
 	res := resolver{
 		resolve:     actRes,
 		selectIndex: sel,

--- a/lib/netext/tls.go
+++ b/lib/netext/tls.go
@@ -28,7 +28,7 @@ import (
 	"go.k6.io/k6/lib"
 )
 
-//nolint: golint
+//nolint:golint
 const (
 	OCSP_STATUS_GOOD                   = "good"
 	OCSP_STATUS_REVOKED                = "revoked"

--- a/lib/options.go
+++ b/lib/options.go
@@ -41,7 +41,7 @@ import (
 const DefaultScenarioName = "default"
 
 // DefaultSummaryTrendStats are the default trend columns shown in the test summary output
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var DefaultSummaryTrendStats = []string{"avg", "min", "med", "max", "p(90)", "p(95)"}
 
 // Describes a TLS version. Serialised to/from JSON as a string, eg. "tls1.2".
@@ -192,7 +192,7 @@ func decryptPrivateKey(privKey, password string) ([]byte, error) {
 	   being used here because it is deprecated due to it not supporting *good* crypography
 	   ultimately though we want to support something so we will be using it for now.
 	*/
-	decryptedKey, err := x509.DecryptPEMBlock(block, []byte(password)) //nolint: staticcheck
+	decryptedKey, err := x509.DecryptPEMBlock(block, []byte(password)) //nolint:staticcheck
 	if err != nil {
 		return nil, err
 	}

--- a/lib/options.go
+++ b/lib/options.go
@@ -41,7 +41,7 @@ import (
 const DefaultScenarioName = "default"
 
 // DefaultSummaryTrendStats are the default trend columns shown in the test summary output
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var DefaultSummaryTrendStats = []string{"avg", "min", "med", "max", "p(90)", "p(95)"}
 
 // Describes a TLS version. Serialised to/from JSON as a string, eg. "tls1.2".
@@ -192,7 +192,7 @@ func decryptPrivateKey(privKey, password string) ([]byte, error) {
 	   being used here because it is deprecated due to it not supporting *good* crypography
 	   ultimately though we want to support something so we will be using it for now.
 	*/
-	decryptedKey, err := x509.DecryptPEMBlock(block, []byte(password)) // nolint: staticcheck
+	decryptedKey, err := x509.DecryptPEMBlock(block, []byte(password)) //nolint: staticcheck
 	if err != nil {
 		return nil, err
 	}

--- a/lib/runtime_options.go
+++ b/lib/runtime_options.go
@@ -28,7 +28,7 @@ import (
 )
 
 // CompatibilityMode specifies the JS compatibility mode
-// nolint:lll
+//nolint:lll
 //go:generate enumer -type=CompatibilityMode -transform=snake -trimprefix CompatibilityMode -output compatibility_mode_gen.go
 type CompatibilityMode uint8
 

--- a/lib/tlsconfig.go
+++ b/lib/tlsconfig.go
@@ -24,7 +24,7 @@ import "crypto/tls"
 // From https://golang.org/pkg/crypto/tls/#pkg-constants
 
 // SupportedTLSVersions is string-to-constant map of available TLS versions.
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var SupportedTLSVersions = map[string]TLSVersion{
 	"tls1.0": tls.VersionTLS10,
 	"tls1.1": tls.VersionTLS11,
@@ -33,7 +33,7 @@ var SupportedTLSVersions = map[string]TLSVersion{
 }
 
 // SupportedTLSVersionsToString is constant-to-string map of available TLS versions.
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var SupportedTLSVersionsToString = map[TLSVersion]string{
 	tls.VersionTLS10: "tls1.0",
 	tls.VersionTLS11: "tls1.1",
@@ -42,7 +42,7 @@ var SupportedTLSVersionsToString = map[TLSVersion]string{
 }
 
 // SupportedTLSCipherSuites is string-to-constant map of available TLS cipher suites.
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var SupportedTLSCipherSuites = map[string]uint16{
 	// TLS 1.0 - 1.2 cipher suites.
 	"TLS_RSA_WITH_RC4_128_SHA":                tls.TLS_RSA_WITH_RC4_128_SHA,
@@ -75,7 +75,7 @@ var SupportedTLSCipherSuites = map[string]uint16{
 }
 
 // SupportedTLSCipherSuitesToString is constant-to-string map of available TLS cipher suites.
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var SupportedTLSCipherSuitesToString = map[uint16]string{
 	tls.TLS_RSA_WITH_RC4_128_SHA:                "TLS_RSA_WITH_RC4_128_SHA",
 	tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA:           "TLS_RSA_WITH_3DES_EDE_CBC_SHA",

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -47,7 +47,7 @@ type SourceData struct {
 
 type loaderFunc func(logger logrus.FieldLogger, path string, parts []string) (string, error)
 
-//nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var (
 	loaders = []struct {
 		name string

--- a/metrics/thresholds_parser.go
+++ b/metrics/thresholds_parser.go
@@ -144,7 +144,7 @@ const (
 // the smallest common substring, the actual slice order matters.
 // Longer tokens with symbols in common with shorter ones must appear
 // first in the list in order to be effectively matched.
-var operatorTokens = [7]string{ // nolint:gochecknoglobals
+var operatorTokens = [7]string{ //nolint:gochecknoglobals
 	tokenLessEqual,
 	tokenLess,
 	tokenGreaterEqual,
@@ -190,7 +190,7 @@ const (
 // It is meant to be used during the parsing of threshold expressions.
 // Although declared as a `var`, being an array, it is effectively
 // immutable and can be considered constant.
-var aggregationMethodTokens = [8]string{ // nolint:gochecknoglobals
+var aggregationMethodTokens = [8]string{ //nolint:gochecknoglobals
 	tokenValue,
 	tokenCount,
 	tokenRate,


### PR DESCRIPTION
I thought this was already checked but apparently not, so inspired from https://github.com/grafana/xk6-redis/pull/5#discussion_r920908995 I added a strict policy around the format.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
