### PR TITLE
Update goja

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.8.0
 	github.com/Soontao/goHttpDigestClient v0.0.0-20170320082612-6d28bb1415c5
 	github.com/andybalholm/brotli v1.0.4
-	github.com/dop251/goja v0.0.0-20220815083517-0c74f9139fd6
+	github.com/dop251/goja v0.0.0-20220927172339-ea66e911853d
 	github.com/fatih/color v1.13.0
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnm
 github.com/dop251/goja v0.0.0-20211022113120-dc8c55024d06/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja v0.0.0-20220405120441-9037c2b61cbf/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja v0.0.0-20220516123900-4418d4575a41/go.mod h1:TQJQ+ZNyFVvUtUEtCZxBhfWiH7RJqR3EivNmvD6Waik=
-github.com/dop251/goja v0.0.0-20220815083517-0c74f9139fd6 h1:xHdUVG+c8SWJnct16Z3QJOVlaYo3OwoJyamo6kR6OL0=
-github.com/dop251/goja v0.0.0-20220815083517-0c74f9139fd6/go.mod h1:yRkwfj0CBpOGre+TwBsqPV0IH0Pk73e4PXJOeNDboGs=
+github.com/dop251/goja v0.0.0-20220927172339-ea66e911853d h1:9ov+GfT+d71fMUpTl1DQ3PCUcfRySXwPt8IjpVUAnn4=
+github.com/dop251/goja v0.0.0-20220927172339-ea66e911853d/go.mod h1:yRkwfj0CBpOGre+TwBsqPV0IH0Pk73e4PXJOeNDboGs=
 github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
 github.com/dop251/goja_nodejs v0.0.0-20211022123610-8dd9abb0616d/go.mod h1:DngW8aVqWbuLRMHItjPUyqdj+HWPvnQe8V8y1nDpIbM=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/vendor/github.com/dop251/goja/builtin_function.go
+++ b/vendor/github.com/dop251/goja/builtin_function.go
@@ -28,6 +28,10 @@ func (r *Runtime) builtin_Function(args []Value, proto *Object) *Object {
 	return ret
 }
 
+func nativeFuncString(f *nativeFuncObject) Value {
+	return newStringValue(fmt.Sprintf("function %s() { [native code] }", nilSafe(f.getStr("name", nil)).toString()))
+}
+
 func (r *Runtime) functionproto_toString(call FunctionCall) Value {
 	obj := r.toObject(call.This)
 repeat:
@@ -41,9 +45,11 @@ repeat:
 	case *arrowFuncObject:
 		return newStringValue(f.src)
 	case *nativeFuncObject:
-		return newStringValue(fmt.Sprintf("function %s() { [native code] }", nilSafe(f.getStr("name", nil)).toString()))
+		return nativeFuncString(f)
 	case *boundFuncObject:
-		return newStringValue(fmt.Sprintf("function %s() { [native code] }", nilSafe(f.getStr("name", nil)).toString()))
+		return nativeFuncString(&f.nativeFuncObject)
+	case *wrappedFuncObject:
+		return nativeFuncString(&f.nativeFuncObject)
 	case *lazyObject:
 		obj.self = f.create(obj)
 		goto repeat

--- a/vendor/github.com/dop251/goja/func.go
+++ b/vendor/github.com/dop251/goja/func.go
@@ -56,6 +56,11 @@ type nativeFuncObject struct {
 	construct func(args []Value, newTarget *Object) *Object
 }
 
+type wrappedFuncObject struct {
+	nativeFuncObject
+	wrapped reflect.Value
+}
+
 type boundFuncObject struct {
 	nativeFuncObject
 	wrapped *Object
@@ -63,6 +68,14 @@ type boundFuncObject struct {
 
 func (f *nativeFuncObject) export(*objectExportCtx) interface{} {
 	return f.f
+}
+
+func (f *wrappedFuncObject) exportType() reflect.Type {
+	return f.wrapped.Type()
+}
+
+func (f *wrappedFuncObject) export(*objectExportCtx) interface{} {
+	return f.wrapped.Interface()
 }
 
 func (f *funcObject) _addProto(n unistring.String) Value {

--- a/vendor/github.com/dop251/goja/object_goarray_reflect.go
+++ b/vendor/github.com/dop251/goja/object_goarray_reflect.go
@@ -70,18 +70,18 @@ func (o *objectGoArrayReflect) init() {
 }
 
 func (o *objectGoArrayReflect) updateLen() {
-	o.lengthProp.value = intToValue(int64(o.value.Len()))
+	o.lengthProp.value = intToValue(int64(o.fieldsValue.Len()))
 }
 
 func (o *objectGoArrayReflect) _hasIdx(idx valueInt) bool {
-	if idx := int64(idx); idx >= 0 && idx < int64(o.value.Len()) {
+	if idx := int64(idx); idx >= 0 && idx < int64(o.fieldsValue.Len()) {
 		return true
 	}
 	return false
 }
 
 func (o *objectGoArrayReflect) _hasStr(name unistring.String) bool {
-	if idx := strToIdx64(name); idx >= 0 && idx < int64(o.value.Len()) {
+	if idx := strToIdx64(name); idx >= 0 && idx < int64(o.fieldsValue.Len()) {
 		return true
 	}
 	return false
@@ -92,7 +92,7 @@ func (o *objectGoArrayReflect) _getIdx(idx int) Value {
 		return v.esValue()
 	}
 
-	v := o.value.Index(idx)
+	v := o.fieldsValue.Index(idx)
 
 	res, w := o.elemToValue(v)
 	if w != nil {
@@ -103,7 +103,7 @@ func (o *objectGoArrayReflect) _getIdx(idx int) Value {
 }
 
 func (o *objectGoArrayReflect) getIdx(idx valueInt, receiver Value) Value {
-	if idx := toIntStrict(int64(idx)); idx >= 0 && idx < o.value.Len() {
+	if idx := toIntStrict(int64(idx)); idx >= 0 && idx < o.fieldsValue.Len() {
 		return o._getIdx(idx)
 	}
 	return o.objectGoReflect.getStr(idx.string(), receiver)
@@ -111,7 +111,7 @@ func (o *objectGoArrayReflect) getIdx(idx valueInt, receiver Value) Value {
 
 func (o *objectGoArrayReflect) getStr(name unistring.String, receiver Value) Value {
 	var ownProp Value
-	if idx := strToGoIdx(name); idx >= 0 && idx < o.value.Len() {
+	if idx := strToGoIdx(name); idx >= 0 && idx < o.fieldsValue.Len() {
 		ownProp = o._getIdx(idx)
 	} else if name == "length" {
 		ownProp = &o.lengthProp
@@ -123,7 +123,7 @@ func (o *objectGoArrayReflect) getStr(name unistring.String, receiver Value) Val
 
 func (o *objectGoArrayReflect) getOwnPropStr(name unistring.String) Value {
 	if idx := strToGoIdx(name); idx >= 0 {
-		if idx < o.value.Len() {
+		if idx < o.fieldsValue.Len() {
 			return &valueProperty{
 				value:      o._getIdx(idx),
 				writable:   true,
@@ -139,7 +139,7 @@ func (o *objectGoArrayReflect) getOwnPropStr(name unistring.String) Value {
 }
 
 func (o *objectGoArrayReflect) getOwnPropIdx(idx valueInt) Value {
-	if idx := toIntStrict(int64(idx)); idx >= 0 && idx < o.value.Len() {
+	if idx := toIntStrict(int64(idx)); idx >= 0 && idx < o.fieldsValue.Len() {
 		return &valueProperty{
 			value:      o._getIdx(idx),
 			writable:   true,
@@ -155,7 +155,7 @@ func (o *objectGoArrayReflect) _putIdx(idx int, v Value, throw bool) bool {
 		copyReflectValueWrapper(cached)
 	}
 
-	rv := o.value.Index(idx)
+	rv := o.fieldsValue.Index(idx)
 	err := o.val.runtime.toReflectValue(v, rv, &objectExportCtx{})
 	if err != nil {
 		if cached != nil {
@@ -172,7 +172,7 @@ func (o *objectGoArrayReflect) _putIdx(idx int, v Value, throw bool) bool {
 
 func (o *objectGoArrayReflect) setOwnIdx(idx valueInt, val Value, throw bool) bool {
 	if i := toIntStrict(int64(idx)); i >= 0 {
-		if i >= o.value.Len() {
+		if i >= o.fieldsValue.Len() {
 			if res, ok := o._setForeignIdx(idx, nil, val, o.val, throw); ok {
 				return res
 			}
@@ -191,7 +191,7 @@ func (o *objectGoArrayReflect) setOwnIdx(idx valueInt, val Value, throw bool) bo
 
 func (o *objectGoArrayReflect) setOwnStr(name unistring.String, val Value, throw bool) bool {
 	if idx := strToGoIdx(name); idx >= 0 {
-		if idx >= o.value.Len() {
+		if idx >= o.fieldsValue.Len() {
 			if res, ok := o._setForeignStr(name, nil, val, o.val, throw); ok {
 				return res
 			}
@@ -261,13 +261,13 @@ func (o *objectGoArrayReflect) toPrimitive() Value {
 }
 
 func (o *objectGoArrayReflect) _deleteIdx(idx int) {
-	if idx < o.value.Len() {
+	if idx < o.fieldsValue.Len() {
 		if cv := o.valueCache.get(idx); cv != nil {
 			copyReflectValueWrapper(cv)
 			o.valueCache[idx] = nil
 		}
 
-		o.value.Index(idx).Set(reflect.Zero(o.value.Type().Elem()))
+		o.fieldsValue.Index(idx).Set(reflect.Zero(o.fieldsValue.Type().Elem()))
 	}
 }
 
@@ -294,7 +294,7 @@ type goArrayReflectPropIter struct {
 }
 
 func (i *goArrayReflectPropIter) next() (propIterItem, iterNextFunc) {
-	if i.idx < i.limit && i.idx < i.o.value.Len() {
+	if i.idx < i.limit && i.idx < i.o.fieldsValue.Len() {
 		name := strconv.Itoa(i.idx)
 		i.idx++
 		return propIterItem{name: asciiString(name), enumerable: _ENUM_TRUE}, i.next
@@ -304,7 +304,7 @@ func (i *goArrayReflectPropIter) next() (propIterItem, iterNextFunc) {
 }
 
 func (o *objectGoArrayReflect) stringKeys(all bool, accum []Value) []Value {
-	for i := 0; i < o.value.Len(); i++ {
+	for i := 0; i < o.fieldsValue.Len(); i++ {
 		accum = append(accum, asciiString(strconv.Itoa(i)))
 	}
 
@@ -314,12 +314,12 @@ func (o *objectGoArrayReflect) stringKeys(all bool, accum []Value) []Value {
 func (o *objectGoArrayReflect) iterateStringKeys() iterNextFunc {
 	return (&goArrayReflectPropIter{
 		o:     o,
-		limit: o.value.Len(),
+		limit: o.fieldsValue.Len(),
 	}).next
 }
 
 func (o *objectGoArrayReflect) sortLen() int {
-	return o.value.Len()
+	return o.fieldsValue.Len()
 }
 
 func (o *objectGoArrayReflect) sortGet(i int) Value {
@@ -327,9 +327,9 @@ func (o *objectGoArrayReflect) sortGet(i int) Value {
 }
 
 func (o *objectGoArrayReflect) swap(i int, j int) {
-	vi := o.value.Index(i)
-	vj := o.value.Index(j)
-	tmp := reflect.New(o.value.Type().Elem()).Elem()
+	vi := o.fieldsValue.Index(i)
+	vj := o.fieldsValue.Index(j)
+	tmp := reflect.New(o.fieldsValue.Type().Elem()).Elem()
 	tmp.Set(vi)
 	vi.Set(vj)
 	vj.Set(tmp)

--- a/vendor/github.com/dop251/goja/object_gomap_reflect.go
+++ b/vendor/github.com/dop251/goja/object_gomap_reflect.go
@@ -14,8 +14,8 @@ type objectGoMapReflect struct {
 
 func (o *objectGoMapReflect) init() {
 	o.objectGoReflect.init()
-	o.keyType = o.value.Type().Key()
-	o.valueType = o.value.Type().Elem()
+	o.keyType = o.fieldsValue.Type().Key()
+	o.valueType = o.fieldsValue.Type().Elem()
 }
 
 func (o *objectGoMapReflect) toKey(n Value, throw bool) reflect.Value {
@@ -40,7 +40,7 @@ func (o *objectGoMapReflect) _get(n Value) Value {
 	if !key.IsValid() {
 		return nil
 	}
-	if v := o.value.MapIndex(key); v.IsValid() {
+	if v := o.fieldsValue.MapIndex(key); v.IsValid() {
 		return o.val.runtime.ToValue(v.Interface())
 	}
 
@@ -52,7 +52,7 @@ func (o *objectGoMapReflect) _getStr(name string) Value {
 	if !key.IsValid() {
 		return nil
 	}
-	if v := o.value.MapIndex(key); v.IsValid() {
+	if v := o.fieldsValue.MapIndex(key); v.IsValid() {
 		return o.val.runtime.ToValue(v.Interface())
 	}
 
@@ -108,12 +108,12 @@ func (o *objectGoMapReflect) toValue(val Value, throw bool) (reflect.Value, bool
 
 func (o *objectGoMapReflect) _put(key reflect.Value, val Value, throw bool) bool {
 	if key.IsValid() {
-		if o.extensible || o.value.MapIndex(key).IsValid() {
+		if o.extensible || o.fieldsValue.MapIndex(key).IsValid() {
 			v, ok := o.toValue(val, throw)
 			if !ok {
 				return false
 			}
-			o.value.SetMapIndex(key, v)
+			o.fieldsValue.SetMapIndex(key, v)
 		} else {
 			o.val.runtime.typeErrorResult(throw, "Cannot set property %s, object is not extensible", key.String())
 			return false
@@ -126,7 +126,7 @@ func (o *objectGoMapReflect) _put(key reflect.Value, val Value, throw bool) bool
 func (o *objectGoMapReflect) setOwnStr(name unistring.String, val Value, throw bool) bool {
 	n := name.String()
 	key := o.strToKey(n, false)
-	if !key.IsValid() || !o.value.MapIndex(key).IsValid() {
+	if !key.IsValid() || !o.fieldsValue.MapIndex(key).IsValid() {
 		if proto := o.prototype; proto != nil {
 			// we know it's foreign because prototype loops are not allowed
 			if res, ok := proto.self.setForeignStr(name, val, o.val, throw); ok {
@@ -150,7 +150,7 @@ func (o *objectGoMapReflect) setOwnStr(name unistring.String, val Value, throw b
 
 func (o *objectGoMapReflect) setOwnIdx(idx valueInt, val Value, throw bool) bool {
 	key := o.toKey(idx, false)
-	if !key.IsValid() || !o.value.MapIndex(key).IsValid() {
+	if !key.IsValid() || !o.fieldsValue.MapIndex(key).IsValid() {
 		if proto := o.prototype; proto != nil {
 			// we know it's foreign because prototype loops are not allowed
 			if res, ok := proto.self.setForeignIdx(idx, val, o.val, throw); ok {
@@ -198,7 +198,7 @@ func (o *objectGoMapReflect) defineOwnPropertyIdx(idx valueInt, descr PropertyDe
 
 func (o *objectGoMapReflect) hasOwnPropertyStr(name unistring.String) bool {
 	key := o.strToKey(name.String(), false)
-	if key.IsValid() && o.value.MapIndex(key).IsValid() {
+	if key.IsValid() && o.fieldsValue.MapIndex(key).IsValid() {
 		return true
 	}
 	return false
@@ -206,7 +206,7 @@ func (o *objectGoMapReflect) hasOwnPropertyStr(name unistring.String) bool {
 
 func (o *objectGoMapReflect) hasOwnPropertyIdx(idx valueInt) bool {
 	key := o.toKey(idx, false)
-	if key.IsValid() && o.value.MapIndex(key).IsValid() {
+	if key.IsValid() && o.fieldsValue.MapIndex(key).IsValid() {
 		return true
 	}
 	return false
@@ -217,7 +217,7 @@ func (o *objectGoMapReflect) deleteStr(name unistring.String, throw bool) bool {
 	if !key.IsValid() {
 		return false
 	}
-	o.value.SetMapIndex(key, reflect.Value{})
+	o.fieldsValue.SetMapIndex(key, reflect.Value{})
 	return true
 }
 
@@ -226,7 +226,7 @@ func (o *objectGoMapReflect) deleteIdx(idx valueInt, throw bool) bool {
 	if !key.IsValid() {
 		return false
 	}
-	o.value.SetMapIndex(key, reflect.Value{})
+	o.fieldsValue.SetMapIndex(key, reflect.Value{})
 	return true
 }
 
@@ -239,7 +239,7 @@ type gomapReflectPropIter struct {
 func (i *gomapReflectPropIter) next() (propIterItem, iterNextFunc) {
 	for i.idx < len(i.keys) {
 		key := i.keys[i.idx]
-		v := i.o.value.MapIndex(key)
+		v := i.o.fieldsValue.MapIndex(key)
 		i.idx++
 		if v.IsValid() {
 			return propIterItem{name: newStringValue(key.String()), enumerable: _ENUM_TRUE}, i.next
@@ -252,13 +252,13 @@ func (i *gomapReflectPropIter) next() (propIterItem, iterNextFunc) {
 func (o *objectGoMapReflect) iterateStringKeys() iterNextFunc {
 	return (&gomapReflectPropIter{
 		o:    o,
-		keys: o.value.MapKeys(),
+		keys: o.fieldsValue.MapKeys(),
 	}).next
 }
 
 func (o *objectGoMapReflect) stringKeys(_ bool, accum []Value) []Value {
 	// all own keys are enumerable
-	for _, key := range o.value.MapKeys() {
+	for _, key := range o.fieldsValue.MapKeys() {
 		accum = append(accum, newStringValue(key.String()))
 	}
 

--- a/vendor/github.com/dop251/goja/object_goslice_reflect.go
+++ b/vendor/github.com/dop251/goja/object_goslice_reflect.go
@@ -19,46 +19,46 @@ func (o *objectGoSliceReflect) init() {
 }
 
 func (o *objectGoSliceReflect) _putIdx(idx int, v Value, throw bool) bool {
-	if idx >= o.value.Len() {
+	if idx >= o.fieldsValue.Len() {
 		o.grow(idx + 1)
 	}
 	return o.objectGoArrayReflect._putIdx(idx, v, throw)
 }
 
 func (o *objectGoSliceReflect) grow(size int) {
-	oldcap := o.value.Cap()
+	oldcap := o.fieldsValue.Cap()
 	if oldcap < size {
-		n := reflect.MakeSlice(o.value.Type(), size, growCap(size, o.value.Len(), oldcap))
-		reflect.Copy(n, o.value)
-		o.value.Set(n)
+		n := reflect.MakeSlice(o.fieldsValue.Type(), size, growCap(size, o.fieldsValue.Len(), oldcap))
+		reflect.Copy(n, o.fieldsValue)
+		o.fieldsValue.Set(n)
 		l := len(o.valueCache)
 		if l > size {
 			l = size
 		}
 		for i, w := range o.valueCache[:l] {
 			if w != nil {
-				w.setReflectValue(o.value.Index(i))
+				w.setReflectValue(o.fieldsValue.Index(i))
 			}
 		}
 	} else {
-		tail := o.value.Slice(o.value.Len(), size)
-		zero := reflect.Zero(o.value.Type().Elem())
+		tail := o.fieldsValue.Slice(o.fieldsValue.Len(), size)
+		zero := reflect.Zero(o.fieldsValue.Type().Elem())
 		for i := 0; i < tail.Len(); i++ {
 			tail.Index(i).Set(zero)
 		}
-		o.value.SetLen(size)
+		o.fieldsValue.SetLen(size)
 	}
 	o.updateLen()
 }
 
 func (o *objectGoSliceReflect) shrink(size int) {
 	o.valueCache.shrink(size)
-	tail := o.value.Slice(size, o.value.Len())
-	zero := reflect.Zero(o.value.Type().Elem())
+	tail := o.fieldsValue.Slice(size, o.fieldsValue.Len())
+	zero := reflect.Zero(o.fieldsValue.Type().Elem())
 	for i := 0; i < tail.Len(); i++ {
 		tail.Index(i).Set(zero)
 	}
-	o.value.SetLen(size)
+	o.fieldsValue.SetLen(size)
 	o.updateLen()
 }
 
@@ -67,7 +67,7 @@ func (o *objectGoSliceReflect) putLength(v uint32, throw bool) bool {
 		panic(rangeError("Integer value overflows 32-bit int"))
 	}
 	newLen := int(v)
-	curLen := o.value.Len()
+	curLen := o.fieldsValue.Len()
 	if newLen > curLen {
 		o.grow(newLen)
 	} else if newLen < curLen {

--- a/vendor/github.com/dop251/goja/parser/lexer.go
+++ b/vendor/github.com/dop251/goja/parser/lexer.go
@@ -425,6 +425,11 @@ func (self *_parser) scan() (tkn token.Token, literal string, parsedLiteral unis
 			case '`':
 				tkn = token.BACKTICK
 			case '#':
+				if self.chrOffset == 1 && self.chr == '!' {
+					self.skipSingleLineComment()
+					continue
+				}
+
 				var err string
 				literal, parsedLiteral, _, err = self.scanIdentifier()
 				if err != "" || literal == "" {

--- a/vendor/github.com/dop251/goja/value.go
+++ b/vendor/github.com/dop251/goja/value.go
@@ -51,6 +51,7 @@ var (
 	reflectTypeArray  = reflect.TypeOf([]interface{}{})
 	reflectTypeString = reflect.TypeOf("")
 	reflectTypeFunc   = reflect.TypeOf((func(FunctionCall) Value)(nil))
+	reflectTypeError  = reflect.TypeOf((*error)(nil)).Elem()
 )
 
 var intCache [256]Value

--- a/vendor/github.com/dop251/goja/vm.go
+++ b/vendor/github.com/dop251/goja/vm.go
@@ -3201,6 +3201,8 @@ repeat:
 		return
 	case *nativeFuncObject:
 		vm._nativeCall(f, n)
+	case *wrappedFuncObject:
+		vm._nativeCall(&f.nativeFuncObject, n)
 	case *boundFuncObject:
 		vm._nativeCall(&f.nativeFuncObject, n)
 	case *proxyObject:
@@ -4329,7 +4331,7 @@ func (_typeof) exec(vm *vm) {
 	case *Object:
 	repeat:
 		switch s := v.self.(type) {
-		case *classFuncObject, *methodFuncObject, *funcObject, *nativeFuncObject, *boundFuncObject, *arrowFuncObject:
+		case *classFuncObject, *methodFuncObject, *funcObject, *nativeFuncObject, *wrappedFuncObject, *boundFuncObject, *arrowFuncObject:
 			r = stringFunction
 		case *proxyObject:
 			if s.call == nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,7 +29,7 @@ github.com/dgryski/go-rendezvous
 ## explicit; go 1.13
 github.com/dlclark/regexp2
 github.com/dlclark/regexp2/syntax
-# github.com/dop251/goja v0.0.0-20220815083517-0c74f9139fd6
+# github.com/dop251/goja v0.0.0-20220927172339-ea66e911853d
 ## explicit; go 1.16
 github.com/dop251/goja
 github.com/dop251/goja/ast


### PR DESCRIPTION
- return the original function on Export() after usage of ToValue()
- function returning a single result that is a non-nil `error` is consired throwing an exception, the same as when the results >1
- automatically unwrap the goja.GoError before throwing it
- treat first line starting with shebang(`#`) as a comment
- allow accesing methods defined on pointers to be used from literal value
