### PR TITLE
Disable containedctx

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,4 +81,5 @@ linters:
   - decorder
   - nonamedreturns
   - nosnakecase
+  - containedctx
   fast: false


### PR DESCRIPTION
# What?

Disabling the `containedctx`

# Why?

It make no sense for this repo