### PR TITLE
Improve the comments for `EventLoop.RegisterCallback()`

### DIFF
--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -89,9 +89,9 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 //
 // A common pattern for async work is something like this:
 //
-//    func doAsyncWork() *goja.Promise {
+//    func doAsyncWork(vu modules.VU) *goja.Promise {
 //        addToMainThreadQueue := vu.RegisterPendingCallback()
-//        p, resolve, reject := runtime.NewPromise()
+//        p, resolve, reject := vu.Runtime().NewPromise()
 //
 //        // Do the actual async work in a new independent goroutine, but make
 //        // sure that the Promise resolution is done on the main thread:

--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -66,7 +66,7 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 // RegisterPendingCallback signals to the event loop that you are going to do
 // some asynchronous work off the main thread and that you may need to execute
 // some code back on the main thread when you are done. So, once you call this
-// method, the even loop will wait for you to finish and give it the callback it
+// method, the event loop will wait for you to finish and give it the callback it
 // needs to run back on the main thread before it can end the whole iteration.
 //
 // RegisterPendingCallback() *must* be called from the main runtime thread, but
@@ -85,7 +85,7 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 // be stuck until the VU itself has been stopped (e.g. because the whole test or
 // scenario has ended).
 //
-// A common patten for async work is something like this:
+// A common pattern for async work is something like this:
 //
 //    func doAsyncWork() *goja.Promise {
 //        addToMainThreadQueue := vu.RegisterPendingCallback()

--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -55,9 +55,11 @@ func (e *EventLoop) wakeup() {
 	}
 }
 
+// RegisterCallback is deprecated, see RegisterPendingCallback.
+//
 // Deprecated: due to the confusing name, we renamed this method to
-// RegisterPendingCallback
-func (e *EventLoop) RegisterCallback() func(func() error) {
+// RegisterPendingCallback.
+func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 	return e.RegisterPendingCallback()
 }
 

--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -71,18 +71,18 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 // script iteration.
 //
 // ReservePendingCallback() *must* be called from the main runtime thread, but
-// its result queueCallback() is thread-safe and can be called from any
-// goroutine. queueCallback() ensures that its callback parameter is added to
+// its result enqueueCallback() is thread-safe and can be called from any
+// goroutine. enqueueCallback() ensures that its callback parameter is added to
 // the VU runtime's tasks queue, to be executed on the main runtime thread
 // eventually, when the VU is done with the other tasks before it. Unless the
-// whole event loop has been stopped, invoking queueCallback() will queue its
+// whole event loop has been stopped, invoking enqueueCallback() will queue its
 // argument and "wake up" the loop (if it was idle, but not stopped).
 //
 // Keep in mind that once you call ReservePendingCallback(), you *must* also
-// call queueCallback() exactly once, even if don't actually need to run any
+// call enqueueCallback() exactly once, even if don't actually need to run any
 // code on the main thread. If that's the case, you can pass an empty no-op
 // callback to it, but you must call it! The event loop will wait for the
-// queueCallback() invocation and the k6 iteration won't finish and will be
+// enqueueCallback() invocation and the k6 iteration won't finish and will be
 // stuck until the VU itself has been stopped (e.g. because the whole test or
 // scenario has ended). Any error returned by any callback on the main thread
 // will abort the current iteration and no further event loop callbacks will be
@@ -91,7 +91,7 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 // A common pattern for async work is something like this:
 //
 //    func doAsyncWork(vu modules.VU) *goja.Promise {
-//        queueCallback := vu.ReservePendingCallback()
+//        enqueueCallback := vu.ReservePendingCallback()
 //        p, resolve, reject := vu.Runtime().NewPromise()
 //
 //        // Do the actual async work in a new independent goroutine, but make
@@ -100,7 +100,7 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 //            // Also make sure to abort early if the context is cancelled, so
 //            // the VU is not stuck when the scenario ends or Ctrl+C is used:
 //            result, err := doTheActualAsyncWork(vu.Context())
-//            queueCallback(func() error {
+//            enqueueCallback(func() error {
 //                if err != nil {
 //                    reject(err)
 //                } else {
@@ -117,7 +117,7 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 // is immediately returned and the main thread resumes execution. It also
 // ensures that the Promise resolution happens safely back on the main thread
 // once the async work is done, as required by goja and all other JS runtimes.
-func (e *EventLoop) ReservePendingCallback() (queueCallback func(func() error)) {
+func (e *EventLoop) ReservePendingCallback() (enqueueCallback func(func() error)) {
 	e.lock.Lock()
 	var callbackCalled bool
 	e.registeredCallbacks++

--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -96,7 +96,9 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 //        // Do the actual async work in a new independent goroutine, but make
 //        // sure that the Promise resolution is done on the main thread:
 //        go func() {
-//            result, err := doTheActualAsyncWork()
+//            // Also make sure to abort early if the context is cancelled, so
+//            // the VU is not stuck when the scenario ends or Ctrl+C is used:
+//            result, err := doTheActualAsyncWork(vu.Context())
 //            addToMainThreadQueue(func() error {
 //                if err != nil {
 //                    reject(err)

--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -83,7 +83,9 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 // callback to it, but you must call it! The event loop will wait for the
 // addToMainThreadQueue() invocation and the k6 iteration won't finish and will
 // be stuck until the VU itself has been stopped (e.g. because the whole test or
-// scenario has ended).
+// scenario has ended). Any error returned by any callback on the main thread
+// will abort the current iteration and no further event loop callbacks will be
+// executed this iteration.
 //
 // A common pattern for async work is something like this:
 //
@@ -91,6 +93,8 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 //        addToMainThreadQueue := vu.RegisterPendingCallback()
 //        p, resolve, reject := runtime.NewPromise()
 //
+//        // Do the actual async work in a new independent goroutine, but make
+//        // sure that the Promise resolution is done on the main thread:
 //        go func() {
 //            result, err := doTheActualAsyncWork()
 //            addToMainThreadQueue(func() error {
@@ -99,7 +103,7 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 //                } else {
 //                    resolve(result)
 //                }
-//                return nil
+//                return nil  // do not abort the iteration
 //            })
 //        }()
 //

--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -55,11 +55,60 @@ func (e *EventLoop) wakeup() {
 	}
 }
 
-// RegisterCallback register that a callback will be invoked on the loop, preventing it from returning/finishing.
-// The returned function, upon invocation, will queue its argument and wakeup the loop if needed.
-// If the eventLoop has since stopped, it will not be executed.
-// This function *must* be called from within running on the event loop, but its result can be called from anywhere.
+// Deprecated: due to the confusing name, we renamed this method to
+// RegisterPendingCallback
 func (e *EventLoop) RegisterCallback() func(func() error) {
+	return e.RegisterPendingCallback()
+}
+
+// RegisterPendingCallback signals to the event loop that you are going to do
+// some asynchronous work off the main thread and that you may need to execute
+// some code back on the main thread when you are done. So, once you call this
+// method, the even loop will wait for you to finish and give it the callback it
+// needs to run back on the main thread before it can end the whole iteration.
+//
+// RegisterPendingCallback() *must* be called from the main runtime thread, but
+// its result addToMainThreadQueue() is thread-safe and can be called from any
+// goroutine. addToMainThreadQueue() ensures that its callback parameter is
+// added to the VU runtime's tasks queue, to be executed on the main runtime
+// thread eventually, when the VU is done with the other tasks before it. Unless
+// the whole event loop has been stopped, invoking addToMainThreadQueue() will
+// queue its argument and "wake up" the loop (if it was idle, but not stopped).
+//
+// Keep in mind that once you call RegisterPendingCallback(), you *must* also
+// call addToMainThreadQueue() exactly once, even if don't actually need to run
+// any code on the main thread. If that's the case, you can pass an empty no-op
+// callback to it, but you must call it! The event loop will wait for the
+// addToMainThreadQueue() invocation and the k6 iteration won't finish and will
+// be stuck until the VU itself has been stopped (e.g. because the whole test or
+// scenario has ended).
+//
+// A common patten for async work is something like this:
+//
+//    func doAsyncWork() *goja.Promise {
+//        addToMainThreadQueue := vu.RegisterPendingCallback()
+//        p, resolve, reject := runtime.NewPromise()
+//
+//        go func() {
+//            result, err := doTheActualAsyncWork()
+//            addToMainThreadQueue(func() error {
+//                if err != nil {
+//                    reject(err)
+//                } else {
+//                    resolve(result)
+//                }
+//                return nil
+//            })
+//        }()
+//
+//        return p
+//    }
+//
+// This ensures that the actual work happens asynchronously, while the Promise
+// is immediately returned and the main thread resumes execution. It also
+// ensures that the Promise resolution happens safely back on the main thread
+// once the async work is done, as required by goja and all other JS runtimes.
+func (e *EventLoop) RegisterPendingCallback() (addToMainThreadQueue func(callback func() error)) {
 	e.lock.Lock()
 	var callbackCalled bool
 	e.registeredCallbacks++

--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -86,7 +86,7 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 // stuck until the VU itself has been stopped (e.g. because the whole test or
 // scenario has ended). Any error returned by any callback on the main thread
 // will abort the current iteration and no further event loop callbacks will be
-// executed this iteration.
+// executed in the same iteration.
 //
 // A common pattern for async work is something like this:
 //

--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -55,33 +55,25 @@ func (e *EventLoop) wakeup() {
 	}
 }
 
-// RegisterCallback is deprecated, see ReservePendingCallback.
-//
-// Deprecated: due to the confusing name, we renamed this method to
-// ReservePendingCallback.
-func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
-	return e.ReservePendingCallback()
-}
-
-// ReservePendingCallback signals to the event loop that you are going to do
-// some asynchronous work off the main thread and that you may need to execute
-// some code back on the main thread when you are done. So, once you call this
+// RegisterCallback signals to the event loop that you are going to do some
+// asynchronous work off the main thread and that you may need to execute some
+// code back on the main thread when you are done. So, once you call this
 // method, the event loop will wait for you to finish and give it the callback
 // it needs to run back on the main thread before it can end the whole current
 // script iteration.
 //
-// ReservePendingCallback() *must* be called from the main runtime thread, but
-// its result enqueueCallback() is thread-safe and can be called from any
-// goroutine. enqueueCallback() ensures that its callback parameter is added to
-// the VU runtime's tasks queue, to be executed on the main runtime thread
-// eventually, when the VU is done with the other tasks before it. Unless the
-// whole event loop has been stopped, invoking enqueueCallback() will queue its
-// argument and "wake up" the loop (if it was idle, but not stopped).
+// RegisterCallback() *must* be called from the main runtime thread, but its
+// result enqueueCallback() is thread-safe and can be called from any goroutine.
+// enqueueCallback() ensures that its callback parameter is added to the VU
+// runtime's tasks queue, to be executed on the main runtime thread eventually,
+// when the VU is done with the other tasks before it. Unless the whole event
+// loop has been stopped, invoking enqueueCallback() will queue its argument and
+// "wake up" the loop (if it was idle, but not stopped).
 //
-// Keep in mind that once you call ReservePendingCallback(), you *must* also
-// call enqueueCallback() exactly once, even if don't actually need to run any
-// code on the main thread. If that's the case, you can pass an empty no-op
-// callback to it, but you must call it! The event loop will wait for the
+// Keep in mind that once you call RegisterCallback(), you *must* also call
+// enqueueCallback() exactly once, even if don't actually need to run any code
+// on the main thread. If that's the case, you can pass an empty no-op callback
+// to it, but you must call it! The event loop will wait for the
 // enqueueCallback() invocation and the k6 iteration won't finish and will be
 // stuck until the VU itself has been stopped (e.g. because the whole test or
 // scenario has ended). Any error returned by any callback on the main thread
@@ -91,7 +83,7 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 // A common pattern for async work is something like this:
 //
 //    func doAsyncWork(vu modules.VU) *goja.Promise {
-//        enqueueCallback := vu.ReservePendingCallback()
+//        enqueueCallback := vu.RegisterCallback()
 //        p, resolve, reject := vu.Runtime().NewPromise()
 //
 //        // Do the actual async work in a new independent goroutine, but make
@@ -117,7 +109,9 @@ func (e *EventLoop) RegisterCallback() func(func() error) { // TODO: remove
 // is immediately returned and the main thread resumes execution. It also
 // ensures that the Promise resolution happens safely back on the main thread
 // once the async work is done, as required by goja and all other JS runtimes.
-func (e *EventLoop) ReservePendingCallback() (enqueueCallback func(func() error)) {
+//
+// TODO: rename to ReservePendingCallback or something more appropriate?
+func (e *EventLoop) RegisterCallback() (enqueueCallback func(func() error)) {
 	e.lock.Lock()
 	var callbackCalled bool
 	e.registeredCallbacks++

--- a/js/modules/modules.go
+++ b/js/modules/modules.go
@@ -95,20 +95,14 @@ type VU interface {
 	// Runtime returns the goja.Runtime for the current VU
 	Runtime() *goja.Runtime
 
-	// RegisterCallback lets a module declare that it wants to run a function on the event loop *at a later point in time*.
-	// It needs to be called from within the event loop, so not in a goroutine spawned by a module.
-	// Its result can be called with a function that will be executed *on the event loop* -
-	// possibly letting you call RegisterCallback again.
-	// Calling the result can be done at any time. The event loop will block until that happens, (if it doesn't
-	// have something else to run) so in the event of an iteration end or abort (for example due to an exception),
-	// It is the module responsibility to monitor the context and abort on it being done.
-	// This still means that the returned function here *needs* to be called to signal that the module
-	// has aborted the operation and will not do anything more, not doing so will block k6.
+	// RegisterCallback lets a JS module declare that it wants to run a function
+	// on the event loop *at a later point in time*. See the documentation for
+	// `EventLoop.RegisterCallback()` in the `k6/js/eventloop` Go module for
+	// the very important details on its usage and restrictions.
 	//
-	// Experimental
-	//
-	// Notice: This API is EXPERIMENTAL and may be changed or removed in a later release.
-	RegisterCallback() func(func() error)
+	// Notice: This API is EXPERIMENTAL and may be changed, renamed or
+	// completely removed in a later k6 release.
+	RegisterCallback() (enqueueCallback func(func() error))
 
 	// sealing field will help probably with pointing users that they just need to embed this in their Instance
 	// implementations


### PR DESCRIPTION
~I will rename all of the uses of `EventLoop.RegisterCallback()` in the code as well, once we agree on the name.~

I have scaled this back to just improving the comments and adding a `TODO` with a rename suggestion for the future (e.g. during https://github.com/grafana/k6/issues/2544)