### PR TITLE
Update template for release notes

### DIFF
--- a/release notes/template.md
+++ b/release notes/template.md
@@ -1,14 +1,47 @@
-TODO: Intro
+k6 `<version>` is here 🎉! This release includes:
 
-## New Features!
+- (_optional_) `<highlight of breaking changes>`
+- `<Summary of new features>` (_one or multiple bullets_)
 
-### Category: Title (#533)
 
-Description of feature.
+## Breaking changes
 
-**Docs**: [Title](http://k6.readme.io/docs/TODO)
+- `#pr`, `<small_break_1>`
+- `#pr`, `<small_break_2>`
 
-## Bugs fixed!
+### (_optional h3_) `<big_breaking_change>` `#pr`
 
-* Category: description of bug ([#PR](https://github.com/grafana/k6/issue-number)). Thanks, @external-contributor!
-  Note: the period includes the PR link.
+## New features
+
+_optional intro here_
+
+### `<big_feature_1>` `#pr`
+
+_what, why, and what this means for the user_
+
+### `<big_feature_n>` `#pr`
+
+_what, why, and what this means for the user_
+
+### UX improvements and enhancements
+
+_Format as `<number> <present_verb> <object>. <credit>`_:
+
+- _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
+- `#pr` `<description>`
+- `#pr` `<description>`
+
+## Bugs fixes
+
+_Format as `<number> <present_verb> <object>. <credit>`_:
+- _`#111` fixes race condition in runtime_
+
+## Maintenance and internal improvements
+
+_Format as `<number> <present_verb> <object>. <credit>`_:
+- _`#2770` Refactors parts of the JS module._
+
+## _Optional_ Roadmap
+
+_Discussion of future plans_
+

--- a/release notes/template.md
+++ b/release notes/template.md
@@ -31,7 +31,7 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - `#pr` `<description>`
 - `#pr` `<description>`
 
-## Bugs fixes
+## Bug fixes
 
 _Format as `<number> <present_verb> <object>. <credit>`_:
 - _`#111` fixes race condition in runtime_


### PR DESCRIPTION
The main goal is to reduce guessing from the writer's and the editor's work.  Besides that, a standardized structure also makes it easier for readers to scan across multiple release-note pages.

I based this on the [v0.40.0 Release notes](https://github.com/grafana/k6/blob/master/release%20notes/v0.40.0.md), which I thought were particularly successful.