### PR TITLE
chore: update golangci-lint to the v1.47.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.47.1
+# v1.47.2
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   deadline: 5m


### PR DESCRIPTION
# What?

Update the golangci-lint to v1.47.2 and use the list defined by the maintainers.

# Why?

Keep the project codebase nice & clean using the latest possibility of automation.