### PR TITLE
Add new `errext.AbortReason` type, move and use old `RunStatus` type only for k6 cloud code

### DIFF
--- a/api/v1/setup_teardown_routes_test.go
+++ b/api/v1/setup_teardown_routes_test.go
@@ -142,7 +142,7 @@ func TestSetupData(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NoError(t, engine.OutputManager.StartOutputs())
-			defer engine.OutputManager.StopOutputs()
+			defer engine.OutputManager.StopOutputs(nil)
 
 			globalCtx, globalCancel := context.WithCancel(context.Background())
 			runCtx, runCancel := context.WithCancel(globalCtx)

--- a/api/v1/status_routes_test.go
+++ b/api/v1/status_routes_test.go
@@ -116,7 +116,7 @@ func TestPatchStatus(t *testing.T) {
 			require.NoError(t, err)
 
 			require.NoError(t, engine.OutputManager.StartOutputs())
-			defer engine.OutputManager.StopOutputs()
+			defer engine.OutputManager.StopOutputs(nil)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			run, wait, err := engine.Init(ctx, ctx)

--- a/cloudapi/api.go
+++ b/cloudapi/api.go
@@ -43,10 +43,10 @@ type CreateTestRunResponse struct {
 }
 
 type TestProgressResponse struct {
-	RunStatusText string        `json:"run_status_text"`
-	RunStatus     lib.RunStatus `json:"run_status"`
-	ResultStatus  ResultStatus  `json:"result_status"`
-	Progress      float64       `json:"progress"`
+	RunStatusText string       `json:"run_status_text"`
+	RunStatus     RunStatus    `json:"run_status"`
+	ResultStatus  ResultStatus `json:"result_status"`
+	Progress      float64      `json:"progress"`
 }
 
 type LoginResponse struct {
@@ -133,7 +133,9 @@ func (c *Client) StartCloudTestRun(name string, projectID int64, arc *lib.Archiv
 	return &ctrr, nil
 }
 
-func (c *Client) TestFinished(referenceID string, thresholds ThresholdResult, tained bool, runStatus lib.RunStatus) error {
+// TestFinished sends the result and run status values to the cloud, along with
+// information for the test thresholds, and marks the test run as finished.
+func (c *Client) TestFinished(referenceID string, thresholds ThresholdResult, tained bool, runStatus RunStatus) error {
 	url := fmt.Sprintf("%s/tests/%s", c.baseURL, referenceID)
 
 	resultStatus := ResultStatusPassed
@@ -143,7 +145,7 @@ func (c *Client) TestFinished(referenceID string, thresholds ThresholdResult, ta
 
 	data := struct {
 		ResultStatus ResultStatus    `json:"result_status"`
-		RunStatus    lib.RunStatus   `json:"run_status"`
+		RunStatus    RunStatus       `json:"run_status"`
 		Thresholds   ThresholdResult `json:"thresholds"`
 	}{
 		resultStatus,

--- a/cloudapi/run_status.go
+++ b/cloudapi/run_status.go
@@ -1,10 +1,7 @@
-package lib
+package cloudapi
 
-// TODO: move to some other package - types? models?
-
-// RunStatus values can be used by k6 to denote how a script run ends
-// and by the cloud executor and collector so that k6 knows the current
-// status of a particular script run.
+// RunStatus values are used to tell the cloud output how a local test run
+// ended, and to get that information from the cloud for cloud tests.
 type RunStatus int
 
 // Possible run status values; iota isn't used intentionally

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -63,6 +63,7 @@ func (c *cmdCloud) preRun(cmd *cobra.Command, args []string) error {
 }
 
 // TODO: split apart some more
+//
 //nolint:funlen,gocognit,cyclop
 func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	printBanner(c.gs)

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -235,9 +235,9 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 
 			statusText := testProgress.RunStatusText
 
-			if testProgress.RunStatus == lib.RunStatusFinished {
+			if testProgress.RunStatus == cloudapi.RunStatusFinished {
 				testProgress.Progress = 1
-			} else if testProgress.RunStatus == lib.RunStatusRunning {
+			} else if testProgress.RunStatus == cloudapi.RunStatusRunning {
 				if startTime.IsZero() {
 					startTime = time.Now()
 				}
@@ -274,8 +274,8 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 		testProgress = newTestProgress
 		testProgressLock.Unlock()
 
-		if (newTestProgress.RunStatus > lib.RunStatusRunning) ||
-			(c.exitOnRunning && newTestProgress.RunStatus == lib.RunStatusRunning) {
+		if (newTestProgress.RunStatus > cloudapi.RunStatusRunning) ||
+			(c.exitOnRunning && newTestProgress.RunStatus == cloudapi.RunStatusRunning) {
 			globalCancel()
 			break
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,7 +37,7 @@ type cmdRun struct {
 // TODO: split apart some more
 //
 //nolint:funlen,gocognit,gocyclo,cyclop
-func (c *cmdRun) run(cmd *cobra.Command, args []string) error {
+func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 	printBanner(c.gs)
 
 	test, err := loadAndConfigureTest(c.gs, cmd, args, getConfig)
@@ -159,7 +159,9 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	defer engine.OutputManager.StopOutputs()
+	defer func() {
+		engine.OutputManager.StopOutputs(err)
+	}()
 
 	printExecutionDescription(
 		c.gs, "local", args[0], "", conf, execScheduler.GetState().ExecutionTuple, executionPlan, outputs,
@@ -274,7 +276,9 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) error {
 		} else {
 			logger.Error("some thresholds have failed") // log this, even if there was already a previous error
 		}
-		err = errext.WithExitCodeIfNone(err, exitcodes.ThresholdsHaveFailed)
+		err = errext.WithAbortReasonIfNone(
+			errext.WithExitCodeIfNone(err, exitcodes.ThresholdsHaveFailed), errext.AbortedByThresholdsAfterTestEnd,
+		)
 	}
 	return err
 }

--- a/cmd/tests/cmd_cloud_test.go
+++ b/cmd/tests/cmd_cloud_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/cmd"
-	"go.k6.io/k6/lib"
 )
 
 func cloudTestStartSimple(t *testing.T, testRunID int) http.Handler {
@@ -34,7 +33,7 @@ func getMockCloud(
 	testProgressURL := fmt.Sprintf("GET ^/v1/test-progress/%d$", testRunID)
 	defaultProgress := cloudapi.TestProgressResponse{
 		RunStatusText: "Finished",
-		RunStatus:     lib.RunStatusFinished,
+		RunStatus:     cloudapi.RunStatusFinished,
 		ResultStatus:  cloudapi.ResultStatusPassed,
 		Progress:      1,
 	}
@@ -130,7 +129,7 @@ func TestCloudExitOnRunning(t *testing.T) {
 	cs := func() cloudapi.TestProgressResponse {
 		return cloudapi.TestProgressResponse{
 			RunStatusText: "Running",
-			RunStatus:     lib.RunStatusRunning,
+			RunStatus:     cloudapi.RunStatusRunning,
 		}
 	}
 

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -24,7 +24,6 @@ import (
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/cmd"
 	"go.k6.io/k6/errext/exitcodes"
-	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/lib/testutils/httpmultibin"
@@ -426,7 +425,7 @@ func getTestServer(t *testing.T, routes map[string]http.Handler) *httptest.Serve
 
 func getCloudTestEndChecker(
 	t *testing.T, testRunID int,
-	testStart http.Handler, expRunStatus lib.RunStatus, expResultStatus cloudapi.ResultStatus,
+	testStart http.Handler, expRunStatus cloudapi.RunStatus, expResultStatus cloudapi.ResultStatus,
 ) *httptest.Server {
 	testFinished := false
 
@@ -449,7 +448,7 @@ func getCloudTestEndChecker(
 			runStatus := gjson.GetBytes(body, "run_status")
 			require.True(t, runStatus.Exists()) // important to check, since run_status can be 0
 			assert.Equalf(
-				t, expRunStatus, lib.RunStatus(runStatus.Int()),
+				t, expRunStatus, cloudapi.RunStatus(runStatus.Int()),
 				"received wrong run_status value",
 			)
 
@@ -473,7 +472,7 @@ func getCloudTestEndChecker(
 
 func getSimpleCloudOutputTestState(
 	t *testing.T, script string, cliFlags []string,
-	expRunStatus lib.RunStatus, expResultStatus cloudapi.ResultStatus, expExitCode exitcodes.ExitCode,
+	expRunStatus cloudapi.RunStatus, expResultStatus cloudapi.ResultStatus, expExitCode exitcodes.ExitCode,
 ) *GlobalTestState {
 	if cliFlags == nil {
 		cliFlags = []string{"-v", "--log-output=stdout"}
@@ -520,7 +519,7 @@ func TestSetupTeardownThresholds(t *testing.T) {
 		};
 	`)
 
-	ts := getSimpleCloudOutputTestState(t, script, nil, lib.RunStatusFinished, cloudapi.ResultStatusPassed, 0)
+	ts := getSimpleCloudOutputTestState(t, script, nil, cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed, 0)
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 	stdOut := ts.Stdout.String()
@@ -566,7 +565,7 @@ func TestThresholdsFailed(t *testing.T) {
 	// Since these thresholds don't have an abortOnFail property, the run_status
 	// in the cloud will still be Finished, even if the test itself failed.
 	ts := getSimpleCloudOutputTestState(
-		t, script, nil, lib.RunStatusFinished, cloudapi.ResultStatusFailed, exitcodes.ThresholdsHaveFailed,
+		t, script, nil, cloudapi.RunStatusFinished, cloudapi.ResultStatusFailed, exitcodes.ThresholdsHaveFailed,
 	)
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
@@ -607,7 +606,7 @@ func TestAbortedByThreshold(t *testing.T) {
 	`
 
 	ts := getSimpleCloudOutputTestState(
-		t, script, nil, lib.RunStatusAbortedThreshold, cloudapi.ResultStatusFailed, exitcodes.ThresholdsHaveFailed,
+		t, script, nil, cloudapi.RunStatusAbortedThreshold, cloudapi.ResultStatusFailed, exitcodes.ThresholdsHaveFailed,
 	)
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
@@ -654,7 +653,7 @@ func TestAbortedByUserWithGoodThresholds(t *testing.T) {
 		};
 	`
 
-	ts := getSimpleCloudOutputTestState(t, script, nil, lib.RunStatusAbortedUser, cloudapi.ResultStatusPassed, exitcodes.ExternalAbort)
+	ts := getSimpleCloudOutputTestState(t, script, nil, cloudapi.RunStatusAbortedUser, cloudapi.ResultStatusPassed, exitcodes.ExternalAbort)
 
 	asyncWaitForStdoutAndStopTestWithInterruptSignal(t, ts, 15, time.Second, "simple iter 2")
 
@@ -782,7 +781,7 @@ func TestAbortedByUserWithRestAPI(t *testing.T) {
 
 	ts := getSimpleCloudOutputTestState(
 		t, script, []string{"-v", "--log-output=stdout", "--iterations", "20"},
-		lib.RunStatusAbortedUser, cloudapi.ResultStatusPassed, exitcodes.ScriptStoppedFromRESTAPI,
+		cloudapi.RunStatusAbortedUser, cloudapi.ResultStatusPassed, exitcodes.ScriptStoppedFromRESTAPI,
 	)
 
 	asyncWaitForStdoutAndStopTestFromRESTAPI(t, ts, 15, time.Second, "a simple iteration")
@@ -822,7 +821,7 @@ func TestAbortedByScriptSetupErrorWithDependency(t *testing.T) {
 		export { handleSummary } from "./bar.js";
 	`
 
-	srv := getCloudTestEndChecker(t, 123, nil, lib.RunStatusAbortedScriptError, cloudapi.ResultStatusPassed)
+	srv := getCloudTestEndChecker(t, 123, nil, cloudapi.RunStatusAbortedScriptError, cloudapi.ResultStatusPassed)
 
 	ts := NewGlobalTestState(t)
 	require.NoError(t, afero.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), []byte(mainScript), 0o644))
@@ -937,7 +936,7 @@ func TestAbortedByScriptTeardownError(t *testing.T) {
 
 func testAbortedByScriptError(t *testing.T, script string, runTest func(*testing.T, *GlobalTestState)) *GlobalTestState {
 	ts := getSimpleCloudOutputTestState(
-		t, script, nil, lib.RunStatusAbortedScriptError, cloudapi.ResultStatusPassed, exitcodes.ScriptException,
+		t, script, nil, cloudapi.RunStatusAbortedScriptError, cloudapi.ResultStatusPassed, exitcodes.ScriptException,
 	)
 	runTest(t, ts)
 
@@ -1082,7 +1081,7 @@ func testAbortedByScriptTestAbort(
 	t *testing.T, shouldHaveMetrics bool, script string, runTest func(*testing.T, *GlobalTestState),
 ) *GlobalTestState { //nolint:unparam
 	ts := getSimpleCloudOutputTestState(
-		t, script, nil, lib.RunStatusAbortedUser, cloudapi.ResultStatusPassed, exitcodes.ScriptAborted,
+		t, script, nil, cloudapi.RunStatusAbortedUser, cloudapi.ResultStatusPassed, exitcodes.ScriptAborted,
 	)
 	runTest(t, ts)
 
@@ -1125,7 +1124,7 @@ func TestAbortedByInterruptDuringVUInit(t *testing.T) {
 	// This is testing the current behavior, which is expected, but it's not
 	// actually the desired one! See https://github.com/grafana/k6/issues/2804
 	ts := getSimpleCloudOutputTestState(
-		t, script, nil, lib.RunStatusAbortedSystem, cloudapi.ResultStatusPassed, exitcodes.GenericEngine,
+		t, script, nil, cloudapi.RunStatusAbortedSystem, cloudapi.ResultStatusPassed, exitcodes.GenericEngine,
 	)
 	asyncWaitForStdoutAndStopTestWithInterruptSignal(t, ts, 15, time.Second, "VU init sleeping for a while")
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
@@ -1157,7 +1156,7 @@ func TestAbortedByScriptInitError(t *testing.T) {
 	`
 
 	ts := getSimpleCloudOutputTestState(
-		t, script, nil, lib.RunStatusAbortedScriptError, cloudapi.ResultStatusPassed, exitcodes.ScriptException,
+		t, script, nil, cloudapi.RunStatusAbortedScriptError, cloudapi.ResultStatusPassed, exitcodes.ScriptException,
 	)
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
@@ -1257,7 +1256,7 @@ func TestMetricTagAndSetupDataIsolation(t *testing.T) {
 
 	ts := getSimpleCloudOutputTestState(
 		t, script, []string{"--quiet", "--log-output", "stdout"},
-		lib.RunStatusFinished, cloudapi.ResultStatusPassed, 0,
+		cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed, 0,
 	)
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
@@ -1429,7 +1428,7 @@ func TestMinIterationDuration(t *testing.T) {
 		export function teardown() { c.add(1); };
 	`
 
-	ts := getSimpleCloudOutputTestState(t, script, nil, lib.RunStatusFinished, cloudapi.ResultStatusPassed, 0)
+	ts := getSimpleCloudOutputTestState(t, script, nil, cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed, 0)
 
 	start := time.Now()
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
@@ -1566,7 +1565,7 @@ func TestRunWithCloudOutputOverrides(t *testing.T) {
 		_, err := fmt.Fprint(resp, `{"reference_id": "132", "config": {"webAppURL": "https://bogus.url"}}`)
 		assert.NoError(t, err)
 	})
-	srv := getCloudTestEndChecker(t, 132, configOverride, lib.RunStatusFinished, cloudapi.ResultStatusPassed)
+	srv := getCloudTestEndChecker(t, 132, configOverride, cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed)
 	ts.Env["K6_CLOUD_HOST"] = srv.URL
 
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
@@ -1601,7 +1600,7 @@ func TestRunWithCloudOutputMoreOverrides(t *testing.T) {
 		}`)
 		assert.NoError(t, err)
 	})
-	srv := getCloudTestEndChecker(t, 1337, configOverride, lib.RunStatusFinished, cloudapi.ResultStatusPassed)
+	srv := getCloudTestEndChecker(t, 1337, configOverride, cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed)
 	ts.Env["K6_CLOUD_HOST"] = srv.URL
 
 	cmd.ExecuteWithGlobalState(ts.GlobalState)

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -1413,7 +1413,7 @@ func TestMinIterationDuration(t *testing.T) {
 		import { Counter } from 'k6/metrics';
 
 		export let options = {
-			minIterationDuration: '5s',
+			minIterationDuration: '7s',
 			setupTimeout: '2s',
 			teardownTimeout: '2s',
 			thresholds: {
@@ -1433,9 +1433,9 @@ func TestMinIterationDuration(t *testing.T) {
 	start := time.Now()
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 	elapsed := time.Since(start)
-	assert.Greater(t, elapsed, 5*time.Second, "expected more time to have passed because of minIterationDuration")
+	assert.Greater(t, elapsed, 7*time.Second, "expected more time to have passed because of minIterationDuration")
 	assert.Less(
-		t, elapsed, 10*time.Second,
+		t, elapsed, 14*time.Second,
 		"expected less time to have passed because minIterationDuration should not affect setup() and teardown() ",
 	)
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/errext"
 	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/lib"
@@ -108,7 +107,6 @@ func (e *Engine) Init(globalCtx, runCtx context.Context) (run func() error, wait
 	// TODO: if we ever need metrics processing in the init context, we can move
 	// this below the other components... or even start them concurrently?
 	if err := e.ExecutionScheduler.Init(runCtx, e.Samples); err != nil {
-		e.setRunStatusFromError(err)
 		return nil, nil, err
 	}
 
@@ -148,18 +146,6 @@ func (e *Engine) Init(globalCtx, runCtx context.Context) (run func() error, wait
 	return runFn, waitFn, nil
 }
 
-func (e *Engine) setRunStatusFromError(err error) {
-	var serr errext.Exception
-	switch {
-	case errors.As(err, &serr):
-		e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedScriptError)
-	case errext.IsInterruptError(err):
-		e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedUser)
-	default:
-		e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedSystem)
-	}
-}
-
 // This starts a bunch of goroutines to process metrics, thresholds, and set the
 // test run status when it ends. It returns a function that can be used after
 // the provided context is called, to wait for the complete winding down of all
@@ -196,27 +182,31 @@ func (e *Engine) startBackgroundProcesses(
 		case err = <-execRunResult:
 			if err != nil {
 				e.logger.WithError(err).Debug("run: execution scheduler returned an error")
-				e.setRunStatusFromError(err)
 			} else {
 				e.logger.Debug("run: execution scheduler finished nominally")
-				e.OutputManager.SetRunStatus(cloudapi.RunStatusFinished)
 			}
 			// do nothing, return the same err value we got from the Run()
 			// ExecutionScheduler result, we just set the run_status based on it
 		case <-runCtx.Done():
 			e.logger.Debug("run: context expired; exiting...")
-			e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedUser)
-			err = errext.WithExitCodeIfNone(errors.New("test run aborted by signal"), exitcodes.ExternalAbort)
+			err = errext.WithAbortReasonIfNone(
+				errext.WithExitCodeIfNone(errors.New("test run aborted by signal"), exitcodes.ExternalAbort),
+				errext.AbortedByUser,
+			)
 		case <-e.stopChan:
 			runSubCancel()
 			e.logger.Debug("run: stopped by user via REST API; exiting...")
-			e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedUser)
-			err = errext.WithExitCodeIfNone(errors.New("test run stopped from the REST API"), exitcodes.ScriptStoppedFromRESTAPI)
+			err = errext.WithAbortReasonIfNone(
+				errext.WithExitCodeIfNone(errors.New("test run stopped from the REST API"), exitcodes.ScriptStoppedFromRESTAPI),
+				errext.AbortedByUser,
+			)
 		case <-thresholdAbortChan:
 			e.logger.Debug("run: stopped by thresholds; exiting...")
 			runSubCancel()
-			e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedThreshold)
-			err = errext.WithExitCodeIfNone(errors.New("test run aborted by failed thresholds"), exitcodes.ThresholdsHaveFailed)
+			err = errext.WithAbortReasonIfNone(
+				errext.WithExitCodeIfNone(errors.New("test run aborted by failed thresholds"), exitcodes.ThresholdsHaveFailed),
+				errext.AbortedByThreshold,
+			)
 		}
 	}()
 

--- a/core/engine.go
+++ b/core/engine.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/errext"
 	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/lib"
@@ -151,11 +152,11 @@ func (e *Engine) setRunStatusFromError(err error) {
 	var serr errext.Exception
 	switch {
 	case errors.As(err, &serr):
-		e.OutputManager.SetRunStatus(lib.RunStatusAbortedScriptError)
+		e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedScriptError)
 	case errext.IsInterruptError(err):
-		e.OutputManager.SetRunStatus(lib.RunStatusAbortedUser)
+		e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedUser)
 	default:
-		e.OutputManager.SetRunStatus(lib.RunStatusAbortedSystem)
+		e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedSystem)
 	}
 }
 
@@ -198,23 +199,23 @@ func (e *Engine) startBackgroundProcesses(
 				e.setRunStatusFromError(err)
 			} else {
 				e.logger.Debug("run: execution scheduler finished nominally")
-				e.OutputManager.SetRunStatus(lib.RunStatusFinished)
+				e.OutputManager.SetRunStatus(cloudapi.RunStatusFinished)
 			}
 			// do nothing, return the same err value we got from the Run()
 			// ExecutionScheduler result, we just set the run_status based on it
 		case <-runCtx.Done():
 			e.logger.Debug("run: context expired; exiting...")
-			e.OutputManager.SetRunStatus(lib.RunStatusAbortedUser)
+			e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedUser)
 			err = errext.WithExitCodeIfNone(errors.New("test run aborted by signal"), exitcodes.ExternalAbort)
 		case <-e.stopChan:
 			runSubCancel()
 			e.logger.Debug("run: stopped by user via REST API; exiting...")
-			e.OutputManager.SetRunStatus(lib.RunStatusAbortedUser)
+			e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedUser)
 			err = errext.WithExitCodeIfNone(errors.New("test run stopped from the REST API"), exitcodes.ScriptStoppedFromRESTAPI)
 		case <-thresholdAbortChan:
 			e.logger.Debug("run: stopped by thresholds; exiting...")
 			runSubCancel()
-			e.OutputManager.SetRunStatus(lib.RunStatusAbortedThreshold)
+			e.OutputManager.SetRunStatus(cloudapi.RunStatusAbortedThreshold)
 			err = errext.WithExitCodeIfNone(errors.New("test run aborted by failed thresholds"), exitcodes.ThresholdsHaveFailed)
 		}
 	}()

--- a/core/engine_test.go
+++ b/core/engine_test.go
@@ -109,7 +109,7 @@ func newTestEngineWithTestPreInitState( //nolint:golint
 			test.runCancel()
 			globalCancel()
 			waitFn()
-			engine.OutputManager.StopOutputs()
+			engine.OutputManager.StopOutputs(nil)
 		},
 		piState: piState,
 	}
@@ -1333,7 +1333,7 @@ func TestActiveVUsCount(t *testing.T) {
 		require.NoError(t, err)
 		cancel()
 		waitFn()
-		engine.OutputManager.StopOutputs()
+		engine.OutputManager.StopOutputs(nil)
 		require.False(t, engine.IsTainted())
 	}
 

--- a/errext/abort_reason.go
+++ b/errext/abort_reason.go
@@ -1,0 +1,54 @@
+package errext
+
+import "errors"
+
+// AbortReason is used to signal to outputs what type of error caused the test
+// run to be stopped prematurely.
+type AbortReason uint8
+
+// These are the various reasons why a test might have been aborted prematurely.
+const (
+	AbortedByUser AbortReason = iota + 1
+	AbortedByThreshold
+	AbortedByThresholdsAfterTestEnd // TODO: rename?
+	AbortedByScriptError
+	AbortedByScriptAbort
+	AbortedByTimeout
+)
+
+// HasAbortReason is a wrapper around an error with an attached abort reason.
+type HasAbortReason interface {
+	error
+	AbortReason() AbortReason
+}
+
+// WithAbortReasonIfNone can attach an abort reason to the given error, if it
+// doesn't have one already. It won't do anything if the error already had an
+// abort reason attached. Similarly, if there is no error (i.e. the given error
+// is nil), it also won't do anything and will return nil.
+func WithAbortReasonIfNone(err error, abortReason AbortReason) error {
+	if err == nil {
+		return nil // No error, do nothing
+	}
+	var arerr HasAbortReason
+	if errors.As(err, &arerr) {
+		// The given error already has an abort reason, do nothing
+		return err
+	}
+	return withAbortReason{err, abortReason}
+}
+
+type withAbortReason struct {
+	error
+	abortReason AbortReason
+}
+
+func (ar withAbortReason) Unwrap() error {
+	return ar.error
+}
+
+func (ar withAbortReason) AbortReason() AbortReason {
+	return ar.abortReason
+}
+
+var _ HasAbortReason = withAbortReason{}

--- a/errext/exception.go
+++ b/errext/exception.go
@@ -5,5 +5,6 @@ package errext
 // a stack trace that lead to them.
 type Exception interface {
 	error
+	HasAbortReason
 	StackTrace() string
 }

--- a/errext/interrupt_error.go
+++ b/errext/interrupt_error.go
@@ -11,7 +11,10 @@ type InterruptError struct {
 	Reason string
 }
 
-var _ HasExitCode = &InterruptError{}
+var _ interface {
+	HasExitCode
+	HasAbortReason
+} = &InterruptError{}
 
 // Error returns the reason of the interruption.
 func (i *InterruptError) Error() string {
@@ -21,6 +24,12 @@ func (i *InterruptError) Error() string {
 // ExitCode returns the status code used when the k6 process exits.
 func (i *InterruptError) ExitCode() exitcodes.ExitCode {
 	return exitcodes.ScriptAborted
+}
+
+// AbortReason is used to signal that an InterruptError is caused by the
+// test.abort() functin in k6/execution.
+func (i *InterruptError) AbortReason() AbortReason {
+	return AbortedByScriptAbort
 }
 
 // AbortTest is the reason emitted when a test script calls test.abort()

--- a/js/runner.go
+++ b/js/runner.go
@@ -845,11 +845,12 @@ type scriptException struct {
 	inner *goja.Exception
 }
 
-var (
-	_ errext.Exception   = &scriptException{}
-	_ errext.HasExitCode = &scriptException{}
-	_ errext.HasHint     = &scriptException{}
-)
+var _ interface {
+	errext.Exception
+	errext.HasExitCode
+	errext.HasHint
+	errext.HasAbortReason
+} = &scriptException{}
 
 func (s *scriptException) Error() string {
 	// this calls String instead of error so that by default if it's printed to print the stacktrace
@@ -866,6 +867,10 @@ func (s *scriptException) Unwrap() error {
 
 func (s *scriptException) Hint() string {
 	return "script exception"
+}
+
+func (s *scriptException) AbortReason() errext.AbortReason {
+	return errext.AbortedByScriptError
 }
 
 func (s *scriptException) ExitCode() exitcodes.ExitCode {

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -391,7 +391,7 @@ func TestDataIsolation(t *testing.T) {
 	engine, err := core.NewEngine(testRunState, execScheduler, []output.Output{mockOutput})
 	require.NoError(t, err)
 	require.NoError(t, engine.OutputManager.StartOutputs())
-	defer engine.OutputManager.StopOutputs()
+	defer engine.OutputManager.StopOutputs(nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	run, wait, err := engine.Init(ctx, ctx)

--- a/js/timeout_error.go
+++ b/js/timeout_error.go
@@ -15,10 +15,11 @@ type timeoutError struct {
 	d     time.Duration
 }
 
-var (
-	_ errext.HasExitCode = timeoutError{}
-	_ errext.HasHint     = timeoutError{}
-)
+var _ interface {
+	errext.HasExitCode
+	errext.HasHint
+	errext.HasAbortReason
+} = timeoutError{}
 
 // newTimeoutError returns a new timeout error, reporting that a timeout has
 // happened at the given place and given duration.
@@ -42,6 +43,10 @@ func (t timeoutError) Hint() string {
 		hint = "You can increase the time limit via the teardownTimeout option"
 	}
 	return hint
+}
+
+func (t timeoutError) AbortReason() errext.AbortReason {
+	return errext.AbortedByTimeout
 }
 
 // ExitCode returns the coresponding exit code value to the place.

--- a/lib/testutils/mockoutput/mockoutput.go
+++ b/lib/testutils/mockoutput/mockoutput.go
@@ -1,9 +1,7 @@
 package mockoutput
 
 import (
-	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
-	"go.k6.io/k6/output"
 )
 
 // New exists so that the usage from tests avoids repetition, i.e. is
@@ -16,14 +14,11 @@ func New() *MockOutput {
 type MockOutput struct {
 	SampleContainers []metrics.SampleContainer
 	Samples          []metrics.Sample
-	RunStatus        lib.RunStatus
 
 	DescFn  func() string
 	StartFn func() error
 	StopFn  func() error
 }
-
-var _ output.WithRunStatusUpdates = &MockOutput{}
 
 // AddMetricSamples just saves the results in memory.
 func (mo *MockOutput) AddMetricSamples(scs []metrics.SampleContainer) {
@@ -31,11 +26,6 @@ func (mo *MockOutput) AddMetricSamples(scs []metrics.SampleContainer) {
 	for _, sc := range scs {
 		mo.Samples = append(mo.Samples, sc.GetSamples()...)
 	}
-}
-
-// SetRunStatus updates the RunStatus property.
-func (mo *MockOutput) SetRunStatus(latestStatus lib.RunStatus) {
-	mo.RunStatus = latestStatus
 }
 
 // Description calls the supplied DescFn callback, if available.

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -36,7 +36,7 @@ type Output struct {
 	thresholds    map[string][]*metrics.Threshold
 	client        *MetricsClient
 
-	runStatus lib.RunStatus
+	runStatus cloudapi.RunStatus
 
 	bufferMutex      sync.Mutex
 	bufferHTTPTrails []*httpext.Trail
@@ -284,7 +284,7 @@ func (out *Output) Description() string {
 }
 
 // SetRunStatus receives the latest run status from the Engine.
-func (out *Output) SetRunStatus(status lib.RunStatus) {
+func (out *Output) SetRunStatus(status cloudapi.RunStatus) {
 	out.runStatus = status
 }
 
@@ -634,8 +634,8 @@ func (out *Output) testFinished() error {
 		}
 	}
 
-	runStatus := lib.RunStatusFinished
-	if out.runStatus != lib.RunStatusQueued {
+	runStatus := cloudapi.RunStatusFinished
+	if out.runStatus != cloudapi.RunStatusQueued {
 		runStatus = out.runStatus
 	}
 

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -506,7 +506,6 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 
 	require.NoError(t, out.Stop())
 
-	require.Equal(t, cloudapi.RunStatusQueued, out.runStatus)
 	select {
 	case <-out.stopSendingMetrics:
 		// all is fine
@@ -598,7 +597,6 @@ func TestCloudOutputAggregationPeriodZeroNoBlock(t *testing.T) {
 	tb.Mux.HandleFunc(fmt.Sprintf("/v1/metrics/%s", out.referenceID), getSampleChecker(t, expSamples))
 
 	require.NoError(t, out.Stop())
-	require.Equal(t, cloudapi.RunStatusQueued, out.runStatus)
 }
 
 func TestCloudOutputPushRefID(t *testing.T) {

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -506,7 +506,7 @@ func testCloudOutputStopSendingMetric(t *testing.T, stopOnError bool) {
 
 	require.NoError(t, out.Stop())
 
-	require.Equal(t, lib.RunStatusQueued, out.runStatus)
+	require.Equal(t, cloudapi.RunStatusQueued, out.runStatus)
 	select {
 	case <-out.stopSendingMetrics:
 		// all is fine
@@ -598,7 +598,7 @@ func TestCloudOutputAggregationPeriodZeroNoBlock(t *testing.T) {
 	tb.Mux.HandleFunc(fmt.Sprintf("/v1/metrics/%s", out.referenceID), getSampleChecker(t, expSamples))
 
 	require.NoError(t, out.Stop())
-	require.Equal(t, lib.RunStatusQueued, out.runStatus)
+	require.Equal(t, cloudapi.RunStatusQueued, out.runStatus)
 }
 
 func TestCloudOutputPushRefID(t *testing.T) {

--- a/output/manager.go
+++ b/output/manager.go
@@ -2,7 +2,7 @@ package output
 
 import (
 	"github.com/sirupsen/logrus"
-	"go.k6.io/k6/lib"
+	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/metrics"
 )
 
@@ -58,7 +58,7 @@ func (om *Manager) stopOutputs(upToID int) {
 
 // SetRunStatus checks which outputs implement the WithRunStatusUpdates
 // interface and sets the provided RunStatus to them.
-func (om *Manager) SetRunStatus(status lib.RunStatus) {
+func (om *Manager) SetRunStatus(status cloudapi.RunStatus) {
 	for _, out := range om.outputs {
 		if statUpdOut, ok := out.(WithRunStatusUpdates); ok {
 			statUpdOut.SetRunStatus(status)

--- a/output/types.go
+++ b/output/types.go
@@ -11,7 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
-	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
 )
@@ -76,10 +75,17 @@ type WithTestRunStop interface {
 	SetTestRunStopCallback(func(error))
 }
 
-// WithRunStatusUpdates means the output can receive test run status updates.
-type WithRunStatusUpdates interface {
+// WithStopWithTestError allows output to receive the error value that the test
+// finished with. It could be nil, if the test finished nominally.
+//
+// If this interface is implemented by the output, StopWithError() will be
+// called instead of Stop().
+//
+// TODO: refactor the main interface to use this method instead of Stop()? Or
+// something else along the lines of https://github.com/grafana/k6/issues/2430 ?
+type WithStopWithTestError interface {
 	Output
-	SetRunStatus(latestStatus cloudapi.RunStatus)
+	StopWithTestError(testRunErr error) error // nil testRunErr means error-free test run
 }
 
 // WithBuiltinMetrics means the output can receive the builtin metrics.

--- a/output/types.go
+++ b/output/types.go
@@ -11,6 +11,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
+	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
 )
@@ -78,7 +79,7 @@ type WithTestRunStop interface {
 // WithRunStatusUpdates means the output can receive test run status updates.
 type WithRunStatusUpdates interface {
 	Output
-	SetRunStatus(latestStatus lib.RunStatus)
+	SetRunStatus(latestStatus cloudapi.RunStatus)
 }
 
 // WithBuiltinMetrics means the output can receive the builtin metrics.


### PR DESCRIPTION
This is built on top of https://github.com/grafana/k6/pull/2807 and is a part of https://github.com/grafana/k6/issues/1889 and part of https://github.com/grafana/k6/issues/2430

`RunStatus` is very specific to the k6 cloud and doesn't map perfectly to how k6 OSS sees the causes of prematurely stopped tests. So, this PR restricts the usage of `RunStatus` only to the `cloudapi/` package and to the `k6 cloud` command handling in `cmd/cloud.go`.

It does that by introducing a new type, `errext.AbortReason`, and a way to attach this type to test run errors. This allows us a cleaner error propagation to the outputs, and every output can map these generic values to its own internal ones however it wants. It is not necessary for that mapping to be exactly 1:1 and, indeed, as you can see, the `errext.AbortReason`:`cloudapi.RunStatus` mapping in `cloudapi/` is not 1:1.