### PR TITLE
Move to Iterative Trie implementation (`trieNode`)

### DIFF
--- a/lib/types/hostnametrie.go
+++ b/lib/types/hostnametrie.go
@@ -127,7 +127,8 @@ func (t *HostnameTrie) insert(s string) error {
 		return err
 	}
 
-	return t.trieNode.insert(s)
+	t.trieNode.insert(s)
+	return nil
 }
 
 // Contains returns whether s matches a pattern in the HostnameTrie

--- a/lib/types/hostnametrie.go
+++ b/lib/types/hostnametrie.go
@@ -134,5 +134,6 @@ func (t *HostnameTrie) insert(s string) error {
 // Contains returns whether s matches a pattern in the HostnameTrie
 // along with the matching pattern, if one was found.
 func (t *HostnameTrie) Contains(s string) (matchedPattern string, matchFound bool) {
+	s = strings.ToLower(s)
 	return t.trieNode.contains(s)
 }

--- a/lib/types/trie.go
+++ b/lib/types/trie.go
@@ -7,10 +7,10 @@ type trieNode struct {
 	children map[rune]*trieNode
 }
 
-func (t *trieNode) insert(s string) error {
+func (t *trieNode) insert(s string) {
 	if len(s) == 0 {
 		t.isLeaf = true
-		return nil
+		return
 	}
 
 	// mask creation of the trie by initializing the root here
@@ -21,11 +21,12 @@ func (t *trieNode) insert(s string) error {
 	rStr := []rune(s) // need to iterate by runes for intl' names
 	last := len(rStr) - 1
 	if c, ok := t.children[rStr[last]]; ok {
-		return c.insert(string(rStr[:last]))
+		c.insert(string(rStr[:last]))
+		return
 	}
 
 	t.children[rStr[last]] = &trieNode{children: make(map[rune]*trieNode)}
-	return t.children[rStr[last]].insert(string(rStr[:last]))
+	t.children[rStr[last]].insert(string(rStr[:last]))
 }
 
 func (t *trieNode) contains(s string) (matchedPattern string, matchFound bool) {

--- a/lib/types/trie.go
+++ b/lib/types/trie.go
@@ -1,0 +1,52 @@
+package types
+
+import "strings"
+
+type trieNode struct {
+	isLeaf   bool
+	children map[rune]*trieNode
+}
+
+func (t *trieNode) insert(s string) error {
+	if len(s) == 0 {
+		t.isLeaf = true
+		return nil
+	}
+
+	// mask creation of the trie by initializing the root here
+	if t.children == nil {
+		t.children = make(map[rune]*trieNode)
+	}
+
+	rStr := []rune(s) // need to iterate by runes for intl' names
+	last := len(rStr) - 1
+	if c, ok := t.children[rStr[last]]; ok {
+		return c.insert(string(rStr[:last]))
+	}
+
+	t.children[rStr[last]] = &trieNode{children: make(map[rune]*trieNode)}
+	return t.children[rStr[last]].insert(string(rStr[:last]))
+}
+
+func (t *trieNode) contains(s string) (matchedPattern string, matchFound bool) {
+	s = strings.ToLower(s)
+	if len(s) == 0 {
+		if t.isLeaf {
+			return "", true
+		}
+	} else {
+		rStr := []rune(s)
+		last := len(rStr) - 1
+		if c, ok := t.children[rStr[last]]; ok {
+			if match, matched := c.contains(string(rStr[:last])); matched {
+				return match + string(rStr[last]), true
+			}
+		}
+	}
+
+	if _, wild := t.children['*']; wild {
+		return "*", true
+	}
+
+	return "", false
+}

--- a/lib/types/trie.go
+++ b/lib/types/trie.go
@@ -16,12 +16,11 @@ func (t *trieNode) insert(s string) {
 
 	ptr := t
 	for i := len(runes) - 1; i >= 0; i-- {
-		r := runes[i]
-		c, ok := ptr.children[r]
+		c, ok := ptr.children[runes[i]]
 
 		if !ok {
-			ptr.children[r] = &trieNode{children: map[rune]*trieNode{}}
-			c = ptr.children[r]
+			ptr.children[runes[i]] = &trieNode{children: map[rune]*trieNode{}}
+			c = ptr.children[runes[i]]
 		}
 
 		ptr = c
@@ -39,9 +38,8 @@ func (t *trieNode) contains(s string) (string, bool) {
 	ptr := t
 	for i := len(rs) - 1; i >= 0; i-- {
 		child, ok := ptr.children[rs[i]]
-		_, wOk := ptr.children['*']
 
-		if wOk {
+		if _, wOk := ptr.children['*']; wOk {
 			wMatch = builder.String() + string('*')
 		}
 
@@ -55,18 +53,18 @@ func (t *trieNode) contains(s string) (string, bool) {
 	}
 
 	if found && ptr.isLeaf {
-		return reverse(builder.String()), true
+		return reverseString(builder.String()), true
 	}
 
 	if _, ok := ptr.children['*']; ok {
 		builder.WriteRune('*')
-		return reverse(builder.String()), true
+		return reverseString(builder.String()), true
 	}
 
-	return reverse(wMatch), wMatch != ""
+	return reverseString(wMatch), wMatch != ""
 }
 
-func reverse(s string) string {
+func reverseString(s string) string {
 	rs := []rune(s)
 	for i, j := 0, len(rs)-1; i < len(rs)/2; i, j = i+1, j-1 {
 		rs[i], rs[j] = rs[j], rs[i]

--- a/lib/types/trie.go
+++ b/lib/types/trie.go
@@ -31,7 +31,7 @@ func (t *trieNode) insert(s string) {
 }
 
 func (t *trieNode) contains(s string) (string, bool) {
-	rs := []rune(strings.ToLower(s))
+	rs := []rune(s)
 
 	builder, wMatch := strings.Builder{}, ""
 	found := true

--- a/lib/types/trie_test.go
+++ b/lib/types/trie_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTrieInsert(t *testing.T) {
@@ -61,7 +62,27 @@ func TestTrieContains(t *testing.T) {
 			require.Equal(t, tc.expVal, val)
 		})
 	}
+}
 
+func TestReverse(t *testing.T) {
+	t.Parallel()
+
+	tcs := []struct{ str, rev string }{
+		{str: "even", rev: "neve"},
+		{str: "odd", rev: "ddo"},
+		{str: "", rev: ""},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+
+		t.Run(tc.str, func(t *testing.T) {
+			t.Parallel()
+			val := reverse(tc.str)
+
+			require.Equal(t, tc.rev, val)
+		})
+	}
 }
 
 func BenchmarkTrieInsert(b *testing.B) {

--- a/lib/types/trie_test.go
+++ b/lib/types/trie_test.go
@@ -64,7 +64,7 @@ func TestTrieContains(t *testing.T) {
 	}
 }
 
-func TestReverse(t *testing.T) {
+func TestReverseString(t *testing.T) {
 	t.Parallel()
 
 	tcs := []struct{ str, rev string }{
@@ -78,7 +78,7 @@ func TestReverse(t *testing.T) {
 
 		t.Run(tc.str, func(t *testing.T) {
 			t.Parallel()
-			val := reverse(tc.str)
+			val := reverseString(tc.str)
 
 			require.Equal(t, tc.rev, val)
 		})

--- a/lib/types/trie_test.go
+++ b/lib/types/trie_test.go
@@ -1,6 +1,68 @@
 package types
 
-import "testing"
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestTrieInsert(t *testing.T) {
+	t.Parallel()
+
+	root := trieNode{}
+
+	const val = "k6.io"
+	root.insert(val)
+
+	ptr := &root
+	for i, rs := len(val)-1, []rune(val); i >= 0; i-- {
+		next, ok := ptr.children[rs[i]]
+		require.True(t, ok)
+		ptr = next
+	}
+
+	require.True(t, ptr.isLeaf)
+}
+
+func TestTrieContains(t *testing.T) {
+	t.Parallel()
+
+	root := trieNode{}
+	root.insert("k6.io")
+	root.insert("specific.k6.io")
+	root.insert("*.k6.io")
+
+	tcs := []struct {
+		query, expVal string
+		found         bool
+	}{
+		// Trie functionality
+		{query: "k6.io", expVal: "k6.io", found: true},
+		{query: "io", expVal: "", found: false},
+		{query: "no.k6.no.io", expVal: "", found: false},
+		{query: "specific.k6.io", expVal: "specific.k6.io", found: true},
+		{query: "", expVal: "", found: false},
+		{query: "long.long.long.long.long.long.long.long.no.match", expVal: "", found: false},
+		{query: "pre.matching.long.long.long.long.test.k6.noio", expVal: "", found: false},
+
+		// Wildcard
+		{query: "foo.k6.io", expVal: "*.k6.io", found: true},
+		{query: "specific.k6.io", expVal: "specific.k6.io", found: true},
+		{query: "not.specific.k6.io", expVal: "*.k6.io", found: true},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.query, func(t *testing.T) {
+			t.Parallel()
+
+			val, ok := root.contains(tc.query)
+
+			require.Equal(t, tc.found, ok)
+			require.Equal(t, tc.expVal, val)
+		})
+	}
+
+}
 
 func BenchmarkTrieInsert(b *testing.B) {
 	arr := []string{

--- a/lib/types/trie_test.go
+++ b/lib/types/trie_test.go
@@ -1,0 +1,37 @@
+package types
+
+import "testing"
+
+func BenchmarkTrieInsert(b *testing.B) {
+	arr := []string{
+		"k6.io", "*.sub.k6.io", "specific.sub.k6.io",
+		"grafana.com", "*.sub.sub.grafana.com", "test.sub.sub.grafana.com",
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		root := trieNode{}
+		for _, v := range arr {
+			root.insert(v)
+		}
+	}
+}
+
+func BenchmarkTrieContains(b *testing.B) {
+	root := trieNode{}
+	arr := []string{
+		"k6.io", "*.sub.k6.io", "specific.sub.k6.io",
+		"grafana.com", "*.sub.sub.grafana.com", "test.sub.sub.grafana.com",
+	}
+
+	for _, v := range arr {
+		root.insert(v)
+	}
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		for _, v := range arr {
+			root.contains(v)
+		}
+	}
+}

--- a/lib/types/types.go
+++ b/lib/types/types.go
@@ -1,3 +1,6 @@
+// Package types contains types used in the codebase
+// Most of the types have a Null prefix like gopkg.in/guregu/null.v3
+// and UnmarshalJSON and MarshalJSON methods.
 package types
 
 import (


### PR DESCRIPTION
Hi @codebien 👋🏻 here is the aforementioned PR

What have changed:

- Moved `trieNode` to separate file
- New unit tests for trie implementation
- New benchmarks for the `trieNode.insert()` and `trieNode.contains()` methods
- Moved from recursive to iterative implementation

Here is a simple script that I used to create the benchmarks on my machine.

```bash
bench(){
  echo "started: $2 benchmark"
  git checkout "$1"  2> /dev/null
  go test -run=^$ -bench=BenchmarkTrie -benchmem -count 30 > "$2"
}

cd lib/types

bench 2f14099  "original"
bench e11e0679 "remove_error"
bench 08933201 "iterative"

benchstat original remove_error > "bs_remove_error"
benchstat original iterative > "bs_iterative"
```

# Benchmarks

My machine was idle.

```
goos: darwin
goarch: amd64
pkg: go.k6.io/k6/lib/types
cpu: Intel(R) Core(TM) i5-8257U CPU @ 1.40GHz
```

##  `bs_iterative`

```
name            old time/op    new time/op    delta
TrieInsert-8      13.3µs ± 1%     6.3µs ± 1%  -52.78%  (p=0.000 n=29+30)
TrieContains-8    11.7µs ± 2%     3.1µs ± 1%  -73.01%  (p=0.000 n=30+27)

name            old alloc/op   new alloc/op   delta
TrieInsert-8      7.46kB ± 0%    7.46kB ± 0%     ~     (all equal)
TrieContains-8    1.02kB ± 0%    0.42kB ± 0%  -58.27%  (p=0.000 n=30+30)

name            old allocs/op  new allocs/op  delta
TrieInsert-8         130 ± 0%       130 ± 0%     ~     (all equal)
TrieContains-8      90.0 ± 0%      24.0 ± 0%  -73.33%  (p=0.000 n=30+30)
```

##  `bs_remove_error`

```
name          old time/op    new time/op    delta
TrieInsert-8    14.0µs ± 0%    13.3µs ± 1%   ~     (p=0.106 n=1+28)

name          old alloc/op   new alloc/op   delta
TrieInsert-8    7.46kB ± 0%    7.46kB ± 0%   ~     (all equal)

name          old allocs/op  new allocs/op  delta
TrieInsert-8       130 ± 0%       130 ± 0%   ~     (all equal)
```
