### PR TITLE
Return HTTP response to user for failed connections.

### DIFF
--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -279,7 +279,6 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*HTTPResponse, error) {
 		if state.Options.Throw.Bool {
 			return nil, connErr
 		}
-
 		if httpResponse != nil {
 			return wrapHTTPResponse(httpResponse)
 		}

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -279,7 +279,10 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*HTTPResponse, error) {
 		if state.Options.Throw.Bool {
 			return nil, connErr
 		}
-		state.Logger.WithError(connErr).Warn("Attempt to establish a WebSocket connection failed")
+
+		if httpResponse != nil {
+			return wrapHTTPResponse(httpResponse)
+		}
 		return &HTTPResponse{
 			Error: connErr.Error(),
 		}, nil

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -729,6 +729,21 @@ func TestErrors(t *testing.T) {
 	})
 }
 
+func TestWrongStatusCode(t *testing.T) {
+	t.Parallel()
+	test := newTestState(t)
+	tb := httpmultibin.NewHTTPMultiBin(t)
+	sr := tb.Replacer.Replace
+	test.VU.StateField.Options.Throw = null.BoolFrom(false)
+	_, err := test.VU.Runtime().RunString(sr(`
+	var res = ws.connect("WSBIN_URL/status/404", function(socket){});
+	if (res.status != 404) {
+		throw new Error ("no status code set for invalid response");
+	}
+	`))
+	assert.NoError(t, err)
+}
+
 func TestSystemTags(t *testing.T) {
 	t.Parallel()
 	testedSystemTags := []string{"status", "subproto", "url", "ip"}

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -1235,6 +1235,5 @@ func TestWSConnectDisableThrowErrorOption(t *testing.T) {
 		`)
 	assert.NoError(t, err)
 	entries := logHook.Drain()
-	require.Len(t, entries, 1)
-	assert.Contains(t, entries[0].Message, "Attempt to establish a WebSocket connection failed")
+	require.Len(t, entries, 0)
 }

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -729,7 +729,7 @@ func TestErrors(t *testing.T) {
 	})
 }
 
-func TestWrongStatusCode(t *testing.T) {
+func TestConnectWrongStatusCode(t *testing.T) {
 	t.Parallel()
 	test := newTestState(t)
 	tb := httpmultibin.NewHTTPMultiBin(t)
@@ -1248,7 +1248,7 @@ func TestWSConnectDisableThrowErrorOption(t *testing.T) {
 			throw new Error("res.error is expected to be not null");
 		}
 		`)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	entries := logHook.Drain()
-	require.Len(t, entries, 0)
+	assert.Empty(t, entries)
 }


### PR DESCRIPTION
Allow users to process the error response, for example to implement and test backoff after receiving a 429 Slow Down.

I've also removed the log message for failed connections.  In my own load tests this is swamping out other log messages.

Issue link: https://github.com/grafana/k6/issues/2711