### PR TITLE
Use non-zero exit codes for some aborted by Ctrl+C or REST API tests

### DIFF
--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -19,8 +20,10 @@ import (
 
 func getTestPreInitState(tb testing.TB) *lib.TestPreInitState {
 	reg := metrics.NewRegistry()
+	logger := testutils.NewLogger(tb)
+	logger.SetLevel(logrus.DebugLevel)
 	return &lib.TestPreInitState{
-		Logger:         testutils.NewLogger(tb),
+		Logger:         logger,
 		RuntimeOptions: lib.RuntimeOptions{},
 		Registry:       reg,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(reg),

--- a/api/v1/status_routes_test.go
+++ b/api/v1/status_routes_test.go
@@ -128,7 +128,7 @@ func TestPatchStatus(t *testing.T) {
 			}()
 
 			go func() {
-				assert.NoError(t, run())
+				assert.ErrorContains(t, run(), "test run aborted by signal")
 			}()
 			// wait for the executor to initialize to avoid a potential data race below
 			time.Sleep(200 * time.Millisecond)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -206,6 +206,7 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) error {
 	initBar.Modify(pb.WithConstProgress(0, "Starting test..."))
 	err = engineRun()
 	if err != nil {
+		err = errext.WithExitCodeIfNone(common.UnwrapGojaInterruptedError(err), exitcodes.GenericEngine)
 		logger.WithError(err).Debug("Engine terminated with an error")
 	} else {
 		logger.Debug("Engine run terminated cleanly")
@@ -265,13 +266,16 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) error {
 			logger.WithError(klErr).Warn("Error while closing the SSLKEYLOGFILE")
 		}
 	}
-	if err != nil {
-		return errext.WithExitCodeIfNone(common.UnwrapGojaInterruptedError(err), exitcodes.GenericEngine)
-	}
+
 	if engine.IsTainted() {
-		return errext.WithExitCodeIfNone(errors.New("some thresholds have failed"), exitcodes.ThresholdsHaveFailed)
+		if err == nil {
+			err = errors.New("some thresholds have failed")
+		} else {
+			logger.Error("some thresholds have failed") // log this, even if there was already a previous error
+		}
+		err = errext.WithExitCodeIfNone(err, exitcodes.ThresholdsHaveFailed)
 	}
-	return nil
+	return err
 }
 
 func (c *cmdRun) flagSet() *pflag.FlagSet {

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -141,7 +141,7 @@ func TestEngineRun(t *testing.T) {
 		defer test.wait()
 
 		startTime := time.Now()
-		assert.NoError(t, test.run())
+		assert.ErrorContains(t, test.run(), "test run aborted by signal")
 		assert.WithinDuration(t, startTime.Add(duration), time.Now(), 100*time.Millisecond)
 		<-done
 	})
@@ -192,7 +192,7 @@ func TestEngineRun(t *testing.T) {
 		go func() { errC <- test.run() }()
 		<-signalChan
 		test.runCancel()
-		assert.NoError(t, <-errC)
+		assert.ErrorContains(t, <-errC, "test run aborted by signal")
 		test.wait()
 
 		found := 0
@@ -455,7 +455,7 @@ func TestEngineAbortedByThresholds(t *testing.T) {
 	defer test.wait()
 
 	go func() {
-		assert.NoError(t, test.run())
+		require.ErrorContains(t, test.run(), "aborted by failed thresholds")
 	}()
 
 	select {
@@ -1229,7 +1229,7 @@ func TestEngineRunsTeardownEvenAfterTestRunIsAborted(t *testing.T) {
 		VUs: null.IntFrom(1), Iterations: null.IntFrom(1),
 	}, piState)
 
-	assert.NoError(t, test.run())
+	assert.ErrorContains(t, test.run(), "test run aborted by signal")
 	test.wait()
 
 	var count float64

--- a/errext/exitcodes/codes.go
+++ b/errext/exitcodes/codes.go
@@ -1,4 +1,5 @@
 // Package exitcodes contains the constants representing possible k6 exit error codes.
+//
 //nolint:golint
 package exitcodes
 
@@ -13,10 +14,11 @@ const (
 	SetupTimeout             ExitCode = 100
 	TeardownTimeout          ExitCode = 101
 	GenericTimeout           ExitCode = 102 // TODO: remove?
-	GenericEngine            ExitCode = 103
+	GenericEngine            ExitCode = 103 // TODO: remove after https://github.com/grafana/k6/issues/2804
 	InvalidConfig            ExitCode = 104
 	ExternalAbort            ExitCode = 105
 	CannotStartRESTAPI       ExitCode = 106
 	ScriptException          ExitCode = 107
 	ScriptAborted            ExitCode = 108
+	ScriptStoppedFromRESTAPI ExitCode = 109
 )


### PR DESCRIPTION
This is built on top of https://github.com/grafana/k6/pull/2803 and tackles a small part of https://github.com/grafana/k6/issues/2804, though definitely not the whole issue.

It was necessary to be able to split apart https://github.com/grafana/k6/issues/1889 into a few smaller PRs and it was also necessary for https://github.com/grafana/k6/issues/1342 in its own right.