### PR TITLE
Remove NewTagSet (old NewSampleTags) 

### DIFF
--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -302,7 +302,7 @@ func TestEngine_processSamples(t *testing.T) {
 				out <- metrics.Sample{
 					Metric: metric,
 					Value:  1.25,
-					Tags:   metrics.NewTagSet(map[string]string{"a": "1"}).SampleTags(),
+					Tags:   piState.Registry.BranchTagSetRootWith(map[string]string{"a": "1"}).SampleTags(),
 				}
 				close(done)
 				return nil
@@ -342,7 +342,7 @@ func TestEngine_processSamples(t *testing.T) {
 				out <- metrics.Sample{
 					Metric: metric,
 					Value:  1.25,
-					Tags:   metrics.NewTagSet(map[string]string{"a": "1", "b": "2"}).SampleTags(),
+					Tags:   piState.Registry.BranchTagSetRootWith(map[string]string{"a": "1", "b": "2"}).SampleTags(),
 				}
 				close(done)
 				return nil
@@ -398,7 +398,7 @@ func TestEngineThresholdsWillAbort(t *testing.T) {
 			out <- metrics.Sample{
 				Metric: metric,
 				Value:  1.25,
-				Tags:   metrics.NewTagSet(map[string]string{"a": "1"}).SampleTags(),
+				Tags:   piState.Registry.BranchTagSetRootWith(map[string]string{"a": "1"}).SampleTags(),
 			}
 			close(done)
 			return nil
@@ -444,7 +444,7 @@ func TestEngineAbortedByThresholds(t *testing.T) {
 			out <- metrics.Sample{
 				Metric: metric,
 				Value:  1.25,
-				Tags:   metrics.NewTagSet(map[string]string{"a": "1"}).SampleTags(),
+				Tags:   piState.Registry.BranchTagSetRootWith(map[string]string{"a": "1"}).SampleTags(),
 			}
 			<-ctx.Done()
 			close(done)

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -1243,8 +1243,8 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 		}
 	}
 
-	getTags := func(args ...string) *metrics.SampleTags {
-		tags := metrics.NewTagSet(nil)
+	getTags := func(r *metrics.Registry, args ...string) *metrics.SampleTags {
+		tags := r.BranchTagSetRoot()
 		for i := 0; i < len(args)-1; i += 2 {
 			tags.AddTag(args[i], args[i+1])
 		}
@@ -1256,7 +1256,7 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 		return metrics.Sample{
 			Metric: expMetric,
 			Time:   time.Now(),
-			Tags:   getTags(expTags...),
+			Tags:   getTags(piState.Registry, expTags...),
 			Value:  expValue,
 		}
 	}
@@ -1267,7 +1267,7 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 			net.Dialer{},
 			netext.NewResolver(net.LookupIP, 0, types.DNSfirst, types.DNSpreferIPv4),
 		).GetTrail(time.Now(), time.Now(),
-			true, emitIterations, getTags(expTags...), piState.BuiltinMetrics)
+			true, emitIterations, getTags(piState.Registry, expTags...), piState.BuiltinMetrics)
 	}
 
 	// Initially give a long time (5s) for the execScheduler to start

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -401,7 +401,7 @@ func TestRequestWithBinaryFile(t *testing.T) {
 		BPool:          bpool.NewBufferPool(1),
 		Samples:        make(chan metrics.SampleContainer, 500),
 		BuiltinMetrics: builtinMetrics,
-		Tags:           lib.NewTagMap(metrics.NewTagSet(nil)),
+		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -548,7 +548,7 @@ func TestRequestWithMultipleBinaryFiles(t *testing.T) {
 		BPool:          bpool.NewBufferPool(1),
 		Samples:        make(chan metrics.SampleContainer, 500),
 		BuiltinMetrics: builtinMetrics,
-		Tags:           lib.NewTagMap(metrics.NewTagSet(nil)),
+		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -42,7 +42,8 @@ func TestVUTags(t *testing.T) {
 
 		tenv := setupTagsExecEnv(t)
 		tenv.MoveToVUContext(&lib.State{
-			Tags: lib.NewTagMap(metrics.NewTagSet(map[string]string{"vu": "42"})),
+			Tags: lib.NewTagMap(
+				metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
 		})
 		tag, err := tenv.VU.Runtime().RunString(`exec.vu.tags["vu"]`)
 		require.NoError(t, err)
@@ -62,7 +63,8 @@ func TestVUTags(t *testing.T) {
 			Options: lib.Options{
 				SystemTags: metrics.NewSystemTagSet(metrics.TagVU),
 			},
-			Tags: lib.NewTagMap(metrics.NewTagSet(map[string]string{"vu": "42"})),
+			Tags: lib.NewTagMap(
+				metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
 		})
 		state := tenv.VU.State()
 		state.Tags.Set("custom-tag", "mytag1")
@@ -92,7 +94,8 @@ func TestVUTags(t *testing.T) {
 
 			tenv := setupTagsExecEnv(t)
 			tenv.MoveToVUContext(&lib.State{
-				Tags: lib.NewTagMap(metrics.NewTagSet(map[string]string{"vu": "42"})),
+				Tags: lib.NewTagMap(
+					metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
 			})
 
 			for _, tc := range tests {
@@ -111,7 +114,8 @@ func TestVUTags(t *testing.T) {
 
 			tenv := setupTagsExecEnv(t)
 			tenv.MoveToVUContext(&lib.State{
-				Tags: lib.NewTagMap(metrics.NewTagSet(map[string]string{"vu": "42"})),
+				Tags: lib.NewTagMap(
+					metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
 			})
 
 			_, err := tenv.VU.Runtime().RunString(`exec.vu.tags["vu"] = "vu101"`)
@@ -126,7 +130,8 @@ func TestVUTags(t *testing.T) {
 
 			tenv := setupTagsExecEnv(t)
 			tenv.MoveToVUContext(&lib.State{
-				Tags: lib.NewTagMap(metrics.NewTagSet(map[string]string{"vu": "42"})),
+				Tags: lib.NewTagMap(
+					metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
 			})
 
 			state := tenv.VU.State()
@@ -158,7 +163,8 @@ func TestVUTags(t *testing.T) {
 				Options: lib.Options{
 					SystemTags: metrics.NewSystemTagSet(metrics.TagVU),
 				},
-				Tags:   lib.NewTagMap(metrics.NewTagSet(map[string]string{"vu": "42"})),
+				Tags: lib.NewTagMap(
+					metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
 				Logger: testLog,
 			})
 			_, err := tenv.VU.Runtime().RunString(`exec.vu.tags["custom-tag"] = [1, 3, 5]`)
@@ -183,7 +189,8 @@ func TestVUTags(t *testing.T) {
 				Options: lib.Options{
 					SystemTags: metrics.NewSystemTagSet(metrics.TagVU),
 				},
-				Tags:   lib.NewTagMap(metrics.NewTagSet(map[string]string{"vu": "42"})),
+				Tags: lib.NewTagMap(
+					metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
 				Logger: testLog,
 			})
 			for _, val := range cases {

--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -701,8 +701,10 @@ func TestClient(t *testing.T) {
 			val, err := replace(tt.initString.code)
 			assertResponse(t, tt.initString, err, val, ts)
 
+			registry := metrics.NewRegistry()
 			root, err := lib.NewGroup("", nil)
 			require.NoError(t, err)
+
 			state := &lib.State{
 				Group:     root,
 				Dialer:    ts.httpBin.Dialer,
@@ -715,10 +717,8 @@ func TestClient(t *testing.T) {
 					),
 					UserAgent: null.StringFrom("k6-test"),
 				},
-				BuiltinMetrics: metrics.RegisterBuiltinMetrics(
-					metrics.NewRegistry(),
-				),
-				Tags: lib.NewTagMap(metrics.NewTagSet(nil)),
+				BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+				Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
 			}
 			ts.MoveToVUContext(state)
 			val, err = replace(tt.vuString.code)

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -159,7 +159,7 @@ func newRuntime(t testing.TB) (
 		Transport: tb.HTTPTransport,
 		BPool:     bpool.NewBufferPool(1),
 		Samples:   samples,
-		Tags: lib.NewTagMap(metrics.NewTagSet(map[string]string{
+		Tags: lib.NewTagMap(registry.BranchTagSetRootWith(map[string]string{
 			"group": root.Path,
 		})),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
@@ -1113,7 +1113,7 @@ func TestRequestAndBatch(t *testing.T) {
 			t.Run("tags-precedence", func(t *testing.T) {
 				oldTags := state.Tags
 				defer func() { state.Tags = oldTags }()
-				state.Tags = lib.NewTagMap(metrics.NewTagSet(map[string]string{
+				state.Tags = lib.NewTagMap(metrics.NewRegistry().BranchTagSetRootWith(map[string]string{
 					"runtag1": "val1",
 					"runtag2": "val2",
 				}))

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -122,9 +122,10 @@ func TestMetrics(t *testing.T) {
 					}
 					test.rt = goja.New()
 					test.rt.SetFieldNameMapper(common.FieldNameMapper{})
+					registry := metrics.NewRegistry()
 					mii := &modulestest.VU{
 						RuntimeField: test.rt,
-						InitEnvField: &common.InitEnvironment{Registry: metrics.NewRegistry()},
+						InitEnvField: &common.InitEnvironment{Registry: registry},
 						CtxField:     context.Background(),
 					}
 					m, ok := New().NewModuleInstance(mii).(*ModuleInstance)
@@ -134,7 +135,7 @@ func TestMetrics(t *testing.T) {
 					state := &lib.State{
 						Options: lib.Options{},
 						Samples: test.samples,
-						Tags: lib.NewTagMap(metrics.NewTagSet(map[string]string{
+						Tags: lib.NewTagMap(registry.BranchTagSetRootWith(map[string]string{
 							"key": "value",
 						})),
 					}

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -106,7 +106,7 @@ func newTestState(t testing.TB) testState {
 
 	root, err := lib.NewGroup("", nil)
 	require.NoError(t, err)
-
+	registry := metrics.NewRegistry()
 	state := &lib.State{
 		Group:  root,
 		Dialer: tb.Dialer,
@@ -122,8 +122,8 @@ func newTestState(t testing.TB) testState {
 		},
 		Samples:        samples,
 		TLSConfig:      tb.TLSClientConfig,
-		BuiltinMetrics: metrics.RegisterBuiltinMetrics(metrics.NewRegistry()),
-		Tags:           lib.NewTagMap(metrics.NewTagSet(nil)),
+		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
 	}
 
 	m := New().NewModuleInstance(testRuntime.VU)

--- a/js/summary_test.go
+++ b/js/summary_test.go
@@ -99,7 +99,7 @@ func TestTextSummaryWithSubMetrics(t *testing.T) {
 	t.Parallel()
 
 	registry := metrics.NewRegistry()
-	rootTagSet := metrics.NewTagSet(nil)
+	rootTagSet := registry.BranchTagSetRoot()
 	parentMetric, err := registry.NewMetric("my_parent", metrics.Counter)
 	require.NoError(t, err)
 	parentMetric.Sink.Add(metrics.Sample{Value: 11})

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -120,7 +120,7 @@ func TestMakeRequestError(t *testing.T) {
 		state := &lib.State{
 			Transport: http.DefaultTransport,
 			Logger:    logrus.New(),
-			Tags:      lib.NewTagMap(metrics.NewTagSet(nil)),
+			Tags:      lib.NewTagMap(metrics.NewRegistry().BranchTagSetRoot()),
 		}
 		_, err = MakeRequest(ctx, state, preq)
 		require.Error(t, err)
@@ -142,7 +142,7 @@ func TestMakeRequestError(t *testing.T) {
 		state := &lib.State{
 			Transport: srv.Client().Transport,
 			Logger:    logger,
-			Tags:      lib.NewTagMap(metrics.NewTagSet(nil)),
+			Tags:      lib.NewTagMap(metrics.NewRegistry().BranchTagSetRoot()),
 		}
 		req, _ := http.NewRequest("GET", srv.URL, nil)
 		preq := &ParsedHTTPRequest{
@@ -194,7 +194,7 @@ func TestResponseStatus(t *testing.T) {
 					Logger:         logger,
 					Samples:        samples,
 					BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-					Tags:           lib.NewTagMap(metrics.NewTagSet(nil)),
+					Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
 				}
 				req, err := http.NewRequest("GET", server.URL, nil)
 				require.NoError(t, err)
@@ -275,7 +275,7 @@ func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 		Logger:         logger,
 		BPool:          bpool.NewBufferPool(100),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-		Tags:           lib.NewTagMap(metrics.NewTagSet(nil)),
+		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
 	}
 	req, _ := http.NewRequest("GET", srv.URL, nil)
 	preq := &ParsedHTTPRequest{
@@ -351,7 +351,7 @@ func TestTrailFailed(t *testing.T) {
 				Logger:         logger,
 				BPool:          bpool.NewBufferPool(2),
 				BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-				Tags:           lib.NewTagMap(metrics.NewTagSet(nil)),
+				Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
 			}
 			req, _ := http.NewRequest("GET", srv.URL, nil)
 			preq := &ParsedHTTPRequest{
@@ -416,7 +416,7 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 		Logger:         logger,
 		BPool:          bpool.NewBufferPool(100),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-		Tags:           lib.NewTagMap(metrics.NewTagSet(nil)),
+		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
 	}
 
 	req, _ := http.NewRequest("GET", "http://"+addr.String(), nil)
@@ -470,7 +470,7 @@ func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 		Logger:         logger,
 		BPool:          bpool.NewBufferPool(100),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-		Tags:           lib.NewTagMap(metrics.NewTagSet(nil)),
+		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
 	}
 	req, _ := http.NewRequest("GET", srv.URL, nil)
 	preq := &ParsedHTTPRequest{

--- a/lib/netext/httpext/tracer_test.go
+++ b/lib/netext/httpext/tracer_test.go
@@ -130,7 +130,8 @@ func TestTracer(t *testing.T) { //nolint:tparallel
 		}
 		prev = val
 	}
-	builtinMetrics := metrics.RegisterBuiltinMetrics(metrics.NewRegistry())
+	registry := metrics.NewRegistry()
+	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
 
 	for tnum, isReuse := range []bool{false, true, true} { //nolint:paralleltest
 		t.Run(fmt.Sprintf("Test #%d", tnum), func(t *testing.T) {
@@ -149,7 +150,7 @@ func TestTracer(t *testing.T) { //nolint:tparallel
 				time.Sleep(traceDelay)
 			}
 			trail := tracer.Done()
-			trail.SaveSamples(builtinMetrics, metrics.NewTagSet(map[string]string{"tag": "value"}).SampleTags())
+			trail.SaveSamples(builtinMetrics, registry.BranchTagSetRootWith(map[string]string{"tag": "value"}).SampleTags())
 			samples := trail.GetSamples()
 
 			assertLaterOrZero(t, tracer.getConn, isReuse)

--- a/lib/state_test.go
+++ b/lib/state_test.go
@@ -17,7 +17,7 @@ func TestTagMapSet(t *testing.T) {
 	t.Run("Sync", func(t *testing.T) {
 		t.Parallel()
 
-		tm := NewTagMap(metrics.NewTagSet(nil))
+		tm := NewTagMap(metrics.NewRegistry().BranchTagSetRoot())
 		tm.Set("mytag", "42")
 		v, found := tm.Get("mytag")
 		assert.True(t, found)
@@ -30,7 +30,7 @@ func TestTagMapSet(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		tm := NewTagMap(metrics.NewTagSet(nil))
+		tm := NewTagMap(metrics.NewRegistry().BranchTagSetRoot())
 
 		go func() {
 			count := 0
@@ -64,7 +64,7 @@ func TestTagMapSet(t *testing.T) {
 
 func TestTagMapGet(t *testing.T) {
 	t.Parallel()
-	tm := NewTagMap(metrics.NewTagSet(map[string]string{
+	tm := NewTagMap(metrics.NewRegistry().BranchTagSetRootWith(map[string]string{
 		"key1": "value1",
 	}))
 	v, ok := tm.Get("key1")
@@ -74,7 +74,7 @@ func TestTagMapGet(t *testing.T) {
 
 func TestTagMapLen(t *testing.T) {
 	t.Parallel()
-	tm := NewTagMap(metrics.NewTagSet(map[string]string{
+	tm := NewTagMap(metrics.NewRegistry().BranchTagSetRootWith(map[string]string{
 		"key1": "value1",
 		"key2": "value2",
 	}))
@@ -83,7 +83,7 @@ func TestTagMapLen(t *testing.T) {
 
 func TestTagMapDelete(t *testing.T) {
 	t.Parallel()
-	tm := NewTagMap(metrics.NewTagSet(map[string]string{
+	tm := NewTagMap(metrics.NewRegistry().BranchTagSetRootWith(map[string]string{
 		"key1": "value1",
 		"key2": "value2",
 	}))
@@ -100,7 +100,7 @@ func TestTagMapDelete(t *testing.T) {
 
 func TestTagMapClone(t *testing.T) {
 	t.Parallel()
-	tm := NewTagMap(metrics.NewTagSet(map[string]string{
+	tm := NewTagMap(metrics.NewRegistry().BranchTagSetRootWith(map[string]string{
 		"key1": "value1",
 		"key2": "value2",
 	}))

--- a/metrics/metric_test.go
+++ b/metrics/metric_test.go
@@ -55,7 +55,7 @@ func TestAddSubmetric(t *testing.T) {
 			t.Parallel()
 
 			m := newMetric("metric", Trend)
-			sm, err := m.AddSubmetric(name, NewTagSet(nil))
+			sm, err := m.AddSubmetric(name, newTagSet(nil))
 			if expected.err {
 				require.Error(t, err)
 				return

--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -146,7 +146,7 @@ func TestSampleTagsJSON(t *testing.T) {
 }
 
 func TestSampleImplementations(t *testing.T) {
-	tagMap := NewTagSet(map[string]string{"key1": "val1", "key2": "val2"})
+	tagMap := newTagSet(map[string]string{"key1": "val1", "key2": "val2"})
 	sampleTags := tagMap.SampleTags()
 	now := time.Now()
 

--- a/metrics/tags.go
+++ b/metrics/tags.go
@@ -14,23 +14,6 @@ type TagSet struct {
 	tags *atlas.Node
 }
 
-// NewTagSet creates a TagSet, if a not-nil map is passed
-// then it adds all the pairs to the set, otherwise an empty set is created.
-// Under the hood it initializes an Atlas root node.
-// It should be only used in a centralized place and
-// all the new TagSet should branch from it for getting
-// the optimal performances.
-func NewTagSet(m map[string]string) *TagSet {
-	node := atlas.New()
-	for k, v := range m {
-		node = node.AddLink(k, v)
-	}
-
-	return &TagSet{
-		tags: node,
-	}
-}
-
 // TagSetFromSampleTags creates a TagSet starting
 // from the set defined by SampleTags.
 // Adding a tag on the new set doesn't impact the SampleTags.

--- a/metrics/tags_test.go
+++ b/metrics/tags_test.go
@@ -12,7 +12,7 @@ import (
 func TestTagSetBranchOut(t *testing.T) {
 	t.Parallel()
 
-	tm := NewTagSet(nil)
+	tm := newTagSet(nil)
 	tm.AddTag("key1", "val1")
 
 	tm2 := tm.BranchOut()
@@ -101,5 +101,16 @@ func TestEnabledTagsTextUnmarshal(t *testing.T) {
 		err := set.UnmarshalText([]byte(input))
 		require.NoError(t, err)
 		require.Equal(t, expected, *set)
+	}
+}
+
+func newTagSet(m map[string]string) *TagSet {
+	node := atlas.New()
+	for k, v := range m {
+		node = node.AddLink(k, v)
+	}
+
+	return &TagSet{
+		tags: node,
 	}
 }

--- a/metrics/thresholds_test.go
+++ b/metrics/thresholds_test.go
@@ -394,7 +394,7 @@ func TestThresholdsValidate(t *testing.T) {
 		t.Parallel()
 
 		testRegistry := NewRegistry()
-		rootTagSet := NewTagSet(nil)
+		rootTagSet := newTagSet(nil)
 
 		testCounter, err := testRegistry.NewMetric("test_counter", Counter)
 		require.NoError(t, err)

--- a/output/cloud/bench_test.go
+++ b/output/cloud/bench_test.go
@@ -89,6 +89,7 @@ func BenchmarkAggregateHTTP(b *testing.B) {
 }
 
 func generateTags(i, tagCount int, additionals ...map[string]string) *metrics.SampleTags {
+	registry := metrics.NewRegistry()
 	res := map[string]string{
 		"test": "mest", "a": "b",
 		"custom": fmt.Sprintf("group%d", i%tagCount%9),
@@ -102,8 +103,7 @@ func generateTags(i, tagCount int, additionals ...map[string]string) *metrics.Sa
 		}
 	}
 
-	// FIXME: optimize
-	return metrics.NewTagSet(res).SampleTags()
+	return registry.BranchTagSetRootWith(res).SampleTags()
 }
 
 func BenchmarkMetricMarshal(b *testing.B) {

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -182,7 +182,8 @@ func runCloudOutputTestCase(t *testing.T, minSamples int) {
 		require.NoError(t, err)
 	}))
 
-	builtinMetrics := metrics.RegisterBuiltinMetrics(metrics.NewRegistry())
+	registry := metrics.NewRegistry()
+	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
 	out, err := newOutput(output.Params{
 		Logger:     testutils.NewLogger(t),
 		JSONConfig: json.RawMessage(fmt.Sprintf(`{"host": "%s", "noCompress": true}`, tb.ServerHTTP.URL)),
@@ -213,7 +214,7 @@ func runCloudOutputTestCase(t *testing.T, minSamples int) {
 
 	now := time.Now()
 	tagMap := map[string]string{"test": "mest", "a": "b", "name": "name", "url": "url"}
-	tags := metrics.NewTagSet(tagMap).SampleTags()
+	tags := registry.BranchTagSetRootWith(tagMap).SampleTags()
 	expectedTags := `{"test": "mest", "a": "b", "name": "name", "url": "name"}`
 
 	expSamples := make(chan []Sample)
@@ -311,7 +312,10 @@ func runCloudOutputTestCase(t *testing.T, minSamples int) {
 
 func TestCloudOutputMaxPerPacket(t *testing.T) {
 	t.Parallel()
-	builtinMetrics := metrics.RegisterBuiltinMetrics(metrics.NewRegistry())
+
+	registry := metrics.NewRegistry()
+	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
+
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	maxMetricSamplesPerPackage := 20
 	tb.Mux.HandleFunc("/v1/tests", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -341,7 +345,7 @@ func TestCloudOutputMaxPerPacket(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, err)
 	now := time.Now()
-	tags := metrics.NewTagSet(map[string]string{"test": "mest", "a": "b"}).SampleTags()
+	tags := registry.BranchTagSetRootWith(map[string]string{"test": "mest", "a": "b"})
 	gotTheLimit := false
 	var m sync.Mutex
 
@@ -364,7 +368,7 @@ func TestCloudOutputMaxPerPacket(t *testing.T) {
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
 		Time:   now,
 		Metric: builtinMetrics.VUs,
-		Tags:   metrics.NewTagSet(tags.CloneTags()).SampleTags(),
+		Tags:   tags.SampleTags(),
 		Value:  1.0,
 	}})
 	for j := time.Duration(1); j <= 200; j++ {
@@ -381,7 +385,7 @@ func TestCloudOutputMaxPerPacket(t *testing.T) {
 				EndTime:      now.Add(i * 100),
 				ConnDuration: 500 * time.Millisecond,
 				Duration:     j * i * 1500 * time.Millisecond,
-				Tags:         metrics.NewTagSet(tags.CloneTags()).SampleTags(),
+				Tags:         tags.SampleTags(),
 			})
 		}
 		out.AddMetricSamples(container)
@@ -405,8 +409,10 @@ func TestCloudOutputStopSendingMetric(t *testing.T) {
 }
 
 func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
-	tb := httpmultibin.NewHTTPMultiBin(t)
+	registry := metrics.NewRegistry()
 	builtinMetrics := metrics.RegisterBuiltinMetrics(metrics.NewRegistry())
+
+	tb := httpmultibin.NewHTTPMultiBin(t)
 	tb.Mux.HandleFunc("/v1/tests", http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		body, err := ioutil.ReadAll(req.Body)
 		require.NoError(t, err)
@@ -456,7 +462,7 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 	}
 	require.NoError(t, err)
 	now := time.Now()
-	tags := metrics.NewTagSet(map[string]string{"test": "mest", "a": "b"}).SampleTags()
+	tags := registry.BranchTagSetRootWith(map[string]string{"test": "mest", "a": "b"})
 
 	count := 1
 	max := 5
@@ -489,7 +495,7 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
 		Time:   now,
 		Metric: builtinMetrics.VUs,
-		Tags:   metrics.NewTagSet(tags.CloneTags()).SampleTags(),
+		Tags:   tags.SampleTags(),
 		Value:  1.0,
 	}})
 	for j := time.Duration(1); j <= 200; j++ {
@@ -506,7 +512,7 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 				EndTime:      now.Add(i * 100),
 				ConnDuration: 500 * time.Millisecond,
 				Duration:     j * i * 1500 * time.Millisecond,
-				Tags:         metrics.NewTagSet(tags.CloneTags()).SampleTags(),
+				Tags:         tags.SampleTags(),
 			})
 		}
 		out.AddMetricSamples(container)
@@ -529,7 +535,7 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
 		Time:   now,
 		Metric: builtinMetrics.VUs,
-		Tags:   metrics.NewTagSet(tags.CloneTags()).SampleTags(),
+		Tags:   tags.SampleTags(),
 		Value:  1.0,
 	}})
 	if nBufferSamples != len(out.bufferSamples) || nBufferHTTPTrails != len(out.bufferHTTPTrails) {
@@ -609,7 +615,10 @@ func TestCloudOutputAggregationPeriodZeroNoBlock(t *testing.T) {
 
 func TestCloudOutputPushRefID(t *testing.T) {
 	t.Parallel()
+
+	registry := metrics.NewRegistry()
 	builtinMetrics := metrics.RegisterBuiltinMetrics(metrics.NewRegistry())
+
 	expSamples := make(chan []Sample)
 	defer close(expSamples)
 
@@ -642,7 +651,7 @@ func TestCloudOutputPushRefID(t *testing.T) {
 	assert.Equal(t, "333", out.referenceID)
 
 	now := time.Now()
-	tags := metrics.NewTagSet(map[string]string{"test": "mest", "a": "b"}).SampleTags()
+	tags := registry.BranchTagSetRootWith(map[string]string{"test": "mest", "a": "b"}).SampleTags()
 	encodedTags, err := json.Marshal(tags)
 	require.NoError(t, err)
 
@@ -923,7 +932,7 @@ func TestUseCloudTags(t *testing.T) {
 			t.Parallel()
 
 			trail := &httpext.Trail{
-				Tags: metrics.NewTagSet(tc.in).SampleTags(),
+				Tags: metrics.NewRegistry().BranchTagSetRootWith(tc.in).SampleTags(),
 			}
 			newTrail := useCloudTags(trail)
 			assert.Equal(t, tc.exp, newTrail.Tags.CloneTags())

--- a/output/csv/output_test.go
+++ b/output/csv/output_test.go
@@ -65,7 +65,8 @@ func TestMakeHeader(t *testing.T) {
 }
 
 func TestSampleToRow(t *testing.T) {
-	testMetric, err := metrics.NewRegistry().NewMetric("my_metric", metrics.Gauge)
+	registry := metrics.NewRegistry()
+	testMetric, err := registry.NewMetric("my_metric", metrics.Gauge)
 	require.NoError(t, err)
 
 	testData := []struct {
@@ -81,7 +82,7 @@ func TestSampleToRow(t *testing.T) {
 				Time:   time.Unix(1562324644, 0),
 				Metric: testMetric,
 				Value:  1,
-				Tags: metrics.NewTagSet(map[string]string{
+				Tags: registry.BranchTagSetRootWith(map[string]string{
 					"tag1": "val1",
 					"tag2": "val2",
 					"tag3": "val3",
@@ -97,7 +98,7 @@ func TestSampleToRow(t *testing.T) {
 				Time:   time.Unix(1562324644, 0),
 				Metric: testMetric,
 				Value:  1,
-				Tags: metrics.NewTagSet(map[string]string{
+				Tags: registry.BranchTagSetRootWith(map[string]string{
 					"tag1": "val1",
 					"tag2": "val2",
 					"tag3": "val3",
@@ -115,7 +116,7 @@ func TestSampleToRow(t *testing.T) {
 				Time:   time.Unix(1562324644, 0),
 				Metric: testMetric,
 				Value:  1,
-				Tags: metrics.NewTagSet(map[string]string{
+				Tags: registry.BranchTagSetRootWith(map[string]string{
 					"tag1": "val1",
 					"tag2": "val2",
 					"tag3": "val3",
@@ -224,7 +225,8 @@ func readCompressedFile(fileName string, fs afero.Fs) string {
 func TestRun(t *testing.T) {
 	t.Parallel()
 
-	testMetric, err := metrics.NewRegistry().NewMetric("my_metric", metrics.Gauge)
+	registry := metrics.NewRegistry()
+	testMetric, err := registry.NewMetric("my_metric", metrics.Gauge)
 	require.NoError(t, err)
 
 	testData := []struct {
@@ -240,7 +242,7 @@ func TestRun(t *testing.T) {
 					Time:   time.Unix(1562324643, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: metrics.NewTagSet(map[string]string{
+					Tags: registry.BranchTagSetRootWith(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
@@ -250,7 +252,7 @@ func TestRun(t *testing.T) {
 					Time:   time.Unix(1562324644, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: metrics.NewTagSet(map[string]string{
+					Tags: registry.BranchTagSetRootWith(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
@@ -269,7 +271,7 @@ func TestRun(t *testing.T) {
 					Time:   time.Unix(1562324643, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: metrics.NewTagSet(map[string]string{
+					Tags: registry.BranchTagSetRootWith(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
@@ -279,7 +281,7 @@ func TestRun(t *testing.T) {
 					Time:   time.Unix(1562324644, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: metrics.NewTagSet(map[string]string{
+					Tags: registry.BranchTagSetRootWith(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
@@ -298,7 +300,7 @@ func TestRun(t *testing.T) {
 					Time:   time.Unix(1562324644, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: metrics.NewTagSet(map[string]string{
+					Tags: registry.BranchTagSetRootWith(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
@@ -308,7 +310,7 @@ func TestRun(t *testing.T) {
 					Time:   time.Unix(1562324644, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: metrics.NewTagSet(map[string]string{
+					Tags: registry.BranchTagSetRootWith(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",

--- a/output/helpers_test.go
+++ b/output/helpers_test.go
@@ -43,7 +43,7 @@ func TestSampleBufferBasics(t *testing.T) {
 		Time:   time.Now(),
 		Metric: metric,
 		Value:  float64(123),
-		Tags:   metrics.NewTagSet(map[string]string{"tag1": "val1"}).SampleTags(),
+		Tags:   registry.BranchTagSetRootWith(map[string]string{"tag1": "val1"}).SampleTags(),
 	}
 	connected := metrics.ConnectedSamples{Samples: []metrics.Sample{single, single}, Time: single.Time}
 	buffer := SampleBuffer{}
@@ -91,7 +91,7 @@ func TestSampleBufferConcurrently(t *testing.T) {
 				Time:   time.Unix(1562324644, 0),
 				Metric: metric,
 				Value:  float64(i),
-				Tags:   metrics.NewTagSet(map[string]string{"tag1": "val1"}).SampleTags(),
+				Tags:   registry.BranchTagSetRootWith(map[string]string{"tag1": "val1"}).SampleTags(),
 			}})
 			time.Sleep(time.Duration(i*sleepModifier) * time.Microsecond)
 		}

--- a/output/influxdb/bench_test.go
+++ b/output/influxdb/bench_test.go
@@ -32,9 +32,10 @@ import (
 )
 
 func benchmarkInfluxdb(b *testing.B, t time.Duration) {
-	metric, err := metrics.NewRegistry().NewMetric("test_gauge", metrics.Gauge)
+	registry := metrics.NewRegistry()
+	metric, err := registry.NewMetric("test_gauge", metrics.Gauge)
 	require.NoError(b, err)
-	tags := metrics.NewTagSet(map[string]string{
+	tags := registry.BranchTagSetRootWith(map[string]string{
 		"something": "else",
 		"VU":        "21",
 		"else":      "something",

--- a/output/influxdb/output_test.go
+++ b/output/influxdb/output_test.go
@@ -108,7 +108,8 @@ func testOutputCycle(t testing.TB, handler http.HandlerFunc, body func(testing.T
 func TestOutput(t *testing.T) {
 	t.Parallel()
 
-	metric, err := metrics.NewRegistry().NewMetric("test_gauge", metrics.Gauge)
+	registry := metrics.NewRegistry()
+	metric, err := registry.NewMetric("test_gauge", metrics.Gauge)
 	require.NoError(t, err)
 
 	var samplesRead int
@@ -136,7 +137,7 @@ func TestOutput(t *testing.T) {
 			samples[i] = metrics.Sample{
 				Metric: metric,
 				Time:   time.Now(),
-				Tags: metrics.NewTagSet(map[string]string{
+				Tags: registry.BranchTagSetRootWith(map[string]string{
 					"something": "else",
 					"VU":        "21",
 					"else":      "something",

--- a/output/json/json_test.go
+++ b/output/json/json_test.go
@@ -60,7 +60,7 @@ func generateTestMetricSamples(t testing.TB) ([]metrics.SampleContainer, func(io
 	metric1, err := registry.NewMetric("my_metric1", metrics.Gauge)
 	require.NoError(t, err)
 
-	_, err = metric1.AddSubmetric("a:1,b:2", metrics.NewTagSet(nil))
+	_, err = metric1.AddSubmetric("a:1,b:2", registry.BranchTagSetRoot())
 	require.NoError(t, err)
 
 	metric2, err := registry.NewMetric("my_metric2", metrics.Counter, metrics.Data)
@@ -70,16 +70,16 @@ func generateTestMetricSamples(t testing.TB) ([]metrics.SampleContainer, func(io
 	time2 := time1.Add(10 * time.Second)
 	time3 := time2.Add(10 * time.Second)
 
-	connTags := metrics.NewTagSet(map[string]string{"key": "val"}).SampleTags()
+	connTags := registry.BranchTagSetRootWith(map[string]string{"key": "val"}).SampleTags()
 
 	samples := []metrics.SampleContainer{
-		metrics.Sample{Time: time1, Metric: metric1, Value: float64(1), Tags: metrics.NewTagSet(map[string]string{"tag1": "val1"}).SampleTags()},
-		metrics.Sample{Time: time1, Metric: metric1, Value: float64(2), Tags: metrics.NewTagSet(map[string]string{"tag2": "val2"}).SampleTags()},
+		metrics.Sample{Time: time1, Metric: metric1, Value: float64(1), Tags: registry.BranchTagSetRootWith(map[string]string{"tag1": "val1"}).SampleTags()},
+		metrics.Sample{Time: time1, Metric: metric1, Value: float64(2), Tags: registry.BranchTagSetRootWith(map[string]string{"tag2": "val2"}).SampleTags()},
 		metrics.ConnectedSamples{Samples: []metrics.Sample{
 			{Time: time2, Metric: metric2, Value: float64(3), Tags: connTags},
 			{Time: time2, Metric: metric1, Value: float64(4), Tags: connTags},
 		}, Time: time2, Tags: connTags},
-		metrics.Sample{Time: time3, Metric: metric2, Value: float64(5), Tags: metrics.NewTagSet(map[string]string{"tag3": "val3"}).SampleTags()},
+		metrics.Sample{Time: time3, Metric: metric2, Value: float64(5), Tags: registry.BranchTagSetRootWith(map[string]string{"tag3": "val3"}).SampleTags()},
 	}
 	expected := []string{
 		`{"type":"Metric","data":{"name":"my_metric1","type":"gauge","contains":"default","thresholds":["rate<0.01","p(99)<250"],"submetrics":[{"name":"my_metric1{a:1,b:2}","suffix":"a:1,b:2","tags":{"a":"1","b":"2"}}]},"metric":"my_metric1"}`,

--- a/output/statsd/helper_test.go
+++ b/output/statsd/helper_test.go
@@ -85,14 +85,17 @@ func baseTest(t *testing.T,
 	defer func() {
 		require.NoError(t, collector.Stop())
 	}()
+
+	registry := metrics.NewRegistry()
 	newSample := func(m *metrics.Metric, value float64, tags map[string]string) metrics.Sample {
 		return metrics.Sample{
 			Time:   time.Now(),
-			Metric: m, Value: value, Tags: metrics.NewTagSet(tags).SampleTags(),
+			Metric: m,
+			Value:  value,
+			Tags:   registry.BranchTagSetRootWith(tags).SampleTags(),
 		}
 	}
 
-	registry := metrics.NewRegistry()
 	myCounter, err := registry.NewMetric("my_counter", metrics.Counter)
 	require.NoError(t, err)
 	myGauge, err := registry.NewMetric("my_gauge", metrics.Gauge)


### PR DESCRIPTION
Note: the source branch is `atlas`. It fixes https://github.com/grafana/k6/pull/2594#discussion_r936304976

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
