### PR TITLE
fix: csv output for non indexable metrics

### DIFF
--- a/output/csv/output.go
+++ b/output/csv/output.go
@@ -48,6 +48,20 @@ func newOutput(params output.Params) (*Output, error) {
 	ignoredTags := []string{}
 	tags := params.ScriptOptions.SystemTags.Map()
 	for tag, flag := range tags {
+		systemTag, err := metrics.SystemTagString(tag)
+		if err != nil {
+			return nil, err
+		}
+
+		// The non-indexable system tags are neither a "resTag"
+		// nor an "ignoreTag". They aren't a "resTag" as they
+		// aren't added as a column in the CSV. Yet they also
+		// shouldn't be ignored as they are added to the
+		// "metadata" column
+		if metrics.NonIndexableSystemTags.Has(systemTag) {
+			continue
+		}
+
 		if flag {
 			resTags = append(resTags, tag)
 		} else {

--- a/output/csv/output_test.go
+++ b/output/csv/output_test.go
@@ -245,6 +245,7 @@ func TestRun(t *testing.T) {
 							"url":   "val2",
 							"error": "val3",
 							"tag4":  "val4",
+							"vu":    "1",
 						}),
 					},
 					Metadata: map[string]string{},
@@ -257,7 +258,7 @@ func TestRun(t *testing.T) {
 			timeFormat:     "",
 			outputContent: "metric_name,timestamp,metric_value,check,error,extra_tags,metadata\n" +
 				"my_metric,1562324643,1.000000,val1,val3,url=val2,\n" +
-				"my_metric,1562324644,1.000000,val1,val3,tag4=val4&url=val2,\n",
+				"my_metric,1562324644,1.000000,val1,val3,tag4=val4&url=val2&vu=1,\n",
 		},
 		{
 			samples: []metrics.SampleContainer{
@@ -350,7 +351,7 @@ func TestRun(t *testing.T) {
 				Environment:    env,
 				ConfigArgument: data.fileName,
 				ScriptOptions: lib.Options{
-					SystemTags: metrics.NewSystemTagSet(metrics.TagError | metrics.TagCheck),
+					SystemTags: metrics.NewSystemTagSet(metrics.TagError | metrics.TagCheck | metrics.TagVU),
 				},
 			})
 			require.NoError(t, err)


### PR DESCRIPTION
## Description

Fix for https://github.com/grafana/k6/issues/2827 without refactoring the CSV output or adding integration tests (which are waiting on https://github.com/grafana/k6/pull/2821).

- Removes the empty `vu` and `iter` columns from the CSV output if they are included as system tags.
- Includes the `vu` and `iter` tags in the `metadata` column of the output if they are included as system tags.

## Manual Testing

I've not added any integration tests as the integration tests are being refactored in https://github.com/grafana/k6/pull/2821

Instead I get the follow results:

```
*** TEST 1 - vu and iter set in system tags ***

SCRIPT:

    import { sleep } from "k6";
    import http from "k6/http";

    export const options = {
      systemTags: ["vu", "iter"],
    };

    export default function () {
      http.get("https://test.k6.io");
      sleep(0.5);
    }

RESULTS (RAW):

metric_name,timestamp,metric_value,extra_tags,metadata
http_reqs,1671829510,1.000000,,vu=1&iter=0
http_req_duration,1671829510,209.901522,,vu=1&iter=0
http_req_blocked,1671829510,243.403270,,vu=1&iter=0
http_req_connecting,1671829510,101.651533,,vu=1&iter=0
http_req_tls_handshaking,1671829510,105.763562,,vu=1&iter=0
http_req_sending,1671829510,0.029080,,iter=0&vu=1
http_req_waiting,1671829510,209.601753,,vu=1&iter=0
http_req_receiving,1671829510,0.270689,,vu=1&iter=0
http_req_failed,1671829510,0.000000,,vu=1&iter=0
data_sent,1671829511,438.000000,,vu=1&iter=0
data_received,1671829511,16962.000000,,vu=1&iter=0
iteration_duration,1671829511,954.882908,,vu=1&iter=0
iterations,1671829511,1.000000,,vu=1&iter=0

RESULTS (FORMATTED):

metric_name               timestamp   metric_value  extra_tags  metadata
http_reqs                 1671829510  1.000000                  vu=1&iter=0
http_req_duration         1671829510  209.901522                vu=1&iter=0
http_req_blocked          1671829510  243.403270                vu=1&iter=0
http_req_connecting       1671829510  101.651533                vu=1&iter=0
http_req_tls_handshaking  1671829510  105.763562                vu=1&iter=0
http_req_sending          1671829510  0.029080                  iter=0&vu=1
http_req_waiting          1671829510  209.601753                vu=1&iter=0
http_req_receiving        1671829510  0.270689                  vu=1&iter=0
http_req_failed           1671829510  0.000000                  vu=1&iter=0
data_sent                 1671829511  438.000000                vu=1&iter=0
data_received             1671829511  16962.000000              vu=1&iter=0
iteration_duration        1671829511  954.882908                vu=1&iter=0
iterations                1671829511  1.000000                  vu=1&iter=0
```

```
*** TEST 2 - vu and iter set in system tags along with an extra tag ***

SCRIPT:

    import { sleep } from "k6";
    import http from "k6/http";

    export const options = {
      systemTags: ["vu", "iter"],
    };

    export default function () {
      http.get("https://test.k6.io", {
        tags: {
          "atesttag": "1"
        }
      });
      sleep(0.5);
    }

RESULTS (RAW):

metric_name,timestamp,metric_value,extra_tags,metadata
http_reqs,1671829512,1.000000,atesttag=1,iter=0&vu=1
http_req_duration,1671829512,196.976420,atesttag=1,vu=1&iter=0
http_req_blocked,1671829512,221.245422,atesttag=1,iter=0&vu=1
http_req_connecting,1671829512,105.763210,atesttag=1,iter=0&vu=1
http_req_tls_handshaking,1671829512,109.340836,atesttag=1,iter=0&vu=1
http_req_sending,1671829512,0.101357,atesttag=1,iter=0&vu=1
http_req_waiting,1671829512,196.618219,atesttag=1,iter=0&vu=1
http_req_receiving,1671829512,0.256844,atesttag=1,iter=0&vu=1
http_req_failed,1671829512,0.000000,atesttag=1,iter=0&vu=1
data_sent,1671829513,438.000000,,vu=1&iter=0
data_received,1671829513,16962.000000,,vu=1&iter=0
iteration_duration,1671829513,919.258656,,iter=0&vu=1
iterations,1671829513,1.000000,,vu=1&iter=0

RESULTS (FORMATTED):

metric_name               timestamp   metric_value  extra_tags  metadata
http_reqs                 1671829512  1.000000      atesttag=1  iter=0&vu=1
http_req_duration         1671829512  196.976420    atesttag=1  vu=1&iter=0
http_req_blocked          1671829512  221.245422    atesttag=1  iter=0&vu=1
http_req_connecting       1671829512  105.763210    atesttag=1  iter=0&vu=1
http_req_tls_handshaking  1671829512  109.340836    atesttag=1  iter=0&vu=1
http_req_sending          1671829512  0.101357      atesttag=1  iter=0&vu=1
http_req_waiting          1671829512  196.618219    atesttag=1  iter=0&vu=1
http_req_receiving        1671829512  0.256844      atesttag=1  iter=0&vu=1
http_req_failed           1671829512  0.000000      atesttag=1  iter=0&vu=1
data_sent                 1671829513  438.000000                vu=1&iter=0
data_received             1671829513  16962.000000              vu=1&iter=0
iteration_duration        1671829513  919.258656                iter=0&vu=1
iterations                1671829513  1.000000                  vu=1&iter=0
```

```
*** TEST 3 - no options or extra tags ***

SCRIPT:

    import { sleep } from "k6";
    import http from "k6/http";

    export default function () {
      http.get("https://test.k6.io");
      sleep(0.5);
    }

RESULTS (RAW):

metric_name,timestamp,metric_value,check,error,error_code,expected_response,group,method,name,proto,scenario,service,status,subproto,tls_version,url,extra_tags,metadata
http_reqs,1671829514,1.000000,,,,true,,GET,https://test.k6.io,HTTP/1.1,default,,200,,tls1.3,https://test.k6.io,,
http_req_duration,1671829514,213.399901,,,,true,,GET,https://test.k6.io,HTTP/1.1,default,,200,,tls1.3,https://test.k6.io,,
http_req_blocked,1671829514,225.515476,,,,true,,GET,https://test.k6.io,HTTP/1.1,default,,200,,tls1.3,https://test.k6.io,,
http_req_connecting,1671829514,108.347288,,,,true,,GET,https://test.k6.io,HTTP/1.1,default,,200,,tls1.3,https://test.k6.io,,
http_req_tls_handshaking,1671829514,112.205076,,,,true,,GET,https://test.k6.io,HTTP/1.1,default,,200,,tls1.3,https://test.k6.io,,
http_req_sending,1671829514,0.047558,,,,true,,GET,https://test.k6.io,HTTP/1.1,default,,200,,tls1.3,https://test.k6.io,,
http_req_waiting,1671829514,212.355127,,,,true,,GET,https://test.k6.io,HTTP/1.1,default,,200,,tls1.3,https://test.k6.io,,
http_req_receiving,1671829514,0.997216,,,,true,,GET,https://test.k6.io,HTTP/1.1,default,,200,,tls1.3,https://test.k6.io,,
http_req_failed,1671829514,0.000000,,,,true,,GET,https://test.k6.io,HTTP/1.1,default,,200,,tls1.3,https://test.k6.io,,
data_sent,1671829515,438.000000,,,,,,,,,default,,,,,,,
data_received,1671829515,16984.000000,,,,,,,,,default,,,,,,,
iteration_duration,1671829515,940.315375,,,,,,,,,default,,,,,,,
iterations,1671829515,1.000000,,,,,,,,,default,,,,,,,

RESULTS (FORMATTED):

metric_name               timestamp   metric_value  check  error  error_code  expected_response  group  method  name                proto     scenario  service  status  subproto  tls_version  url                 extra_tags  metadata
http_reqs                 1671829514  1.000000                                true                      GET     https://test.k6.io  HTTP/1.1  default            200               tls1.3       https://test.k6.io              
http_req_duration         1671829514  213.399901                              true                      GET     https://test.k6.io  HTTP/1.1  default            200               tls1.3       https://test.k6.io              
http_req_blocked          1671829514  225.515476                              true                      GET     https://test.k6.io  HTTP/1.1  default            200               tls1.3       https://test.k6.io              
http_req_connecting       1671829514  108.347288                              true                      GET     https://test.k6.io  HTTP/1.1  default            200               tls1.3       https://test.k6.io              
http_req_tls_handshaking  1671829514  112.205076                              true                      GET     https://test.k6.io  HTTP/1.1  default            200               tls1.3       https://test.k6.io              
http_req_sending          1671829514  0.047558                                true                      GET     https://test.k6.io  HTTP/1.1  default            200               tls1.3       https://test.k6.io              
http_req_waiting          1671829514  212.355127                              true                      GET     https://test.k6.io  HTTP/1.1  default            200               tls1.3       https://test.k6.io              
http_req_receiving        1671829514  0.997216                                true                      GET     https://test.k6.io  HTTP/1.1  default            200               tls1.3       https://test.k6.io              
http_req_failed           1671829514  0.000000                                true                      GET     https://test.k6.io  HTTP/1.1  default            200               tls1.3       https://test.k6.io              
data_sent                 1671829515  438.000000                                                                                              default                                                                           
data_received             1671829515  16984.000000                                                                                            default                                                                           
iteration_duration        1671829515  940.315375                                                                                              default                                                                           
iterations                1671829515  1.000000                                                                                                default                                                                           
```

from the script:

```sh
docker run -it golang:alpine sh -c 'sh <<EOC 
  apk add --no-cache --quiet git make util-linux
  git clone --depth 1 https://github.com/leonyork/k6.git
  cd k6
  make build

  cat <<EOF > test1.js
    import { sleep } from "k6";
    import http from "k6/http";

    export const options = {
      systemTags: ["vu", "iter"],
    };

    export default function () {
      http.get("https://test.k6.io");
      sleep(0.5);
    }
EOF
  ./k6 run test1.js -o csv=results1.csv

  cat <<EOF > test2.js
    import { sleep } from "k6";
    import http from "k6/http";

    export const options = {
      systemTags: ["vu", "iter"],
    };

    export default function () {
      http.get("https://test.k6.io", {
        tags: {
          "atesttag": "1"
        }
      });
      sleep(0.5);
    }
EOF
  ./k6 run test2.js -o csv=results2.csv

  cat <<EOF > test3.js
    import { sleep } from "k6";
    import http from "k6/http";

    export default function () {
      http.get("https://test.k6.io");
      sleep(0.5);
    }
EOF
  ./k6 run test3.js -o csv=results3.csv
  echo
  echo "*** TEST 1 - vu and iter set in system tags ***"
  echo
  echo "SCRIPT:"
  echo
  cat test1.js
  echo 
  echo "RESULTS (RAW):"
  echo
  cat results1.csv
  echo
  echo "RESULTS (FORMATTED):"
  echo
  cat results1.csv | column -t -s ,
  echo
  echo "*** TEST 2 - vu and iter set in system tags along with an extra tag ***"
  echo
  echo "SCRIPT:"
  echo
  cat test2.js
  echo
  echo "RESULTS (RAW):"
  echo 
  cat results2.csv
  echo
  echo "RESULTS (FORMATTED):"
  echo
  cat results2.csv | column -t -s ,
  echo
  echo "*** TEST 3 - no options or extra tags ***"
  echo
  echo "SCRIPT:"
  echo
  cat test3.js
  echo
  echo "RESULTS (RAW):"
  echo 
  cat results3.csv
  echo
  echo "RESULTS (FORMATTED):"
  echo
  cat results3.csv | column -t -s ,
EOC'
```