### PR TITLE
chore: update golangci-lint to the v1.47.1, adjust linter list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.43.0
+# v1.47.1
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   deadline: 5m
@@ -78,7 +78,14 @@ linters:
   - scopelint # deprecated, replaced by exportloopref
   - wrapcheck # a little bit too much for k6, maybe after https://github.com/tomarrell/wrapcheck/issues/2 is fixed
   - golint # this linter is deprecated
-  - varnamelen # disabled before the final decision in (https://github.com/grafana/k6/pull/2323)
+  - varnamelen
   - ireturn
   - tagliatelle
+  - exhaustruct
+  - execinquery
+  - maintidx
+  - grouper
+  - decorder
+  - nonamedreturns
+  - nosnakecase
   fast: false


### PR DESCRIPTION
# What?

Update the golangci-lint to v1.47.1 and use the list defined by the maintainers.

# Why?

Keep the project codebase nice & clean using the latest possibility of automation.

Closes: #2328