### PR TITLE
Fix Docker Hub image labels for official releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -162,18 +162,19 @@ jobs:
       - name: Publish k6:master image to ghcr.io
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
+          echo "Publish as ghcr.io/$GHCR_IMAGE_ID:$VERSION"
           docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$GHCR_IMAGE_ID:master"
           docker push "ghcr.io/$GHCR_IMAGE_ID:master"
       - name: Publish tagged version image to ghcr.io
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           VERSION="${VERSION#v}"
-          echo "Publish GHCR ($DOCKER_IMAGE_ID:$VERSION)"
+          echo "Publish as ghcr.io/$GHCR_IMAGE_ID:$VERSION"
           docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$GHCR_IMAGE_ID:$VERSION"
           docker push "ghcr.io/$GHCR_IMAGE_ID:$VERSION"
           # We also want to tag the latest stable version as latest
           if [[ ! "$VERSION" =~ (RC|rc) ]]; then
-            echo 'Publish GHCR (latest)'
+            echo "Publish as ghcr.io/$GHCR_IMAGE_ID:latest"
             docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$GHCR_IMAGE_ID:latest"
             docker push "ghcr.io/$GHCR_IMAGE_ID:latest"
           fi
@@ -186,6 +187,7 @@ jobs:
       - name: Publish k6:master image to Docker Hub
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
+          echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:master and $LI_DOCKER_IMAGE_ID:master"
           docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:master"
           docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:master"
           docker push "$DOCKER_IMAGE_ID:master"
@@ -194,13 +196,15 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           # We need to push the same image in both the loadimpact and the grafana docker hub orgs
+          VERSION="${VERSION#v}"
+          echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:$VERSION and $LI_DOCKER_IMAGE_ID:$VERSION"
           docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:$VERSION"
           docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:$VERSION"
           docker push "$DOCKER_IMAGE_ID:$VERSION"
           docker push "$LI_DOCKER_IMAGE_ID:$VERSION"
           # We also want to tag the latest stable version as latest
           if [[ ! "$VERSION" =~ (RC|rc) ]]; then
-            echo 'Publish Docker (latest)'
+            echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:latest and $LI_DOCKER_IMAGE_ID:latest"
             docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:latest"
             docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:latest"
             docker push "$DOCKER_IMAGE_ID:latest"


### PR DESCRIPTION
This fixes https://github.com/grafana/k6/issues/2677. Because of a bug introduced in https://github.com/grafana/k6/pull/2591, the CI would push `vX.Y.Z` docker images when before they were with the format `X.Y.Z`, without the "v" prefix. The v0.40.0 image was manually fixed by https://github.com/grafana/k6/commit/c90346ae11b4c14380474d96ea5e8f43db919088
