### PR TITLE
Show bundled extension versions in `k6 run` and `k6 version` outputs

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -41,7 +41,7 @@ func TestVersion(t *testing.T) {
 	assert.Contains(t, stdOut, runtime.Version())
 	assert.Contains(t, stdOut, runtime.GOOS)
 	assert.Contains(t, stdOut, runtime.GOARCH)
-	assert.NotContains(t, stdOut[:len(stdOut)-1], "\n")
+	assert.Contains(t, stdOut, "k6/x/alarmist")
 
 	assert.Empty(t, ts.stdErr.Bytes())
 	assert.Empty(t, ts.loggerHook.Drain())

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -40,9 +40,9 @@ func getAllOutputConstructors() (map[string]output.Constructor, error) {
 		if _, ok := result[e.Name]; ok {
 			return nil, fmt.Errorf("invalid output extension %s, built-in output with the same type already exists", e.Name)
 		}
-		m, ok := e.Mod.(output.Constructor)
+		m, ok := e.Module.(output.Constructor)
 		if !ok {
-			return nil, fmt.Errorf("unexpected output extension type %T", e.Mod)
+			return nil, fmt.Errorf("unexpected output extension type %T", e.Module)
 		}
 		result[e.Name] = m
 	}

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -17,6 +17,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/output"
@@ -81,7 +82,13 @@ func getColor(noColor bool, attributes ...color.Attribute) *color.Color {
 
 func getBanner(noColor bool) string {
 	c := getColor(noColor, color.FgCyan)
-	return c.Sprint(consts.Banner())
+	banner := make([]string, 0, len(modules.GetJSModuleVersions())+1)
+
+	banner = append(banner, consts.Banner())
+	for pkg, version := range modules.GetJSModuleVersions() {
+		banner = append(banner, fmt.Sprintf("extension  %s %s", pkg, version))
+	}
+	return c.Sprint(strings.Join(banner, "\n"))
 }
 
 func printBanner(gs *globalState) {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -17,7 +17,6 @@ import (
 
 	"gopkg.in/yaml.v3"
 
-	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/output"
@@ -82,13 +81,7 @@ func getColor(noColor bool, attributes ...color.Attribute) *color.Color {
 
 func getBanner(noColor bool) string {
 	c := getColor(noColor, color.FgCyan)
-	banner := make([]string, 0, len(modules.GetJSModuleVersions())+1)
-
-	banner = append(banner, consts.Banner())
-	for pkg, version := range modules.GetJSModuleVersions() {
-		banner = append(banner, fmt.Sprintf("extension  %s %s", pkg, version))
-	}
-	return c.Sprint(strings.Join(banner, "\n"))
+	return c.Sprint(consts.Banner())
 }
 
 func printBanner(gs *globalState) {

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -17,6 +17,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"go.k6.io/k6/ext"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/output"
@@ -136,6 +137,12 @@ func printExecutionDescription(
 	buf := &strings.Builder{}
 	fmt.Fprintf(buf, "  execution: %s\n", valueColor.Sprint(execution))
 	fmt.Fprintf(buf, "     script: %s\n", valueColor.Sprint(filename))
+
+	if exts := ext.GetAll(); len(exts) > 0 {
+		extsDesc := getExtensionsDescription(exts, 13, 1)
+		fmt.Fprintf(buf, " extensions: %s\n",
+			valueColor.Sprint(strings.Join(extsDesc, "\n")))
+	}
 
 	var outputDescriptions []string
 	switch {
@@ -400,4 +407,18 @@ func yamlPrint(w io.Writer, v interface{}) error {
 		return fmt.Errorf("could flush the data to the output: %w", err)
 	}
 	return nil
+}
+
+func getExtensionsDescription(exts []*ext.Extension, leftPad, padStart int) []string {
+	extsDesc := make([]string, 0, len(exts))
+	for i, e := range exts {
+		desc := e.String()
+		extFmt := "%s"
+		if i >= padStart {
+			extFmt = fmt.Sprintf("%%%ds", len(desc)+leftPad)
+		}
+		extsDesc = append(extsDesc, fmt.Sprintf(extFmt, desc))
+	}
+
+	return extsDesc
 }

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -139,7 +139,7 @@ func printExecutionDescription(
 	fmt.Fprintf(buf, "     script: %s\n", valueColor.Sprint(filename))
 
 	if exts := ext.GetAll(); len(exts) > 0 {
-		extsDesc := getExtensionsDescription(exts, 13, 1)
+		extsDesc := formatExtensionsDescription(exts, 13, 1)
 		fmt.Fprintf(buf, " extensions: %s\n",
 			valueColor.Sprint(strings.Join(extsDesc, "\n")))
 	}
@@ -409,7 +409,7 @@ func yamlPrint(w io.Writer, v interface{}) error {
 	return nil
 }
 
-func getExtensionsDescription(exts []*ext.Extension, leftPad, padStart int) []string {
+func formatExtensionsDescription(exts []*ext.Extension, leftPad, padStart int) []string {
 	extsDesc := make([]string, 0, len(exts))
 	for i, e := range exts {
 		desc := e.String()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib/consts"
 )
 
@@ -16,6 +17,9 @@ func getCmdVersion(globalState *globalState) *cobra.Command {
 		Long:  `Show the application version and exit.`,
 		Run: func(_ *cobra.Command, _ []string) {
 			printToStdout(globalState, fmt.Sprintf("k6 v%s\n", consts.FullVersion()))
+			for path, version := range modules.GetJSModuleVersions() {
+				printToStdout(globalState, fmt.Sprintf("extension %s %s\n", path, version))
+			}
 		},
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"go.k6.io/k6/ext"
 	"go.k6.io/k6/lib/consts"
 )
 
@@ -16,6 +18,12 @@ func getCmdVersion(globalState *globalState) *cobra.Command {
 		Long:  `Show the application version and exit.`,
 		Run: func(_ *cobra.Command, _ []string) {
 			printToStdout(globalState, fmt.Sprintf("k6 v%s\n", consts.FullVersion()))
+
+			if exts := ext.GetAll(); len(exts) > 0 {
+				extsDesc := getExtensionsDescription(exts, 2, 0)
+				printToStdout(globalState, fmt.Sprintf("Extensions:\n%s\n",
+					strings.Join(extsDesc, "\n")))
+			}
 		},
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,7 +20,7 @@ func getCmdVersion(globalState *globalState) *cobra.Command {
 			printToStdout(globalState, fmt.Sprintf("k6 v%s\n", consts.FullVersion()))
 
 			if exts := ext.GetAll(); len(exts) > 0 {
-				extsDesc := getExtensionsDescription(exts, 2, 0)
+				extsDesc := formatExtensionsDescription(exts, 2, 0)
 				printToStdout(globalState, fmt.Sprintf("Extensions:\n%s\n",
 					strings.Join(extsDesc, "\n")))
 			}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib/consts"
 )
 
@@ -17,9 +16,6 @@ func getCmdVersion(globalState *globalState) *cobra.Command {
 		Long:  `Show the application version and exit.`,
 		Run: func(_ *cobra.Command, _ []string) {
 			printToStdout(globalState, fmt.Sprintf("k6 v%s\n", consts.FullVersion()))
-			for path, version := range modules.GetJSModuleVersions() {
-				printToStdout(globalState, fmt.Sprintf("extension %s %s\n", path, version))
-			}
 		},
 	}
 }

--- a/ext/doc.go
+++ b/ext/doc.go
@@ -1,0 +1,3 @@
+// Package ext contains the extension registry and all generic functionality for
+// k6 extensions.
+package ext

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -65,7 +65,7 @@ func Register(name string, typ ExtensionType, mod interface{}) {
 		panic(fmt.Sprintf("extension already registered: %s", name))
 	}
 
-	path, version := getModuleInfo(mod)
+	path, version := extractModuleInfo(mod)
 
 	exts[name] = &Extension{
 		Name:    name,
@@ -120,9 +120,9 @@ func GetAll() []*Extension {
 	return result
 }
 
-// getModuleInfo attempts to return the package path and version of the Go
+// extractModuleInfo attempts to return the package path and version of the Go
 // module that created the given value.
-func getModuleInfo(mod interface{}) (path, version string) {
+func extractModuleInfo(mod interface{}) (path, version string) {
 	t := reflect.TypeOf(mod)
 
 	switch t.Kind() {

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -1,0 +1,160 @@
+package ext
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"runtime/debug"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// TODO: Make an ExtensionRegistry?
+//
+//nolint:gochecknoglobals
+var (
+	mx         sync.RWMutex
+	extensions = make(map[ExtensionType]map[string]*Extension)
+)
+
+// ExtensionType is the type of all supported k6 extensions.
+type ExtensionType uint8
+
+// All supported k6 extension types.
+const (
+	JSExtension ExtensionType = iota + 1
+	OutputExtension
+)
+
+func (e ExtensionType) String() string {
+	var s string
+	switch e {
+	case JSExtension:
+		s = "js"
+	case OutputExtension:
+		s = "out"
+	}
+	return s
+}
+
+// Extension is a generic container for any k6 extension.
+type Extension struct {
+	Name, Path, Version string
+	Type                ExtensionType
+	Mod                 interface{}
+}
+
+func (e Extension) String() string {
+	return fmt.Sprintf("%s %s, %s [%s]", e.Path, e.Version, e.Name, e.Type)
+}
+
+// Register a new extension with the given name and type. This function will
+// panic if an unsupported extension type is provided, or if an extension of the
+// same type and name is already registered.
+func Register(name string, typ ExtensionType, mod interface{}) {
+	mx.Lock()
+	defer mx.Unlock()
+
+	exts, ok := extensions[typ]
+	if !ok {
+		panic(fmt.Sprintf("unsupported extension type: %T", typ))
+	}
+
+	if _, ok := exts[name]; ok {
+		panic(fmt.Sprintf("extension already registered: %s", name))
+	}
+
+	path, version := getModuleInfo(mod)
+
+	exts[name] = &Extension{
+		Name:    name,
+		Type:    typ,
+		Mod:     mod,
+		Path:    path,
+		Version: version,
+	}
+}
+
+// Get returns all extensions of the specified type.
+func Get(typ ExtensionType) map[string]*Extension {
+	mx.RLock()
+	defer mx.RUnlock()
+
+	exts, ok := extensions[typ]
+	if !ok {
+		panic(fmt.Sprintf("unsupported extension type: %T", typ))
+	}
+
+	result := make(map[string]*Extension, len(exts))
+
+	for name, ext := range exts {
+		result[name] = ext
+	}
+
+	return result
+}
+
+// GetAll returns all extensions, sorted by their import path and name.
+func GetAll() []*Extension {
+	mx.RLock()
+	defer mx.RUnlock()
+
+	js, out := extensions[JSExtension], extensions[OutputExtension]
+	result := make([]*Extension, 0, len(js)+len(out))
+
+	for _, e := range js {
+		result = append(result, e)
+	}
+	for _, e := range out {
+		result = append(result, e)
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Path == result[j].Path {
+			return result[i].Name < result[j].Name
+		}
+		return result[i].Path < result[j].Path
+	})
+
+	return result
+}
+
+// getModuleInfo attempts to return the package path and version of the Go
+// module that created the given value.
+func getModuleInfo(mod interface{}) (path, version string) {
+	t := reflect.TypeOf(mod)
+
+	switch t.Kind() {
+	case reflect.Ptr:
+		if t.Elem() != nil {
+			path = t.Elem().PkgPath()
+		}
+	case reflect.Func:
+		path = runtime.FuncForPC(reflect.ValueOf(mod).Pointer()).Name()
+	default:
+		return
+	}
+
+	buildInfo, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	for _, dep := range buildInfo.Deps {
+		depPath := strings.TrimSpace(dep.Path)
+		if strings.HasPrefix(path, depPath) {
+			if dep.Replace != nil {
+				return depPath, dep.Replace.Version
+			}
+			return depPath, dep.Version
+		}
+	}
+
+	return
+}
+
+func init() {
+	extensions[JSExtension] = make(map[string]*Extension)
+	extensions[OutputExtension] = make(map[string]*Extension)
+}

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -33,7 +33,7 @@ func (e ExtensionType) String() string {
 	case JSExtension:
 		s = "js"
 	case OutputExtension:
-		s = "out"
+		s = "output"
 	}
 	return s
 }

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -42,7 +42,7 @@ func (e ExtensionType) String() string {
 type Extension struct {
 	Name, Path, Version string
 	Type                ExtensionType
-	Mod                 interface{}
+	Module              interface{}
 }
 
 func (e Extension) String() string {
@@ -70,7 +70,7 @@ func Register(name string, typ ExtensionType, mod interface{}) {
 	exts[name] = &Extension{
 		Name:    name,
 		Type:    typ,
-		Mod:     mod,
+		Module:  mod,
 		Path:    path,
 		Version: version,
 	}

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -44,7 +44,7 @@ func getJSModules() map[string]interface{} {
 
 	// external is always prefixed with `k6/x`
 	for _, e := range external {
-		result[e.Name] = e.Mod
+		result[e.Name] = e.Module
 	}
 
 	return result

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -1,7 +1,7 @@
 package js
 
 import (
-	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/ext"
 	"go.k6.io/k6/js/modules/k6"
 	"go.k6.io/k6/js/modules/k6/crypto"
 	"go.k6.io/k6/js/modules/k6/crypto/x509"
@@ -40,11 +40,11 @@ func getInternalJSModules() map[string]interface{} {
 
 func getJSModules() map[string]interface{} {
 	result := getInternalJSModules()
-	external := modules.GetJSModules()
+	external := ext.Get(ext.JSExtension)
 
 	// external is always prefixed with `k6/x`
-	for k, v := range external {
-		result[k] = v
+	for _, e := range external {
+		result[e.Name] = e.Mod
 	}
 
 	return result

--- a/js/modules/modules.go
+++ b/js/modules/modules.go
@@ -3,8 +3,6 @@ package modules
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"runtime/debug"
 	"strings"
 	"sync"
 
@@ -17,9 +15,8 @@ const extPrefix string = "k6/x/"
 
 //nolint:gochecknoglobals
 var (
-	modules        = make(map[string]interface{})
-	moduleVersions = make(map[string]string)
-	mx             sync.RWMutex
+	modules = make(map[string]interface{})
+	mx      sync.RWMutex
 )
 
 // Register the given mod as an external JavaScript module that can be imported
@@ -37,38 +34,6 @@ func Register(name string, mod interface{}) {
 		panic(fmt.Sprintf("module already registered: %s", name))
 	}
 	modules[name] = mod
-	getPackageVersion(mod)
-}
-
-func getPackageVersion(mod interface{}) {
-	t := reflect.TypeOf(mod)
-	p := t.PkgPath()
-	if p == "" {
-		if t.Kind() != reflect.Ptr {
-			return
-		}
-		if t.Elem() != nil {
-			p = t.Elem().PkgPath()
-		}
-	}
-	buildInfo, ok := debug.ReadBuildInfo()
-	if !ok {
-		return
-	}
-	for _, dep := range buildInfo.Deps {
-		packagePath := strings.TrimSpace(dep.Path)
-		if strings.HasPrefix(p, packagePath) {
-			if _, ok := moduleVersions[packagePath]; ok {
-				return
-			}
-			if dep.Replace != nil {
-				moduleVersions[packagePath] = dep.Replace.Version
-			} else {
-				moduleVersions[packagePath] = dep.Version
-			}
-			break
-		}
-	}
 }
 
 // Module is the interface js modules should implement in order to get access to the VU
@@ -86,19 +51,6 @@ func GetJSModules() map[string]interface{} {
 
 	for name, module := range modules {
 		result[name] = module
-	}
-
-	return result
-}
-
-// GetJSModuleVersions returns a map of all registered js modules package and their versions
-func GetJSModuleVersions() map[string]string {
-	mx.Lock()
-	defer mx.Unlock()
-	result := make(map[string]string, len(moduleVersions))
-
-	for name, version := range moduleVersions {
-		result[name] = version
 	}
 
 	return result

--- a/output/extensions.go
+++ b/output/extensions.go
@@ -1,35 +1,12 @@
 package output
 
-import (
-	"fmt"
-	"sync"
-)
+import "go.k6.io/k6/ext"
 
-//nolint:gochecknoglobals
-var (
-	extensions = make(map[string]func(Params) (Output, error))
-	mx         sync.RWMutex
-)
-
-// GetExtensions returns all registered extensions.
-func GetExtensions() map[string]func(Params) (Output, error) {
-	mx.RLock()
-	defer mx.RUnlock()
-	res := make(map[string]func(Params) (Output, error), len(extensions))
-	for k, v := range extensions {
-		res[k] = v
-	}
-	return res
-}
+// Constructor returns an instance of an output extension module.
+type Constructor func(Params) (Output, error)
 
 // RegisterExtension registers the given output extension constructor. This
 // function panics if a module with the same name is already registered.
-func RegisterExtension(name string, mod func(Params) (Output, error)) {
-	mx.Lock()
-	defer mx.Unlock()
-
-	if _, ok := extensions[name]; ok {
-		panic(fmt.Sprintf("output extension already registered: %s", name))
-	}
-	extensions[name] = mod
+func RegisterExtension(name string, c Constructor) {
+	ext.Register(name, ext.OutputExtension, c)
 }


### PR DESCRIPTION
This is based on the work done in #2754 (thanks @HarrisChu!), and the suggested changes there.

It evolved into something slightly more elaborate, where the bulk of the changes are to unify the extension registry, so that registration and retrieval of extension information is done in a single place. See commit cf5fa6102 for details. We still need to keep the existing registration functions in `js/modules/` and `output/` to avoid breaking extensions, but internally they're both now handled in the new root `ext` package. This DRYs the handling of extensions, and simplifies adding new types of extensions. It also simplifies the retrieval of extension versions, which is why it was done on top of #2754.

Here's how it currently looks:

```bash
$ xk6 build 4df8d46169ecc3a0417fd902bdcb28800e8098f0 \
  --with github.com/vesoft-inc/k6-plugin \
  --with github.com/grafana/xk6-output-influxdb
[...]

$ ./k6 version
k6 v0.41.0 ((devel), go1.19.1, linux/amd64)
Extensions:
  github.com/grafana/xk6-output-influxdb v0.2.2, xk6-influxdb [output]
  github.com/vesoft-inc/k6-plugin v1.0.1, aggcsv [output]
  github.com/vesoft-inc/k6-plugin v1.0.1, k6/x/nebulagraph [js]

$ ./k6 run ./samples/thresholds.js

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: ./samples/thresholds.js
 extensions: github.com/grafana/xk6-output-influxdb v0.2.2, xk6-influxdb [output]
             github.com/vesoft-inc/k6-plugin v1.0.1, aggcsv [output]
             github.com/vesoft-inc/k6-plugin v1.0.1, k6/x/nebulagraph [js]
     output: -

  scenarios: (100.00%) 1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):
           * default: 1 iterations for each of 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)
[...]
```

Closes #1741