### PR TITLE
Remove dependency on the `js/` package (and goja) from `lib/*` packages

### DIFF
--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -120,7 +120,7 @@ func (c *Client) Connect(addr string, params map[string]interface{}) (bool, erro
 		return false, fmt.Errorf("invalid grpc.connect() parameters: %w", err)
 	}
 
-	opts := grpcext.DefaultOptions(c.vu)
+	opts := grpcext.DefaultOptions(c.vu.State)
 
 	var tcred credentials.TransportCredentials
 	if !p.IsPlaintext {


### PR DESCRIPTION
This doesn't depend on anything else, it should be safe to merge as is.

This should close https://github.com/grafana/k6/issues/2535, I think :thinking: Between it and https://github.com/grafana/k6/pull/2536, `go.k6.io/lib` and its sub-packages shouldn't depend on `go.k6.io/js` or `github.com/dop251/goja`, right?

`go list -f '{{ join .Imports "\n" }}'  ./... | sort -u | grep -E 'goja|go.k6.io/k6/js'` returns no results in the `lib/` package, at least :crossed_fingers: 

Unfortunately, I couldn't make depbuard work correctly, and I have no time to debug that further, so I'll leave that to someone else if they want to. From what I understand by skimming https://golangci-lint.run/usage/linters/#depguard, adding something like this in the `linters-settings:` section of `.golangci.yml` should have worked, but it didn't:
```yml
  depguard:
    list-type: denylist
    packages:
      - github.com/dop251/goja
      - go.k6.io/k6/js
      - go.k6.io/k6/js/**
    ignore-file-rules:
      - "js/**/*.go"
      - "cmd/*.go"
```

The goal is to ensure we don't import goja or the js package anywhere except `js/` and `cmd/`, and maybe we can even restrict that further :thinking: If someone can make the linter work, that is :sweat_smile: 