### PR TITLE
Integration test improvements and a few bugfixes

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -735,7 +735,14 @@ func TestAbortedByScriptSetupError(t *testing.T) {
 
 	newRootCommand(ts.globalState).execute()
 
+	// FIXME: remove this locking after VU initialization accepts a context and
+	// is properly synchronized: currently when a test is aborted during the
+	// init phase, some logs might be emitted after the above command returns...
+	// see: https://github.com/grafana/k6/issues/2790
+	ts.outMutex.Lock()
 	stdOut := ts.stdOut.String()
+	ts.outMutex.Unlock()
+
 	t.Log(stdOut)
 	require.Contains(t, stdOut, `wonky setup`)
 	require.Contains(t, stdOut, `Error: foo`)
@@ -794,7 +801,14 @@ func TestAbortedByScriptInitError(t *testing.T) {
 
 	newRootCommand(ts.globalState).execute()
 
+	// FIXME: remove this locking after VU initialization accepts a context and
+	// is properly synchronized: currently when a test is aborted during the
+	// init phase, some logs might be emitted after the above command returns...
+	// see: https://github.com/grafana/k6/issues/2790
+	ts.outMutex.Lock()
 	stdOut := ts.stdOut.String()
+	ts.outMutex.Unlock()
+
 	t.Log(stdOut)
 	require.Contains(t, stdOut, `Error: foo`)
 	require.Contains(t, stdOut, `level=debug msg="Sending test finished" output=cloud ref=111 run_status=7 tainted=false`)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -256,6 +256,7 @@ func (c *rootCommand) execute() {
 	if err == nil {
 		cancel()
 		c.waitRemoteLogger()
+		// TODO: explicitly call c.globalState.osExit(0), for simpler tests and clarity?
 		return
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -52,9 +52,19 @@ func newGlobalTestState(t *testing.T) *globalTestState {
 		stdErr:     new(bytes.Buffer),
 	}
 
+	osExitCalled := false
 	defaultOsExitHandle := func(exitCode int) {
 		cancel()
+		osExitCalled = true
 		require.Equal(t, ts.expectedExitCode, exitCode)
+	}
+
+	if ts.expectedExitCode > 0 {
+		// Ensure that, if we expected to receive an error, our `os.Exit()` mock
+		// function was actually called.
+		t.Cleanup(func() {
+			assert.True(t, osExitCalled)
+		})
 	}
 
 	outMutex := &sync.Mutex{}

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -634,15 +634,16 @@ func (out *Output) testFinished() error {
 		}
 	}
 
-	out.logger.WithFields(logrus.Fields{
-		"ref":     out.referenceID,
-		"tainted": testTainted,
-	}).Debug("Sending test finished")
-
 	runStatus := lib.RunStatusFinished
 	if out.runStatus != lib.RunStatusQueued {
 		runStatus = out.runStatus
 	}
+
+	out.logger.WithFields(logrus.Fields{
+		"ref":        out.referenceID,
+		"tainted":    testTainted,
+		"run_status": runStatus,
+	}).Debug("Sending test finished")
 
 	return out.client.TestFinished(out.referenceID, thresholdResults, testTainted, runStatus)
 }


### PR DESCRIPTION
Split among the first 3 commits are various improvements and additions to the existing integration tests: 
- proper exit code detection in integration tests
- mocking of the cloud API and checks for `run_status` and `result_status` values in `k6 run --out cloud` tests
- support for using and testing the k6 REST API in integration tests, without port collisions
- support for mocking signals (like Ctrl+C) mid-test run

The 4th commit actually fixes https://github.com/grafana/k6/issues/2788, a small bug I noticed while trying to remove the whole `core.Engine`  (https://github.com/grafana/k6/issues/1889). However, because the `Engine` removal will likely be merged at the start of the v0.43.0 cycle and because the bug was easy to fix even in the current implementation, I decided to fix it now. 

This way we'll get the fix released in k6 v0.42.0 and I'll have the test already present in `master`, in preparation for the bigger PR.

The 5th commit fixes a minor data-race with the progressbars and masks a few others with dangling goroutines after errors in the init phase, see https://github.com/grafana/k6/pull/2789#issuecomment-1333523756 for details. And the 7th commit fixes another minor data race in the old `Engine`, see https://github.com/grafana/k6/pull/2789#issuecomment-1334226870.