### PR TITLE
Revert "Detecting and filtering invalid environment names"

### DIFF
--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 	"gopkg.in/guregu/null.v3"
 
@@ -56,11 +55,7 @@ func saveBoolFromEnv(env map[string]string, varName string, placeholder *null.Bo
 	return nil
 }
 
-func getRuntimeOptions(
-	logger *logrus.Logger,
-	flags *pflag.FlagSet,
-	environment map[string]string,
-) (lib.RuntimeOptions, error) {
+func getRuntimeOptions(flags *pflag.FlagSet, environment map[string]string) (lib.RuntimeOptions, error) {
 	// TODO: refactor with composable helpers as a part of #883, to reduce copy-paste
 	// TODO: get these options out of the JSON config file as well?
 	opts := lib.RuntimeOptions{
@@ -109,15 +104,7 @@ func getRuntimeOptions(
 	}
 
 	if opts.IncludeSystemEnvVars.Bool { // If enabled, gather the actual system environment variables
-		for k, v := range environment {
-			if !userEnvVarName.MatchString(k) {
-				logger.Warnf("invalid system environment variable name '%s'", k)
-
-				continue
-			}
-
-			opts.Env[k] = v
-		}
+		opts.Env = environment
 	}
 
 	// Set/overwrite environment variables with custom user-supplied values

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -3,11 +3,9 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io"
 	"net/url"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,10 +29,7 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 	flags := runtimeOptionFlagSet(tc.useSysEnv)
 	require.NoError(t, flags.Parse(tc.cliFlags))
 
-	logger := logrus.New()
-	logger.Out = io.Discard
-
-	rtOpts, err := getRuntimeOptions(logger, flags, tc.systemEnv)
+	rtOpts, err := getRuntimeOptions(flags, tc.systemEnv)
 	if tc.expErr {
 		require.Error(t, err)
 		return
@@ -118,12 +113,11 @@ func TestRuntimeOptions(t *testing.T) {
 	runtimeOptionsTestCases := map[string]runtimeOptionsTestCase{
 		"empty env": {
 			useSysEnv: true,
-			systemEnv: map[string]string{},
 			// everything else is empty
 			expRTOpts: lib.RuntimeOptions{
 				IncludeSystemEnvVars: null.NewBool(true, false),
 				CompatibilityMode:    defaultCompatMode,
-				Env:                  map[string]string{},
+				Env:                  nil,
 			},
 		},
 		"disabled sys env by default": {
@@ -210,39 +204,6 @@ func TestRuntimeOptions(t *testing.T) {
 				IncludeSystemEnvVars: null.NewBool(true, true),
 				CompatibilityMode:    defaultCompatMode,
 				Env:                  map[string]string{"test1": "val1"},
-			},
-		},
-		"ignore invalid name system env var name 1": {
-			useSysEnv: false,
-			systemEnv: map[string]string{"test a": "val1", "valid": "val2"},
-			cliFlags:  []string{"--include-system-env-vars=true"},
-			expErr:    false,
-			expRTOpts: lib.RuntimeOptions{
-				IncludeSystemEnvVars: null.NewBool(true, true),
-				CompatibilityMode:    defaultCompatMode,
-				Env:                  map[string]string{"valid": "val2"},
-			},
-		},
-		"ignore invalid name system env var name 2": {
-			useSysEnv: false,
-			systemEnv: map[string]string{"1var": "val1", "valid": "val2"},
-			cliFlags:  []string{"--include-system-env-vars=true"},
-			expErr:    false,
-			expRTOpts: lib.RuntimeOptions{
-				IncludeSystemEnvVars: null.NewBool(true, true),
-				CompatibilityMode:    defaultCompatMode,
-				Env:                  map[string]string{"valid": "val2"},
-			},
-		},
-		"ignore invalid name system env var name 3": {
-			useSysEnv: false,
-			systemEnv: map[string]string{"уникод": "unicode-disabled", "valid": "val2"},
-			cliFlags:  []string{"--include-system-env-vars=true"},
-			expErr:    false,
-			expRTOpts: lib.RuntimeOptions{
-				IncludeSystemEnvVars: null.NewBool(true, true),
-				CompatibilityMode:    defaultCompatMode,
-				Env:                  map[string]string{"valid": "val2"},
 			},
 		},
 		"run only system env": {

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -56,7 +56,7 @@ func loadTest(gs *globalState, cmd *cobra.Command, args []string) (*loadedTest, 
 	)
 
 	gs.logger.Debugf("Gathering k6 runtime options...")
-	runtimeOptions, err := getRuntimeOptions(gs.logger, cmd.Flags(), gs.envVars)
+	runtimeOptions, err := getRuntimeOptions(cmd.Flags(), gs.envVars)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# What?

This reverts commit c6f57c6e22e6966e526643d2d0944e48df0ea36c.

And revert PR: #2652

To address the original issue, I'll open the task soon.

# Why?

After an internal discussion, we decided to revoluate the pattern and probably relax the constraints.