### PR TITLE
log: add more tokenizer tests

### DIFF
--- a/log/tokenizer_test.go
+++ b/log/tokenizer_test.go
@@ -62,9 +62,6 @@ func TestTokenizerInvalid(t *testing.T) {
 			t.Parallel()
 
 			_, err := tokenize(test.input)
-			if err == nil {
-				t.Fatal("expected an error but got none")
-			}
 			require.EqualError(t, err, test.errorMsg)
 		})
 	}

--- a/log/tokenizer_test.go
+++ b/log/tokenizer_test.go
@@ -4,44 +4,68 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTokenizer(t *testing.T) {
-	tokens, err := tokenize("loki=something,s.e=2231,s=12,12=3,a=[1,2,3],b=[1],s=c")
-	assert.Equal(t, []token{
-		{
-			key:   "loki",
-			value: "something",
-		},
-		{
-			key:   "s.e",
-			value: "2231",
-		},
-		{
-			key:   "s",
-			value: "12",
-		},
-		{
-			key:   "12",
-			value: "3",
-		},
-		{
-			key:    "a",
-			value:  "1,2,3",
-			inside: '[',
-		},
-		{
-			key:    "b",
-			value:  "1",
-			inside: '[',
-		},
-		{
-			key:   "s",
-			value: "c",
-		},
-	}, tokens)
-	assert.NoError(t, err)
+	t.Parallel()
 
-	_, err = tokenize("empty=")
-	assert.EqualError(t, err, "key `empty=` with no value")
+	input := "loki=something,s.e=2231,s=12,12=3,a=[1,2,3],b=[1],s=c"
+	tokens, err := tokenize(input)
+	require.NoError(t, err)
+
+	expected := []token{
+		{key: "loki", value: "something"},
+		{key: "s.e", value: "2231"},
+		{key: "s", value: "12"},
+		{key: "12", value: "3"},
+		{key: "a", value: "1,2,3", inside: '['},
+		{key: "b", value: "1", inside: '['},
+		{key: "s", value: "c"},
+	}
+	assert.Equal(t, expected, tokens)
+}
+
+func TestTokenizerInvalid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		errorMsg string
+	}{
+		{
+			name:     "empty value",
+			input:    "empty=",
+			errorMsg: "key `empty=` with no value",
+		},
+		{
+			name:     "unclosed array",
+			input:    "foo=[1,2,3",
+			errorMsg: "array value for key `foo` didn't end",
+		},
+		{
+			name:     "bad characters after array",
+			input:    "foo=[1,2,3]bar",
+			errorMsg: "there was no ',' after an array with key 'foo'",
+		},
+		{
+			name:     "empty key",
+			input:    ",foo=bar",
+			errorMsg: "key `` with no value",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := tokenize(test.input)
+			if err == nil {
+				t.Fatal("expected an error but got none")
+			}
+			require.EqualError(t, err, test.errorMsg)
+		})
+	}
 }


### PR DESCRIPTION
Adds a couple more tests to the tokenizer in `log` package. Also formats the tests a bit to make it easy to add more if desired.
