### PR TITLE
Detecting and filtering invalid environment names

### DIFF
--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -56,7 +56,7 @@ func loadTest(gs *globalState, cmd *cobra.Command, args []string) (*loadedTest, 
 	)
 
 	gs.logger.Debugf("Gathering k6 runtime options...")
-	runtimeOptions, err := getRuntimeOptions(cmd.Flags(), gs.envVars)
+	runtimeOptions, err := getRuntimeOptions(gs.logger, cmd.Flags(), gs.envVars)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# What?

Align the `--include-system-env-vars` with the `--env` in terms of the name validation.

In case of detecting an invalid name issue, the user will be warned.

```
 env -i 'LOREM-ISPUM=hello' IPSUM=lorem ./k6 run --include-system-env-vars samples/http_2.js
```

As the result, archive metadata should contain only `IPSUM=lorem`.

# Why?

Closes: #2650