### PR TITLE
Simplify the atlas integration and have a `TimeSeries` for every `metrics.Sample`

### DIFF
--- a/.github/workflows/xk6-tests/xk6-js-test/jstest.go
+++ b/.github/workflows/xk6-tests/xk6-js-test/jstest.go
@@ -58,11 +58,10 @@ func (j *JSTest) Foo(arg float64) (bool, error) {
 
 	ctx := j.vu.Context()
 
-	tags := state.CloneTags()
-	tags["foo"] = "bar"
+	tags := state.Tags.GetCurrentValues().With("foo", "bar")
 	metrics.PushIfNotDone(ctx, state.Samples, metrics.Sample{
 		Time:   time.Now(),
-		Metric: j.foos, Tags: metrics.IntoSampleTags(&tags),
+		Metric: j.foos, Tags: tags,
 		Value: arg,
 	})
 

--- a/.github/workflows/xk6-tests/xk6-js-test/jstest.go
+++ b/.github/workflows/xk6-tests/xk6-js-test/jstest.go
@@ -60,9 +60,9 @@ func (j *JSTest) Foo(arg float64) (bool, error) {
 
 	tags := state.Tags.GetCurrentValues().With("foo", "bar")
 	metrics.PushIfNotDone(ctx, state.Samples, metrics.Sample{
-		Time:   time.Now(),
-		Metric: j.foos, Tags: tags,
-		Value: arg,
+		Time:       time.Now(),
+		TimeSeries: metrics.TimeSeries{Metric: j.foos, Tags: tags},
+		Value:      arg,
 	})
 
 	return true, nil

--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -54,7 +54,7 @@ func getTestRunState(tb testing.TB, options lib.Options, runner lib.Runner) *lib
 		TestPreInitState: piState,
 		Options:          options,
 		Runner:           runner,
-		RunTags:          piState.Registry.BranchTagSetRootWith(options.RunTags),
+		RunTags:          piState.Registry.RootTagSet().SortAndAddTags(options.RunTags),
 	}
 }
 

--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -54,7 +54,7 @@ func getTestRunState(tb testing.TB, options lib.Options, runner lib.Runner) *lib
 		TestPreInitState: piState,
 		Options:          options,
 		Runner:           runner,
-		RunTags:          piState.Registry.RootTagSet().SortAndAddTags(options.RunTags),
+		RunTags:          piState.Registry.RootTagSet().WithTagsFromMap(options.RunTags),
 	}
 }
 

--- a/cmd/integration_tests/eventloop/eventloop_test.go
+++ b/cmd/integration_tests/eventloop/eventloop_test.go
@@ -54,7 +54,7 @@ func eventLoopTest(t *testing.T, script []byte, testHandle func(context.Context,
 		TestPreInitState: piState,
 		Options:          newOpts,
 		Runner:           runner,
-		RunTags:          piState.Registry.BranchTagSetRootWith(newOpts.RunTags),
+		RunTags:          piState.Registry.RootTagSet().SortAndAddTags(newOpts.RunTags),
 	}
 
 	execScheduler, err := local.NewExecutionScheduler(testState)

--- a/cmd/integration_tests/eventloop/eventloop_test.go
+++ b/cmd/integration_tests/eventloop/eventloop_test.go
@@ -54,7 +54,7 @@ func eventLoopTest(t *testing.T, script []byte, testHandle func(context.Context,
 		TestPreInitState: piState,
 		Options:          newOpts,
 		Runner:           runner,
-		RunTags:          piState.Registry.RootTagSet().SortAndAddTags(newOpts.RunTags),
+		RunTags:          piState.Registry.RootTagSet().WithTagsFromMap(newOpts.RunTags),
 	}
 
 	execScheduler, err := local.NewExecutionScheduler(testState)

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -253,7 +253,7 @@ func (lct *loadedAndConfiguredTest) buildTestRunState(
 		TestPreInitState: lct.preInitState,
 		Runner:           lct.initRunner,
 		Options:          lct.derivedConfig.Options, // we will always run with the derived options
-		RunTags:          lct.preInitState.Registry.BranchTagSetRootWith(configToReinject.RunTags),
+		RunTags:          lct.preInitState.Registry.RootTagSet().SortAndAddTags(configToReinject.RunTags),
 	}, nil
 }
 

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -253,7 +253,7 @@ func (lct *loadedAndConfiguredTest) buildTestRunState(
 		TestPreInitState: lct.preInitState,
 		Runner:           lct.initRunner,
 		Options:          lct.derivedConfig.Options, // we will always run with the derived options
-		RunTags:          lct.preInitState.Registry.RootTagSet().SortAndAddTags(configToReinject.RunTags),
+		RunTags:          lct.preInitState.Registry.RootTagSet().WithTagsFromMap(configToReinject.RunTags),
 	}, nil
 }
 

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -187,10 +187,17 @@ func TestEngineRun(t *testing.T) {
 
 		runner := &minirunner.MiniRunner{
 			Fn: func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
-				metrics.PushIfNotDone(ctx, out, metrics.Sample{Metric: testMetric, Time: time.Now(), Value: 1})
+				metrics.PushIfNotDone(ctx, out, metrics.Sample{
+					TimeSeries: metrics.TimeSeries{Metric: testMetric, Tags: piState.Registry.RootTagSet()},
+					Time:       time.Now(),
+					Value:      1,
+				})
 				close(signalChan)
 				<-ctx.Done()
-				metrics.PushIfNotDone(ctx, out, metrics.Sample{Metric: testMetric, Time: time.Now(), Value: 1})
+				metrics.PushIfNotDone(ctx, out, metrics.Sample{
+					TimeSeries: metrics.TimeSeries{Metric: testMetric, Tags: piState.Registry.RootTagSet()},
+					Time:       time.Now(), Value: 1,
+				})
 				return nil
 			},
 		}
@@ -255,7 +262,7 @@ func TestEngineOutput(t *testing.T) {
 
 	runner := &minirunner.MiniRunner{
 		Fn: func(_ context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
-			out <- metrics.Sample{Metric: testMetric}
+			out <- metrics.Sample{TimeSeries: metrics.TimeSeries{Metric: testMetric}}
 			return nil
 		},
 	}
@@ -300,9 +307,12 @@ func TestEngine_processSamples(t *testing.T) {
 		runner := &minirunner.MiniRunner{
 			Fn: func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
 				out <- metrics.Sample{
-					Metric: metric,
-					Value:  1.25,
-					Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1"}),
+					TimeSeries: metrics.TimeSeries{
+						Metric: metric,
+						Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1"}),
+					},
+					Value: 1.25,
+					Time:  time.Now(),
 				}
 				close(done)
 				return nil
@@ -340,9 +350,12 @@ func TestEngine_processSamples(t *testing.T) {
 		runner := &minirunner.MiniRunner{
 			Fn: func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
 				out <- metrics.Sample{
-					Metric: metric,
-					Value:  1.25,
-					Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1", "b": "2"}),
+					TimeSeries: metrics.TimeSeries{
+						Metric: metric,
+						Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1", "b": "2"}),
+					},
+					Value: 1.25,
+					Time:  time.Now(),
 				}
 				close(done)
 				return nil
@@ -396,9 +409,12 @@ func TestEngineThresholdsWillAbort(t *testing.T) {
 	runner := &minirunner.MiniRunner{
 		Fn: func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
 			out <- metrics.Sample{
-				Metric: metric,
-				Value:  1.25,
-				Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1"}),
+				TimeSeries: metrics.TimeSeries{
+					Metric: metric,
+					Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1"}),
+				},
+				Time:  time.Now(),
+				Value: 1.25,
 			}
 			close(done)
 			return nil
@@ -442,9 +458,12 @@ func TestEngineAbortedByThresholds(t *testing.T) {
 	runner := &minirunner.MiniRunner{
 		Fn: func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
 			out <- metrics.Sample{
-				Metric: metric,
-				Value:  1.25,
-				Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1"}),
+				TimeSeries: metrics.TimeSeries{
+					Metric: metric,
+					Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1"}),
+				},
+				Time:  time.Now(),
+				Value: 1.25,
 			}
 			<-ctx.Done()
 			close(done)
@@ -528,14 +547,20 @@ func TestEngine_processThresholds(t *testing.T) {
 			test.engine.OutputManager.AddMetricSamples(
 				[]metrics.SampleContainer{
 					metrics.Sample{
-						Metric: gaugeMetric,
-						Value:  1.25,
-						Tags:   tag1,
+						TimeSeries: metrics.TimeSeries{
+							Metric: gaugeMetric,
+							Tags:   tag1,
+						},
+						Time:  time.Now(),
+						Value: 1.25,
 					},
 					metrics.Sample{
-						Metric: counterMetric,
-						Value:  2,
-						Tags:   tag2,
+						TimeSeries: metrics.TimeSeries{
+							Metric: counterMetric,
+							Tags:   tag2,
+						},
+						Time:  time.Now(),
+						Value: 2,
 					},
 				},
 			)
@@ -1197,7 +1222,14 @@ func TestEngineRunsTeardownEvenAfterTestRunIsAborted(t *testing.T) {
 			return nil
 		},
 		TeardownFn: func(_ context.Context, out chan<- metrics.SampleContainer) error {
-			out <- metrics.Sample{Metric: testMetric, Value: 1}
+			out <- metrics.Sample{
+				TimeSeries: metrics.TimeSeries{
+					Metric: testMetric,
+					Tags:   piState.Registry.RootTagSet(),
+				},
+				Time:  time.Now(),
+				Value: 1,
+			}
 			return nil
 		},
 	}

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -80,7 +80,7 @@ func getTestRunState(
 		TestPreInitState: piState,
 		Options:          options,
 		Runner:           runner,
-		RunTags:          piState.Registry.RootTagSet().SortAndAddTags(options.RunTags),
+		RunTags:          piState.Registry.RootTagSet().WithTagsFromMap(options.RunTags),
 	}
 }
 
@@ -309,7 +309,7 @@ func TestEngine_processSamples(t *testing.T) {
 				out <- metrics.Sample{
 					TimeSeries: metrics.TimeSeries{
 						Metric: metric,
-						Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1"}),
+						Tags:   piState.Registry.RootTagSet().WithTagsFromMap(map[string]string{"a": "1"}),
 					},
 					Value: 1.25,
 					Time:  time.Now(),
@@ -352,7 +352,7 @@ func TestEngine_processSamples(t *testing.T) {
 				out <- metrics.Sample{
 					TimeSeries: metrics.TimeSeries{
 						Metric: metric,
-						Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1", "b": "2"}),
+						Tags:   piState.Registry.RootTagSet().WithTagsFromMap(map[string]string{"a": "1", "b": "2"}),
 					},
 					Value: 1.25,
 					Time:  time.Now(),
@@ -411,7 +411,7 @@ func TestEngineThresholdsWillAbort(t *testing.T) {
 			out <- metrics.Sample{
 				TimeSeries: metrics.TimeSeries{
 					Metric: metric,
-					Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1"}),
+					Tags:   piState.Registry.RootTagSet().WithTagsFromMap(map[string]string{"a": "1"}),
 				},
 				Time:  time.Now(),
 				Value: 1.25,
@@ -460,7 +460,7 @@ func TestEngineAbortedByThresholds(t *testing.T) {
 			out <- metrics.Sample{
 				TimeSeries: metrics.TimeSeries{
 					Metric: metric,
-					Tags:   piState.Registry.RootTagSet().SortAndAddTags(map[string]string{"a": "1"}),
+					Tags:   piState.Registry.RootTagSet().WithTagsFromMap(map[string]string{"a": "1"}),
 				},
 				Time:  time.Now(),
 				Value: 1.25,

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -224,7 +224,7 @@ func (e *ExecutionScheduler) initVUsConcurrently(
 
 func (e *ExecutionScheduler) emitVUsAndVUsMax(ctx context.Context, out chan<- metrics.SampleContainer) {
 	e.state.Test.Logger.Debug("Starting emission of VUs and VUsMax metrics...")
-	tags := e.state.Test.RunTags.SampleTags()
+	tags := e.state.Test.RunTags
 
 	emitMetrics := func() {
 		t := time.Now()

--- a/core/local/local.go
+++ b/core/local/local.go
@@ -231,15 +231,19 @@ func (e *ExecutionScheduler) emitVUsAndVUsMax(ctx context.Context, out chan<- me
 		samples := metrics.ConnectedSamples{
 			Samples: []metrics.Sample{
 				{
-					Time:   t,
-					Metric: e.state.Test.BuiltinMetrics.VUs,
-					Value:  float64(e.state.GetCurrentlyActiveVUsCount()),
-					Tags:   tags,
+					TimeSeries: metrics.TimeSeries{
+						Metric: e.state.Test.BuiltinMetrics.VUs,
+						Tags:   tags,
+					},
+					Time:  t,
+					Value: float64(e.state.GetCurrentlyActiveVUsCount()),
 				}, {
-					Time:   t,
-					Metric: e.state.Test.BuiltinMetrics.VUsMax,
-					Value:  float64(e.state.GetInitializedVUsCount()),
-					Tags:   tags,
+					TimeSeries: metrics.TimeSeries{
+						Metric: e.state.Test.BuiltinMetrics.VUsMax,
+						Tags:   tags,
+					},
+					Time:  t,
+					Value: float64(e.state.GetInitializedVUsCount()),
 				},
 			},
 			Tags: tags,

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -939,7 +939,12 @@ func TestExecutionSchedulerEndErrors(t *testing.T) {
 
 func TestExecutionSchedulerEndIterations(t *testing.T) {
 	t.Parallel()
-	metric := &metrics.Metric{Name: "test_metric"}
+	registry := metrics.NewRegistry()
+	metric := registry.MustNewMetric("test_metric", metrics.Counter)
+	ts := metrics.TimeSeries{
+		Metric: metric,
+		Tags:   registry.RootTagSet(),
+	}
 
 	options, err := executor.DeriveScenariosFromShortcuts(lib.Options{
 		VUs:        null.IntFrom(1),
@@ -956,7 +961,10 @@ func TestExecutionSchedulerEndIterations(t *testing.T) {
 			default:
 				atomic.AddInt64(&i, 1)
 			}
-			out <- metrics.Sample{Metric: metric, Value: 1.0}
+			out <- metrics.Sample{
+				TimeSeries: ts,
+				Value:      1.0,
+			}
 			return nil
 		},
 		Options: options,
@@ -980,7 +988,7 @@ func TestExecutionSchedulerEndIterations(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		mySample, ok := <-samples
 		require.True(t, ok)
-		assert.Equal(t, metrics.Sample{Metric: metric, Value: 1.0}, mySample)
+		assert.Equal(t, metrics.Sample{TimeSeries: ts, Value: 1.0}, mySample)
 	}
 }
 
@@ -1241,10 +1249,12 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 	require.NoError(t, err)
 	getSample := func(expValue float64, expMetric *metrics.Metric, expTags ...string) metrics.SampleContainer {
 		return metrics.Sample{
-			Metric: expMetric,
-			Time:   time.Now(),
-			Tags:   getTags(piState.Registry, expTags...),
-			Value:  expValue,
+			TimeSeries: metrics.TimeSeries{
+				Metric: expMetric,
+				Tags:   getTags(piState.Registry, expTags...),
+			},
+			Time:  time.Now(),
+			Value: expValue,
 		}
 	}
 	getDummyTrail := func(group string, emitIterations bool, addExpTags ...string) metrics.SampleContainer {

--- a/core/local/local_test.go
+++ b/core/local/local_test.go
@@ -72,7 +72,7 @@ func getTestRunState(
 		TestPreInitState: piState,
 		Options:          options,
 		Runner:           runner,
-		RunTags:          piState.Registry.RootTagSet().SortAndAddTags(options.RunTags),
+		RunTags:          piState.Registry.RootTagSet().WithTagsFromMap(options.RunTags),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 )
 
-require github.com/mstoykov/atlas v0.0.0-20220727131014-23cc720eb639
+require github.com/mstoykov/atlas v0.0.0-20220808085829-90340e9998bd
 
 require (
 	github.com/andybalholm/cascadia v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mccutchen/go-httpbin v1.1.2-0.20190116014521-c5cb2f4802fa h1:lx8ZnNPwjkXSzOROz0cg69RlErRXs+L3eDkggASWKLo=
 github.com/mccutchen/go-httpbin v1.1.2-0.20190116014521-c5cb2f4802fa/go.mod h1:fhpOYavp5g2K74XDl/ao2y4KvhqVtKlkg1e+0UaQv7I=
-github.com/mstoykov/atlas v0.0.0-20220727131014-23cc720eb639 h1:XMAwXwr7ZJcBhhzLWB2LHHVO028vXuxUeE65iRz1Myw=
-github.com/mstoykov/atlas v0.0.0-20220727131014-23cc720eb639/go.mod h1:9vRHVuLCjoFfE3GT06X0spdOAO+Zzo4AMjdIwUHBvAk=
+github.com/mstoykov/atlas v0.0.0-20220808085829-90340e9998bd h1:x/wQ8/umYu2x0icx5wNNTSK1NlkYVmsgzQ+U6v4ijv0=
+github.com/mstoykov/atlas v0.0.0-20220808085829-90340e9998bd/go.mod h1:9vRHVuLCjoFfE3GT06X0spdOAO+Zzo4AMjdIwUHBvAk=
 github.com/mstoykov/envconfig v1.4.1-0.20220114105314-765c6d8c76f1 h1:94EkGmhXrVUEal+uLwFUf4fMXPhZpM5tYxuIsxrCCbI=
 github.com/mstoykov/envconfig v1.4.1-0.20220114105314-765c6d8c76f1/go.mod h1:vk/d9jpexY2Z9Bb0uB4Ndesss1Sr0Z9ZiGUrg5o9VGk=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -401,7 +401,7 @@ func TestRequestWithBinaryFile(t *testing.T) {
 		BPool:          bpool.NewBufferPool(1),
 		Samples:        make(chan metrics.SampleContainer, 500),
 		BuiltinMetrics: builtinMetrics,
-		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
+		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -548,7 +548,7 @@ func TestRequestWithMultipleBinaryFiles(t *testing.T) {
 		BPool:          bpool.NewBufferPool(1),
 		Samples:        make(chan metrics.SampleContainer, 500),
 		BuiltinMetrics: builtinMetrics,
-		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
+		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -42,8 +42,8 @@ func TestVUTags(t *testing.T) {
 
 		tenv := setupTagsExecEnv(t)
 		tenv.MoveToVUContext(&lib.State{
-			Tags: lib.NewTagMap(
-				metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
+			Tags: lib.NewVUStateTags(
+				metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
 		})
 		tag, err := tenv.VU.Runtime().RunString(`exec.vu.tags["vu"]`)
 		require.NoError(t, err)
@@ -63,11 +63,13 @@ func TestVUTags(t *testing.T) {
 			Options: lib.Options{
 				SystemTags: metrics.NewSystemTagSet(metrics.TagVU),
 			},
-			Tags: lib.NewTagMap(
-				metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
+			Tags: lib.NewVUStateTags(
+				metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
 		})
 		state := tenv.VU.State()
-		state.Tags.Set("custom-tag", "mytag1")
+		state.Tags.Modify(func(currentTags *metrics.TagSet) *metrics.TagSet {
+			return currentTags.With("custom-tag", "mytag1")
+		})
 
 		encoded, err := tenv.VU.Runtime().RunString(`JSON.stringify(exec.vu.tags)`)
 		require.NoError(t, err)
@@ -94,8 +96,8 @@ func TestVUTags(t *testing.T) {
 
 			tenv := setupTagsExecEnv(t)
 			tenv.MoveToVUContext(&lib.State{
-				Tags: lib.NewTagMap(
-					metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
+				Tags: lib.NewVUStateTags(
+					metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
 			})
 
 			for _, tc := range tests {
@@ -114,8 +116,8 @@ func TestVUTags(t *testing.T) {
 
 			tenv := setupTagsExecEnv(t)
 			tenv.MoveToVUContext(&lib.State{
-				Tags: lib.NewTagMap(
-					metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
+				Tags: lib.NewVUStateTags(
+					metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
 			})
 
 			_, err := tenv.VU.Runtime().RunString(`exec.vu.tags["vu"] = "vu101"`)
@@ -130,8 +132,8 @@ func TestVUTags(t *testing.T) {
 
 			tenv := setupTagsExecEnv(t)
 			tenv.MoveToVUContext(&lib.State{
-				Tags: lib.NewTagMap(
-					metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
+				Tags: lib.NewVUStateTags(
+					metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
 			})
 
 			state := tenv.VU.State()
@@ -163,8 +165,8 @@ func TestVUTags(t *testing.T) {
 				Options: lib.Options{
 					SystemTags: metrics.NewSystemTagSet(metrics.TagVU),
 				},
-				Tags: lib.NewTagMap(
-					metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
+				Tags: lib.NewVUStateTags(
+					metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
 				Logger: testLog,
 			})
 			_, err := tenv.VU.Runtime().RunString(`exec.vu.tags["custom-tag"] = [1, 3, 5]`)
@@ -189,8 +191,8 @@ func TestVUTags(t *testing.T) {
 				Options: lib.Options{
 					SystemTags: metrics.NewSystemTagSet(metrics.TagVU),
 				},
-				Tags: lib.NewTagMap(
-					metrics.NewRegistry().BranchTagSetRootWith(map[string]string{"vu": "42"})),
+				Tags: lib.NewVUStateTags(
+					metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
 				Logger: testLog,
 			})
 			for _, val := range cases {

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -43,7 +43,7 @@ func TestVUTags(t *testing.T) {
 		tenv := setupTagsExecEnv(t)
 		tenv.MoveToVUContext(&lib.State{
 			Tags: lib.NewVUStateTags(
-				metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
+				metrics.NewRegistry().RootTagSet().WithTagsFromMap(map[string]string{"vu": "42"})),
 		})
 		tag, err := tenv.VU.Runtime().RunString(`exec.vu.tags["vu"]`)
 		require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestVUTags(t *testing.T) {
 				SystemTags: metrics.NewSystemTagSet(metrics.TagVU),
 			},
 			Tags: lib.NewVUStateTags(
-				metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
+				metrics.NewRegistry().RootTagSet().WithTagsFromMap(map[string]string{"vu": "42"})),
 		})
 		state := tenv.VU.State()
 		state.Tags.Modify(func(currentTags *metrics.TagSet) *metrics.TagSet {
@@ -97,7 +97,7 @@ func TestVUTags(t *testing.T) {
 			tenv := setupTagsExecEnv(t)
 			tenv.MoveToVUContext(&lib.State{
 				Tags: lib.NewVUStateTags(
-					metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
+					metrics.NewRegistry().RootTagSet().WithTagsFromMap(map[string]string{"vu": "42"})),
 			})
 
 			for _, tc := range tests {
@@ -117,7 +117,7 @@ func TestVUTags(t *testing.T) {
 			tenv := setupTagsExecEnv(t)
 			tenv.MoveToVUContext(&lib.State{
 				Tags: lib.NewVUStateTags(
-					metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
+					metrics.NewRegistry().RootTagSet().WithTagsFromMap(map[string]string{"vu": "42"})),
 			})
 
 			_, err := tenv.VU.Runtime().RunString(`exec.vu.tags["vu"] = "vu101"`)
@@ -133,7 +133,7 @@ func TestVUTags(t *testing.T) {
 			tenv := setupTagsExecEnv(t)
 			tenv.MoveToVUContext(&lib.State{
 				Tags: lib.NewVUStateTags(
-					metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
+					metrics.NewRegistry().RootTagSet().WithTagsFromMap(map[string]string{"vu": "42"})),
 			})
 
 			state := tenv.VU.State()
@@ -166,7 +166,7 @@ func TestVUTags(t *testing.T) {
 					SystemTags: metrics.NewSystemTagSet(metrics.TagVU),
 				},
 				Tags: lib.NewVUStateTags(
-					metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
+					metrics.NewRegistry().RootTagSet().WithTagsFromMap(map[string]string{"vu": "42"})),
 				Logger: testLog,
 			})
 			_, err := tenv.VU.Runtime().RunString(`exec.vu.tags["custom-tag"] = [1, 3, 5]`)
@@ -192,7 +192,7 @@ func TestVUTags(t *testing.T) {
 					SystemTags: metrics.NewSystemTagSet(metrics.TagVU),
 				},
 				Tags: lib.NewVUStateTags(
-					metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{"vu": "42"})),
+					metrics.NewRegistry().RootTagSet().WithTagsFromMap(map[string]string{"vu": "42"})),
 				Logger: testLog,
 			})
 			for _, val := range cases {

--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -171,25 +171,23 @@ func (c *Client) Invoke(
 	ctx, cancel := context.WithTimeout(c.vu.Context(), p.Timeout)
 	defer cancel()
 
-	tags := state.Tags.BranchOut()
-	for k, v := range p.Tags {
-		tags.AddTag(k, v)
-	}
+	tags := state.Tags.GetCurrentValues()
+	tags = tags.SortAndAddTags(p.Tags)
 
 	if state.Options.SystemTags.Has(metrics.TagURL) {
-		tags.AddTag("url", fmt.Sprintf("%s%s", c.addr, method))
+		tags = tags.With("url", fmt.Sprintf("%s%s", c.addr, method))
 	}
 	parts := strings.Split(method[1:], "/")
 	if state.Options.SystemTags.Has(metrics.TagService) {
-		tags.AddTag("service", parts[0])
+		tags = tags.With("service", parts[0])
 	}
 	if state.Options.SystemTags.Has(metrics.TagMethod) {
-		tags.AddTag("method", parts[1])
+		tags = tags.With("method", parts[1])
 	}
 
 	// Only set the name system tag if the user didn't explicitly set it beforehand
 	if _, ok := tags.Get("name"); !ok && state.Options.SystemTags.Has(metrics.TagName) {
-		tags.AddTag("name", method)
+		tags = tags.With("name", method)
 	}
 
 	reqmsg := grpcext.Request{

--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -172,7 +172,7 @@ func (c *Client) Invoke(
 	defer cancel()
 
 	tags := state.Tags.GetCurrentValues()
-	tags = tags.SortAndAddTags(p.Tags)
+	tags = tags.WithTagsFromMap(p.Tags)
 
 	if state.Options.SystemTags.Has(metrics.TagURL) {
 		tags = tags.With("url", fmt.Sprintf("%s%s", c.addr, method))

--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -718,7 +718,7 @@ func TestClient(t *testing.T) {
 					UserAgent: null.StringFrom("k6-test"),
 				},
 				BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-				Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
+				Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 			}
 			ts.MoveToVUContext(state)
 			val, err = replace(tt.vuString.code)

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -159,7 +159,7 @@ func newRuntime(t testing.TB) (
 		Transport: tb.HTTPTransport,
 		BPool:     bpool.NewBufferPool(1),
 		Samples:   samples,
-		Tags: lib.NewVUStateTags(registry.RootTagSet().SortAndAddTags(map[string]string{
+		Tags: lib.NewVUStateTags(registry.RootTagSet().WithTagsFromMap(map[string]string{
 			"group": root.Path,
 		})),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
@@ -1113,7 +1113,7 @@ func TestRequestAndBatch(t *testing.T) {
 			t.Run("tags-precedence", func(t *testing.T) {
 				oldTags := state.Tags
 				defer func() { state.Tags = oldTags }()
-				state.Tags = lib.NewVUStateTags(metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{
+				state.Tags = lib.NewVUStateTags(metrics.NewRegistry().RootTagSet().WithTagsFromMap(map[string]string{
 					"runtag1": "val1",
 					"runtag2": "val2",
 				}))

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -168,10 +168,14 @@ func TestResponse(t *testing.T) {
 			if assert.NoError(t, err) {
 				old := state.Group
 				state.Group = g
-				state.Tags.Set("group", g.Path)
+				state.Tags.Modify(func(currentTags *metrics.TagSet) *metrics.TagSet {
+					return currentTags.With("group", g.Path)
+				})
 				defer func() {
 					state.Group = old
-					state.Tags.Set("group", old.Path)
+					state.Tags.Modify(func(currentTags *metrics.TagSet) *metrics.TagSet {
+						return currentTags.With("group", old.Path)
+					})
 				}()
 			}
 

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -144,10 +144,12 @@ func (mi *K6) Group(name string, fn goja.Callable) (goja.Value, error) {
 
 	ctx := mi.vu.Context()
 	metrics.PushIfNotDone(ctx, state.Samples, metrics.Sample{
-		Time:   t,
-		Metric: state.BuiltinMetrics.GroupDuration,
-		Tags:   state.Tags.GetCurrentValues(),
-		Value:  metrics.D(t.Sub(startTime)),
+		TimeSeries: metrics.TimeSeries{
+			Metric: state.BuiltinMetrics.GroupDuration,
+			Tags:   state.Tags.GetCurrentValues(),
+		},
+		Time:  t,
+		Value: metrics.D(t.Sub(startTime)),
 	})
 
 	return ret, err
@@ -209,10 +211,12 @@ func (mi *K6) Check(arg0, checks goja.Value, extras ...goja.Value) (bool, error)
 		case <-ctx.Done():
 		default:
 			sample := metrics.Sample{
-				Time:   t,
-				Metric: state.BuiltinMetrics.Checks,
-				Tags:   tags,
-				Value:  0,
+				TimeSeries: metrics.TimeSeries{
+					Metric: state.BuiltinMetrics.Checks,
+					Tags:   tags,
+				},
+				Time:  t,
+				Value: 0,
 			}
 			if val.ToBoolean() {
 				atomic.AddInt64(&check.Passes, 1)

--- a/js/modules/k6/k6_test.go
+++ b/js/modules/k6/k6_test.go
@@ -226,7 +226,7 @@ func checkTestRuntime(t testing.TB) (*goja.Runtime, chan metrics.SampleContainer
 			SystemTags: &metrics.DefaultSystemTagSet,
 		},
 		Samples:        samples,
-		Tags:           lib.NewVUStateTags(registry.RootTagSet().SortAndAddTags(map[string]string{"group": root.Path})),
+		Tags:           lib.NewVUStateTags(registry.RootTagSet().WithTagsFromMap(map[string]string{"group": root.Path})),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 	}
 	test.MoveToVUContext(state)
@@ -433,7 +433,7 @@ func TestCheckContextExpiry(t *testing.T) {
 			SystemTags: &metrics.DefaultSystemTagSet,
 		},
 		Samples: samples,
-		Tags: lib.NewVUStateTags(registry.RootTagSet().SortAndAddTags(map[string]string{
+		Tags: lib.NewVUStateTags(registry.RootTagSet().WithTagsFromMap(map[string]string{
 			"group": root.Path,
 		})),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -128,11 +128,11 @@ func (m Metric) add(v goja.Value, addTags goja.Value) (bool, error) {
 		return raiseNan()
 	}
 
-	tags := state.Tags.BranchOut()
+	tags := state.Tags.GetCurrentValues()
 	if addTags != nil {
 		tagsobj := addTags.ToObject(m.vu.Runtime())
 		for _, key := range tagsobj.Keys() {
-			tags.AddTag(key, tagsobj.Get(key).String())
+			tags = tags.With(key, tagsobj.Get(key).String())
 		}
 	}
 
@@ -140,7 +140,7 @@ func (m Metric) add(v goja.Value, addTags goja.Value) (bool, error) {
 		Time:   time.Now(),
 		Metric: m.metric,
 		Value:  vfloat,
-		Tags:   tags.SampleTags(),
+		Tags:   tags,
 	}
 	metrics.PushIfNotDone(m.vu.Context(), state.Samples, sample)
 	return true, nil

--- a/js/modules/k6/metrics/metrics.go
+++ b/js/modules/k6/metrics/metrics.go
@@ -137,10 +137,12 @@ func (m Metric) add(v goja.Value, addTags goja.Value) (bool, error) {
 	}
 
 	sample := metrics.Sample{
-		Time:   time.Now(),
-		Metric: m.metric,
-		Value:  vfloat,
-		Tags:   tags,
+		TimeSeries: metrics.TimeSeries{
+			Metric: m.metric,
+			Tags:   tags,
+		},
+		Time:  time.Now(),
+		Value: vfloat,
 	}
 	metrics.PushIfNotDone(m.vu.Context(), state.Samples, sample)
 	return true, nil

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -79,7 +79,7 @@ func (a addTest) run(t *testing.T) {
 
 		assert.NotZero(t, sample.Time)
 		assert.Equal(t, a.val.Float, sample.Value)
-		assert.Equal(t, a.expectedTags, sample.Tags.CloneTags())
+		assert.Equal(t, a.expectedTags, sample.Tags.Map())
 		assert.Equal(t, "my_metric", sample.Metric.Name)
 		assert.Equal(t, a.mtyp, sample.Metric.Type)
 		assert.Equal(t, a.valueType, sample.Metric.Contains)
@@ -135,7 +135,7 @@ func TestMetrics(t *testing.T) {
 					state := &lib.State{
 						Options: lib.Options{},
 						Samples: test.samples,
-						Tags: lib.NewTagMap(registry.BranchTagSetRootWith(map[string]string{
+						Tags: lib.NewVUStateTags(registry.RootTagSet().SortAndAddTags(map[string]string{
 							"key": "value",
 						})),
 					}

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -135,7 +135,7 @@ func TestMetrics(t *testing.T) {
 					state := &lib.State{
 						Options: lib.Options{},
 						Samples: test.samples,
-						Tags: lib.NewVUStateTags(registry.RootTagSet().SortAndAddTags(map[string]string{
+						Tags: lib.NewVUStateTags(registry.RootTagSet().WithTagsFromMap(map[string]string{
 							"key": "value",
 						})),
 					}

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -277,8 +277,22 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 
 	metrics.PushIfNotDone(ctx, state.Samples, metrics.ConnectedSamples{
 		Samples: []metrics.Sample{
-			{Metric: state.BuiltinMetrics.WSSessions, Time: start, Tags: tags, Value: 1},
-			{Metric: state.BuiltinMetrics.WSConnecting, Time: start, Tags: tags, Value: connectionDuration},
+			{
+				TimeSeries: metrics.TimeSeries{
+					Metric: state.BuiltinMetrics.WSSessions,
+					Tags:   tags,
+				},
+				Time:  start,
+				Value: 1,
+			},
+			{
+				TimeSeries: metrics.TimeSeries{
+					Metric: state.BuiltinMetrics.WSConnecting,
+					Tags:   tags,
+				},
+				Time:  start,
+				Value: connectionDuration,
+			},
 		},
 		Tags: tags,
 		Time: start,
@@ -339,10 +353,12 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 		sessionDuration := metrics.D(end.Sub(start))
 
 		metrics.PushIfNotDone(ctx, state.Samples, metrics.Sample{
-			Metric: socket.builtinMetrics.WSSessionDuration,
-			Tags:   socket.sampleTags,
-			Time:   start,
-			Value:  sessionDuration,
+			TimeSeries: metrics.TimeSeries{
+				Metric: socket.builtinMetrics.WSSessionDuration,
+				Tags:   socket.sampleTags,
+			},
+			Time:  start,
+			Value: sessionDuration,
 		})
 	}()
 
@@ -367,10 +383,12 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*WSHTTPResponse, error) {
 
 		case msg := <-readDataChan:
 			metrics.PushIfNotDone(ctx, socket.samplesOutput, metrics.Sample{
-				Metric: socket.builtinMetrics.WSMessagesReceived,
-				Time:   time.Now(),
-				Tags:   socket.sampleTags,
-				Value:  1,
+				TimeSeries: metrics.TimeSeries{
+					Metric: socket.builtinMetrics.WSMessagesReceived,
+					Tags:   socket.sampleTags,
+				},
+				Time:  time.Now(),
+				Value: 1,
 			})
 
 			if msg.mtype == websocket.BinaryMessage {
@@ -427,10 +445,12 @@ func (s *Socket) Send(message string) {
 	}
 
 	metrics.PushIfNotDone(s.ctx, s.samplesOutput, metrics.Sample{
-		Metric: s.builtinMetrics.WSMessagesSent,
-		Time:   time.Now(),
-		Tags:   s.sampleTags,
-		Value:  1,
+		TimeSeries: metrics.TimeSeries{
+			Metric: s.builtinMetrics.WSMessagesSent,
+			Tags:   s.sampleTags,
+		},
+		Time:  time.Now(),
+		Value: 1,
 	})
 }
 
@@ -457,10 +477,12 @@ func (s *Socket) SendBinary(message goja.Value) {
 	}
 
 	metrics.PushIfNotDone(s.ctx, s.samplesOutput, metrics.Sample{
-		Metric: s.builtinMetrics.WSMessagesSent,
-		Time:   time.Now(),
-		Tags:   s.sampleTags,
-		Value:  1,
+		TimeSeries: metrics.TimeSeries{
+			Metric: s.builtinMetrics.WSMessagesSent,
+			Tags:   s.sampleTags,
+		},
+		Time:  time.Now(),
+		Value: 1,
 	})
 }
 
@@ -490,10 +512,12 @@ func (s *Socket) trackPong(pingID string) {
 	pingTimestamp := s.pingSendTimestamps[pingID]
 
 	metrics.PushIfNotDone(s.ctx, s.samplesOutput, metrics.Sample{
-		Metric: s.builtinMetrics.WSPing,
-		Time:   pongTimestamp,
-		Tags:   s.sampleTags,
-		Value:  metrics.D(pongTimestamp.Sub(pingTimestamp)),
+		TimeSeries: metrics.TimeSeries{
+			Metric: s.builtinMetrics.WSPing,
+			Tags:   s.sampleTags,
+		},
+		Time:  pongTimestamp,
+		Value: metrics.D(pongTimestamp.Sub(pingTimestamp)),
 	})
 }
 

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -54,7 +54,7 @@ func assertSessionMetricsEmitted(t *testing.T, sampleContainers []metrics.Sample
 
 	for _, sampleContainer := range sampleContainers {
 		for _, sample := range sampleContainer.GetSamples() {
-			tags := sample.Tags.CloneTags()
+			tags := sample.Tags.Map()
 			if tags["url"] == url {
 				switch sample.Metric.Name {
 				case metrics.WSConnectingName:
@@ -123,7 +123,7 @@ func newTestState(t testing.TB) testState {
 		Samples:        samples,
 		TLSConfig:      tb.TLSClientConfig,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
+		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
 
 	m := New().NewModuleInstance(testRuntime.VU)
@@ -687,8 +687,8 @@ func TestSystemTags(t *testing.T) {
 			for _, sampleContainer := range containers {
 				require.NotEmpty(t, sampleContainer.GetSamples())
 				for _, sample := range sampleContainer.GetSamples() {
-					require.NotEmpty(t, sample.Tags.CloneTags())
-					for emittedTag := range sample.Tags.CloneTags() {
+					require.NotEmpty(t, sample.Tags.Map())
+					for emittedTag := range sample.Tags.Map() {
 						assert.Equal(t, expectedTag, emittedTag)
 					}
 				}

--- a/js/runner.go
+++ b/js/runner.go
@@ -458,7 +458,7 @@ func (r *Runner) SetOptions(opts lib.Options) error {
 	}
 
 	// FIXME: add tests
-	r.RunTags = r.preInitState.Registry.RootTagSet().SortAndAddTags(r.Bundle.Options.RunTags)
+	r.RunTags = r.preInitState.Registry.RootTagSet().WithTagsFromMap(r.Bundle.Options.RunTags)
 
 	return nil
 }
@@ -636,7 +636,7 @@ func (u *VU) Activate(params *lib.VUActivationParams) lib.ActiveVU {
 	opts := u.Runner.Bundle.Options
 
 	u.state.Tags.Modify(func(tags *metrics.TagSet) *metrics.TagSet {
-		tags = tags.SortAndAddTags(params.Tags)
+		tags = tags.WithTagsFromMap(params.Tags)
 
 		if opts.SystemTags.Has(metrics.TagVU) {
 			tags = tags.With("vu", strconv.FormatUint(u.ID, 10))

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -313,7 +313,7 @@ func TestSetupDataIsolation(t *testing.T) {
 		TestPreInitState: runner.preInitState,
 		Options:          options,
 		Runner:           runner,
-		RunTags:          runner.preInitState.Registry.BranchTagSetRootWith(options.RunTags),
+		RunTags:          runner.preInitState.Registry.RootTagSet().SortAndAddTags(options.RunTags),
 	}
 
 	execScheduler, err := local.NewExecutionScheduler(testRunState)
@@ -1978,7 +1978,7 @@ func TestSystemTags(t *testing.T) {
 			require.NotEmpty(t, bufSamples)
 			for _, sample := range bufSamples[0].GetSamples() {
 				assert.NotEmpty(t, sample.Tags)
-				for emittedTag, emittedVal := range sample.Tags.CloneTags() {
+				for emittedTag, emittedVal := range sample.Tags.Map() {
 					assert.Equal(t, tc.tag, emittedTag)
 					assert.Equal(t, tc.expVal, emittedVal)
 				}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -313,7 +313,7 @@ func TestSetupDataIsolation(t *testing.T) {
 		TestPreInitState: runner.preInitState,
 		Options:          options,
 		Runner:           runner,
-		RunTags:          runner.preInitState.Registry.RootTagSet().SortAndAddTags(options.RunTags),
+		RunTags:          runner.preInitState.Registry.RootTagSet().WithTagsFromMap(options.RunTags),
 	}
 
 	execScheduler, err := local.NewExecutionScheduler(testRunState)

--- a/js/summary_test.go
+++ b/js/summary_test.go
@@ -99,7 +99,6 @@ func TestTextSummaryWithSubMetrics(t *testing.T) {
 	t.Parallel()
 
 	registry := metrics.NewRegistry()
-	rootTagSet := registry.BranchTagSetRoot()
 	parentMetric, err := registry.NewMetric("my_parent", metrics.Counter)
 	require.NoError(t, err)
 	parentMetric.Sink.Add(metrics.Sample{Value: 11})
@@ -108,11 +107,11 @@ func TestTextSummaryWithSubMetrics(t *testing.T) {
 	require.NoError(t, err)
 	parentMetricPost.Sink.Add(metrics.Sample{Value: 22})
 
-	subMetric, err := parentMetric.AddSubmetric("sub:1", rootTagSet)
+	subMetric, err := parentMetric.AddSubmetric("sub:1")
 	require.NoError(t, err)
 	subMetric.Metric.Sink.Add(metrics.Sample{Value: 1})
 
-	subMetricPost, err := parentMetricPost.AddSubmetric("sub:2", rootTagSet)
+	subMetricPost, err := parentMetricPost.AddSubmetric("sub:2")
 	require.NoError(t, err)
 	subMetricPost.Metric.Sink.Add(metrics.Sample{Value: 2})
 

--- a/lib/executor/base_executor.go
+++ b/lib/executor/base_executor.go
@@ -92,13 +92,13 @@ func (bs *BaseExecutor) GetProgress() *pb.ProgressBar {
 
 // getMetricTags returns a tag set that can be used to emit metrics by the
 // executor. The VU ID is optional.
-func (bs *BaseExecutor) getMetricTags(vuID *uint64) *metrics.SampleTags {
-	tags := bs.executionState.Test.RunTags.BranchOut()
+func (bs *BaseExecutor) getMetricTags(vuID *uint64) *metrics.TagSet {
+	tags := bs.executionState.Test.RunTags
 	if bs.executionState.Test.Options.SystemTags.Has(metrics.TagScenario) {
-		tags.AddTag("scenario", bs.config.GetName())
+		tags = tags.With("scenario", bs.config.GetName())
 	}
 	if vuID != nil && bs.executionState.Test.Options.SystemTags.Has(metrics.TagVU) {
-		tags.AddTag("vu", strconv.FormatUint(*vuID, 10))
+		tags = tags.With("vu", strconv.FormatUint(*vuID, 10))
 	}
-	return tags.SampleTags()
+	return tags
 }

--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -57,7 +57,7 @@ func getTestRunState(tb testing.TB, options lib.Options, runner lib.Runner) *lib
 		TestPreInitState: piState,
 		Options:          options,
 		Runner:           runner,
-		RunTags:          piState.Registry.BranchTagSetRootWith(options.RunTags),
+		RunTags:          piState.Registry.RootTagSet().SortAndAddTags(options.RunTags),
 	}
 }
 

--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -57,7 +57,7 @@ func getTestRunState(tb testing.TB, options lib.Options, runner lib.Runner) *lib
 		TestPreInitState: piState,
 		Options:          options,
 		Runner:           runner,
-		RunTags:          piState.Registry.RootTagSet().SortAndAddTags(options.RunTags),
+		RunTags:          piState.Registry.RootTagSet().WithTagsFromMap(options.RunTags),
 	}
 }
 

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -353,8 +353,12 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 			// dropped - we aren't going to try to recover it, but
 
 			metrics.PushIfNotDone(parentCtx, out, metrics.Sample{
-				Value: 1, Metric: droppedIterationMetric,
-				Tags: metricTags, Time: time.Now(),
+				TimeSeries: metrics.TimeSeries{
+					Metric: droppedIterationMetric,
+					Tags:   metricTags,
+				},
+				Time:  time.Now(),
+				Value: 1,
 			})
 
 			// We'll try to start allocating another VU in the background,

--- a/lib/executor/per_vu_iterations.go
+++ b/lib/executor/per_vu_iterations.go
@@ -233,8 +233,12 @@ func (pvi PerVUIterations) Run(parentCtx context.Context, out chan<- metrics.Sam
 			select {
 			case <-regDurationDone:
 				metrics.PushIfNotDone(parentCtx, out, metrics.Sample{
-					Value: float64(iterations - i), Metric: droppedIterationMetric,
-					Tags: pvi.getMetricTags(&vuID), Time: time.Now(),
+					TimeSeries: metrics.TimeSeries{
+						Metric: droppedIterationMetric,
+						Tags:   pvi.getMetricTags(&vuID),
+					},
+					Time:  time.Now(),
+					Value: float64(iterations - i),
 				})
 				return // don't make more iterations
 			default:

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -482,10 +482,12 @@ func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 		// Since there aren't any free VUs available, consider this iteration
 		// dropped - we aren't going to try to recover it, but
 		metrics.PushIfNotDone(parentCtx, out, metrics.Sample{
-			Metric: varr.executionState.Test.BuiltinMetrics.DroppedIterations,
-			Tags:   metricTags,
-			Time:   time.Now(),
-			Value:  1,
+			TimeSeries: metrics.TimeSeries{
+				Metric: varr.executionState.Test.BuiltinMetrics.DroppedIterations,
+				Tags:   metricTags,
+			},
+			Time:  time.Now(),
+			Value: 1,
 		})
 
 		// We'll try to start allocating another VU in the background,

--- a/lib/executor/shared_iterations.go
+++ b/lib/executor/shared_iterations.go
@@ -237,9 +237,12 @@ func (si SharedIterations) Run(parentCtx context.Context, out chan<- metrics.Sam
 		activeVUs.Wait()
 		if attemptedIters < totalIters {
 			metrics.PushIfNotDone(parentCtx, out, metrics.Sample{
-				Value:  float64(totalIters - attemptedIters),
-				Metric: si.executionState.Test.BuiltinMetrics.DroppedIterations,
-				Tags:   si.getMetricTags(nil), Time: time.Now(),
+				TimeSeries: metrics.TimeSeries{
+					Metric: si.executionState.Test.BuiltinMetrics.DroppedIterations,
+					Tags:   si.getMetricTags(nil),
+				},
+				Value: float64(totalIters - attemptedIters),
+				Time:  time.Now(),
 			})
 		}
 	}()

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -94,7 +94,7 @@ func (d *Dialer) DialContext(ctx context.Context, proto, addr string) (net.Conn,
 // TODO: Refactor this according to
 // https://github.com/k6io/k6/pull/1203#discussion_r337938370
 func (d *Dialer) GetTrail(
-	startTime, endTime time.Time, fullIteration bool, emitIterations bool, tags *metrics.SampleTags,
+	startTime, endTime time.Time, fullIteration bool, emitIterations bool, tags *metrics.TagSet,
 	builtinMetrics *metrics.BuiltinMetrics,
 ) *NetTrail {
 	bytesWritten := atomic.SwapInt64(&d.BytesWritten, 0)
@@ -222,7 +222,7 @@ type NetTrail struct {
 	FullIteration bool
 	StartTime     time.Time
 	EndTime       time.Time
-	Tags          *metrics.SampleTags
+	Tags          *metrics.TagSet
 	Samples       []metrics.Sample
 }
 
@@ -235,7 +235,7 @@ func (ntr *NetTrail) GetSamples() []metrics.Sample {
 }
 
 // GetTags implements the metrics.ConnectedSampleContainer interface.
-func (ntr *NetTrail) GetTags() *metrics.SampleTags {
+func (ntr *NetTrail) GetTags() *metrics.TagSet {
 	return ntr.Tags
 }
 

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -101,31 +101,39 @@ func (d *Dialer) GetTrail(
 	bytesRead := atomic.SwapInt64(&d.BytesRead, 0)
 	samples := []metrics.Sample{
 		{
-			Time:   endTime,
-			Metric: builtinMetrics.DataSent,
-			Value:  float64(bytesWritten),
-			Tags:   tags,
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.DataSent,
+				Tags:   tags,
+			},
+			Time:  endTime,
+			Value: float64(bytesWritten),
 		},
 		{
-			Time:   endTime,
-			Metric: builtinMetrics.DataReceived,
-			Value:  float64(bytesRead),
-			Tags:   tags,
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.DataReceived,
+				Tags:   tags,
+			},
+			Time:  endTime,
+			Value: float64(bytesRead),
 		},
 	}
 	if fullIteration {
 		samples = append(samples, metrics.Sample{
-			Time:   endTime,
-			Metric: builtinMetrics.IterationDuration,
-			Value:  metrics.D(endTime.Sub(startTime)),
-			Tags:   tags,
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.IterationDuration,
+				Tags:   tags,
+			},
+			Time:  endTime,
+			Value: metrics.D(endTime.Sub(startTime)),
 		})
 		if emitIterations {
 			samples = append(samples, metrics.Sample{
-				Time:   endTime,
-				Metric: builtinMetrics.Iterations,
-				Value:  1,
-				Tags:   tags,
+				TimeSeries: metrics.TimeSeries{
+					Metric: builtinMetrics.Iterations,
+					Tags:   tags,
+				},
+				Time:  endTime,
+				Value: 1,
 			})
 		}
 	}

--- a/lib/netext/grpcext/conn.go
+++ b/lib/netext/grpcext/conn.go
@@ -220,10 +220,12 @@ func (h statsHandler) HandleRPC(ctx context.Context, stat grpcstats.RPCStats) {
 		}
 
 		metrics.PushIfNotDone(ctx, state.Samples, metrics.Sample{
-			Metric: state.BuiltinMetrics.GRPCReqDuration,
-			Tags:   stateRPC.tags,
-			Value:  metrics.D(s.EndTime.Sub(s.BeginTime)),
-			Time:   s.EndTime,
+			TimeSeries: metrics.TimeSeries{
+				Metric: state.BuiltinMetrics.GRPCReqDuration,
+				Tags:   stateRPC.tags,
+			},
+			Time:  s.EndTime,
+			Value: metrics.D(s.EndTime.Sub(s.BeginTime)),
 		})
 	}
 

--- a/lib/netext/grpcext/conn.go
+++ b/lib/netext/grpcext/conn.go
@@ -209,7 +209,6 @@ func (h statsHandler) HandleRPC(ctx context.Context, stat grpcstats.RPCStats) {
 	case *grpcstats.OutHeader:
 		// TODO: figure out something better, e.g. via TagConn() or TagRPC()?
 		if state.Options.SystemTags.Has(metrics.TagIP) && s.RemoteAddr != nil {
-			stateRPC.ip = s.RemoteAddr.String()
 			if ip, _, err := net.SplitHostPort(s.RemoteAddr.String()); err == nil {
 				stateRPC.tags = stateRPC.tags.With("ip", ip)
 			}
@@ -307,7 +306,6 @@ type contextKey string
 var ctxKeyRPCState = contextKey("rpcState") //nolint:gochecknoglobals
 
 type rpcState struct {
-	ip   string
 	tags *metrics.TagSet
 }
 

--- a/lib/netext/grpcext/conn_test.go
+++ b/lib/netext/grpcext/conn_test.go
@@ -329,3 +329,5 @@ func (invokemock) NewStream(ctx context.Context, desc *grpc.StreamDesc, method s
 func (invokemock) Close() error {
 	return nil
 }
+
+// TODO: add a test for the ip metric tag

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -187,17 +187,17 @@ func MakeRequest(ctx context.Context, state *lib.State, preq *ParsedHTTPRequest)
 		}
 	}
 
-	tags := state.Tags.BranchOut()
+	tags := state.Tags.GetCurrentValues()
 	// Override any global tags with request-specific ones.
 	for _, tag := range preq.Tags {
-		tags.AddTag(tag[0], tag[1])
+		tags = tags.With(tag[0], tag[1])
 	}
 
 	// Only set the name system tag if the user didn't explicitly set it beforehand,
 	// and the Name was generated from a tagged template string (via http.url).
 	if _, ok := tags.Get("name"); !ok && state.Options.SystemTags.Has(metrics.TagName) &&
 		preq.URL.Name != "" && preq.URL.Name != preq.URL.Clean() {
-		tags.AddTag("name", preq.URL.Name)
+		tags = tags.With("name", preq.URL.Name)
 	}
 
 	// Check rate limit *after* we've prepared a request; no need to wait with that part.

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -120,7 +120,7 @@ func TestMakeRequestError(t *testing.T) {
 		state := &lib.State{
 			Transport: http.DefaultTransport,
 			Logger:    logrus.New(),
-			Tags:      lib.NewTagMap(metrics.NewRegistry().BranchTagSetRoot()),
+			Tags:      lib.NewVUStateTags(metrics.NewRegistry().RootTagSet()),
 		}
 		_, err = MakeRequest(ctx, state, preq)
 		require.Error(t, err)
@@ -142,7 +142,7 @@ func TestMakeRequestError(t *testing.T) {
 		state := &lib.State{
 			Transport: srv.Client().Transport,
 			Logger:    logger,
-			Tags:      lib.NewTagMap(metrics.NewRegistry().BranchTagSetRoot()),
+			Tags:      lib.NewVUStateTags(metrics.NewRegistry().RootTagSet()),
 		}
 		req, _ := http.NewRequest("GET", srv.URL, nil)
 		preq := &ParsedHTTPRequest{
@@ -194,7 +194,7 @@ func TestResponseStatus(t *testing.T) {
 					Logger:         logger,
 					Samples:        samples,
 					BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-					Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
+					Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 				}
 				req, err := http.NewRequest("GET", server.URL, nil)
 				require.NoError(t, err)
@@ -275,7 +275,7 @@ func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 		Logger:         logger,
 		BPool:          bpool.NewBufferPool(100),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
+		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
 	req, _ := http.NewRequest("GET", srv.URL, nil)
 	preq := &ParsedHTTPRequest{
@@ -303,7 +303,7 @@ func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 		"name":              srv.URL,
 	}
 	for _, s := range allSamples {
-		assert.Equal(t, expTags, s.Tags.CloneTags())
+		assert.Equal(t, expTags, s.Tags.Map())
 	}
 }
 
@@ -351,7 +351,7 @@ func TestTrailFailed(t *testing.T) {
 				Logger:         logger,
 				BPool:          bpool.NewBufferPool(2),
 				BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-				Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
+				Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 			}
 			req, _ := http.NewRequest("GET", srv.URL, nil)
 			preq := &ParsedHTTPRequest{
@@ -416,7 +416,7 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 		Logger:         logger,
 		BPool:          bpool.NewBufferPool(100),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
+		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
 
 	req, _ := http.NewRequest("GET", "http://"+addr.String(), nil)
@@ -445,7 +445,7 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 		"name":              req.URL.String(),
 	}
 	for _, s := range allSamples {
-		assert.Equal(t, expTags, s.Tags.CloneTags())
+		assert.Equal(t, expTags, s.Tags.Map())
 	}
 }
 
@@ -470,7 +470,7 @@ func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 		Logger:         logger,
 		BPool:          bpool.NewBufferPool(100),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
-		Tags:           lib.NewTagMap(registry.BranchTagSetRoot()),
+		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
 	req, _ := http.NewRequest("GET", srv.URL, nil)
 	preq := &ParsedHTTPRequest{
@@ -498,6 +498,6 @@ func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 		"name":              srv.URL,
 	}
 	for _, s := range allSamples {
-		assert.Equal(t, expTags, s.Tags.CloneTags())
+		assert.Equal(t, expTags, s.Tags.Map())
 	}
 }

--- a/lib/netext/httpext/tracer.go
+++ b/lib/netext/httpext/tracer.go
@@ -55,12 +55,12 @@ type Trail struct {
 
 	Failed null.Bool
 	// Populated by SaveSamples()
-	Tags    *metrics.SampleTags
+	Tags    *metrics.TagSet
 	Samples []metrics.Sample
 }
 
 // SaveSamples populates the Trail's sample slice so they're accesible via GetSamples()
-func (tr *Trail) SaveSamples(builtinMetrics *metrics.BuiltinMetrics, tags *metrics.SampleTags) {
+func (tr *Trail) SaveSamples(builtinMetrics *metrics.BuiltinMetrics, tags *metrics.TagSet) {
 	tr.Tags = tags
 	tr.Samples = make([]metrics.Sample, 0, 9) // this is with 1 more for a possible HTTPReqFailed
 	tr.Samples = append(tr.Samples, []metrics.Sample{
@@ -81,7 +81,7 @@ func (tr *Trail) GetSamples() []metrics.Sample {
 }
 
 // GetTags implements the metrics.ConnectedSampleContainer interface.
-func (tr *Trail) GetTags() *metrics.SampleTags {
+func (tr *Trail) GetTags() *metrics.TagSet {
 	return tr.Tags
 }
 

--- a/lib/netext/httpext/tracer.go
+++ b/lib/netext/httpext/tracer.go
@@ -64,14 +64,70 @@ func (tr *Trail) SaveSamples(builtinMetrics *metrics.BuiltinMetrics, tags *metri
 	tr.Tags = tags
 	tr.Samples = make([]metrics.Sample, 0, 9) // this is with 1 more for a possible HTTPReqFailed
 	tr.Samples = append(tr.Samples, []metrics.Sample{
-		{Metric: builtinMetrics.HTTPReqs, Time: tr.EndTime, Tags: tags, Value: 1},
-		{Metric: builtinMetrics.HTTPReqDuration, Time: tr.EndTime, Tags: tags, Value: metrics.D(tr.Duration)},
-		{Metric: builtinMetrics.HTTPReqBlocked, Time: tr.EndTime, Tags: tags, Value: metrics.D(tr.Blocked)},
-		{Metric: builtinMetrics.HTTPReqConnecting, Time: tr.EndTime, Tags: tags, Value: metrics.D(tr.Connecting)},
-		{Metric: builtinMetrics.HTTPReqTLSHandshaking, Time: tr.EndTime, Tags: tags, Value: metrics.D(tr.TLSHandshaking)},
-		{Metric: builtinMetrics.HTTPReqSending, Time: tr.EndTime, Tags: tags, Value: metrics.D(tr.Sending)},
-		{Metric: builtinMetrics.HTTPReqWaiting, Time: tr.EndTime, Tags: tags, Value: metrics.D(tr.Waiting)},
-		{Metric: builtinMetrics.HTTPReqReceiving, Time: tr.EndTime, Tags: tags, Value: metrics.D(tr.Receiving)},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.HTTPReqs,
+				Tags:   tags,
+			},
+			Time:  tr.EndTime,
+			Value: 1,
+		},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.HTTPReqDuration,
+				Tags:   tags,
+			},
+			Time:  tr.EndTime,
+			Value: metrics.D(tr.Duration),
+		},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.HTTPReqBlocked,
+				Tags:   tags,
+			},
+			Time:  tr.EndTime,
+			Value: metrics.D(tr.Blocked),
+		},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.HTTPReqConnecting,
+				Tags:   tags,
+			},
+			Time:  tr.EndTime,
+			Value: metrics.D(tr.Connecting),
+		},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.HTTPReqTLSHandshaking,
+				Tags:   tags,
+			},
+			Time:  tr.EndTime,
+			Value: metrics.D(tr.TLSHandshaking),
+		},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.HTTPReqSending,
+				Tags:   tags,
+			},
+			Time:  tr.EndTime,
+			Value: metrics.D(tr.Sending),
+		},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.HTTPReqWaiting,
+				Tags:   tags,
+			},
+			Time:  tr.EndTime,
+			Value: metrics.D(tr.Waiting),
+		},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: builtinMetrics.HTTPReqReceiving,
+				Tags:   tags,
+			},
+			Time:  tr.EndTime,
+			Value: metrics.D(tr.Receiving),
+		},
 	}...)
 }
 

--- a/lib/netext/httpext/tracer_test.go
+++ b/lib/netext/httpext/tracer_test.go
@@ -150,7 +150,7 @@ func TestTracer(t *testing.T) { //nolint:tparallel
 				time.Sleep(traceDelay)
 			}
 			trail := tracer.Done()
-			trail.SaveSamples(builtinMetrics, registry.BranchTagSetRootWith(map[string]string{"tag": "value"}).SampleTags())
+			trail.SaveSamples(builtinMetrics, registry.RootTagSet().SortAndAddTags(map[string]string{"tag": "value"}))
 			samples := trail.GetSamples()
 
 			assertLaterOrZero(t, tracer.getConn, isReuse)
@@ -172,7 +172,7 @@ func TestTracer(t *testing.T) { //nolint:tparallel
 				seenMetrics[s.Metric] = true
 
 				assert.False(t, s.Time.IsZero())
-				assert.Equal(t, map[string]string{"tag": "value"}, s.Tags.CloneTags())
+				assert.Equal(t, map[string]string{"tag": "value"}, s.Tags.Map())
 
 				switch s.Metric {
 				case builtinMetrics.HTTPReqs:

--- a/lib/netext/httpext/tracer_test.go
+++ b/lib/netext/httpext/tracer_test.go
@@ -150,7 +150,7 @@ func TestTracer(t *testing.T) { //nolint:tparallel
 				time.Sleep(traceDelay)
 			}
 			trail := tracer.Done()
-			trail.SaveSamples(builtinMetrics, registry.RootTagSet().SortAndAddTags(map[string]string{"tag": "value"}))
+			trail.SaveSamples(builtinMetrics, registry.RootTagSet().WithTagsFromMap(map[string]string{"tag": "value"}))
 			samples := trail.GetSamples()
 
 			assertLaterOrZero(t, tracer.getConn, isReuse)

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -188,10 +188,12 @@ func (t *transport) measureAndEmitMetrics(unfReq *unfinishedRequest) *finishedRe
 		}
 		trail.Samples = append(trail.Samples,
 			metrics.Sample{
-				Metric: t.state.BuiltinMetrics.HTTPReqFailed,
-				Time:   trail.EndTime,
-				Tags:   tags,
-				Value:  failed,
+				TimeSeries: metrics.TimeSeries{
+					Metric: t.state.BuiltinMetrics.HTTPReqFailed,
+					Tags:   tags,
+				},
+				Time:  trail.EndTime,
+				Value: failed,
 			},
 		)
 	}

--- a/lib/state_test.go
+++ b/lib/state_test.go
@@ -70,7 +70,7 @@ func TestVUStateTagsSafeConcurrent(t *testing.T) {
 
 func TestVUStateTagsDelete(t *testing.T) {
 	t.Parallel()
-	tm := NewVUStateTags(metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{
+	tm := NewVUStateTags(metrics.NewRegistry().RootTagSet().WithTagsFromMap(map[string]string{
 		"key1": "value1",
 		"key2": "value2",
 	}))
@@ -90,7 +90,7 @@ func TestVUStateTagsDelete(t *testing.T) {
 
 func TestVUStateTagsMap(t *testing.T) {
 	t.Parallel()
-	tm := NewVUStateTags(metrics.NewRegistry().RootTagSet().SortAndAddTags(map[string]string{
+	tm := NewVUStateTags(metrics.NewRegistry().RootTagSet().WithTagsFromMap(map[string]string{
 		"key1": "value1",
 		"key2": "value2",
 	}))

--- a/lib/testutils/minirunner/minirunner.go
+++ b/lib/testutils/minirunner/minirunner.go
@@ -63,7 +63,7 @@ func (r MiniRunner) MakeArchive() *lib.Archive {
 func (r *MiniRunner) NewVU(idLocal, idGlobal uint64, out chan<- metrics.SampleContainer) (lib.InitializedVU, error) {
 	state := &lib.State{VUID: idLocal, VUIDGlobal: idGlobal, Iteration: int64(-1)}
 	if r.runTags != nil {
-		state.Tags = lib.NewTagMap(r.runTags)
+		state.Tags = lib.NewVUStateTags(r.runTags)
 	}
 	return &VU{
 		R:            r,
@@ -126,7 +126,7 @@ func (r *MiniRunner) SetOptions(opts lib.Options) error {
 	r.Options = opts
 
 	if r.PreInitState != nil {
-		r.runTags = r.PreInitState.Registry.BranchTagSetRootWith(r.Options.RunTags)
+		r.runTags = r.PreInitState.Registry.RootTagSet().SortAndAddTags(r.Options.RunTags)
 	}
 
 	return nil

--- a/lib/testutils/minirunner/minirunner.go
+++ b/lib/testutils/minirunner/minirunner.go
@@ -126,7 +126,7 @@ func (r *MiniRunner) SetOptions(opts lib.Options) error {
 	r.Options = opts
 
 	if r.PreInitState != nil {
-		r.runTags = r.PreInitState.Registry.RootTagSet().SortAndAddTags(r.Options.RunTags)
+		r.runTags = r.PreInitState.Registry.RootTagSet().WithTagsFromMap(r.Options.RunTags)
 	}
 
 	return nil

--- a/metrics/engine/engine.go
+++ b/metrics/engine/engine.go
@@ -77,9 +77,7 @@ func (me *MetricsEngine) getThresholdMetricOrSubmetric(name string) (*metrics.Me
 	if submetricDefinition[len(submetricDefinition)-1] != '}' {
 		return nil, fmt.Errorf("missing ending bracket, sub-metric format needs to be 'metric{key:value}'")
 	}
-	sm, err := metric.AddSubmetric(
-		submetricDefinition[:len(submetricDefinition)-1],
-		me.es.Test.Registry.BranchTagSetRoot())
+	sm, err := metric.AddSubmetric(submetricDefinition[:len(submetricDefinition)-1])
 	if err != nil {
 		return nil, err
 	}

--- a/metrics/metric.go
+++ b/metrics/metric.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"gopkg.in/guregu/null.v3"
 )
 
 // A Metric defines the shape of a set of data.
 type Metric struct {
+	registry *Registry  `json:"-"`
 	Name     string     `json:"name"`
 	Type     MetricType `json:"type"`
 	Contains ValueType  `json:"contains"`
@@ -25,50 +25,11 @@ type Metric struct {
 	Observed   bool         `json:"-"`
 }
 
-// Sample samples the metric at the given time, with the provided tags and value
-func (m *Metric) Sample(t time.Time, tags *SampleTags, value float64) Sample {
-	return Sample{
-		Time:   t,
-		Tags:   tags,
-		Value:  value,
-		Metric: m,
-	}
-}
-
-// newMetric instantiates a new Metric
-func newMetric(name string, mt MetricType, vt ...ValueType) *Metric {
-	valueType := Default
-	if len(vt) > 0 {
-		valueType = vt[0]
-	}
-
-	var sink Sink
-	switch mt {
-	case Counter:
-		sink = &CounterSink{}
-	case Gauge:
-		sink = &GaugeSink{}
-	case Trend:
-		sink = &TrendSink{}
-	case Rate:
-		sink = &RateSink{}
-	default:
-		return nil
-	}
-
-	return &Metric{
-		Name:     name,
-		Type:     mt,
-		Contains: valueType,
-		Sink:     sink,
-	}
-}
-
 // A Submetric represents a filtered dataset based on a parent metric.
 type Submetric struct {
-	Name   string      `json:"name"`
-	Suffix string      `json:"suffix"` // TODO: rename?
-	Tags   *SampleTags `json:"tags"`
+	Name   string  `json:"name"`
+	Suffix string  `json:"suffix"` // TODO: rename?
+	Tags   *TagSet `json:"tags"`
 
 	Metric *Metric `json:"-"`
 	Parent *Metric `json:"-"`
@@ -76,15 +37,13 @@ type Submetric struct {
 
 // AddSubmetric creates a new submetric from the key:value threshold definition
 // and adds it to the metric's submetrics list.
-//
-// FIXME: documentation for rootTagSet
-func (m *Metric) AddSubmetric(keyValues string, root *TagSet) (*Submetric, error) {
+func (m *Metric) AddSubmetric(keyValues string) (*Submetric, error) {
 	keyValues = strings.TrimSpace(keyValues)
 	if len(keyValues) == 0 {
 		return nil, fmt.Errorf("submetric criteria for metric '%s' cannot be empty", m.Name)
 	}
 	kvs := strings.Split(keyValues, ",")
-	rawTags := root.BranchOut()
+	tags := m.registry.RootTagSet()
 	for _, kv := range kvs {
 		if kv == "" {
 			continue
@@ -93,17 +52,16 @@ func (m *Metric) AddSubmetric(keyValues string, root *TagSet) (*Submetric, error
 
 		key := strings.Trim(strings.TrimSpace(parts[0]), `"'`)
 		if len(parts) != 2 {
-			rawTags.AddTag(key, "")
+			tags = tags.With(key, "")
 			continue
 		}
 
 		value := strings.Trim(strings.TrimSpace(parts[1]), `"'`)
-		rawTags.AddTag(key, value)
+		tags = tags.With(key, value)
 	}
-	tags := rawTags.SampleTags()
 
 	for _, sm := range m.Submetrics {
-		if sm.Tags.IsEqual(tags) {
+		if tags == sm.Tags {
 			return sm, nil
 		}
 	}
@@ -114,7 +72,7 @@ func (m *Metric) AddSubmetric(keyValues string, root *TagSet) (*Submetric, error
 		Tags:   tags,
 		Parent: m,
 	}
-	subMetricMetric := newMetric(subMetric.Name, m.Type, m.Contains)
+	subMetricMetric := m.registry.newMetric(subMetric.Name, m.Type, m.Contains)
 	subMetricMetric.Sub = subMetric // sigh
 	subMetric.Metric = subMetricMetric
 

--- a/metrics/metric_test.go
+++ b/metrics/metric_test.go
@@ -23,7 +23,8 @@ func TestNewMetric(t *testing.T) {
 		name, data := name, data
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			m := newMetric("my_metric", data.Type)
+			r := NewRegistry()
+			m := r.newMetric("my_metric", data.Type)
 			assert.Equal(t, "my_metric", m.Name)
 			assert.IsType(t, data.SinkType, m.Sink)
 		})
@@ -54,15 +55,16 @@ func TestAddSubmetric(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			m := newMetric("metric", Trend)
-			sm, err := m.AddSubmetric(name, newTagSet(nil))
+			r := NewRegistry()
+			m := r.MustNewMetric("metric", Trend)
+			sm, err := m.AddSubmetric(name)
 			if expected.err {
 				require.Error(t, err)
 				return
 			}
 			require.NoError(t, err)
 			require.NotNil(t, sm)
-			assert.EqualValues(t, expected.tags, sm.Tags.CloneTags())
+			assert.EqualValues(t, expected.tags, sm.Tags.Map())
 		})
 	}
 }

--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -80,7 +80,7 @@ func TestRegistryBranchTagSetRootWith(t *testing.T) {
 	}
 
 	r := NewRegistry()
-	tags := r.BranchTagSetRootWith(raw)
+	tags := r.RootTagSet().SortAndAddTags(raw)
 	require.NotNil(t, tags)
 
 	assert.Equal(t, raw, tags.Map())

--- a/metrics/registry_test.go
+++ b/metrics/registry_test.go
@@ -80,7 +80,7 @@ func TestRegistryBranchTagSetRootWith(t *testing.T) {
 	}
 
 	r := NewRegistry()
-	tags := r.RootTagSet().SortAndAddTags(raw)
+	tags := r.RootTagSet().WithTagsFromMap(raw)
 	require.NotNil(t, tags)
 
 	assert.Equal(t, raw, tags.Map())

--- a/metrics/sample.go
+++ b/metrics/sample.go
@@ -8,10 +8,17 @@ import (
 	"time"
 )
 
-// A Sample is a single measurement.
+// A TimeSeries uniquely identifies the metric and the set of metric tags that a
+// Sample (i.e. a metric measurement) has. TimeSeries objects are comparable
+// with the == operator and can be used as map indexes.
+type TimeSeries struct {
+	Metric *Metric
+	Tags   *TagSet
+}
+
+// A Sample is a single metric measurement.
 type Sample struct {
-	Metric   *Metric
-	Tags     *TagSet
+	TimeSeries
 	Time     time.Time
 	Value    float64
 	Metadata map[string]string // could be nil

--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -14,10 +14,12 @@ func TestSampleImplementations(t *testing.T) {
 	now := time.Now()
 
 	sample := Sample{
-		Metric: r.MustNewMetric("test_metric", Counter),
-		Time:   now,
-		Tags:   sampleTags,
-		Value:  1.0,
+		TimeSeries: TimeSeries{
+			Metric: r.MustNewMetric("test_metric", Counter),
+			Tags:   sampleTags,
+		},
+		Time:  now,
+		Value: 1.0,
 	}
 	samples := Samples(sample.GetSamples())
 	cSamples := ConnectedSamples{

--- a/metrics/sink_test.go
+++ b/metrics/sink_test.go
@@ -35,14 +35,14 @@ func TestCounterSink(t *testing.T) {
 	t.Run("add", func(t *testing.T) {
 		t.Run("one value", func(t *testing.T) {
 			sink := CounterSink{}
-			sink.Add(Sample{Metric: &Metric{}, Value: 1.0, Time: now})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: 1.0, Time: now})
 			assert.Equal(t, 1.0, sink.Value)
 			assert.Equal(t, now, sink.First)
 		})
 		t.Run("values", func(t *testing.T) {
 			sink := CounterSink{}
 			for _, s := range samples10 {
-				sink.Add(Sample{Metric: &Metric{}, Value: s, Time: now})
+				sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s, Time: now})
 			}
 			assert.Equal(t, 145.0, sink.Value)
 			assert.Equal(t, now, sink.First)
@@ -57,7 +57,7 @@ func TestCounterSink(t *testing.T) {
 	t.Run("format", func(t *testing.T) {
 		sink := CounterSink{}
 		for _, s := range samples10 {
-			sink.Add(Sample{Metric: &Metric{}, Value: s, Time: now})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s, Time: now})
 		}
 		assert.Equal(t, map[string]float64{"count": 145, "rate": 145.0}, sink.Format(1*time.Second))
 	})
@@ -69,7 +69,7 @@ func TestGaugeSink(t *testing.T) {
 	t.Run("add", func(t *testing.T) {
 		t.Run("one value", func(t *testing.T) {
 			sink := GaugeSink{}
-			sink.Add(Sample{Metric: &Metric{}, Value: 1.0})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: 1.0})
 			assert.Equal(t, 1.0, sink.Value)
 			assert.Equal(t, 1.0, sink.Min)
 			assert.Equal(t, true, sink.minSet)
@@ -78,7 +78,7 @@ func TestGaugeSink(t *testing.T) {
 		t.Run("values", func(t *testing.T) {
 			sink := GaugeSink{}
 			for _, s := range samples6 {
-				sink.Add(Sample{Metric: &Metric{}, Value: s})
+				sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s})
 			}
 			assert.Equal(t, 5.0, sink.Value)
 			assert.Equal(t, 1.0, sink.Min)
@@ -97,7 +97,7 @@ func TestGaugeSink(t *testing.T) {
 	t.Run("format", func(t *testing.T) {
 		sink := GaugeSink{}
 		for _, s := range samples6 {
-			sink.Add(Sample{Metric: &Metric{}, Value: s})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s})
 		}
 		assert.Equal(t, map[string]float64{"value": 5.0}, sink.Format(0))
 	})
@@ -110,7 +110,7 @@ func TestTrendSink(t *testing.T) {
 	t.Run("add", func(t *testing.T) {
 		t.Run("one value", func(t *testing.T) {
 			sink := TrendSink{}
-			sink.Add(Sample{Metric: &Metric{}, Value: 7.0})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: 7.0})
 			assert.Equal(t, uint64(1), sink.Count)
 			assert.Equal(t, true, sink.jumbled)
 			assert.Equal(t, 7.0, sink.Min)
@@ -121,7 +121,7 @@ func TestTrendSink(t *testing.T) {
 		t.Run("values", func(t *testing.T) {
 			sink := TrendSink{}
 			for _, s := range unsortedSamples10 {
-				sink.Add(Sample{Metric: &Metric{}, Value: s})
+				sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s})
 			}
 			assert.Equal(t, uint64(len(unsortedSamples10)), sink.Count)
 			assert.Equal(t, true, sink.jumbled)
@@ -142,7 +142,7 @@ func TestTrendSink(t *testing.T) {
 		t.Run("odd number of samples median", func(t *testing.T) {
 			sink := TrendSink{}
 			for _, s := range unsortedSamples5 {
-				sink.Add(Sample{Metric: &Metric{}, Value: s})
+				sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s})
 			}
 			sink.Calc()
 			assert.Equal(t, uint64(len(unsortedSamples5)), sink.Count)
@@ -152,7 +152,7 @@ func TestTrendSink(t *testing.T) {
 		t.Run("sorted", func(t *testing.T) {
 			sink := TrendSink{}
 			for _, s := range unsortedSamples10 {
-				sink.Add(Sample{Metric: &Metric{}, Value: s})
+				sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s})
 			}
 			sink.Calc()
 			assert.Equal(t, uint64(len(unsortedSamples10)), sink.Count)
@@ -174,15 +174,15 @@ func TestTrendSink(t *testing.T) {
 		})
 		t.Run("one value", func(t *testing.T) {
 			sink := TrendSink{}
-			sink.Add(Sample{Metric: &Metric{}, Value: 10.0})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: 10.0})
 			for i := 1; i <= 100; i++ {
 				assert.Equal(t, 10.0, sink.P(float64(i)/100.0))
 			}
 		})
 		t.Run("two values", func(t *testing.T) {
 			sink := TrendSink{}
-			sink.Add(Sample{Metric: &Metric{}, Value: 5.0})
-			sink.Add(Sample{Metric: &Metric{}, Value: 10.0})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: 5.0})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: 10.0})
 			assert.Equal(t, 5.0, sink.P(0.0))
 			assert.Equal(t, 7.5, sink.P(0.5))
 			assert.Equal(t, 5+(10-5)*0.95, sink.P(0.95))
@@ -192,7 +192,7 @@ func TestTrendSink(t *testing.T) {
 		t.Run("more than 2", func(t *testing.T) {
 			sink := TrendSink{}
 			for _, s := range unsortedSamples10 {
-				sink.Add(Sample{Metric: &Metric{}, Value: s})
+				sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s})
 			}
 			assert.InDelta(t, 0.0, sink.P(0.0), tolerance)
 			assert.InDelta(t, 55.0, sink.P(0.5), tolerance)
@@ -204,7 +204,7 @@ func TestTrendSink(t *testing.T) {
 	t.Run("format", func(t *testing.T) {
 		sink := TrendSink{}
 		for _, s := range unsortedSamples10 {
-			sink.Add(Sample{Metric: &Metric{}, Value: s})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s})
 		}
 		expected := map[string]float64{
 			"min":   0.0,
@@ -229,20 +229,20 @@ func TestRateSink(t *testing.T) {
 	t.Run("add", func(t *testing.T) {
 		t.Run("one true", func(t *testing.T) {
 			sink := RateSink{}
-			sink.Add(Sample{Metric: &Metric{}, Value: 1.0})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: 1.0})
 			assert.Equal(t, int64(1), sink.Total)
 			assert.Equal(t, int64(1), sink.Trues)
 		})
 		t.Run("one false", func(t *testing.T) {
 			sink := RateSink{}
-			sink.Add(Sample{Metric: &Metric{}, Value: 0.0})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: 0.0})
 			assert.Equal(t, int64(1), sink.Total)
 			assert.Equal(t, int64(0), sink.Trues)
 		})
 		t.Run("values", func(t *testing.T) {
 			sink := RateSink{}
 			for _, s := range samples6 {
-				sink.Add(Sample{Metric: &Metric{}, Value: s})
+				sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s})
 			}
 			assert.Equal(t, int64(6), sink.Total)
 			assert.Equal(t, int64(3), sink.Trues)
@@ -257,7 +257,7 @@ func TestRateSink(t *testing.T) {
 	t.Run("format", func(t *testing.T) {
 		sink := RateSink{}
 		for _, s := range samples6 {
-			sink.Add(Sample{Metric: &Metric{}, Value: s})
+			sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s})
 		}
 		assert.Equal(t, map[string]float64{"rate": 0.5}, sink.Format(0))
 	})

--- a/metrics/tags_test.go
+++ b/metrics/tags_test.go
@@ -4,44 +4,106 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/mstoykov/atlas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestTagSetBranchOut(t *testing.T) {
+func TestTagsWith(t *testing.T) {
 	t.Parallel()
 
-	tm := newTagSet(nil)
-	tm.AddTag("key1", "val1")
-
-	tm2 := tm.BranchOut()
-	tm2.AddTag("key2", "val2")
-
-	tm.AddTag("key3", "val3")
+	tm := NewRegistry().RootTagSet().With("key1", "val1")
+	tm2 := tm.With("key2", "val2")
+	tm = tm.With("key3", "val3")
 
 	assert.Equal(t, map[string]string{"key1": "val1", "key3": "val3"}, tm.Map())
 	assert.Equal(t, map[string]string{
 		"key1": "val1",
 		"key2": "val2",
 	}, tm2.Map())
+
+	assert.Equal(t, map[string]string{"key2": "val2"}, tm2.Without("key1").Map())
 }
 
-func TestTagSetFromSampleTags(t *testing.T) {
+func TestRootTagSet(t *testing.T) {
 	t.Parallel()
 
-	rootNode := atlas.New()
-	rootNode = rootNode.AddLink("key1", "val1")
-	st := &SampleTags{tags: rootNode}
+	r := NewRegistry()
 
-	tm := TagSetFromSampleTags(st)
-	tm.AddTag("key2", "val2")
+	root := r.RootTagSet()
+	require.NotNil(t, root)
+	assert.True(t, root == r.RootTagSet())
+	assert.True(t, root.IsEmpty())
+	assert.Equal(t, map[string]string{}, root.Map())
 
-	assert.Equal(t, map[string]string{"key1": "val1"}, st.CloneTags())
-	assert.Equal(t, map[string]string{
-		"key1": "val1",
-		"key2": "val2",
-	}, tm.Map())
+	val, ok := root.Get("foo")
+	assert.False(t, ok)
+	assert.Empty(t, val)
+
+	rJSON, err := root.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(rJSON))
+}
+
+func TestTagSets(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	root := r.RootTagSet()
+
+	tags := root.With("tag1", "value1")
+	assert.True(t, root != tags)
+	assert.True(t, tags == root.With("tag1", "value1"))
+	assert.False(t, tags.IsEmpty())
+	assert.Equal(t, map[string]string{"tag1": "value1"}, tags.Map())
+
+	tags2 := tags.
+		With("tag2", "value2").
+		SortAndAddTags(map[string]string{"tag1": "foo", "tag3": "value3"}).
+		Without("tag3")
+
+	assert.Equal(t, map[string]string{"tag1": "foo", "tag2": "value2"}, tags2.Map())
+
+	val, ok := tags2.Get("foo")
+	assert.False(t, ok)
+	assert.Empty(t, val)
+
+	val, ok = tags2.Get("tag1")
+	assert.True(t, ok)
+	assert.Equal(t, val, "foo")
+
+	rJSON, err := tags2.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, `{"tag1":"foo","tag2":"value2"}`, string(rJSON))
+
+	assert.True(t, tags2.Contains(root))
+	assert.False(t, tags2.Contains(tags))
+
+	tags3 := tags.With("tag1", "foo")
+	assert.True(t, tags2.Contains(tags3))
+	tags4 := tags3.With("tag3", "value3")
+	assert.False(t, tags2.Contains(tags4))
+	assert.False(t, tags4.Contains(tags2))
+	assert.True(t, tags4.Contains(tags3))
+	assert.True(t, tags4.Contains(tags4))
+}
+
+func TestTagSetContains(t *testing.T) {
+	t.Parallel()
+
+	r := NewRegistry()
+	root := r.RootTagSet()
+
+	st := root.With("maintag", "mainvalue")
+
+	branch := st.With("tag1", "val1").With("tag2", "val2")
+	inner := st.With("tag1", "val1")
+	outer := st.With("tag3", "val2")
+
+	assert.True(t, st.Contains(st))
+	assert.True(t, branch.Contains(st))
+	assert.True(t, branch.Contains(inner))
+	assert.False(t, branch.Contains(outer))
+	assert.False(t, st.Contains(outer))
 }
 
 func TestEnabledTagsMarshalJSON(t *testing.T) {
@@ -101,16 +163,5 @@ func TestEnabledTagsTextUnmarshal(t *testing.T) {
 		err := set.UnmarshalText([]byte(input))
 		require.NoError(t, err)
 		require.Equal(t, expected, *set)
-	}
-}
-
-func newTagSet(m map[string]string) *TagSet {
-	node := atlas.New()
-	for k, v := range m {
-		node = node.AddLink(k, v)
-	}
-
-	return &TagSet{
-		tags: node,
 	}
 }

--- a/metrics/tags_test.go
+++ b/metrics/tags_test.go
@@ -32,6 +32,7 @@ func TestRootTagSet(t *testing.T) {
 	root := r.RootTagSet()
 	require.NotNil(t, root)
 	assert.True(t, root == r.RootTagSet())
+	assert.True(t, root == root.Without("foo"))
 	assert.True(t, root.IsEmpty())
 	assert.Equal(t, map[string]string{}, root.Map())
 
@@ -58,7 +59,7 @@ func TestTagSets(t *testing.T) {
 
 	tags2 := tags.
 		With("tag2", "value2").
-		SortAndAddTags(map[string]string{"tag1": "foo", "tag3": "value3"}).
+		WithTagsFromMap(map[string]string{"tag1": "foo", "tag3": "value3"}).
 		Without("tag3")
 
 	assert.Equal(t, map[string]string{"tag1": "foo", "tag2": "value2"}, tags2.Map())
@@ -70,6 +71,8 @@ func TestTagSets(t *testing.T) {
 	val, ok = tags2.Get("tag1")
 	assert.True(t, ok)
 	assert.Equal(t, val, "foo")
+
+	assert.True(t, tags2 == tags2.Without("foo"))
 
 	rJSON, err := tags2.MarshalJSON()
 	require.NoError(t, err)

--- a/metrics/thresholds_test.go
+++ b/metrics/thresholds_test.go
@@ -394,13 +394,11 @@ func TestThresholdsValidate(t *testing.T) {
 		t.Parallel()
 
 		testRegistry := NewRegistry()
-		rootTagSet := newTagSet(nil)
-
 		testCounter, err := testRegistry.NewMetric("test_counter", Counter)
 		require.NoError(t, err)
-		_, err = testCounter.AddSubmetric("foo:bar", rootTagSet)
+		_, err = testCounter.AddSubmetric("foo:bar")
 		require.NoError(t, err)
-		_, err = testCounter.AddSubmetric("abc:123,easyas:doremi", rootTagSet)
+		_, err = testCounter.AddSubmetric("abc:123,easyas:doremi")
 		require.NoError(t, err)
 
 		_, err = testRegistry.NewMetric("test_rate", Rate)

--- a/output/cloud/bench_test.go
+++ b/output/cloud/bench_test.go
@@ -88,7 +88,7 @@ func BenchmarkAggregateHTTP(b *testing.B) {
 	}
 }
 
-func generateTags(i, tagCount int, additionals ...map[string]string) *metrics.SampleTags {
+func generateTags(i, tagCount int, additionals ...map[string]string) *metrics.TagSet {
 	registry := metrics.NewRegistry()
 	res := map[string]string{
 		"test": "mest", "a": "b",
@@ -103,7 +103,7 @@ func generateTags(i, tagCount int, additionals ...map[string]string) *metrics.Sa
 		}
 	}
 
-	return registry.BranchTagSetRootWith(res).SampleTags()
+	return registry.RootTagSet().SortAndAddTags(res)
 }
 
 func BenchmarkMetricMarshal(b *testing.B) {
@@ -278,7 +278,7 @@ func generateSamples(count int) []*Sample {
 	return samples
 }
 
-func generateHTTPExtTrail(now time.Time, i time.Duration, tags *metrics.SampleTags) *httpext.Trail {
+func generateHTTPExtTrail(now time.Time, i time.Duration, tags *metrics.TagSet) *httpext.Trail {
 	return &httpext.Trail{
 		Blocked:        i % 200 * 100 * time.Millisecond,
 		Connecting:     i % 200 * 200 * time.Millisecond,

--- a/output/cloud/bench_test.go
+++ b/output/cloud/bench_test.go
@@ -103,7 +103,7 @@ func generateTags(i, tagCount int, additionals ...map[string]string) *metrics.Ta
 		}
 	}
 
-	return registry.RootTagSet().SortAndAddTags(res)
+	return registry.RootTagSet().WithTagsFromMap(res)
 }
 
 func BenchmarkMetricMarshal(b *testing.B) {

--- a/output/cloud/data.go
+++ b/output/cloud/data.go
@@ -131,9 +131,12 @@ func NewSampleFromTrail(trail *httpext.Trail) *Sample {
 		Time:   toMicroSecond(trail.GetTime()),
 		Values: values,
 	}
-	if tags := trail.GetTags(); !tags.IsEmpty() {
-		sdata.Tags, _ = easyjson.Marshal(tags)
+	if !trail.Tags.IsEmpty() {
+		if tagsJSON, err := easyjson.Marshal(trail.Tags); err == nil {
+			sdata.Tags = tagsJSON
+		}
 	}
+
 	return &Sample{
 		Type:   DataTypeMap,
 		Metric: "http_req_li_all",
@@ -237,7 +240,7 @@ func (am *AggregatedMetric) Calc(count float64) {
 	am.Avg = metrics.D(am.sumD) / count
 }
 
-type aggregationBucket map[*metrics.SampleTags][]*httpext.Trail
+type aggregationBucket map[*metrics.TagSet][]*httpext.Trail
 
 type durations []time.Duration
 

--- a/output/cloud/data_test.go
+++ b/output/cloud/data_test.go
@@ -39,7 +39,8 @@ import (
 func TestSampleMarshaling(t *testing.T) {
 	t.Parallel()
 
-	builtinMetrics := metrics.RegisterBuiltinMetrics(metrics.NewRegistry())
+	registry := metrics.NewRegistry()
+	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
 	now := time.Now()
 	exptoMicroSecond := now.UnixNano() / 1000
 
@@ -86,6 +87,7 @@ func TestSampleMarshaling(t *testing.T) {
 				Sending:        4000,
 				Waiting:        5000,
 				Receiving:      6000,
+				Tags:           registry.RootTagSet(),
 			}),
 			fmt.Sprintf(`{"type":"Points","metric":"http_req_li_all","data":{"time":"%d","type":"counter","values":{"http_req_blocked":0.001,"http_req_connecting":0.002,"http_req_duration":0.123,"http_req_receiving":0.006,"http_req_sending":0.004,"http_req_tls_handshaking":0.003,"http_req_waiting":0.005,"http_reqs":1}}}`, exptoMicroSecond),
 		},
@@ -100,6 +102,7 @@ func TestSampleMarshaling(t *testing.T) {
 				Waiting:        5000,
 				Receiving:      6000,
 				Failed:         null.NewBool(false, true),
+				Tags:           registry.RootTagSet(),
 			}),
 			fmt.Sprintf(`{"type":"Points","metric":"http_req_li_all","data":{"time":"%d","type":"counter","values":{"http_req_blocked":0.001,"http_req_connecting":0.002,"http_req_duration":0.123,"http_req_failed":0,"http_req_receiving":0.006,"http_req_sending":0.004,"http_req_tls_handshaking":0.003,"http_req_waiting":0.005,"http_reqs":1}}}`, exptoMicroSecond),
 		},

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -214,7 +214,7 @@ func runCloudOutputTestCase(t *testing.T, minSamples int) {
 
 	now := time.Now()
 	tagMap := map[string]string{"test": "mest", "a": "b", "name": "name", "url": "url"}
-	tags := registry.BranchTagSetRootWith(tagMap).SampleTags()
+	tags := registry.RootTagSet().SortAndAddTags(tagMap)
 	expectedTags := `{"test": "mest", "a": "b", "name": "name", "url": "name"}`
 
 	expSamples := make(chan []Sample)
@@ -345,7 +345,7 @@ func TestCloudOutputMaxPerPacket(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, err)
 	now := time.Now()
-	tags := registry.BranchTagSetRootWith(map[string]string{"test": "mest", "a": "b"})
+	tags := registry.RootTagSet().SortAndAddTags(map[string]string{"test": "mest", "a": "b"})
 	gotTheLimit := false
 	var m sync.Mutex
 
@@ -368,7 +368,7 @@ func TestCloudOutputMaxPerPacket(t *testing.T) {
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
 		Time:   now,
 		Metric: builtinMetrics.VUs,
-		Tags:   tags.SampleTags(),
+		Tags:   tags,
 		Value:  1.0,
 	}})
 	for j := time.Duration(1); j <= 200; j++ {
@@ -385,7 +385,7 @@ func TestCloudOutputMaxPerPacket(t *testing.T) {
 				EndTime:      now.Add(i * 100),
 				ConnDuration: 500 * time.Millisecond,
 				Duration:     j * i * 1500 * time.Millisecond,
-				Tags:         tags.SampleTags(),
+				Tags:         tags,
 			})
 		}
 		out.AddMetricSamples(container)
@@ -462,7 +462,7 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 	}
 	require.NoError(t, err)
 	now := time.Now()
-	tags := registry.BranchTagSetRootWith(map[string]string{"test": "mest", "a": "b"})
+	tags := registry.RootTagSet().SortAndAddTags(map[string]string{"test": "mest", "a": "b"})
 
 	count := 1
 	max := 5
@@ -495,7 +495,7 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
 		Time:   now,
 		Metric: builtinMetrics.VUs,
-		Tags:   tags.SampleTags(),
+		Tags:   tags,
 		Value:  1.0,
 	}})
 	for j := time.Duration(1); j <= 200; j++ {
@@ -512,7 +512,7 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 				EndTime:      now.Add(i * 100),
 				ConnDuration: 500 * time.Millisecond,
 				Duration:     j * i * 1500 * time.Millisecond,
-				Tags:         tags.SampleTags(),
+				Tags:         tags,
 			})
 		}
 		out.AddMetricSamples(container)
@@ -535,7 +535,7 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
 		Time:   now,
 		Metric: builtinMetrics.VUs,
-		Tags:   tags.SampleTags(),
+		Tags:   tags,
 		Value:  1.0,
 	}})
 	if nBufferSamples != len(out.bufferSamples) || nBufferHTTPTrails != len(out.bufferHTTPTrails) {
@@ -651,7 +651,7 @@ func TestCloudOutputPushRefID(t *testing.T) {
 	assert.Equal(t, "333", out.referenceID)
 
 	now := time.Now()
-	tags := registry.BranchTagSetRootWith(map[string]string{"test": "mest", "a": "b"}).SampleTags()
+	tags := registry.RootTagSet().SortAndAddTags(map[string]string{"test": "mest", "a": "b"})
 	encodedTags, err := json.Marshal(tags)
 	require.NoError(t, err)
 
@@ -932,11 +932,11 @@ func TestUseCloudTags(t *testing.T) {
 			t.Parallel()
 
 			trail := &httpext.Trail{
-				Tags: metrics.NewRegistry().BranchTagSetRootWith(tc.in).SampleTags(),
+				Tags: metrics.NewRegistry().RootTagSet().SortAndAddTags(tc.in),
 			}
 			newTrail := useCloudTags(trail)
-			assert.Equal(t, tc.exp, newTrail.Tags.CloneTags())
-			assert.Equal(t, tc.in, trail.Tags.CloneTags())
+			assert.Equal(t, tc.exp, newTrail.Tags.Map())
+			assert.Equal(t, tc.in, trail.Tags.Map())
 		})
 	}
 }

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -214,7 +214,7 @@ func runCloudOutputTestCase(t *testing.T, minSamples int) {
 
 	now := time.Now()
 	tagMap := map[string]string{"test": "mest", "a": "b", "name": "name", "url": "url"}
-	tags := registry.RootTagSet().SortAndAddTags(tagMap)
+	tags := registry.RootTagSet().WithTagsFromMap(tagMap)
 	expectedTags := `{"test": "mest", "a": "b", "name": "name", "url": "name"}`
 
 	expSamples := make(chan []Sample)
@@ -347,7 +347,7 @@ func TestCloudOutputMaxPerPacket(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, err)
 	now := time.Now()
-	tags := registry.RootTagSet().SortAndAddTags(map[string]string{"test": "mest", "a": "b"})
+	tags := registry.RootTagSet().WithTagsFromMap(map[string]string{"test": "mest", "a": "b"})
 	gotTheLimit := false
 	var m sync.Mutex
 
@@ -466,7 +466,7 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 	}
 	require.NoError(t, err)
 	now := time.Now()
-	tags := registry.RootTagSet().SortAndAddTags(map[string]string{"test": "mest", "a": "b"})
+	tags := registry.RootTagSet().WithTagsFromMap(map[string]string{"test": "mest", "a": "b"})
 
 	count := 1
 	max := 5
@@ -659,7 +659,7 @@ func TestCloudOutputPushRefID(t *testing.T) {
 	assert.Equal(t, "333", out.referenceID)
 
 	now := time.Now()
-	tags := registry.RootTagSet().SortAndAddTags(map[string]string{"test": "mest", "a": "b"})
+	tags := registry.RootTagSet().WithTagsFromMap(map[string]string{"test": "mest", "a": "b"})
 	encodedTags, err := json.Marshal(tags)
 	require.NoError(t, err)
 
@@ -952,7 +952,7 @@ func TestUseCloudTags(t *testing.T) {
 			t.Parallel()
 
 			trail := &httpext.Trail{
-				Tags: metrics.NewRegistry().RootTagSet().SortAndAddTags(tc.in),
+				Tags: metrics.NewRegistry().RootTagSet().WithTagsFromMap(tc.in),
 			}
 			newTrail := useCloudTags(trail)
 			assert.Equal(t, tc.exp, newTrail.Tags.Map())

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -225,10 +225,12 @@ func runCloudOutputTestCase(t *testing.T, minSamples int) {
 	})
 
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
-		Time:   now,
-		Metric: builtinMetrics.VUs,
-		Tags:   tags,
-		Value:  1.0,
+		TimeSeries: metrics.TimeSeries{
+			Metric: builtinMetrics.VUs,
+			Tags:   tags,
+		},
+		Time:  now,
+		Value: 1.0,
 	}})
 
 	enctags, err := json.Marshal(tags)
@@ -366,10 +368,12 @@ func TestCloudOutputMaxPerPacket(t *testing.T) {
 	require.NoError(t, out.Start())
 
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
-		Time:   now,
-		Metric: builtinMetrics.VUs,
-		Tags:   tags,
-		Value:  1.0,
+		TimeSeries: metrics.TimeSeries{
+			Metric: builtinMetrics.VUs,
+			Tags:   tags,
+		},
+		Time:  now,
+		Value: 1.0,
 	}})
 	for j := time.Duration(1); j <= 200; j++ {
 		container := make([]metrics.SampleContainer, 0, 500)
@@ -493,10 +497,12 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 	require.NoError(t, out.Start())
 
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
-		Time:   now,
-		Metric: builtinMetrics.VUs,
-		Tags:   tags,
-		Value:  1.0,
+		TimeSeries: metrics.TimeSeries{
+			Metric: builtinMetrics.VUs,
+			Tags:   tags,
+		},
+		Time:  now,
+		Value: 1.0,
 	}})
 	for j := time.Duration(1); j <= 200; j++ {
 		container := make([]metrics.SampleContainer, 0, 500)
@@ -533,10 +539,12 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 	nBufferSamples := len(out.bufferSamples)
 	nBufferHTTPTrails := len(out.bufferHTTPTrails)
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
-		Time:   now,
-		Metric: builtinMetrics.VUs,
-		Tags:   tags,
-		Value:  1.0,
+		TimeSeries: metrics.TimeSeries{
+			Metric: builtinMetrics.VUs,
+			Tags:   tags,
+		},
+		Time:  now,
+		Value: 1.0,
 	}})
 	if nBufferSamples != len(out.bufferSamples) || nBufferHTTPTrails != len(out.bufferHTTPTrails) {
 		t.Errorf("Output still collects data after stop sending metrics")
@@ -656,10 +664,12 @@ func TestCloudOutputPushRefID(t *testing.T) {
 	require.NoError(t, err)
 
 	out.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
-		Time:   now,
-		Metric: builtinMetrics.HTTPReqDuration,
-		Tags:   tags,
-		Value:  123.45,
+		TimeSeries: metrics.TimeSeries{
+			Metric: builtinMetrics.HTTPReqDuration,
+			Tags:   tags,
+		},
+		Time:  now,
+		Value: 123.45,
 	}})
 	exp := []Sample{{
 		Type:   DataTypeSingle,
@@ -683,7 +693,8 @@ func TestCloudOutputPushRefID(t *testing.T) {
 
 func TestCloudOutputRecvIterLIAllIterations(t *testing.T) {
 	t.Parallel()
-	builtinMetrics := metrics.RegisterBuiltinMetrics(metrics.NewRegistry())
+	registry := metrics.NewRegistry()
+	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	tb.Mux.HandleFunc("/v1/tests", http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 		body, err := ioutil.ReadAll(req.Body)
@@ -752,19 +763,28 @@ func TestCloudOutputRecvIterLIAllIterations(t *testing.T) {
 		EndTime:       now,
 		Samples: []metrics.Sample{
 			{
-				Time:   now,
-				Metric: builtinMetrics.DataSent,
-				Value:  float64(200),
+				TimeSeries: metrics.TimeSeries{
+					Metric: builtinMetrics.DataSent,
+					Tags:   registry.RootTagSet(),
+				},
+				Time:  now,
+				Value: float64(200),
 			},
 			{
-				Time:   now,
-				Metric: builtinMetrics.DataReceived,
-				Value:  float64(100),
+				TimeSeries: metrics.TimeSeries{
+					Metric: builtinMetrics.DataReceived,
+					Tags:   registry.RootTagSet(),
+				},
+				Time:  now,
+				Value: float64(100),
 			},
 			{
-				Time:   now,
-				Metric: builtinMetrics.Iterations,
-				Value:  1,
+				TimeSeries: metrics.TimeSeries{
+					Metric: builtinMetrics.Iterations,
+					Tags:   registry.RootTagSet(),
+				},
+				Time:  now,
+				Value: 1,
 			},
 		},
 	}

--- a/output/csv/output.go
+++ b/output/csv/output.go
@@ -221,7 +221,7 @@ func SampleToRow(sample *metrics.Sample, resTags []string, ignoredTags []string,
 	}
 
 	row[2] = fmt.Sprintf("%f", sample.Value)
-	sampleTags := sample.Tags.CloneTags()
+	sampleTags := sample.Tags.Map()
 
 	for ind, tag := range resTags {
 		row[ind+3] = sampleTags[tag]

--- a/output/csv/output_test.go
+++ b/output/csv/output_test.go
@@ -82,11 +82,11 @@ func TestSampleToRow(t *testing.T) {
 				Time:   time.Unix(1562324644, 0),
 				Metric: testMetric,
 				Value:  1,
-				Tags: registry.BranchTagSetRootWith(map[string]string{
+				Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
 					"tag1": "val1",
 					"tag2": "val2",
 					"tag3": "val3",
-				}).SampleTags(),
+				}),
 			},
 			resTags:     []string{"tag1"},
 			ignoredTags: []string{"tag2"},
@@ -98,13 +98,13 @@ func TestSampleToRow(t *testing.T) {
 				Time:   time.Unix(1562324644, 0),
 				Metric: testMetric,
 				Value:  1,
-				Tags: registry.BranchTagSetRootWith(map[string]string{
+				Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
 					"tag1": "val1",
 					"tag2": "val2",
 					"tag3": "val3",
 					"tag4": "val4",
 					"tag5": "val5",
-				}).SampleTags(),
+				}),
 			},
 			resTags:     []string{"tag1", "tag2"},
 			ignoredTags: []string{},
@@ -116,14 +116,14 @@ func TestSampleToRow(t *testing.T) {
 				Time:   time.Unix(1562324644, 0),
 				Metric: testMetric,
 				Value:  1,
-				Tags: registry.BranchTagSetRootWith(map[string]string{
+				Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
 					"tag1": "val1",
 					"tag2": "val2",
 					"tag3": "val3",
 					"tag4": "val4",
 					"tag5": "val5",
 					"tag6": "val6",
-				}).SampleTags(),
+				}),
 			},
 			resTags:     []string{"tag1", "tag3"},
 			ignoredTags: []string{"tag4", "tag6"},
@@ -242,22 +242,22 @@ func TestRun(t *testing.T) {
 					Time:   time.Unix(1562324643, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: registry.BranchTagSetRootWith(map[string]string{
+					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
-					}).SampleTags(),
+					}),
 				},
 				metrics.Sample{
 					Time:   time.Unix(1562324644, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: registry.BranchTagSetRootWith(map[string]string{
+					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
 						"tag4":  "val4",
-					}).SampleTags(),
+					}),
 				},
 			},
 			fileName:       "test",
@@ -271,22 +271,22 @@ func TestRun(t *testing.T) {
 					Time:   time.Unix(1562324643, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: registry.BranchTagSetRootWith(map[string]string{
+					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
-					}).SampleTags(),
+					}),
 				},
 				metrics.Sample{
 					Time:   time.Unix(1562324644, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: registry.BranchTagSetRootWith(map[string]string{
+					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
 						"name":  "val4",
-					}).SampleTags(),
+					}),
 				},
 			},
 			fileName:       "test.gz",
@@ -300,22 +300,22 @@ func TestRun(t *testing.T) {
 					Time:   time.Unix(1562324644, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: registry.BranchTagSetRootWith(map[string]string{
+					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
-					}).SampleTags(),
+					}),
 				},
 				metrics.Sample{
 					Time:   time.Unix(1562324644, 0),
 					Metric: testMetric,
 					Value:  1,
-					Tags: registry.BranchTagSetRootWith(map[string]string{
+					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
 						"check": "val1",
 						"url":   "val2",
 						"error": "val3",
 						"name":  "val4",
-					}).SampleTags(),
+					}),
 				},
 			},
 			fileName:       "test",

--- a/output/csv/output_test.go
+++ b/output/csv/output_test.go
@@ -79,14 +79,16 @@ func TestSampleToRow(t *testing.T) {
 		{
 			testname: "One res tag, one ignored tag, one extra tag",
 			sample: &metrics.Sample{
-				Time:   time.Unix(1562324644, 0),
-				Metric: testMetric,
-				Value:  1,
-				Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
-					"tag1": "val1",
-					"tag2": "val2",
-					"tag3": "val3",
-				}),
+				TimeSeries: metrics.TimeSeries{
+					Metric: testMetric,
+					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+						"tag1": "val1",
+						"tag2": "val2",
+						"tag3": "val3",
+					}),
+				},
+				Time:  time.Unix(1562324644, 0),
+				Value: 1,
 			},
 			resTags:     []string{"tag1"},
 			ignoredTags: []string{"tag2"},
@@ -95,16 +97,18 @@ func TestSampleToRow(t *testing.T) {
 		{
 			testname: "Two res tags, three extra tags",
 			sample: &metrics.Sample{
-				Time:   time.Unix(1562324644, 0),
-				Metric: testMetric,
-				Value:  1,
-				Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
-					"tag1": "val1",
-					"tag2": "val2",
-					"tag3": "val3",
-					"tag4": "val4",
-					"tag5": "val5",
-				}),
+				TimeSeries: metrics.TimeSeries{
+					Metric: testMetric,
+					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+						"tag1": "val1",
+						"tag2": "val2",
+						"tag3": "val3",
+						"tag4": "val4",
+						"tag5": "val5",
+					}),
+				},
+				Time:  time.Unix(1562324644, 0),
+				Value: 1,
 			},
 			resTags:     []string{"tag1", "tag2"},
 			ignoredTags: []string{},
@@ -113,17 +117,19 @@ func TestSampleToRow(t *testing.T) {
 		{
 			testname: "Two res tags, two ignored, with RFC3339 timestamp",
 			sample: &metrics.Sample{
-				Time:   time.Unix(1562324644, 0),
-				Metric: testMetric,
-				Value:  1,
-				Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
-					"tag1": "val1",
-					"tag2": "val2",
-					"tag3": "val3",
-					"tag4": "val4",
-					"tag5": "val5",
-					"tag6": "val6",
-				}),
+				TimeSeries: metrics.TimeSeries{
+					Metric: testMetric,
+					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+						"tag1": "val1",
+						"tag2": "val2",
+						"tag3": "val3",
+						"tag4": "val4",
+						"tag5": "val5",
+						"tag6": "val6",
+					}),
+				},
+				Time:  time.Unix(1562324644, 0),
+				Value: 1,
 			},
 			resTags:     []string{"tag1", "tag3"},
 			ignoredTags: []string{"tag4", "tag6"},
@@ -239,25 +245,29 @@ func TestRun(t *testing.T) {
 		{
 			samples: []metrics.SampleContainer{
 				metrics.Sample{
-					Time:   time.Unix(1562324643, 0),
-					Metric: testMetric,
-					Value:  1,
-					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
-						"check": "val1",
-						"url":   "val2",
-						"error": "val3",
-					}),
+					TimeSeries: metrics.TimeSeries{
+						Metric: testMetric,
+						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+							"check": "val1",
+							"url":   "val2",
+							"error": "val3",
+						}),
+					},
+					Time:  time.Unix(1562324643, 0),
+					Value: 1,
 				},
 				metrics.Sample{
-					Time:   time.Unix(1562324644, 0),
-					Metric: testMetric,
-					Value:  1,
-					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
-						"check": "val1",
-						"url":   "val2",
-						"error": "val3",
-						"tag4":  "val4",
-					}),
+					TimeSeries: metrics.TimeSeries{
+						Metric: testMetric,
+						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+							"check": "val1",
+							"url":   "val2",
+							"error": "val3",
+							"tag4":  "val4",
+						}),
+					},
+					Time:  time.Unix(1562324644, 0),
+					Value: 1,
 				},
 			},
 			fileName:       "test",
@@ -268,25 +278,29 @@ func TestRun(t *testing.T) {
 		{
 			samples: []metrics.SampleContainer{
 				metrics.Sample{
-					Time:   time.Unix(1562324643, 0),
-					Metric: testMetric,
-					Value:  1,
-					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
-						"check": "val1",
-						"url":   "val2",
-						"error": "val3",
-					}),
+					TimeSeries: metrics.TimeSeries{
+						Metric: testMetric,
+						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+							"check": "val1",
+							"url":   "val2",
+							"error": "val3",
+						}),
+					},
+					Time:  time.Unix(1562324643, 0),
+					Value: 1,
 				},
 				metrics.Sample{
-					Time:   time.Unix(1562324644, 0),
-					Metric: testMetric,
-					Value:  1,
-					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
-						"check": "val1",
-						"url":   "val2",
-						"error": "val3",
-						"name":  "val4",
-					}),
+					TimeSeries: metrics.TimeSeries{
+						Metric: testMetric,
+						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+							"check": "val1",
+							"url":   "val2",
+							"error": "val3",
+							"name":  "val4",
+						}),
+					},
+					Time:  time.Unix(1562324644, 0),
+					Value: 1,
 				},
 			},
 			fileName:       "test.gz",
@@ -297,25 +311,29 @@ func TestRun(t *testing.T) {
 		{
 			samples: []metrics.SampleContainer{
 				metrics.Sample{
-					Time:   time.Unix(1562324644, 0),
-					Metric: testMetric,
-					Value:  1,
-					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
-						"check": "val1",
-						"url":   "val2",
-						"error": "val3",
-					}),
+					TimeSeries: metrics.TimeSeries{
+						Metric: testMetric,
+						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+							"check": "val1",
+							"url":   "val2",
+							"error": "val3",
+						}),
+					},
+					Time:  time.Unix(1562324644, 0),
+					Value: 1,
 				},
 				metrics.Sample{
-					Time:   time.Unix(1562324644, 0),
-					Metric: testMetric,
-					Value:  1,
-					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
-						"check": "val1",
-						"url":   "val2",
-						"error": "val3",
-						"name":  "val4",
-					}),
+					TimeSeries: metrics.TimeSeries{
+						Metric: testMetric,
+						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+							"check": "val1",
+							"url":   "val2",
+							"error": "val3",
+							"name":  "val4",
+						}),
+					},
+					Time:  time.Unix(1562324644, 0),
+					Value: 1,
 				},
 			},
 			fileName:       "test",

--- a/output/csv/output_test.go
+++ b/output/csv/output_test.go
@@ -81,7 +81,7 @@ func TestSampleToRow(t *testing.T) {
 			sample: &metrics.Sample{
 				TimeSeries: metrics.TimeSeries{
 					Metric: testMetric,
-					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+					Tags: registry.RootTagSet().WithTagsFromMap(map[string]string{
 						"tag1": "val1",
 						"tag2": "val2",
 						"tag3": "val3",
@@ -99,7 +99,7 @@ func TestSampleToRow(t *testing.T) {
 			sample: &metrics.Sample{
 				TimeSeries: metrics.TimeSeries{
 					Metric: testMetric,
-					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+					Tags: registry.RootTagSet().WithTagsFromMap(map[string]string{
 						"tag1": "val1",
 						"tag2": "val2",
 						"tag3": "val3",
@@ -119,7 +119,7 @@ func TestSampleToRow(t *testing.T) {
 			sample: &metrics.Sample{
 				TimeSeries: metrics.TimeSeries{
 					Metric: testMetric,
-					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+					Tags: registry.RootTagSet().WithTagsFromMap(map[string]string{
 						"tag1": "val1",
 						"tag2": "val2",
 						"tag3": "val3",
@@ -247,7 +247,7 @@ func TestRun(t *testing.T) {
 				metrics.Sample{
 					TimeSeries: metrics.TimeSeries{
 						Metric: testMetric,
-						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+						Tags: registry.RootTagSet().WithTagsFromMap(map[string]string{
 							"check": "val1",
 							"url":   "val2",
 							"error": "val3",
@@ -259,7 +259,7 @@ func TestRun(t *testing.T) {
 				metrics.Sample{
 					TimeSeries: metrics.TimeSeries{
 						Metric: testMetric,
-						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+						Tags: registry.RootTagSet().WithTagsFromMap(map[string]string{
 							"check": "val1",
 							"url":   "val2",
 							"error": "val3",
@@ -280,7 +280,7 @@ func TestRun(t *testing.T) {
 				metrics.Sample{
 					TimeSeries: metrics.TimeSeries{
 						Metric: testMetric,
-						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+						Tags: registry.RootTagSet().WithTagsFromMap(map[string]string{
 							"check": "val1",
 							"url":   "val2",
 							"error": "val3",
@@ -292,7 +292,7 @@ func TestRun(t *testing.T) {
 				metrics.Sample{
 					TimeSeries: metrics.TimeSeries{
 						Metric: testMetric,
-						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+						Tags: registry.RootTagSet().WithTagsFromMap(map[string]string{
 							"check": "val1",
 							"url":   "val2",
 							"error": "val3",
@@ -313,7 +313,7 @@ func TestRun(t *testing.T) {
 				metrics.Sample{
 					TimeSeries: metrics.TimeSeries{
 						Metric: testMetric,
-						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+						Tags: registry.RootTagSet().WithTagsFromMap(map[string]string{
 							"check": "val1",
 							"url":   "val2",
 							"error": "val3",
@@ -325,7 +325,7 @@ func TestRun(t *testing.T) {
 				metrics.Sample{
 					TimeSeries: metrics.TimeSeries{
 						Metric: testMetric,
-						Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+						Tags: registry.RootTagSet().WithTagsFromMap(map[string]string{
 							"check": "val1",
 							"url":   "val2",
 							"error": "val3",

--- a/output/helpers_test.go
+++ b/output/helpers_test.go
@@ -43,7 +43,7 @@ func TestSampleBufferBasics(t *testing.T) {
 		Time:   time.Now(),
 		Metric: metric,
 		Value:  float64(123),
-		Tags:   registry.BranchTagSetRootWith(map[string]string{"tag1": "val1"}).SampleTags(),
+		Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"}),
 	}
 	connected := metrics.ConnectedSamples{Samples: []metrics.Sample{single, single}, Time: single.Time}
 	buffer := SampleBuffer{}
@@ -91,7 +91,7 @@ func TestSampleBufferConcurrently(t *testing.T) {
 				Time:   time.Unix(1562324644, 0),
 				Metric: metric,
 				Value:  float64(i),
-				Tags:   registry.BranchTagSetRootWith(map[string]string{"tag1": "val1"}).SampleTags(),
+				Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"}),
 			}})
 			time.Sleep(time.Duration(i*sleepModifier) * time.Microsecond)
 		}

--- a/output/helpers_test.go
+++ b/output/helpers_test.go
@@ -42,7 +42,7 @@ func TestSampleBufferBasics(t *testing.T) {
 	single := metrics.Sample{
 		TimeSeries: metrics.TimeSeries{
 			Metric: metric,
-			Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"}),
+			Tags:   registry.RootTagSet().WithTagsFromMap(map[string]string{"tag1": "val1"}),
 		},
 		Time:  time.Now(),
 		Value: float64(123),
@@ -92,7 +92,7 @@ func TestSampleBufferConcurrently(t *testing.T) {
 			buffer.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
 				TimeSeries: metrics.TimeSeries{
 					Metric: metric,
-					Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"}),
+					Tags:   registry.RootTagSet().WithTagsFromMap(map[string]string{"tag1": "val1"}),
 				},
 				Time:  time.Unix(1562324644, 0),
 				Value: float64(i),

--- a/output/helpers_test.go
+++ b/output/helpers_test.go
@@ -40,10 +40,12 @@ func TestSampleBufferBasics(t *testing.T) {
 	require.NoError(t, err)
 
 	single := metrics.Sample{
-		Time:   time.Now(),
-		Metric: metric,
-		Value:  float64(123),
-		Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"}),
+		TimeSeries: metrics.TimeSeries{
+			Metric: metric,
+			Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"}),
+		},
+		Time:  time.Now(),
+		Value: float64(123),
 	}
 	connected := metrics.ConnectedSamples{Samples: []metrics.Sample{single, single}, Time: single.Time}
 	buffer := SampleBuffer{}
@@ -88,10 +90,12 @@ func TestSampleBufferConcurrently(t *testing.T) {
 	fillBuffer := func() {
 		for i := 0; i < sampleCount; i++ {
 			buffer.AddMetricSamples([]metrics.SampleContainer{metrics.Sample{
-				Time:   time.Unix(1562324644, 0),
-				Metric: metric,
-				Value:  float64(i),
-				Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"}),
+				TimeSeries: metrics.TimeSeries{
+					Metric: metric,
+					Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"}),
+				},
+				Time:  time.Unix(1562324644, 0),
+				Value: float64(i),
 			}})
 			time.Sleep(time.Duration(i*sleepModifier) * time.Microsecond)
 		}

--- a/output/influxdb/bench_test.go
+++ b/output/influxdb/bench_test.go
@@ -35,11 +35,11 @@ func benchmarkInfluxdb(b *testing.B, t time.Duration) {
 	registry := metrics.NewRegistry()
 	metric, err := registry.NewMetric("test_gauge", metrics.Gauge)
 	require.NoError(b, err)
-	tags := registry.BranchTagSetRootWith(map[string]string{
+	tags := registry.RootTagSet().SortAndAddTags(map[string]string{
 		"something": "else",
 		"VU":        "21",
 		"else":      "something",
-	}).SampleTags()
+	})
 	testOutputCycle(b, func(rw http.ResponseWriter, r *http.Request) {
 		for {
 			time.Sleep(t)

--- a/output/influxdb/bench_test.go
+++ b/output/influxdb/bench_test.go
@@ -35,7 +35,7 @@ func benchmarkInfluxdb(b *testing.B, t time.Duration) {
 	registry := metrics.NewRegistry()
 	metric, err := registry.NewMetric("test_gauge", metrics.Gauge)
 	require.NoError(b, err)
-	tags := registry.RootTagSet().SortAndAddTags(map[string]string{
+	tags := registry.RootTagSet().WithTagsFromMap(map[string]string{
 		"something": "else",
 		"VU":        "21",
 		"else":      "something",

--- a/output/influxdb/bench_test.go
+++ b/output/influxdb/bench_test.go
@@ -56,10 +56,12 @@ func benchmarkInfluxdb(b *testing.B, t time.Duration) {
 		samples := make(metrics.Samples, 10)
 		for i := 0; i < len(samples); i++ {
 			samples[i] = metrics.Sample{
-				Metric: metric,
-				Time:   time.Now(),
-				Tags:   tags,
-				Value:  2.0,
+				TimeSeries: metrics.TimeSeries{
+					Metric: metric,
+					Tags:   tags,
+				},
+				Time:  time.Now(),
+				Value: 2.0,
 			}
 		}
 

--- a/output/influxdb/output.go
+++ b/output/influxdb/output.go
@@ -134,7 +134,7 @@ func (o *Output) batchFromSamples(containers []metrics.SampleContainer) (client.
 		tags   map[string]string
 		values map[string]interface{}
 	}
-	cache := map[*metrics.SampleTags]cacheItem{}
+	cache := map[*metrics.TagSet]cacheItem{}
 	for _, container := range containers {
 		samples := container.GetSamples()
 		for _, sample := range samples {
@@ -146,7 +146,7 @@ func (o *Output) batchFromSamples(containers []metrics.SampleContainer) (client.
 					values[k] = v
 				}
 			} else {
-				tags = sample.Tags.CloneTags()
+				tags = sample.Tags.Map()
 				o.extractTagsToValues(tags, values)
 				cache[sample.Tags] = cacheItem{tags, values}
 			}

--- a/output/influxdb/output_test.go
+++ b/output/influxdb/output_test.go
@@ -137,11 +137,11 @@ func TestOutput(t *testing.T) {
 			samples[i] = metrics.Sample{
 				Metric: metric,
 				Time:   time.Now(),
-				Tags: registry.BranchTagSetRootWith(map[string]string{
+				Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
 					"something": "else",
 					"VU":        "21",
 					"else":      "something",
-				}).SampleTags(),
+				}),
 				Value: 2.0,
 			}
 		}
@@ -176,7 +176,8 @@ func TestOutputFlushMetricsConcurrency(t *testing.T) {
 		ts.Close()
 	}()
 
-	metric, err := metrics.NewRegistry().NewMetric("test_gauge", metrics.Gauge)
+	registry := metrics.NewRegistry()
+	metric, err := registry.NewMetric("test_gauge", metrics.Gauge)
 	require.NoError(t, err)
 
 	o, err := newOutput(output.Params{
@@ -194,6 +195,7 @@ func TestOutputFlushMetricsConcurrency(t *testing.T) {
 				metrics.Sample{
 					Metric: metric,
 					Value:  2.0,
+					Tags:   registry.RootTagSet(),
 				},
 			}})
 			o.flushMetrics()

--- a/output/influxdb/output_test.go
+++ b/output/influxdb/output_test.go
@@ -137,7 +137,7 @@ func TestOutput(t *testing.T) {
 			samples[i] = metrics.Sample{
 				TimeSeries: metrics.TimeSeries{
 					Metric: metric,
-					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+					Tags: registry.RootTagSet().WithTagsFromMap(map[string]string{
 						"something": "else",
 						"VU":        "21",
 						"else":      "something",

--- a/output/influxdb/output_test.go
+++ b/output/influxdb/output_test.go
@@ -135,13 +135,15 @@ func TestOutput(t *testing.T) {
 		samples := make(metrics.Samples, 10)
 		for i := 0; i < len(samples); i++ {
 			samples[i] = metrics.Sample{
-				Metric: metric,
-				Time:   time.Now(),
-				Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
-					"something": "else",
-					"VU":        "21",
-					"else":      "something",
-				}),
+				TimeSeries: metrics.TimeSeries{
+					Metric: metric,
+					Tags: registry.RootTagSet().SortAndAddTags(map[string]string{
+						"something": "else",
+						"VU":        "21",
+						"else":      "something",
+					}),
+				},
+				Time:  time.Now(),
 				Value: 2.0,
 			}
 		}
@@ -193,9 +195,12 @@ func TestOutputFlushMetricsConcurrency(t *testing.T) {
 			wg.Add(1)
 			o.AddMetricSamples([]metrics.SampleContainer{metrics.Samples{
 				metrics.Sample{
-					Metric: metric,
-					Value:  2.0,
-					Tags:   registry.RootTagSet(),
+					TimeSeries: metrics.TimeSeries{
+						Metric: metric,
+						Tags:   registry.RootTagSet(),
+					},
+					Time:  time.Now(),
+					Value: 2.0,
 				},
 			}})
 			o.flushMetrics()

--- a/output/json/json_easyjson.go
+++ b/output/json/json_easyjson.go
@@ -86,9 +86,9 @@ func (v *sampleEnvelope) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjson42239ddeDecodeGoK6IoK6OutputJson(l, v)
 }
 func easyjson42239ddeDecode(in *jlexer.Lexer, out *struct {
-	Time  time.Time           `json:"time"`
-	Value float64             `json:"value"`
-	Tags  *metrics.SampleTags `json:"tags"`
+	Time  time.Time       `json:"time"`
+	Value float64         `json:"value"`
+	Tags  *metrics.TagSet `json:"tags"`
 }) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
@@ -120,11 +120,9 @@ func easyjson42239ddeDecode(in *jlexer.Lexer, out *struct {
 				out.Tags = nil
 			} else {
 				if out.Tags == nil {
-					out.Tags = new(metrics.SampleTags)
+					out.Tags = new(metrics.TagSet)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Tags).UnmarshalJSON(data))
-				}
+				(*out.Tags).UnmarshalEasyJSON(in)
 			}
 		default:
 			in.SkipRecursive()
@@ -137,9 +135,9 @@ func easyjson42239ddeDecode(in *jlexer.Lexer, out *struct {
 	}
 }
 func easyjson42239ddeEncode(out *jwriter.Writer, in struct {
-	Time  time.Time           `json:"time"`
-	Value float64             `json:"value"`
-	Tags  *metrics.SampleTags `json:"tags"`
+	Time  time.Time       `json:"time"`
+	Value float64         `json:"value"`
+	Tags  *metrics.TagSet `json:"tags"`
 }) {
 	out.RawByte('{')
 	first := true
@@ -392,11 +390,9 @@ func easyjson42239ddeDecodeGoK6IoK6Metrics(in *jlexer.Lexer, out *metrics.Submet
 				out.Tags = nil
 			} else {
 				if out.Tags == nil {
-					out.Tags = new(metrics.SampleTags)
+					out.Tags = new(metrics.TagSet)
 				}
-				if data := in.Raw(); in.Ok() {
-					in.AddError((*out.Tags).UnmarshalJSON(data))
-				}
+				(*out.Tags).UnmarshalEasyJSON(in)
 			}
 		default:
 			in.SkipRecursive()

--- a/output/json/json_test.go
+++ b/output/json/json_test.go
@@ -60,7 +60,7 @@ func generateTestMetricSamples(t testing.TB) ([]metrics.SampleContainer, func(io
 	metric1, err := registry.NewMetric("my_metric1", metrics.Gauge)
 	require.NoError(t, err)
 
-	_, err = metric1.AddSubmetric("a:1,b:2", registry.BranchTagSetRoot())
+	_, err = metric1.AddSubmetric("a:1,b:2")
 	require.NoError(t, err)
 
 	metric2, err := registry.NewMetric("my_metric2", metrics.Counter, metrics.Data)
@@ -70,16 +70,16 @@ func generateTestMetricSamples(t testing.TB) ([]metrics.SampleContainer, func(io
 	time2 := time1.Add(10 * time.Second)
 	time3 := time2.Add(10 * time.Second)
 
-	connTags := registry.BranchTagSetRootWith(map[string]string{"key": "val"}).SampleTags()
+	connTags := registry.RootTagSet().SortAndAddTags(map[string]string{"key": "val"})
 
 	samples := []metrics.SampleContainer{
-		metrics.Sample{Time: time1, Metric: metric1, Value: float64(1), Tags: registry.BranchTagSetRootWith(map[string]string{"tag1": "val1"}).SampleTags()},
-		metrics.Sample{Time: time1, Metric: metric1, Value: float64(2), Tags: registry.BranchTagSetRootWith(map[string]string{"tag2": "val2"}).SampleTags()},
+		metrics.Sample{Time: time1, Metric: metric1, Value: float64(1), Tags: registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"})},
+		metrics.Sample{Time: time1, Metric: metric1, Value: float64(2), Tags: registry.RootTagSet().SortAndAddTags(map[string]string{"tag2": "val2"})},
 		metrics.ConnectedSamples{Samples: []metrics.Sample{
 			{Time: time2, Metric: metric2, Value: float64(3), Tags: connTags},
 			{Time: time2, Metric: metric1, Value: float64(4), Tags: connTags},
 		}, Time: time2, Tags: connTags},
-		metrics.Sample{Time: time3, Metric: metric2, Value: float64(5), Tags: registry.BranchTagSetRootWith(map[string]string{"tag3": "val3"}).SampleTags()},
+		metrics.Sample{Time: time3, Metric: metric2, Value: float64(5), Tags: registry.RootTagSet().SortAndAddTags(map[string]string{"tag3": "val3"})},
 	}
 	expected := []string{
 		`{"type":"Metric","data":{"name":"my_metric1","type":"gauge","contains":"default","thresholds":["rate<0.01","p(99)<250"],"submetrics":[{"name":"my_metric1{a:1,b:2}","suffix":"a:1,b:2","tags":{"a":"1","b":"2"}}]},"metric":"my_metric1"}`,

--- a/output/json/json_test.go
+++ b/output/json/json_test.go
@@ -70,13 +70,13 @@ func generateTestMetricSamples(t testing.TB) ([]metrics.SampleContainer, func(io
 	time2 := time1.Add(10 * time.Second)
 	time3 := time2.Add(10 * time.Second)
 
-	connTags := registry.RootTagSet().SortAndAddTags(map[string]string{"key": "val"})
+	connTags := registry.RootTagSet().WithTagsFromMap(map[string]string{"key": "val"})
 
 	samples := []metrics.SampleContainer{
 		metrics.Sample{
 			TimeSeries: metrics.TimeSeries{
 				Metric: metric1,
-				Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"}),
+				Tags:   registry.RootTagSet().WithTagsFromMap(map[string]string{"tag1": "val1"}),
 			},
 			Time:  time1,
 			Value: float64(1),
@@ -84,7 +84,7 @@ func generateTestMetricSamples(t testing.TB) ([]metrics.SampleContainer, func(io
 		metrics.Sample{
 			TimeSeries: metrics.TimeSeries{
 				Metric: metric1,
-				Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag2": "val2"}),
+				Tags:   registry.RootTagSet().WithTagsFromMap(map[string]string{"tag2": "val2"}),
 			},
 			Time:  time1,
 			Value: float64(2),
@@ -110,7 +110,7 @@ func generateTestMetricSamples(t testing.TB) ([]metrics.SampleContainer, func(io
 		metrics.Sample{
 			TimeSeries: metrics.TimeSeries{
 				Metric: metric2,
-				Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag3": "val3"}),
+				Tags:   registry.RootTagSet().WithTagsFromMap(map[string]string{"tag3": "val3"}),
 			},
 			Time:  time3,
 			Value: float64(5),

--- a/output/json/json_test.go
+++ b/output/json/json_test.go
@@ -73,13 +73,48 @@ func generateTestMetricSamples(t testing.TB) ([]metrics.SampleContainer, func(io
 	connTags := registry.RootTagSet().SortAndAddTags(map[string]string{"key": "val"})
 
 	samples := []metrics.SampleContainer{
-		metrics.Sample{Time: time1, Metric: metric1, Value: float64(1), Tags: registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"})},
-		metrics.Sample{Time: time1, Metric: metric1, Value: float64(2), Tags: registry.RootTagSet().SortAndAddTags(map[string]string{"tag2": "val2"})},
+		metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: metric1,
+				Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag1": "val1"}),
+			},
+			Time:  time1,
+			Value: float64(1),
+		},
+		metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: metric1,
+				Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag2": "val2"}),
+			},
+			Time:  time1,
+			Value: float64(2),
+		},
 		metrics.ConnectedSamples{Samples: []metrics.Sample{
-			{Time: time2, Metric: metric2, Value: float64(3), Tags: connTags},
-			{Time: time2, Metric: metric1, Value: float64(4), Tags: connTags},
+			{
+				TimeSeries: metrics.TimeSeries{
+					Metric: metric2,
+					Tags:   connTags,
+				},
+				Time:  time2,
+				Value: float64(3),
+			},
+			{
+				TimeSeries: metrics.TimeSeries{
+					Metric: metric1,
+					Tags:   connTags,
+				},
+				Time:  time2,
+				Value: float64(4),
+			},
 		}, Time: time2, Tags: connTags},
-		metrics.Sample{Time: time3, Metric: metric2, Value: float64(5), Tags: registry.RootTagSet().SortAndAddTags(map[string]string{"tag3": "val3"})},
+		metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: metric2,
+				Tags:   registry.RootTagSet().SortAndAddTags(map[string]string{"tag3": "val3"}),
+			},
+			Time:  time3,
+			Value: float64(5),
+		},
 	}
 	expected := []string{
 		`{"type":"Metric","data":{"name":"my_metric1","type":"gauge","contains":"default","thresholds":["rate<0.01","p(99)<250"],"submetrics":[{"name":"my_metric1{a:1,b:2}","suffix":"a:1,b:2","tags":{"a":"1","b":"2"}}]},"metric":"my_metric1"}`,
@@ -190,7 +225,9 @@ func TestJsonOutputFileGzipped(t *testing.T) {
 func TestWrapSampleWithSamplePointer(t *testing.T) {
 	t.Parallel()
 	out := wrapSample(metrics.Sample{
-		Metric: &metrics.Metric{},
+		TimeSeries: metrics.TimeSeries{
+			Metric: &metrics.Metric{},
+		},
 	})
 	assert.NotEqual(t, out, (*sampleEnvelope)(nil))
 }

--- a/output/json/wrapper.go
+++ b/output/json/wrapper.go
@@ -32,9 +32,9 @@ import (
 type sampleEnvelope struct {
 	Type string `json:"type"`
 	Data struct {
-		Time  time.Time           `json:"time"`
-		Value float64             `json:"value"`
-		Tags  *metrics.SampleTags `json:"tags"`
+		Time  time.Time       `json:"time"`
+		Value float64         `json:"value"`
+		Tags  *metrics.TagSet `json:"tags"`
 	} `json:"data"`
 	Metric string `json:"metric"`
 }

--- a/output/statsd/helper_test.go
+++ b/output/statsd/helper_test.go
@@ -92,7 +92,7 @@ func baseTest(t *testing.T,
 			Time:   time.Now(),
 			Metric: m,
 			Value:  value,
-			Tags:   registry.BranchTagSetRootWith(tags).SampleTags(),
+			Tags:   registry.RootTagSet().SortAndAddTags(tags),
 		}
 	}
 

--- a/output/statsd/helper_test.go
+++ b/output/statsd/helper_test.go
@@ -91,7 +91,7 @@ func baseTest(t *testing.T,
 		return metrics.Sample{
 			TimeSeries: metrics.TimeSeries{
 				Metric: m,
-				Tags:   registry.RootTagSet().SortAndAddTags(tags),
+				Tags:   registry.RootTagSet().WithTagsFromMap(tags),
 			},
 			Time:  time.Now(),
 			Value: value,

--- a/output/statsd/helper_test.go
+++ b/output/statsd/helper_test.go
@@ -89,10 +89,12 @@ func baseTest(t *testing.T,
 	registry := metrics.NewRegistry()
 	newSample := func(m *metrics.Metric, value float64, tags map[string]string) metrics.Sample {
 		return metrics.Sample{
-			Time:   time.Now(),
-			Metric: m,
-			Value:  value,
-			Tags:   registry.RootTagSet().SortAndAddTags(tags),
+			TimeSeries: metrics.TimeSeries{
+				Metric: m,
+				Tags:   registry.RootTagSet().SortAndAddTags(tags),
+			},
+			Time:  time.Now(),
+			Value: value,
 		}
 	}
 

--- a/output/statsd/output.go
+++ b/output/statsd/output.go
@@ -66,7 +66,7 @@ type Output struct {
 func (o *Output) dispatch(entry metrics.Sample) error {
 	var tagList []string
 	if o.config.EnableTags.Bool {
-		tagList = processTags(o.config.TagBlocklist, entry.Tags.CloneTags())
+		tagList = processTags(o.config.TagBlocklist, entry.Tags.Map())
 	}
 
 	switch entry.Metric.Type {

--- a/output/statsd/output_test.go
+++ b/output/statsd/output_test.go
@@ -88,7 +88,7 @@ func TestStatsdEnabledTags(t *testing.T) {
 			for j, sample := range container.GetSamples() {
 				lines++
 				var (
-					expectedTagList    = processTags(tagMap, sample.GetTags().CloneTags())
+					expectedTagList    = processTags(tagMap, sample.GetTags().Map())
 					expectedOutputLine = expectedOutputLines[i*j+i]
 					outputLine         = outputLines[i*j+i]
 					outputWithoutTags  = outputLine

--- a/vendor/github.com/mstoykov/atlas/atlas.go
+++ b/vendor/github.com/mstoykov/atlas/atlas.go
@@ -35,6 +35,11 @@ func (n *Node) IsRoot() bool {
 	return n.root == n
 }
 
+// Data returns the previous node and the key and value of the current one.
+func (n *Node) Data() (prev *Node, key string, value string) {
+	return n.prev, n.linkKey[0], n.linkKey[1]
+}
+
 // ValueByKey gets the value of key written in this Node or any of its ancestor.
 func (n *Node) ValueByKey(k string) (string, bool) {
 	if n.root == n {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -106,7 +106,7 @@ github.com/mattn/go-isatty
 github.com/mccutchen/go-httpbin/httpbin
 github.com/mccutchen/go-httpbin/httpbin/assets
 github.com/mccutchen/go-httpbin/httpbin/digest
-# github.com/mstoykov/atlas v0.0.0-20220727131014-23cc720eb639
+# github.com/mstoykov/atlas v0.0.0-20220808085829-90340e9998bd
 ## explicit; go 1.18
 github.com/mstoykov/atlas
 # github.com/mstoykov/envconfig v1.4.1-0.20220114105314-765c6d8c76f1


### PR DESCRIPTION
The two commits here implement the two decisions as described in https://github.com/grafana/k6/pull/2594#issuecomment-1205273413 and https://github.com/grafana/k6/pull/2594#issuecomment-1205359198, with some minor modifications. 

For example, instead of an `TagSet.Add()` method, I decided to name it `TagSet.With()`, which seems more well-suited to the immutable nature of the operation and less error-prone. I also refactored the mutable container of tags in every VU's `State` to have just 2 thread-safe operations, `GetCurrentValues() *metrics.TagSet` and a callback-based `Modify(callback func(currentTags *metrics.TagSet) (newTags *metrics.TagSet))`. I think the results look pretty nice: https://github.com/grafana/k6/blob/45223dffbbef51663faa1dd0d6db49e33684bd25/js/runner.go#L638-L654

(I also want to rename `SortAndAddTags()`, but I don't have a good idea for a better name :disappointed:)