### PR TITLE
Fixes for promise rejection reporting

### DIFF
--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -176,7 +176,6 @@ func (e *EventLoop) Start(firstCallback func() error) error {
 		// This will get a random unhandled rejection instead of the first one, for example.
 		// But that seems to be the case in other tools as well so it seems to not be that big of a problem.
 		for promise := range e.pendingPromiseRejections {
-			// TODO maybe throw the whole promise up and get make a better message outside of the event loop
 			value := promise.Result()
 			if !goja.IsNull(value) && !goja.IsUndefined(value) {
 				if o := value.ToObject(e.vu.Runtime()); o != nil {

--- a/js/eventloop/eventloop.go
+++ b/js/eventloop/eventloop.go
@@ -178,10 +178,12 @@ func (e *EventLoop) Start(firstCallback func() error) error {
 		for promise := range e.pendingPromiseRejections {
 			// TODO maybe throw the whole promise up and get make a better message outside of the event loop
 			value := promise.Result()
-			if o := value.ToObject(e.vu.Runtime()); o != nil {
-				stack := o.Get("stack")
-				if stack != nil {
-					value = stack
+			if !goja.IsNull(value) && !goja.IsUndefined(value) {
+				if o := value.ToObject(e.vu.Runtime()); o != nil {
+					stack := o.Get("stack")
+					if stack != nil {
+						value = e.vu.Runtime().ToValue(fmt.Sprintf("%s: %s\n", value, stack))
+					}
 				}
 			}
 			// this is the de facto wording in both firefox and deno at least


### PR DESCRIPTION
- fix a panic on `Promise.reject()` - rejection with `undefined` reason.
- include the actual rejection instead of only it's stack in case the stack exists.

