### PR TITLE
Fix VERSION_DETAILS does not contain the latest tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.18-alpine as builder
 WORKDIR $GOPATH/src/go.k6.io/k6
 ADD . .
 RUN apk --no-cache add git
-RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)"
+RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"
 
 FROM alpine:3.15
 RUN apk add --no-cache ca-certificates && \

--- a/build-release.sh
+++ b/build-release.sh
@@ -10,7 +10,7 @@ export OUT_DIR="${1-dist}"
 export VERSION=${2:-$(git describe --tags --always --dirty)}
 
 # To overwrite the version details, pass something as the third arg. Empty string disables it.
-export VERSION_DETAILS=${3-"$(date -u +"%FT%T%z")/$(git describe --always --long --dirty)"}
+export VERSION_DETAILS=${3-"$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"}
 set +x
 
 build() {


### PR DESCRIPTION
# What?

Add a `--tags` flag to fetch all tags for the `git describe`.

# Why?

Without that flag k6's version details gets a previous flag.

Closes: #2676