### PR TITLE
lib/options: Migrated RunTags to map[string]string type

### DIFF
--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -370,6 +370,20 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 				)
 			},
 		},
+
+		// Test-wide Tags
+		{
+			opts{
+				fs:  defaultConfig(`{"tags": { "codeTagKey": "codeTagValue"}}`),
+				cli: []string{"--tag", "clitagkey=clitagvalue"},
+			},
+			exp{},
+			func(t *testing.T, c Config) {
+				exp := map[string]string{"clitagkey": "clitagvalue"}
+				assert.Equal(t, exp, c.RunTags)
+			},
+		},
+
 		// Test summary trend stats
 		{opts{}, exp{}, func(t *testing.T, c Config) {
 			assert.Equal(t, lib.DefaultSummaryTrendStats, c.Options.SummaryTrendStats)

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -245,7 +245,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 			}
 			parsedRunTags[name] = value
 		}
-		opts.RunTags = metrics.IntoSampleTags(&parsedRunTags)
+		opts.RunTags = parsedRunTags
 	}
 
 	redirectConFile, err := flags.GetString("console-output")

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -224,6 +224,7 @@ func (e *ExecutionScheduler) initVUsConcurrently(
 
 func (e *ExecutionScheduler) emitVUsAndVUsMax(ctx context.Context, out chan<- metrics.SampleContainer) {
 	e.state.Test.Logger.Debug("Starting emission of VUs and VUsMax metrics...")
+	runTags := metrics.NewSampleTags(e.state.Test.Options.RunTags)
 
 	emitMetrics := func() {
 		t := time.Now()
@@ -233,15 +234,15 @@ func (e *ExecutionScheduler) emitVUsAndVUsMax(ctx context.Context, out chan<- me
 					Time:   t,
 					Metric: e.state.Test.BuiltinMetrics.VUs,
 					Value:  float64(e.state.GetCurrentlyActiveVUsCount()),
-					Tags:   e.state.Test.Options.RunTags,
+					Tags:   runTags,
 				}, {
 					Time:   t,
 					Metric: e.state.Test.BuiltinMetrics.VUsMax,
 					Value:  float64(e.state.GetInitializedVUsCount()),
-					Tags:   e.state.Test.Options.RunTags,
+					Tags:   runTags,
 				},
 			},
-			Tags: e.state.Test.Options.RunTags,
+			Tags: runTags,
 			Time: t,
 		}
 		metrics.PushIfNotDone(ctx, out, samples)

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -352,7 +352,7 @@ func TestOptionsTestFull(t *testing.T) {
 					sysm := metrics.TagIter | metrics.TagVU
 					return &sysm
 				}(),
-				RunTags:                 metrics.NewSampleTags(map[string]string{"runtag-key": "runtag-value"}),
+				RunTags:                 map[string]string{"runtag-key": "runtag-value"},
 				MetricSamplesBufferSize: null.IntFrom(8),
 				ConsoleOutput:           null.StringFrom("loadtest.log"),
 				LocalIPs: func() types.NullIPPool {

--- a/js/runner.go
+++ b/js/runner.go
@@ -257,7 +257,7 @@ func (r *Runner) newVU(idLocal, idGlobal uint64, samplesOut chan<- metrics.Sampl
 		VUID:           vu.ID,
 		VUIDGlobal:     vu.IDGlobal,
 		Samples:        vu.Samples,
-		Tags:           lib.NewTagMap(vu.Runner.Bundle.Options.RunTags.CloneTags()),
+		Tags:           lib.NewTagMap(copyStringMap(vu.Runner.Bundle.Options.RunTags)),
 		Group:          r.defaultGroup,
 		BuiltinMetrics: r.preInitState.BuiltinMetrics,
 	}
@@ -630,7 +630,7 @@ func (u *VU) Activate(params *lib.VUActivationParams) lib.ActiveVU {
 
 	opts := u.Runner.Bundle.Options
 	// TODO: maybe we can cache the original tags only clone them and add (if any) new tags on top ?
-	u.state.Tags = lib.NewTagMap(opts.RunTags.CloneTags())
+	u.state.Tags = lib.NewTagMap(copyStringMap(opts.RunTags))
 	for k, v := range params.Tags {
 		u.state.Tags.Set(k, v)
 	}
@@ -860,4 +860,12 @@ func (s *scriptException) Hint() string {
 
 func (s *scriptException) ExitCode() exitcodes.ExitCode {
 	return exitcodes.ScriptException
+}
+
+func copyStringMap(m map[string]string) map[string]string {
+	clone := make(map[string]string, len(m))
+	for ktag, vtag := range m {
+		clone[ktag] = vtag
+	}
+	return clone
 }

--- a/lib/executor/base_executor.go
+++ b/lib/executor/base_executor.go
@@ -93,7 +93,10 @@ func (bs *BaseExecutor) GetProgress() *pb.ProgressBar {
 // getMetricTags returns a tag set that can be used to emit metrics by the
 // executor. The VU ID is optional.
 func (bs *BaseExecutor) getMetricTags(vuID *uint64) *metrics.SampleTags {
-	tags := bs.executionState.Test.Options.RunTags.CloneTags()
+	tags := make(map[string]string, len(bs.executionState.Test.Options.RunTags))
+	for k, v := range bs.executionState.Test.Options.RunTags {
+		tags[k] = v
+	}
 	if bs.executionState.Test.Options.SystemTags.Has(metrics.TagScenario) {
 		tags["scenario"] = bs.config.GetName()
 	}

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -118,7 +118,6 @@ func TestMakeRequestError(t *testing.T) {
 			Compressions: []CompressionType{badCompressionType},
 		}
 		state := &lib.State{
-			Options:   lib.Options{RunTags: &metrics.SampleTags{}},
 			Transport: http.DefaultTransport,
 			Logger:    logrus.New(),
 			Tags:      lib.NewTagMap(nil),
@@ -141,7 +140,6 @@ func TestMakeRequestError(t *testing.T) {
 		logger := logrus.New()
 		logger.Level = logrus.DebugLevel
 		state := &lib.State{
-			Options:   lib.Options{RunTags: &metrics.SampleTags{}},
 			Transport: srv.Client().Transport,
 			Logger:    logger,
 			Tags:      lib.NewTagMap(nil),
@@ -192,7 +190,6 @@ func TestResponseStatus(t *testing.T) {
 				samples := make(chan<- metrics.SampleContainer, 1)
 				registry := metrics.NewRegistry()
 				state := &lib.State{
-					Options:        lib.Options{RunTags: &metrics.SampleTags{}},
 					Transport:      server.Client().Transport,
 					Logger:         logger,
 					Samples:        samples,
@@ -271,7 +268,6 @@ func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 	registry := metrics.NewRegistry()
 	state := &lib.State{
 		Options: lib.Options{
-			RunTags:    &metrics.SampleTags{},
 			SystemTags: &metrics.DefaultSystemTagSet,
 		},
 		Transport:      srv.Client().Transport,
@@ -348,7 +344,6 @@ func TestTrailFailed(t *testing.T) {
 			registry := metrics.NewRegistry()
 			state := &lib.State{
 				Options: lib.Options{
-					RunTags:    &metrics.SampleTags{},
 					SystemTags: &metrics.DefaultSystemTagSet,
 				},
 				Transport:      srv.Client().Transport,
@@ -410,7 +405,6 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 	registry := metrics.NewRegistry()
 	state := &lib.State{
 		Options: lib.Options{
-			RunTags:    &metrics.SampleTags{},
 			SystemTags: &metrics.DefaultSystemTagSet,
 		},
 		Transport: &http.Transport{
@@ -469,7 +463,6 @@ func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 	registry := metrics.NewRegistry()
 	state := &lib.State{
 		Options: lib.Options{
-			RunTags:    &metrics.SampleTags{},
 			SystemTags: &metrics.DefaultSystemTagSet,
 		},
 		Transport:      srv.Client().Transport,

--- a/lib/netext/httpext/transport_test.go
+++ b/lib/netext/httpext/transport_test.go
@@ -46,7 +46,6 @@ func BenchmarkMeasureAndEmitMetrics(b *testing.B) {
 	registry := metrics.NewRegistry()
 	state := &lib.State{
 		Options: lib.Options{
-			RunTags:    &metrics.SampleTags{},
 			SystemTags: &metrics.DefaultSystemTagSet,
 		},
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),

--- a/lib/options.go
+++ b/lib/options.go
@@ -411,8 +411,8 @@ type Options struct {
 	// Use pointer for identifying whether user provide any tag or not.
 	SystemTags *metrics.SystemTagSet `json:"systemTags" envconfig:"K6_SYSTEM_TAGS"`
 
-	// Tags to be applied to all samples for this running
-	RunTags *metrics.SampleTags `json:"tags" envconfig:"K6_TAGS"`
+	// Tags are key-value pairs to be applied to all samples for the run.
+	RunTags map[string]string `json:"tags" envconfig:"K6_TAGS"`
 
 	// Buffer size of the channel for metric samples; 0 means unbuffered
 	MetricSamplesBufferSize null.Int `json:"metricSamplesBufferSize" envconfig:"K6_METRIC_SAMPLES_BUFFER_SIZE"`
@@ -567,7 +567,7 @@ func (o Options) Apply(opts Options) Options {
 	if opts.SystemTags != nil {
 		o.SystemTags = opts.SystemTags
 	}
-	if !opts.RunTags.IsEmpty() {
+	if len(opts.RunTags) > 0 {
 		o.RunTags = opts.RunTags
 	}
 	if opts.MetricSamplesBufferSize.Valid {

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -562,7 +562,7 @@ func TestOptions(t *testing.T) {
 	})
 	t.Run("RunTags", func(t *testing.T) {
 		t.Parallel()
-		tags := metrics.IntoSampleTags(&map[string]string{"myTag": "hello"})
+		tags := map[string]string{"myTag": "hello"}
 		opts := Options{}.Apply(Options{RunTags: tags})
 		assert.Equal(t, tags, opts.RunTags)
 	})


### PR DESCRIPTION
It removes the dependency from SampleTags. In this way, it facilitates the transition to a more efficient SampleTags.

Related to: https://github.com/grafana/k6/pull/2594

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
