### PR TITLE
Fix spelling of "lose"

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -86,7 +86,7 @@ type Config struct {
 	//       since it could lead to a huge loss of granularity and the masking
 	//       of any outlier samples in the data.
 	//     - By default (since AggregationSkipOutlierDetection is not enabled),
-	//       the collected HTTP trails will be checked for outliers, so we don't loose
+	//       the collected HTTP trails will be checked for outliers, so we don't lose
 	//       granularity by accidentally aggregating them. That happens by finding
 	//       the "quartiles" (by default the 75th and 25th percentiles) in the
 	//       sub-bucket datapoints and using the inter-quartile range (IQR) to find

--- a/lib/helpers.go
+++ b/lib/helpers.go
@@ -103,7 +103,7 @@ func GetEndOffset(steps []ExecutionStep) (lastStepOffset time.Duration, isFinal 
 // ConcatErrors is a a helper function for joining error messages into a single
 // string.
 //
-// TODO: use Go 2.0/xerrors style errors so we don't loose error type information and
+// TODO: use Go 2.0/xerrors style errors so we don't lose error type information and
 // metadata.
 func ConcatErrors(errors []error, separator string) string {
 	errStrings := make([]string, len(errors))


### PR DESCRIPTION
Minor fix to a misspelling in a comment.  
No user visible changes.  No code changes.