### PR TITLE
Wait for metrics handling to finish even when there is an error

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -185,35 +185,27 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) error {
 
 	// Start the test run
 	initBar.Modify(pb.WithConstProgress(0, "Starting test..."))
-	var interrupt error
 	err = engineRun()
 	if err != nil {
-		err = common.UnwrapGojaInterruptedError(err)
-		if errext.IsInterruptError(err) {
-			// Don't return here since we need to work with --linger,
-			// show the end-of-test summary and exit cleanly.
-			interrupt = err
-		}
-		if !conf.Linger.Bool && interrupt == nil {
-			return errext.WithExitCodeIfNone(err, exitcodes.GenericEngine)
-		}
+		logger.WithError(err).Debug("Engine terminated with an error")
+	} else {
+		logger.Debug("Engine run terminated cleanly")
 	}
 	runCancel()
-	logger.Debug("Engine run terminated cleanly")
 
 	progressCancel()
 	progressBarWG.Wait()
 
 	executionState := execScheduler.GetState()
 	// Warn if no iterations could be completed.
-	if executionState.GetFullIterationCount() == 0 {
+	if err == nil && executionState.GetFullIterationCount() == 0 {
 		logger.Warn("No script iterations finished, consider making the test duration longer")
 	}
 
 	// Handle the end-of-test summary.
 	if !testRunState.RuntimeOptions.NoSummary.Bool {
 		engine.MetricsEngine.MetricsLock.Lock() // TODO: refactor so this is not needed
-		summaryResult, err := test.initRunner.HandleSummary(globalCtx, &lib.Summary{
+		summaryResult, hsErr := test.initRunner.HandleSummary(globalCtx, &lib.Summary{
 			Metrics:         engine.MetricsEngine.ObservedMetrics,
 			RootGroup:       execScheduler.GetRunner().GetDefaultGroup(),
 			TestRunDuration: executionState.GetCurrentTestRunDuration(),
@@ -224,11 +216,11 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) error {
 			},
 		})
 		engine.MetricsEngine.MetricsLock.Unlock()
-		if err == nil {
-			err = handleSummaryResult(c.gs.fs, c.gs.stdOut, c.gs.stdErr, summaryResult)
+		if hsErr == nil {
+			hsErr = handleSummaryResult(c.gs.fs, c.gs.stdOut, c.gs.stdErr, summaryResult)
 		}
-		if err != nil {
-			logger.WithError(err).Error("failed to handle the end-of-test summary")
+		if hsErr != nil {
+			logger.WithError(hsErr).Error("failed to handle the end-of-test summary")
 		}
 	}
 
@@ -250,12 +242,12 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) error {
 	engineWait()
 	logger.Debug("Everything has finished, exiting k6!")
 	if test.keyLogger != nil {
-		if err := test.keyLogger.Close(); err != nil {
-			logger.WithError(err).Warn("Error while closing the SSLKEYLOGFILE")
+		if klErr := test.keyLogger.Close(); klErr != nil {
+			logger.WithError(klErr).Warn("Error while closing the SSLKEYLOGFILE")
 		}
 	}
-	if interrupt != nil {
-		return interrupt
+	if err != nil {
+		return errext.WithExitCodeIfNone(common.UnwrapGojaInterruptedError(err), exitcodes.GenericEngine)
 	}
 	if engine.IsTainted() {
 		return errext.WithExitCodeIfNone(errors.New("some thresholds have failed"), exitcodes.ThresholdsHaveFailed)

--- a/core/engine.go
+++ b/core/engine.go
@@ -263,6 +263,7 @@ func (e *Engine) processMetrics(globalCtx context.Context, processMetricsAfterRu
 			e.thresholdsTainted = thresholdsTainted
 			e.thresholdsTaintedLock.Unlock()
 		}
+		e.logger.Debug("Metrics processing finished!")
 	}()
 
 	ticker := time.NewTicker(collectRate)


### PR DESCRIPTION
Before these changes, `setup()` and `teardown()` exceptions or `test.abort()` calls would have made k6 exit prematurely, without waiting for the metrics processing to finish. **This bug was probably a cause for some of the "timed out" `k6 run --out cloud` tests we have seen, e.g. if they had some sort an error in `setup()` or `teardown()`.** It also caused a data race in the recent integration tests, this is how I caught it. So, as a nice bonus, this fix allowed me to remove one of the `FIXME`s for unnecessary locking in there earlier than expected :tada: 

This is another thing that should be fixed by the new `Engine`-less architecture (https://github.com/grafana/k6/issues/1889). However, once again, the fix was easy enough to do even now, and the bug severe enough that it's probably worth it to include it in the upcoming k6 v0.42.0. 

I also added and expanded a bunch of integration tests, particularly when it comes to validating aborted tests and `--linger`, and this PR is built on top of https://github.com/grafana/k6/pull/2795, so hopefully its last minute merging won't cause any regressions :crossed_fingers: :pray: :prayer_beads: .

It seemed like the bug might have been introduced in k6 v0.36.0, via https://github.com/grafana/k6/pull/2093 (the PR that added `test.abort()`), but it was actually probably introduced way back in k6 v0.27.0, with https://github.com/grafana/k6/pull/1390, or even older... :disappointed: Still, the added tests for `test.abort()` and setup/teardown exceptions should provide some assurance now and in the future.