### PR TITLE
Update xk6-websockets and xk6-timers versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,8 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.5.0
 	github.com/grafana/xk6-redis v0.1.1
-	github.com/grafana/xk6-timers v0.1.1
-	github.com/grafana/xk6-websockets v0.1.1
+	github.com/grafana/xk6-timers v0.1.2
+	github.com/grafana/xk6-websockets v0.1.3
 	github.com/influxdata/influxdb1-client v0.0.0-20190402204710-8ff2fc3824fc
 	github.com/jhump/protoreflect v1.12.0
 	github.com/klauspost/compress v1.15.7

--- a/go.sum
+++ b/go.sum
@@ -98,10 +98,10 @@ github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWm
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/xk6-redis v0.1.1 h1:rvWnLanRB2qzDwuY6NMBe6PXei3wJ3kjYvfCwRJ+q+8=
 github.com/grafana/xk6-redis v0.1.1/go.mod h1:z7el1Tz8advY+ex419KfLbENzSQYgaA2lQYwMlt9yMM=
-github.com/grafana/xk6-timers v0.1.1 h1:Hd1i7B4ihP9CZZHl423c4iRzeXjy0e405QK2fN7PA/M=
-github.com/grafana/xk6-timers v0.1.1/go.mod h1:XHmDIXAKe30NJMXrxKIKMFXx98etsCl0jBYktjsSURc=
-github.com/grafana/xk6-websockets v0.1.1 h1:vKp3chmRYIea+Zh+trWKAADfpc28YppMxEMF837vDr0=
-github.com/grafana/xk6-websockets v0.1.1/go.mod h1:s701X8YdUDq7zgCdorbO74ZWhodorNxTSembb2dkjvA=
+github.com/grafana/xk6-timers v0.1.2 h1:YVM6hPDgvy4SkdZQpd+/r9M0kDi1g+QdbSxW5ClfwDk=
+github.com/grafana/xk6-timers v0.1.2/go.mod h1:XHmDIXAKe30NJMXrxKIKMFXx98etsCl0jBYktjsSURc=
+github.com/grafana/xk6-websockets v0.1.3 h1:x9gn1++FHh5Bd6OGCpDqAz2I+cK+/SYxw+Pu+z6owSU=
+github.com/grafana/xk6-websockets v0.1.3/go.mod h1:s701X8YdUDq7zgCdorbO74ZWhodorNxTSembb2dkjvA=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/github.com/grafana/xk6-timers/timers/timers.go
+++ b/vendor/github.com/grafana/xk6-timers/timers/timers.go
@@ -95,10 +95,8 @@ func (e *Timers) setTimeout(callback goja.Callable, delay float64, args ...goja.
 	go func() {
 		timer := time.NewTimer(time.Duration(delay * float64(time.Millisecond)))
 		defer func() {
+			timer.Stop()
 			e.stopTimerCh(id)
-			if !timer.Stop() {
-				<-timer.C
-			}
 		}()
 
 		select {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -75,10 +75,10 @@ github.com/gorilla/websocket
 # github.com/grafana/xk6-redis v0.1.1
 ## explicit; go 1.17
 github.com/grafana/xk6-redis/redis
-# github.com/grafana/xk6-timers v0.1.1
+# github.com/grafana/xk6-timers v0.1.2
 ## explicit; go 1.17
 github.com/grafana/xk6-timers/timers
-# github.com/grafana/xk6-websockets v0.1.1
+# github.com/grafana/xk6-websockets v0.1.3
 ## explicit; go 1.17
 github.com/grafana/xk6-websockets/websockets
 # github.com/inconshreveable/mousetrap v1.0.0


### PR DESCRIPTION
<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
This PR integrates the recent fixes included in [xk6-websockets](https://github.com/grafana/xk6-websockets) and [xk6-timers](https://github.com/grafana/xk6-timers). It effectively bumps k6's dependency on them to their respective `v0.1.3` and `v0.1.2` versions. Those fixes directly affect the `k6/experimental/websockets` and `k6/experimental/timers` modules.