### PR TITLE
fix: fix ws not support throw option

### DIFF
--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -289,9 +289,7 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 		if state.Options.Throw.Bool {
 			return nil, connErr
 		}
-		if state.Logger != nil {
-			state.Logger.WithField("error", connErr).Warn("Ws Connection Failed")
-		}
+		state.Logger.WithField("error", connErr).Warn("Ws Connection Failed")
 		return &WSHTTPResponse{
 			Error: connErr.Error(),
 		}, nil

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -289,7 +289,9 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 		if state.Options.Throw.Bool {
 			return nil, connErr
 		} else {
-			state.Logger.WithField("error", connErr).Warn("Ws Connection Failed")
+			if state.Logger != nil {
+				state.Logger.WithField("error", connErr).Warn("Ws Connection Failed")
+			}
 			return nil, nil
 		}
 	}

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -292,7 +292,7 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 			if state.Logger != nil {
 				state.Logger.WithField("error", connErr).Warn("Ws Connection Failed")
 			}
-			return nil, nil
+			return &WSHTTPResponse{}, nil
 		}
 	}
 

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -288,12 +288,13 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 		socket.handleEvent("error", rt.ToValue(connErr))
 		if state.Options.Throw.Bool {
 			return nil, connErr
-		} else {
-			if state.Logger != nil {
-				state.Logger.WithField("error", connErr).Warn("Ws Connection Failed")
-			}
-			return &WSHTTPResponse{}, nil
 		}
+		if state.Logger != nil {
+			state.Logger.WithField("error", connErr).Warn("Ws Connection Failed")
+		}
+		return &WSHTTPResponse{
+			Error: connErr.Error(),
+		}, nil
 	}
 
 	// Run the user-provided set up function

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -286,8 +286,12 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 	if connErr != nil {
 		// Pass the error to the user script before exiting immediately
 		socket.handleEvent("error", rt.ToValue(connErr))
-
-		return nil, connErr
+		if state.Options.Throw.Bool {
+			return nil, connErr
+		} else {
+			state.Logger.WithField("error", connErr).Warn("Ws Connection Failed")
+			return nil, nil
+		}
 	}
 
 	// Run the user-provided set up function

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -289,7 +289,7 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 		if state.Options.Throw.Bool {
 			return nil, connErr
 		}
-		state.Logger.WithField("error", connErr).Warn("Ws Connection Failed")
+		state.Logger.WithError(connErr).Warn("Attempt to establish a WebSocket connection failed")
 		return &WSHTTPResponse{
 			Error: connErr.Error(),
 		}, nil

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -1346,9 +1346,9 @@ func TestWSConnectWithThrowErrorOption(t *testing.T) {
 			});
 		});
 		`)
+		require.NoError(t, err)
 		entries := logHook.Drain()
 		require.Len(t, entries, 1)
 		assert.Contains(t, entries[0].Message, "Attempt to establish a WebSocket connection failed")
-		assert.NoError(t, err)
 	})
 }

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -1345,8 +1345,11 @@ func TestWSConnectWithThrowErrorOption(t *testing.T) {
 				socket.close();
 			});
 		});
+		if (res == null && res.error == null) {
+			throw new Error("res.error is expected to be not null");
+		}
 		`)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		entries := logHook.Drain()
 		require.Len(t, entries, 1)
 		assert.Contains(t, entries[0].Message, "Attempt to establish a WebSocket connection failed")

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -1348,7 +1348,7 @@ func TestWSConnectWithThrowErrorOption(t *testing.T) {
 		`)
 		entries := logHook.Drain()
 		require.Len(t, entries, 1)
-		assert.Contains(t, entries[0].Message, "Ws Connection Failed")
+		assert.Contains(t, entries[0].Message, "Attempt to establish a WebSocket connection failed")
 		assert.NoError(t, err)
 	})
 }

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -1293,6 +1293,7 @@ func TestCookieJar(t *testing.T) {
 }
 
 func TestWSConnectWithThrowErrorOption(t *testing.T) {
+	t.Parallel()
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	root, err := lib.NewGroup("", nil)
 	require.NoError(t, err)
@@ -1326,6 +1327,7 @@ func TestWSConnectWithThrowErrorOption(t *testing.T) {
 	require.NoError(t, rt.Set("ws", m.Exports().Default))
 
 	t.Run("ThrowEnabled", func(t *testing.T) {
+		t.Parallel()
 		state.Options.Throw = null.BoolFrom(true)
 		_, err = rt.RunString(`
 		var res = ws.connect("INVALID", function(socket){
@@ -1338,6 +1340,7 @@ func TestWSConnectWithThrowErrorOption(t *testing.T) {
 	})
 
 	t.Run("ThrowDisabled", func(t *testing.T) {
+		t.Parallel()
 		state.Options.Throw = null.BoolFrom(false)
 		_, err = rt.RunString(`
 		var res = ws.connect("INVALID", function(socket){

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -125,6 +125,7 @@ func newTestState(t testing.TB) testState {
 				metrics.TagSubproto,
 			),
 			UserAgent: null.StringFrom("TestUserAgent"),
+			Throw:     null.BoolFrom(true),
 		},
 		Samples:        samples,
 		TLSConfig:      tb.TLSClientConfig,
@@ -1303,8 +1304,6 @@ func TestWSConnectWithThrowErrorOption(t *testing.T) {
 	t.Run("ThrowEnabled", func(t *testing.T) {
 		t.Parallel()
 		ts := newTestState(t)
-		ts.state.Logger = testLog
-		ts.state.Options.Throw = null.BoolFrom(true)
 		_, err := ts.rt.RunString(`
 		var res = ws.connect("INVALID", function(socket){
 			socket.on("open", function() {


### PR DESCRIPTION
<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
# What is the pr for ?
Fix issue #2247 

# Test

## With `throw = false`
<img width="885" alt="image" src="https://user-images.githubusercontent.com/961094/180745026-cdc3cf02-76dd-40e3-8f3a-5d29dbfa7231.png">


## With `throw = true`
<img width="883" alt="image" src="https://user-images.githubusercontent.com/961094/180744942-4191e805-bb3c-444a-8c1f-7250269d21cb.png">
 