### PR TITLE
Renamed TagSet to EnabledTags

### DIFF
--- a/metrics/system_tag.go
+++ b/metrics/system_tag.go
@@ -32,56 +32,6 @@ import (
 //go:generate enumer -type=SystemTagSet -transform=snake -trimprefix=Tag -output system_tag_set_gen.go
 type SystemTagSet uint32
 
-// TagSet is a string to bool map (for lookup efficiency) that is used to keep track
-// of which system tags and non-system tags to include.
-type TagSet map[string]bool
-
-// UnmarshalText converts the tag list to TagSet.
-func (i *TagSet) UnmarshalText(data []byte) error {
-	list := bytes.Split(data, []byte(","))
-	if *i == nil {
-		*i = make(TagSet, len(list))
-	}
-
-	for _, key := range list {
-		key := strings.TrimSpace(string(key))
-		if key == "" {
-			continue
-		}
-		(*i)[key] = true
-	}
-
-	return nil
-}
-
-// MarshalJSON converts the TagSet to a list (JS array).
-func (i *TagSet) MarshalJSON() ([]byte, error) {
-	var tags []string
-	if *i != nil {
-		tags = make([]string, 0, len(*i))
-		for tag := range *i {
-			tags = append(tags, tag)
-		}
-		sort.Strings(tags)
-	}
-
-	return json.Marshal(tags)
-}
-
-// UnmarshalJSON converts the tag list back to expected tag set.
-func (i *TagSet) UnmarshalJSON(data []byte) error {
-	var tags []string
-	if err := json.Unmarshal(data, &tags); err != nil {
-		return err
-	}
-	*i = make(TagSet, len(tags))
-	for _, tag := range tags {
-		(*i)[tag] = true
-	}
-
-	return nil
-}
-
 // Default system tags includes all of the system tags emitted with metrics by default.
 const (
 	TagProto SystemTagSet = 1 << iota
@@ -128,9 +78,9 @@ func (i *SystemTagSet) Has(tag SystemTagSet) bool {
 	return *i&tag != 0
 }
 
-// Map returns the TagSet with current value from SystemTagSet
-func (i SystemTagSet) Map() TagSet {
-	m := TagSet{}
+// Map returns the EnabledTags with current value from SystemTagSet
+func (i SystemTagSet) Map() EnabledTags {
+	m := EnabledTags{}
 	for _, tag := range SystemTagSetValues() {
 		if i.Has(tag) {
 			m[tag.String()] = true

--- a/metrics/system_tag_test.go
+++ b/metrics/system_tag_test.go
@@ -92,11 +92,11 @@ func TestTagSetMarshalJSON(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		tagset   TagSet
+		tagset   EnabledTags
 		expected string
 	}{
-		{tagset: TagSet{"ip": true, "proto": true, "group": true, "custom": true}, expected: `["custom","group","ip","proto"]`},
-		{tagset: TagSet{}, expected: `[]`},
+		{tagset: EnabledTags{"ip": true, "proto": true, "group": true, "custom": true}, expected: `["custom","group","ip","proto"]`},
+		{tagset: EnabledTags{}, expected: `[]`},
 	}
 
 	for _, tc := range tests {
@@ -112,14 +112,14 @@ func TestTagSet_UnmarshalJSON(t *testing.T) {
 
 	tests := []struct {
 		tags []byte
-		sets TagSet
+		sets EnabledTags
 	}{
-		{[]byte(`[]`), TagSet{}},
-		{[]byte(`["ip","custom", "proto"]`), TagSet{"ip": true, "proto": true, "custom": true}},
+		{[]byte(`[]`), EnabledTags{}},
+		{[]byte(`["ip","custom", "proto"]`), EnabledTags{"ip": true, "proto": true, "custom": true}},
 	}
 
 	for _, tc := range tests {
-		ts := new(TagSet)
+		ts := new(EnabledTags)
 		require.Nil(t, json.Unmarshal(tc.tags, ts))
 		for tag := range tc.sets {
 			assert.True(t, (*ts)[tag])
@@ -130,8 +130,8 @@ func TestTagSet_UnmarshalJSON(t *testing.T) {
 func TestTagSetTextUnmarshal(t *testing.T) {
 	t.Parallel()
 
-	testMatrix := map[string]TagSet{
-		"":                           make(TagSet),
+	testMatrix := map[string]EnabledTags{
+		"":                           make(EnabledTags),
 		"ip":                         {"ip": true},
 		"ip,proto":                   {"ip": true, "proto": true},
 		"   ip  ,  proto  ":          {"ip": true, "proto": true},
@@ -141,7 +141,7 @@ func TestTagSetTextUnmarshal(t *testing.T) {
 	}
 
 	for input, expected := range testMatrix {
-		set := new(TagSet)
+		set := new(EnabledTags)
 		err := set.UnmarshalText([]byte(input))
 		require.NoError(t, err)
 		require.Equal(t, expected, *set)

--- a/metrics/tags.go
+++ b/metrics/tags.go
@@ -1,0 +1,58 @@
+package metrics
+
+import (
+	"bytes"
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// EnabledTags is a string to bool map (for lookup efficiency) that is used to keep track
+// of which system tags and non-system tags to include.
+type EnabledTags map[string]bool
+
+// UnmarshalText converts the tag list to EnabledTags.
+func (i *EnabledTags) UnmarshalText(data []byte) error {
+	list := bytes.Split(data, []byte(","))
+	if *i == nil {
+		*i = make(EnabledTags, len(list))
+	}
+
+	for _, key := range list {
+		key := strings.TrimSpace(string(key))
+		if key == "" {
+			continue
+		}
+		(*i)[key] = true
+	}
+
+	return nil
+}
+
+// MarshalJSON converts the EnabledTags to a list (JS array).
+func (i *EnabledTags) MarshalJSON() ([]byte, error) {
+	var tags []string
+	if *i != nil {
+		tags = make([]string, 0, len(*i))
+		for tag := range *i {
+			tags = append(tags, tag)
+		}
+		sort.Strings(tags)
+	}
+
+	return json.Marshal(tags)
+}
+
+// UnmarshalJSON converts the tag list back to expected tag set.
+func (i *EnabledTags) UnmarshalJSON(data []byte) error {
+	var tags []string
+	if err := json.Unmarshal(data, &tags); err != nil {
+		return err
+	}
+	*i = make(EnabledTags, len(tags))
+	for _, tag := range tags {
+		(*i)[tag] = true
+	}
+
+	return nil
+}

--- a/metrics/tags_test.go
+++ b/metrics/tags_test.go
@@ -1,0 +1,69 @@
+package metrics
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnabledTagsMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tagset   EnabledTags
+		expected string
+	}{
+		{tagset: EnabledTags{"ip": true, "proto": true, "group": true, "custom": true}, expected: `["custom","group","ip","proto"]`},
+		{tagset: EnabledTags{}, expected: `[]`},
+	}
+
+	for _, tc := range tests {
+		ts := &tc.tagset
+		got, err := json.Marshal(ts)
+		require.Nil(t, err)
+		require.Equal(t, tc.expected, string(got))
+	}
+}
+
+func TestEnabledTagsUnmarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		tags []byte
+		sets EnabledTags
+	}{
+		{[]byte(`[]`), EnabledTags{}},
+		{[]byte(`["ip","custom", "proto"]`), EnabledTags{"ip": true, "proto": true, "custom": true}},
+	}
+
+	for _, tc := range tests {
+		ts := new(EnabledTags)
+		require.Nil(t, json.Unmarshal(tc.tags, ts))
+		for tag := range tc.sets {
+			assert.True(t, (*ts)[tag])
+		}
+	}
+}
+
+func TestEnabledTagsTextUnmarshal(t *testing.T) {
+	t.Parallel()
+
+	testMatrix := map[string]EnabledTags{
+		"":                           make(EnabledTags),
+		"ip":                         {"ip": true},
+		"ip,proto":                   {"ip": true, "proto": true},
+		"   ip  ,  proto  ":          {"ip": true, "proto": true},
+		"   ip  ,   ,  proto  ":      {"ip": true, "proto": true},
+		"   ip  ,,  proto  ,,":       {"ip": true, "proto": true},
+		"   ip  ,custom,  proto  ,,": {"ip": true, "custom": true, "proto": true},
+	}
+
+	for input, expected := range testMatrix {
+		set := new(EnabledTags)
+		err := set.UnmarshalText([]byte(input))
+		require.NoError(t, err)
+		require.Equal(t, expected, *set)
+	}
+}

--- a/output/statsd/config.go
+++ b/output/statsd/config.go
@@ -33,15 +33,15 @@ import (
 
 // config defines the StatsD configuration.
 type config struct {
-	Addr         null.String        `json:"addr,omitempty" envconfig:"K6_STATSD_ADDR"`
-	BufferSize   null.Int           `json:"bufferSize,omitempty" envconfig:"K6_STATSD_BUFFER_SIZE"`
-	Namespace    null.String        `json:"namespace,omitempty" envconfig:"K6_STATSD_NAMESPACE"`
-	PushInterval types.NullDuration `json:"pushInterval,omitempty" envconfig:"K6_STATSD_PUSH_INTERVAL"`
-	TagBlocklist metrics.TagSet     `json:"tagBlocklist,omitempty" envconfig:"K6_STATSD_TAG_BLOCKLIST"`
-	EnableTags   null.Bool          `json:"enableTags,omitempty" envconfig:"K6_STATSD_ENABLE_TAGS"`
+	Addr         null.String         `json:"addr,omitempty" envconfig:"K6_STATSD_ADDR"`
+	BufferSize   null.Int            `json:"bufferSize,omitempty" envconfig:"K6_STATSD_BUFFER_SIZE"`
+	Namespace    null.String         `json:"namespace,omitempty" envconfig:"K6_STATSD_NAMESPACE"`
+	PushInterval types.NullDuration  `json:"pushInterval,omitempty" envconfig:"K6_STATSD_PUSH_INTERVAL"`
+	TagBlocklist metrics.EnabledTags `json:"tagBlocklist,omitempty" envconfig:"K6_STATSD_TAG_BLOCKLIST"`
+	EnableTags   null.Bool           `json:"enableTags,omitempty" envconfig:"K6_STATSD_ENABLE_TAGS"`
 }
 
-func processTags(t metrics.TagSet, tags map[string]string) []string {
+func processTags(t metrics.EnabledTags, tags map[string]string) []string {
 	var res []string
 	for key, value := range tags {
 		if value != "" && !t[key] {

--- a/output/statsd/output_test.go
+++ b/output/statsd/output_test.go
@@ -62,7 +62,7 @@ func TestStatsdOutput(t *testing.T) {
 
 func TestStatsdEnabledTags(t *testing.T) {
 	t.Parallel()
-	tagMap := metrics.TagSet{"tag1": true, "tag2": true}
+	tagMap := metrics.EnabledTags{"tag1": true, "tag2": true}
 
 	baseTest(t, func(
 		logger logrus.FieldLogger, addr, namespace null.String, bufferSize null.Int, pushInterval types.NullDuration,


### PR DESCRIPTION
It releases the name `TagSet` so we can reuse it for a set of tags instead of system tags that should fit better the name.
I moved it into a dedicated `tags.go` file so we can centralize a bit around tags and I will continue more in the time series.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
