### PR TITLE
Adjust level of the warning for an invalid system variables

### DIFF
--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -111,7 +111,7 @@ func getRuntimeOptions(
 	if opts.IncludeSystemEnvVars.Bool { // If enabled, gather the actual system environment variables
 		for k, v := range environment {
 			if !userEnvVarName.MatchString(k) {
-				logger.Warnf("invalid system environment variable name '%s'", k)
+				logger.Debugf("invalid system environment variable name '%s', will be ignored", k)
 
 				continue
 			}


### PR DESCRIPTION
# What?

Change the log level from a warning to debug for the message about the invalid system variables to improve UX on Windows machines, where by default exist variables like 'CommonProgramFiles(x86)' or 'ProgramFiles(x86)'.

Finding the message when k6 verbose mode is enabled is still possible.

![image](https://user-images.githubusercontent.com/5425600/194911427-d9f7a0f7-bfb4-4d2e-a77b-45fd2fedd7b5.png)

# Why?

It's not a good UX when we show this by default to all windows users.