### PR TITLE
Fix emission of `ws_session_duration` when setup throws an error

### DIFF
--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -275,9 +275,7 @@ func TestSessionBadTimeout(t *testing.T) {
 		});
 		`))
 	require.ErrorContains(t, err, "setTimeout requires a >0 timeout parameter, received 0.00 ")
-	// TODO SessionDuration is not emitted if the "open" handler returns an error - which is what happens here
-	// see https://github.com/grafana/k6/issues/2734
-	// assertSessionMetricsEmitted(t, metrics.GetBufferedSamples(test.samples), "", sr("WSBIN_URL/ws-echo"), statusProtocolSwitch, "")
+	assertSessionMetricsEmitted(t, metrics.GetBufferedSamples(test.samples), "", sr("WSBIN_URL/ws-echo"), statusProtocolSwitch, "")
 }
 
 func TestSessionPing(t *testing.T) {


### PR DESCRIPTION
Closes #2734

This only fixes the issue, but see #2768 for some related refactoring of `WS.Connect()`.