### PR TITLE
Fix 2755 and ensure evaulation of thresholds over trend metrics median 

### DIFF
--- a/js/summary.go
+++ b/js/summary.go
@@ -29,8 +29,6 @@ func metricValueGetter(summaryTrendStats []string) func(metrics.Sink, time.Durat
 	}
 
 	return func(sink metrics.Sink, t time.Duration) (result map[string]float64) {
-		sink.Calc()
-
 		switch sink := sink.(type) {
 		case *metrics.CounterSink:
 			result = sink.Format(t)

--- a/metrics/sample.go
+++ b/metrics/sample.go
@@ -142,7 +142,7 @@ func GetResolversForTrendColumns(trendColumns []string) (map[string]func(s *Tren
 	staticResolvers := map[string]func(s *TrendSink) float64{
 		"avg":   func(s *TrendSink) float64 { return s.Avg },
 		"min":   func(s *TrendSink) float64 { return s.Min },
-		"med":   func(s *TrendSink) float64 { return s.Med },
+		"med":   func(s *TrendSink) float64 { return s.P(0.5) },
 		"max":   func(s *TrendSink) float64 { return s.Max },
 		"count": func(s *TrendSink) float64 { return float64(s.Count) },
 	}

--- a/metrics/sink.go
+++ b/metrics/sink.go
@@ -74,7 +74,6 @@ type TrendSink struct {
 	Count    uint64
 	Min, Max float64
 	Sum, Avg float64
-	Med      float64
 }
 
 // IsEmpty indicates whether the TrendSink is empty.

--- a/metrics/sink.go
+++ b/metrics/sink.go
@@ -17,7 +17,6 @@ var (
 
 type Sink interface {
 	Add(s Sample)                              // Add a sample to the sink.
-	Calc()                                     // Make final calculations.
 	Format(t time.Duration) map[string]float64 // Data for thresholds.
 	IsEmpty() bool                             // Check if the Sink is empty.
 }
@@ -36,8 +35,6 @@ func (c *CounterSink) Add(s Sample) {
 
 // IsEmpty indicates whether the CounterSink is empty.
 func (c *CounterSink) IsEmpty() bool { return c.First.IsZero() }
-
-func (c *CounterSink) Calc() {}
 
 func (c *CounterSink) Format(t time.Duration) map[string]float64 {
 	return map[string]float64{
@@ -66,15 +63,13 @@ func (g *GaugeSink) Add(s Sample) {
 	}
 }
 
-func (g *GaugeSink) Calc() {}
-
 func (g *GaugeSink) Format(t time.Duration) map[string]float64 {
 	return map[string]float64{"value": g.Value}
 }
 
 type TrendSink struct {
-	Values  []float64
-	jumbled bool
+	Values []float64
+	sorted bool
 
 	Count    uint64
 	Min, Max float64
@@ -87,7 +82,7 @@ func (t *TrendSink) IsEmpty() bool { return t.Count == 0 }
 
 func (t *TrendSink) Add(s Sample) {
 	t.Values = append(t.Values, s.Value)
-	t.jumbled = true
+	t.sorted = false
 	t.Count += 1
 	t.Sum += s.Value
 	t.Avg = t.Sum / float64(t.Count)
@@ -108,10 +103,14 @@ func (t *TrendSink) P(pct float64) float64 {
 	case 1:
 		return t.Values[0]
 	default:
+		if !t.sorted {
+			sort.Float64s(t.Values)
+			t.sorted = true
+		}
+
 		// If percentile falls on a value in Values slice, we return that value.
 		// If percentile does not fall on a value in Values slice, we calculate (linear interpolation)
 		// the value that would fall at percentile, given the values above and below that percentile.
-		t.Calc()
 		i := pct * (float64(t.Count) - 1.0)
 		j := t.Values[int(math.Floor(i))]
 		k := t.Values[int(math.Ceil(i))]
@@ -120,30 +119,13 @@ func (t *TrendSink) P(pct float64) float64 {
 	}
 }
 
-func (t *TrendSink) Calc() {
-	if !t.jumbled {
-		return
-	}
-
-	sort.Float64s(t.Values)
-	t.jumbled = false
-
-	// The median of an even number of values is the average of the middle two.
-	if (t.Count & 0x01) == 0 {
-		t.Med = (t.Values[(t.Count/2)-1] + t.Values[(t.Count/2)]) / 2
-	} else {
-		t.Med = t.Values[t.Count/2]
-	}
-}
-
 func (t *TrendSink) Format(tt time.Duration) map[string]float64 {
-	t.Calc()
 	// TODO: respect the summaryTrendStats for REST API
 	return map[string]float64{
 		"min":   t.Min,
 		"max":   t.Max,
 		"avg":   t.Avg,
-		"med":   t.Med,
+		"med":   t.P(0.5),
 		"p(90)": t.P(0.90),
 		"p(95)": t.P(0.95),
 	}
@@ -164,8 +146,6 @@ func (r *RateSink) Add(s Sample) {
 	}
 }
 
-func (r RateSink) Calc() {}
-
 func (r RateSink) Format(t time.Duration) map[string]float64 {
 	var rate float64
 	if r.Total > 0 {
@@ -183,8 +163,6 @@ func (d DummySink) IsEmpty() bool { return len(d) == 0 }
 func (d DummySink) Add(s Sample) {
 	panic(errors.New("you can't add samples to a dummy sink"))
 }
-
-func (d DummySink) Calc() {}
 
 func (d DummySink) Format(t time.Duration) map[string]float64 {
 	return map[string]float64(d)

--- a/metrics/thresholds.go
+++ b/metrics/thresholds.go
@@ -188,7 +188,7 @@ func (ts *Thresholds) Run(sink Sink, duration time.Duration) (bool, error) {
 		ts.sinked["min"] = sinkImpl.Min
 		ts.sinked["max"] = sinkImpl.Max
 		ts.sinked["avg"] = sinkImpl.Avg
-		ts.sinked["med"] = sinkImpl.Med
+		ts.sinked["med"] = sinkImpl.P(0.5)
 
 		// Parse the percentile thresholds and insert them in
 		// the sinks mapping.

--- a/metrics/thresholds_test.go
+++ b/metrics/thresholds_test.go
@@ -638,12 +638,13 @@ func TestThresholdsRunAll(t *testing.T) {
 	}
 }
 
-func TestThresholds_Run(t *testing.T) {
+func TestThresholdsRun(t *testing.T) {
 	t.Parallel()
 
 	type args struct {
-		sink     Sink
-		duration time.Duration
+		sink                 Sink
+		thresholdExpressions []string
+		duration             time.Duration
 	}
 	tests := []struct {
 		name    string
@@ -652,30 +653,83 @@ func TestThresholds_Run(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "Running thresholds of existing sink",
-			args:    args{DummySink{"p(95)": 1234.5}, 0},
+			name: "Running thresholds of existing sink",
+			args: args{
+				sink:                 DummySink{"p(95)": 1234.5},
+				thresholdExpressions: []string{"p(95)<2000"},
+				duration:             0,
+			},
 			want:    true,
 			wantErr: false,
 		},
 		{
-			name:    "Running thresholds of existing sink but failing threshold",
-			args:    args{DummySink{"p(95)": 3000}, 0},
+			name: "Running thresholds of existing sink but failing threshold",
+			args: args{
+				sink:                 DummySink{"p(95)": 3000},
+				thresholdExpressions: []string{"p(95)<2000"},
+				duration:             0,
+			},
 			want:    false,
 			wantErr: false,
 		},
 		{
-			name:    "Running threshold on non existing sink does not fail",
-			args:    args{DummySink{"dummy": 0}, 0},
+			name: "Running threshold on non existing sink does not fail",
+			args: args{
+				sink:                 DummySink{"dummy": 0},
+				thresholdExpressions: []string{"p(95)<2000"},
+				duration:             0,
+			},
 			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Running threshold on trend sink with no values and passing med statement succeeds",
+			args: args{
+				sink:                 &TrendSink{Values: []float64{}, Med: 0},
+				thresholdExpressions: []string{"med<39"},
+				duration:             0,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Running threshold on trend sink with no values and non passing med statement fails",
+			args: args{
+				sink:                 &TrendSink{Values: []float64{}, Med: 0},
+				thresholdExpressions: []string{"med>39"},
+				duration:             0,
+			},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name: "Running threshold on trend sink with values and passing med statement succeeds",
+			args: args{
+				sink:                 &TrendSink{Values: []float64{70, 80, 90}, Count: 3},
+				thresholdExpressions: []string{"med>39"},
+				duration:             0,
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Running threshold on trend sink with values and failing med statement fails",
+			args: args{
+				sink:                 &TrendSink{Values: []float64{70, 80, 90}, Count: 3},
+				thresholdExpressions: []string{"med<39"},
+				duration:             0,
+			},
+			want:    false,
 			wantErr: false,
 		},
 	}
 	for _, testCase := range tests {
 		testCase := testCase
+
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
-			thresholds := NewThresholds([]string{"p(95)<2000"})
+			thresholds := NewThresholds(testCase.args.thresholdExpressions)
 			gotParseErr := thresholds.Parse()
 			require.NoError(t, gotParseErr)
 

--- a/metrics/thresholds_test.go
+++ b/metrics/thresholds_test.go
@@ -685,7 +685,7 @@ func TestThresholdsRun(t *testing.T) {
 		{
 			name: "Running threshold on trend sink with no values and passing med statement succeeds",
 			args: args{
-				sink:                 &TrendSink{Values: []float64{}, Med: 0},
+				sink:                 &TrendSink{Values: []float64{}},
 				thresholdExpressions: []string{"med<39"},
 				duration:             0,
 			},
@@ -695,7 +695,7 @@ func TestThresholdsRun(t *testing.T) {
 		{
 			name: "Running threshold on trend sink with no values and non passing med statement fails",
 			args: args{
-				sink:                 &TrendSink{Values: []float64{}, Med: 0},
+				sink:                 &TrendSink{Values: []float64{}},
 				thresholdExpressions: []string{"med>39"},
 				duration:             0,
 			},


### PR DESCRIPTION
This PR addresses #2755. 

Turns out the Trend Sink median value was never calculated in time for thresholds to be able to evaluate them. The reason for that is that the median value can be quite expensive to compute, as it relies most notably on sorting the sink's array of values. As a result, its calculation happens in a dedicated `Calc` method. It appears we forgot to call that method in the `Thresholds.Run` method during our latest refactoring of the thresholds system.

This PR ensures the `Calc` method is called just in time, so that the costly computation only happens when Thresholds are effectively evaluated. It also adds a couple of tests to protect us from regressions in the future. Finally, it adds some documentation and comments to the code, so that next time we touch that part of the code, there is some background information available to the contributor.

Thanks a lot to @imiric for his collaboration in tracking and getting this issue resolved 🙇🏻 🎉 

Let me know what you think 👍🏻 