### PR TITLE
Added max call (send and receive) size params to the gRPC client.

### DIFF
--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -108,6 +108,14 @@ func (c *Client) Connect(addr string, params map[string]interface{}) (bool, erro
 	ctx, cancel := context.WithTimeout(c.vu.Context(), p.Timeout)
 	defer cancel()
 
+	if p.MaxReceiveSize != 0 {
+		opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(int(p.MaxReceiveSize))))
+	}
+
+	if p.MaxSendSize != 0 {
+		opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallSendMsgSize(int(p.MaxSendSize))))
+	}
+
 	c.addr = addr
 	c.conn, err = grpcext.Dial(ctx, addr, opts...)
 	if err != nil {
@@ -339,6 +347,8 @@ type connectParams struct {
 	IsPlaintext           bool
 	UseReflectionProtocol bool
 	Timeout               time.Duration
+	MaxReceiveSize        int64
+	MaxSendSize           int64
 }
 
 func (c *Client) parseConnectParams(raw map[string]interface{}) (connectParams, error) {
@@ -346,6 +356,8 @@ func (c *Client) parseConnectParams(raw map[string]interface{}) (connectParams, 
 		IsPlaintext:           false,
 		UseReflectionProtocol: false,
 		Timeout:               time.Minute,
+		MaxReceiveSize:        0,
+		MaxSendSize:           0,
 	}
 	for k, v := range raw {
 		switch k {
@@ -366,6 +378,18 @@ func (c *Client) parseConnectParams(raw map[string]interface{}) (connectParams, 
 			params.UseReflectionProtocol, ok = v.(bool)
 			if !ok {
 				return params, fmt.Errorf("invalid reflect value: '%#v', it needs to be boolean", v)
+			}
+		case "maxReceiveSize":
+			var ok bool
+			params.MaxReceiveSize, ok = v.(int64)
+			if !ok {
+				return params, fmt.Errorf("invalid maxReceiveSize value: '%#v', it needs to be an int", v)
+			}
+		case "maxSendSize":
+			var ok bool
+			params.MaxSendSize, ok = v.(int64)
+			if !ok {
+				return params, fmt.Errorf("invalid maxSendSize value: '%#v', it needs to be an int", v)
 			}
 
 		default:


### PR DESCRIPTION
This should close #2666.

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
