### PR TITLE
Remove byte array from redundant error message

### DIFF
--- a/js/common/util.go
+++ b/js/common/util.go
@@ -32,7 +32,7 @@ func GetReader(data interface{}) (io.Reader, error) {
 	case goja.ArrayBuffer:
 		return bytes.NewBuffer(r.Bytes()), nil
 	default:
-		return nil, fmt.Errorf("invalid type %T, it needs to be a string, byte array or an ArrayBuffer", data)
+		return nil, fmt.Errorf("invalid type %T, it needs to be a string or ArrayBuffer", data)
 	}
 }
 


### PR DESCRIPTION
According to the MDN docs, the JavaScript world prefers the term ArrayBuffer and considers "byte array" synonymous.

> [ArrayBuffer] is an array of bytes, often referred to in other languages as a "byte array".
>
> - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer

Having both terms in the same message suggests they are different concepts.
