### PR TITLE
Docs for bumping an experimental module's version

### DIFF
--- a/js/modules/k6/experimental/README.md
+++ b/js/modules/k6/experimental/README.md
@@ -9,7 +9,7 @@ Although [accessible in k6 scripts](../../../initcontext.go) under the `k6/exper
 
 While we intend to keep these modules as stable as possible, we may need to add features or introduce breaking changes. This could happen at any time until we release the module as stable. **use them at your own risk**.
 
-## Upgrade version
+## Upgrading
 
 Experimental modules are based on xk6-extensions, and they introduce a cycle dependency between k6 and the extension. When upgrading an extension's version, it's required to run the following steps:
 

--- a/js/modules/k6/experimental/README.md
+++ b/js/modules/k6/experimental/README.md
@@ -11,7 +11,7 @@ While we intend to keep these modules as stable as possible, we may need to add 
 
 ## Upgrade version
 
-Experimental modules are based on xk6-extensions, and they introduce a cycle dependency between k6 and the extension. Upgrading an extension's version is required to run the following steps:
+Experimental modules are based on xk6-extensions, and they introduce a cycle dependency between k6 and the extension. When upgrading an extension's version, it's required to run the following steps:
 
 1. Get the feature branch ready to be merged. Note: from the next step rebasing of the feature branch should be denied; otherwise, the commit will be lost and the relative dependencies will be broken.
 2. Make a commit in the feature branch that removes the extension package (and any other problematic experimental modules).

--- a/js/modules/k6/experimental/README.md
+++ b/js/modules/k6/experimental/README.md
@@ -8,3 +8,14 @@ Although [accessible in k6 scripts](../../../initcontext.go) under the `k6/exper
 * [`k6/experimental/k6-timers`](https://github.com/grafana/xk6-timers)
 
 While we intend to keep these modules as stable as possible, we may need to add features or introduce breaking changes. This could happen at any time until we release the module as stable. **use them at your own risk**.
+
+## Upgrade version
+
+Experimental modules are based on xk6-extensions, and they introduce a cycle dependency between k6 and the extension. Upgrading an extension's version is required to run the following steps:
+
+1. Get the feature branch ready to be merged. Note: from the next step rebasing of the feature branch should be denied; otherwise, the commit will be lost and the relative dependencies will be broken.
+2. Make a commit in the feature branch that removes the extension package (and any other problematic experimental modules).
+3. Make a PR in the extension's repository and merge it in its main branch that updates the k6 dependency to the commit generated at the previous point.
+4. Tag the newly merged commit creating a new version.
+5. Make another commit in the feature branch on k6 repository that re-adds this latest version of the extension.
+6. Merge the whole feature branch in k6 master with a `Merge` commit (`Create a merge commit` button on GitHub). It will guarantee that the commit used by the extension is preserved.


### PR DESCRIPTION
It adds documentation about the steps for upgrading experimental modules.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
