### PR TITLE
Bump prom rw output @v0.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/fatih/color v1.13.0
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.5.0
-	github.com/grafana/xk6-output-prometheus-remote v0.0.9
+	github.com/grafana/xk6-output-prometheus-remote v0.1.0
 	github.com/grafana/xk6-redis v0.1.1
 	github.com/grafana/xk6-timers v0.1.2
 	github.com/grafana/xk6-websockets v0.1.6

--- a/go.sum
+++ b/go.sum
@@ -183,8 +183,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/xk6-output-prometheus-remote v0.0.9 h1:L//kjBrCs6Uw4F4xmbA8fhaCVBYR7jq4iMkn6SThn0k=
-github.com/grafana/xk6-output-prometheus-remote v0.0.9/go.mod h1:R4o0VbIfbQNNPSGkeeiCBLzwNfG+DEdfKYNsV1oww1Y=
+github.com/grafana/xk6-output-prometheus-remote v0.1.0 h1:yJc09O6TeBYLFfNG/dqBDtvHmM9P1B2ZFTyr0HgvsHY=
+github.com/grafana/xk6-output-prometheus-remote v0.1.0/go.mod h1:R4o0VbIfbQNNPSGkeeiCBLzwNfG+DEdfKYNsV1oww1Y=
 github.com/grafana/xk6-redis v0.1.1 h1:rvWnLanRB2qzDwuY6NMBe6PXei3wJ3kjYvfCwRJ+q+8=
 github.com/grafana/xk6-redis v0.1.1/go.mod h1:z7el1Tz8advY+ex419KfLbENzSQYgaA2lQYwMlt9yMM=
 github.com/grafana/xk6-timers v0.1.2 h1:YVM6hPDgvy4SkdZQpd+/r9M0kDi1g+QdbSxW5ClfwDk=

--- a/vendor/github.com/grafana/xk6-output-prometheus-remote/pkg/remotewrite/prometheus.go
+++ b/vendor/github.com/grafana/xk6-output-prometheus-remote/pkg/remotewrite/prometheus.go
@@ -21,8 +21,11 @@ func MapTagSet(t *metrics.TagSet) []*prompb.Label {
 	labels := make([]*prompb.Label, 0, n.Len())
 	for !n.IsRoot() {
 		prev, key, value := n.Data()
-		labels = append(labels, &prompb.Label{Name: key, Value: value})
 		n = prev
+		if key == "" || value == "" {
+			continue
+		}
+		labels = append(labels, &prompb.Label{Name: key, Value: value})
 	}
 	return labels
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -80,7 +80,7 @@ github.com/golang/snappy
 # github.com/gorilla/websocket v1.5.0
 ## explicit; go 1.12
 github.com/gorilla/websocket
-# github.com/grafana/xk6-output-prometheus-remote v0.0.9
+# github.com/grafana/xk6-output-prometheus-remote v0.1.0
 ## explicit; go 1.18
 github.com/grafana/xk6-output-prometheus-remote/pkg/remote
 github.com/grafana/xk6-output-prometheus-remote/pkg/remotewrite


### PR DESCRIPTION
Bump again the version of the Prometheus remote write output. It fixes a new bug.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
