### PR TITLE
Dont lock the event loop once a promise rejection is left unhandled

### DIFF
--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -154,6 +154,7 @@ func (e *EventLoop) popAll() (queue []func() error, awaiting bool) {
 // or a queued function returns an error. The provided firstCallback will be the first thing executed.
 // After Start returns the event loop can be reused as long as waitOnRegistered is called.
 func (e *EventLoop) Start(firstCallback func() error) error {
+	e.pendingPromiseRejections = make(map[*goja.Promise]struct{})
 	e.queue = []func() error{firstCallback}
 	for {
 		queue, awaiting := e.popAll()


### PR DESCRIPTION
Previously when a promise is rejected but *not* handled, the event loop would end the current iteration and then let a new one start.

Unfortuantely it also didn't clear the failure so the next time it will again *fail* the iteration as it still thinks a promise has been rejected without a handler.

Heavily related to https://github.com/grafana/xk6-browser/issues/510
