### PR TITLE
add extension version

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -17,6 +17,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/output"
@@ -81,7 +82,13 @@ func getColor(noColor bool, attributes ...color.Attribute) *color.Color {
 
 func getBanner(noColor bool) string {
 	c := getColor(noColor, color.FgCyan)
-	return c.Sprint(consts.Banner())
+	banner := make([]string, 0, len(modules.GetJSModuleVersions())+1)
+
+	banner = append(banner, consts.Banner())
+	for pkg, version := range modules.GetJSModuleVersions() {
+		banner = append(banner, fmt.Sprintf("extension  %s %s", pkg, version))
+	}
+	return c.Sprint(strings.Join(banner, "\n"))
 }
 
 func printBanner(gs *globalState) {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib/consts"
 )
 
@@ -16,6 +17,9 @@ func getCmdVersion(globalState *globalState) *cobra.Command {
 		Long:  `Show the application version and exit.`,
 		Run: func(_ *cobra.Command, _ []string) {
 			printToStdout(globalState, fmt.Sprintf("k6 v%s\n", consts.FullVersion()))
+			for path, version := range modules.GetJSModuleVersions() {
+				printToStdout(globalState, fmt.Sprintf("extension %s %s\n", path, version))
+			}
 		},
 	}
 }


### PR DESCRIPTION
<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->

I write a k6 extension and build with xk6, but I cannot know the extension version via command line.

if extension module implement `VersionGetter` interface, could display via version command.

```
package k6plugin

import (
	"github.com/vesoft-inc/k6-plugin/pkg/aggcsv"
	"github.com/vesoft-inc/k6-plugin/pkg/nebulagraph"
	"go.k6.io/k6/js/modules"
	"go.k6.io/k6/output"
)

func init() {
	modules.Register("k6/x/nebulagraph", nebulagraph.NewNebulaGraph())
	output.RegisterExtension("aggcsv", func(p output.Params) (output.Output, error) {
		return aggcsv.New(p)
	})
}
```

```
> ./k6 version
k6 v0.40.0 ((devel), go1.18.5, linux/amd64)
extension k6/x/nebulagraph v1.0.2
```
