### PR TITLE
js: make certain only one copy of the exports is used per each module

### DIFF
--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -52,7 +52,7 @@ type InitContext struct {
 
 	logger logrus.FieldLogger
 
-	modules map[string]interface{}
+	moduleRegistry map[string]interface{}
 }
 
 // NewInitContext creates a new initcontext with the provided arguments
@@ -67,7 +67,7 @@ func NewInitContext(
 		programs:          make(map[string]programWithSource),
 		compatibilityMode: compatMode,
 		logger:            logger,
-		modules:           getJSModules(),
+		moduleRegistry:    getJSModules(),
 		exportsCache:      make(map[string]goja.Value),
 		moduleVUImpl: &moduleVUImpl{
 			ctx:     context.Background(),
@@ -96,7 +96,7 @@ func newBoundInitContext(base *InitContext, vuImpl *moduleVUImpl) *InitContext {
 		compatibilityMode: base.compatibilityMode,
 		exportsCache:      make(map[string]goja.Value),
 		logger:            base.logger,
-		modules:           base.modules,
+		moduleRegistry:    base.moduleRegistry,
 		moduleVUImpl:      vuImpl,
 	}
 }
@@ -152,7 +152,7 @@ func toESModuleExports(exp modules.Exports) interface{} {
 }
 
 func (i *InitContext) requireModule(name string) (goja.Value, error) {
-	mod, ok := i.modules[name]
+	mod, ok := i.moduleRegistry[name]
 	if !ok {
 		return nil, fmt.Errorf("unknown module: %s", name)
 	}

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -68,6 +68,7 @@ func NewInitContext(
 		compatibilityMode: compatMode,
 		logger:            logger,
 		modules:           getJSModules(),
+		exports:           make(map[string]goja.Value),
 		moduleVUImpl: &moduleVUImpl{
 			ctx:     context.Background(),
 			runtime: rt,
@@ -93,6 +94,7 @@ func newBoundInitContext(base *InitContext, vuImpl *moduleVUImpl) *InitContext {
 
 		programs:          programs,
 		compatibilityMode: base.compatibilityMode,
+		exports:           make(map[string]goja.Value),
 		logger:            base.logger,
 		modules:           base.modules,
 		moduleVUImpl:      vuImpl,
@@ -105,12 +107,7 @@ func (i *InitContext) Require(arg string) (export goja.Value) {
 	if export, ok = i.exports[arg]; ok {
 		return export
 	}
-	defer func() {
-		if i.exports == nil {
-			i.exports = make(map[string]goja.Value)
-		}
-		i.exports[arg] = export
-	}()
+	defer func() { i.exports[arg] = export }()
 	switch {
 	case arg == "k6", strings.HasPrefix(arg, "k6/"):
 		// Builtin or external modules ("k6", "k6/*", or "k6/x/*") are handled

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -45,8 +45,8 @@ type InitContext struct {
 	pwd         *url.URL
 
 	// Cache of loaded programs and files.
-	programs map[string]programWithSource
-	exports  map[string]goja.Value
+	programs     map[string]programWithSource
+	exportsCache map[string]goja.Value
 
 	compatibilityMode lib.CompatibilityMode
 
@@ -68,7 +68,7 @@ func NewInitContext(
 		compatibilityMode: compatMode,
 		logger:            logger,
 		modules:           getJSModules(),
-		exports:           make(map[string]goja.Value),
+		exportsCache:      make(map[string]goja.Value),
 		moduleVUImpl: &moduleVUImpl{
 			ctx:     context.Background(),
 			runtime: rt,
@@ -94,7 +94,7 @@ func newBoundInitContext(base *InitContext, vuImpl *moduleVUImpl) *InitContext {
 
 		programs:          programs,
 		compatibilityMode: base.compatibilityMode,
-		exports:           make(map[string]goja.Value),
+		exportsCache:      make(map[string]goja.Value),
 		logger:            base.logger,
 		modules:           base.modules,
 		moduleVUImpl:      vuImpl,
@@ -104,10 +104,10 @@ func newBoundInitContext(base *InitContext, vuImpl *moduleVUImpl) *InitContext {
 // Require is called when a module/file needs to be loaded by a script
 func (i *InitContext) Require(arg string) (export goja.Value) {
 	var ok bool
-	if export, ok = i.exports[arg]; ok {
+	if export, ok = i.exportsCache[arg]; ok {
 		return export
 	}
-	defer func() { i.exports[arg] = export }()
+	defer func() { i.exportsCache[arg] = export }()
 	switch {
 	case arg == "k6", strings.HasPrefix(arg, "k6/"):
 		// Builtin or external modules ("k6", "k6/*", or "k6/x/*") are handled

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -692,20 +692,20 @@ func TestImportModificationsAreConsistentBetweenFiles(t *testing.T) {
 	t.Parallel()
 	logger := testutils.NewLogger(t)
 	fs := afero.NewMemMapFs()
-	require.NoError(t, afero.WriteFile(fs, "/notk6.js", []byte(`export function group() {}`), 0o644))
+	require.NoError(t, afero.WriteFile(fs, "/notk6.js", []byte(`export default {group}; function group() {}`), 0o644))
 	require.NoError(t, afero.WriteFile(fs, "/instrument.js", []byte(`
     import k6 from "k6";
     k6.newKey = 5;
     k6.group = 3;
 
-    import * as notk6 from "./notk6.js";
+    import notk6 from "./notk6.js";
     notk6.group = 3;
     notk6.newKey = 5;
     `), 0o644))
 
 	b, err := getSimpleBundle(t, "/script.js", `
     import k6 from "k6";
-    import * as notk6 from "./notk6.js";
+    import notk6 from "./notk6.js";
     import "./instrument.js";
     if (k6.newKey != 5) { throw "k6.newKey is wrong "+ k6.newKey}
     if (k6.group != 3) { throw "k6.group is wrong "+ k6.group}


### PR DESCRIPTION
This is inline with ESM and works for source code modules, but not for modules written in go as teh code was never made to work with it.

This also lets (as the test suggests) change what `k6/http`.get is across the VU just as it should be possible.

