### PR TITLE
Prevent real requests to the cloud during integration tests

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -154,7 +154,7 @@ func TestWrongEnvVarIterations(t *testing.T) {
 
 	ts := newGlobalTestState(t)
 	ts.args = []string{"k6", "run", "--vus", "2", "-"}
-	ts.envVars = map[string]string{"K6_ITERATIONS": "4"}
+	ts.envVars["K6_ITERATIONS"] = "4"
 	ts.stdIn = bytes.NewBufferString(`export default function() {};`)
 
 	newRootCommand(ts.globalState).execute()
@@ -280,7 +280,7 @@ func testSSLKEYLOGFILE(t *testing.T, ts *globalTestState, filePath string) {
 	// TODO don't use insecureSkipTLSVerify when/if tlsConfig is given to the runner from outside
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	ts.args = []string{"k6", "run", "-"}
-	ts.envVars = map[string]string{"SSLKEYLOGFILE": filePath}
+	ts.envVars["SSLKEYLOGFILE"] = filePath
 	ts.stdIn = bytes.NewReader([]byte(tb.Replacer.Replace(`
     import http from "k6/http"
     export const options = {
@@ -473,7 +473,7 @@ func getSimpleCloudOutputTestState(
 
 	ts := newGlobalTestState(t)
 	require.NoError(t, afero.WriteFile(ts.fs, filepath.Join(ts.cwd, "test.js"), script, 0o644))
-	ts.envVars = map[string]string{"K6_CLOUD_HOST": srv.URL}
+	ts.envVars["K6_CLOUD_HOST"] = srv.URL
 	ts.args = append([]string{"k6", "run", "--out", "cloud", "test.js"}, cliFlags...)
 	ts.expectedExitCode = expExitCode
 
@@ -765,7 +765,7 @@ func TestAbortedByScriptSetupErrorWithDependency(t *testing.T) {
 	require.NoError(t, afero.WriteFile(ts.fs, filepath.Join(ts.cwd, "test.js"), mainScript, 0o644))
 	require.NoError(t, afero.WriteFile(ts.fs, filepath.Join(ts.cwd, "bar.js"), depScript, 0o644))
 
-	ts.envVars = map[string]string{"K6_CLOUD_HOST": srv.URL}
+	ts.envVars["K6_CLOUD_HOST"] = srv.URL
 	ts.args = []string{"k6", "run", "-v", "--out", "cloud", "--log-output=stdout", "test.js"}
 	ts.expectedExitCode = int(exitcodes.ScriptException)
 
@@ -1446,7 +1446,8 @@ func TestRunTags(t *testing.T) {
 		"k6", "run", "-u", "2", "--tag", "foo=bar", "--tag", "test=mest", "--tag", "over=written",
 		"--log-output=stdout", "--out", "json=results.json", "test.js",
 	}
-	ts.envVars = map[string]string{"K6_ITERATIONS": "3", "K6_INSECURE_SKIP_TLS_VERIFY": "true"}
+	ts.envVars["K6_ITERATIONS"] = "3"
+	ts.envVars["K6_INSECURE_SKIP_TLS_VERIFY"] = "true"
 	newRootCommand(ts.globalState).execute()
 
 	stdOut := ts.stdOut.String()

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -3,7 +3,10 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"net"
+	"net/http"
+	"os"
 	"os/signal"
 	"runtime"
 	"strconv"
@@ -17,6 +20,49 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/lib/testutils"
 )
+
+type blockingTransport struct {
+	fallback       http.RoundTripper
+	forbiddenHosts map[string]bool
+	counter        uint32
+}
+
+func (bt *blockingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	host := req.URL.Hostname()
+	if bt.forbiddenHosts[host] {
+		atomic.AddUint32(&bt.counter, 1)
+		panic(fmt.Errorf("trying to make forbidden request to %s during test", host))
+	}
+	return bt.fallback.RoundTrip(req)
+}
+
+func TestMain(m *testing.M) {
+	exitCode := 1 // error out by default
+	defer func() {
+		os.Exit(exitCode)
+	}()
+
+	bt := &blockingTransport{
+		fallback: http.DefaultTransport,
+		forbiddenHosts: map[string]bool{
+			"ingest.k6.io":    true,
+			"cloudlogs.k6.io": true,
+			"app.k6.io":       true,
+			"reports.k6.io":   true,
+		},
+	}
+	http.DefaultTransport = bt
+	defer func() {
+		if bt.counter > 0 {
+			fmt.Printf("Expected blocking transport count to be 0 but was %d\n", bt.counter) //nolint:forbidigo
+			exitCode = 2
+		}
+	}()
+
+	// TODO: add https://github.com/uber-go/goleak
+
+	exitCode = m.Run()
+}
 
 type globalTestState struct {
 	*globalState
@@ -99,7 +145,7 @@ func newGlobalTestState(t *testing.T) *globalTestState {
 		fs:             fs,
 		getwd:          func() (string, error) { return ts.cwd, nil },
 		args:           []string{},
-		envVars:        map[string]string{},
+		envVars:        map[string]string{"K6_NO_USAGE_REPORT": "true"},
 		defaultFlags:   defaultFlags,
 		flags:          defaultFlags,
 		outMutex:       outMutex,


### PR DESCRIPTION
These integration tests might have been a little too real... :sweat_smile: 

The first commit masks a data race around stdout (only until https://github.com/grafana/k6/pull/2800 is merged) and a flaky check. The second commit ensures integration tests don't make usage report requests and adds a check to hopefully prevent a similar mistake in the future.