### PR TITLE
Remove the warning for thresholds on url sub-metrics

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -315,9 +315,8 @@ func TestThresholdDeprecationWarnings(t *testing.T) {
 	newRootCommand(ts.globalState).execute()
 
 	logs := ts.loggerHook.Drain()
-	assert.True(t, testutils.LogContains(logs, logrus.WarnLevel,
-		"Thresholds like 'http_req_duration{url:https://test.k6.io}', based on the high-cardinality 'url' metric tag, are deprecated",
-	))
+	assert.False(t, testutils.LogContains(logs, logrus.WarnLevel, "http_req_duration{url:https://test.k6.io}"))
+
 	assert.True(t, testutils.LogContains(logs, logrus.WarnLevel,
 		"Thresholds like 'http_req_duration{error:foo}', based on the high-cardinality 'error' metric tag, are deprecated",
 	))

--- a/metrics/engine/engine.go
+++ b/metrics/engine/engine.go
@@ -89,15 +89,6 @@ func (me *MetricsEngine) getThresholdMetricOrSubmetric(name string) (*metrics.Me
 
 	// TODO: reword these from "will be deprecated" to "were deprecated" and
 	// maybe make them errors, not warnings, when we introduce un-indexable tags
-
-	if _, ok := sm.Tags.Get("url"); ok {
-		me.logger.Warnf("Thresholds like '%s', based on the high-cardinality 'url' metric tag, "+
-			"are deprecated and will not be supported in future k6 releases. "+
-			"To prevent breaking changes and reduce bugs, use the 'name' metric tag instead, see"+
-			"URL grouping (https://k6.io/docs/using-k6/http-requests/#url-grouping) for more information.", name,
-		)
-	}
-
 	if _, ok := sm.Tags.Get("error"); ok {
 		me.logger.Warnf("Thresholds like '%s', based on the high-cardinality 'error' metric tag, "+
 			"are deprecated and will not be supported in future k6 releases. "+


### PR DESCRIPTION
This was mistakenly added in k6 v0.39.0 (https://github.com/grafana/k6/pull/2583), but it turns out we probably don't need it (see https://github.com/grafana/k6/issues/2584#issuecomment-1219618111)
