### PR TITLE
Keep the provided tags with a consistent order

### DIFF
--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -136,7 +136,6 @@ func (c *Client) parseRequest(
 		Throw:            state.Options.Throw.Bool,
 		Redirects:        state.Options.MaxRedirects,
 		Cookies:          make(map[string]*httpext.HTTPRequestCookie),
-		Tags:             make(map[string]string),
 		ResponseCallback: c.responseCallback,
 	}
 
@@ -336,8 +335,10 @@ func (c *Client) parseRequest(
 				if tagObj == nil {
 					continue
 				}
-				for _, key := range tagObj.Keys() {
-					result.Tags[key] = tagObj.Get(key).String()
+				tagKeys := tagObj.Keys()
+				result.Tags = make([][2]string, 0, len(tagKeys))
+				for _, key := range tagKeys {
+					result.Tags = append(result.Tags, [2]string{key, tagObj.Get(key).String()})
 				}
 			case "auth":
 				result.Auth = params.Get(k).String()

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -92,7 +92,7 @@ func limitValue(v string) string {
 	}, string(omitMsg))
 }
 
-func (m Metric) add(v goja.Value, addTags ...map[string]string) (bool, error) {
+func (m Metric) add(v goja.Value, addTags goja.Value) (bool, error) {
 	state := m.vu.State()
 	if state == nil {
 		return false, ErrMetricsAddInInitContext
@@ -129,9 +129,10 @@ func (m Metric) add(v goja.Value, addTags ...map[string]string) (bool, error) {
 	}
 
 	tags := state.CloneTags()
-	for _, ts := range addTags {
-		for k, v := range ts {
-			tags[k] = v
+	if addTags != nil {
+		tagsobj := addTags.ToObject(m.vu.Runtime())
+		for _, key := range tagsobj.Keys() {
+			tags[key] = tagsobj.Get(key).String()
 		}
 	}
 

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -71,7 +71,7 @@ type ParsedHTTPRequest struct {
 	Redirects        null.Int
 	ActiveJar        *cookiejar.Jar
 	Cookies          map[string]*HTTPRequestCookie
-	Tags             map[string]string
+	Tags             [][2]string
 }
 
 // Matches non-compliant io.Closer implementations (e.g. zstd.Decoder)
@@ -189,8 +189,8 @@ func MakeRequest(ctx context.Context, state *lib.State, preq *ParsedHTTPRequest)
 
 	tags := state.CloneTags()
 	// Override any global tags with request-specific ones.
-	for k, v := range preq.Tags {
-		tags[k] = v
+	for _, tag := range preq.Tags {
+		tags[tag[0]] = tag[1]
 	}
 
 	// Only set the name system tag if the user didn't explicitly set it beforehand,


### PR DESCRIPTION
The new TagSet will be not optimal in the case the same set is provided with a different order. Let's keep them sorted as provided by the JavaScript Object.

Related to: https://github.com/grafana/k6/pull/2594#discussion_r929894515

[:warning: BREAKING CHANGE] It was possible to pass multiple tag sets to [add metric](https://k6.io/docs/javascript-api/k6-metrics/counter/counter-add), it was an error and it has been fixed in this PR.
<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
