### PR TITLE
Fix /v1/status doesn't set json content-type

### DIFF
--- a/api/v1/status_routes.go
+++ b/api/v1/status_routes.go
@@ -20,6 +20,7 @@ func handleGetStatus(rw http.ResponseWriter, r *http.Request) {
 		apiError(rw, "Encoding error", err.Error(), http.StatusInternalServerError)
 		return
 	}
+	rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_, _ = rw.Write(data)
 }
 
@@ -36,6 +37,7 @@ func getFirstExternallyControlledExecutor(
 }
 
 func handlePatchStatus(rw http.ResponseWriter, r *http.Request) {
+	rw.Header().Set("Content-Type", "application/json; charset=utf-8")
 	engine := common.GetEngine(r.Context())
 
 	body, err := ioutil.ReadAll(r.Body)

--- a/api/v1/status_routes_test.go
+++ b/api/v1/status_routes_test.go
@@ -137,6 +137,8 @@ func TestPatchStatus(t *testing.T) {
 			NewHandler().ServeHTTP(rw, newRequestWithEngine(engine, "PATCH", "/v1/status", bytes.NewReader(testCase.Payload)))
 			res := rw.Result()
 
+			require.Equal(t, "application/json; charset=utf-8", rw.Header().Get("Content-Type"))
+
 			require.Equal(t, testCase.ExpectedStatusCode, res.StatusCode)
 
 			if testCase.ExpectedStatusCode != 200 {


### PR DESCRIPTION
Currently, the api doesn't set `Content-Type` header which cause some http client that decode data base on `Content-Type` not working correctly. Fixes by set Content-Type header to /v1/status api (both GET and PATCH).

Fixes: #2688 
