### PR TITLE
Add experimental tracing js module

### DIFF
--- a/cmd/integration_tests/tracing/tracing_test.go
+++ b/cmd/integration_tests/tracing/tracing_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/core/local"
+	"go.k6.io/k6/js"
+	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/js/modules/k6/experimental/tracing"
+	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/executor"
+	"go.k6.io/k6/lib/testutils"
+	"go.k6.io/k6/lib/types"
+	"go.k6.io/k6/loader"
+	"go.k6.io/k6/metrics"
+	"gopkg.in/guregu/null.v3"
+)
+
+func init() {
+	modules.Register("k6/x/tracing", tracing.New())
+}
+
+func TestTracingInstrumentHTTP(t *testing.T) {
+	t.Parallel()
+
+	testScript := []byte(`
+		tracing.instrumentHTTP({propagator: "w3c"});
+	`)
+
+	testHandle := func(ctx context.Context, r lib.Runner, err error, logHook *testutils.SimpleLogrusHook) {
+		require.NoError(t, err)
+	}
+
+	tracingTest(t, testScript, testHandle)
+}
+
+func tracingTest(t *testing.T, script []byte, testHandle func(context.Context, lib.Runner, error, *testutils.SimpleLogrusHook)) {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.InfoLevel, logrus.WarnLevel, logrus.ErrorLevel}}
+	logger.AddHook(logHook)
+
+	registry := metrics.NewRegistry()
+	preInitState := &lib.TestPreInitState{
+		Logger:         logger,
+		Registry:       registry,
+		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+	}
+
+	script = []byte("import tracing from 'k6/x/tracing';\n" + string(script))
+	runner, err := js.New(preInitState, &loader.SourceData{Data: script}, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	newOpts, err := executor.DeriveScenariosFromShortcuts(lib.Options{
+		MetricSamplesBufferSize: null.NewInt(200, false),
+		TeardownTimeout:         types.NullDurationFrom(time.Second),
+		SetupTimeout:            types.NullDurationFrom(time.Second),
+	}.Apply(runner.GetOptions()), nil)
+	require.NoError(t, err)
+	require.Empty(t, newOpts.Validate())
+	require.NoError(t, runner.SetOptions(newOpts))
+
+	testState := &lib.TestRunState{
+		TestPreInitState: preInitState,
+		Options:          newOpts,
+		Runner:           runner,
+		RunTags:          preInitState.Registry.RootTagSet().WithTagsFromMap(newOpts.RunTags),
+	}
+
+	execScheduler, err := local.NewExecutionScheduler(testState)
+	require.NoError(t, err)
+
+	samples := make(chan metrics.SampleContainer, newOpts.MetricSamplesBufferSize.Int64)
+	go func() {
+		for {
+			select {
+			case <-samples:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	require.NoError(t, execScheduler.Init(ctx, samples))
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- execScheduler.Run(ctx, ctx, samples) }()
+
+	select {
+	case err := <-errCh:
+		testHandle(ctx, runner, err, logHook)
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out")
+	}
+}

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -8,6 +8,7 @@ import (
 	"go.k6.io/k6/js/modules/k6/data"
 	"go.k6.io/k6/js/modules/k6/encoding"
 	"go.k6.io/k6/js/modules/k6/execution"
+	"go.k6.io/k6/js/modules/k6/experimental/tracing"
 	"go.k6.io/k6/js/modules/k6/grpc"
 	"go.k6.io/k6/js/modules/k6/html"
 	"go.k6.io/k6/js/modules/k6/http"
@@ -30,6 +31,7 @@ func getInternalJSModules() map[string]interface{} {
 		"k6/experimental/redis":      redis.New(),
 		"k6/experimental/websockets": &expws.RootModule{},
 		"k6/experimental/timers":     timers.New(),
+		"k6/experimental/tracing":    tracing.New(),
 		"k6/net/grpc":                grpc.New(),
 		"k6/html":                    html.New(),
 		"k6/http":                    http.New(),

--- a/js/modules/k6/experimental/tracing/client.go
+++ b/js/modules/k6/experimental/tracing/client.go
@@ -1,0 +1,269 @@
+package tracing
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/js/modules"
+	httpmodule "go.k6.io/k6/js/modules/k6/http"
+	"go.k6.io/k6/metrics"
+)
+
+// Client represents a HTTP Client instrumenting the requests
+// it performs with tracing information.
+type Client struct {
+	vu modules.VU
+
+	// opts holds the client's configuration options.
+	opts options
+
+	// propagator holds the client's trace propagator, used
+	// to produce trace context headers for each supported
+	// formats: w3c, b3, jaeger.
+	propagator Propagator
+
+	// requestFunc holds the http module's request function
+	// used to emit HTTP requests in k6 script. The client
+	// uses it under the hood to emit the requests it
+	// instruments.
+	requestFunc HTTPRequestFunc
+}
+
+type (
+	// HTTPRequestFunc is a type alias representing the prototype of
+	// k6's http module's request function
+	HTTPRequestFunc func(method string, url goja.Value, args ...goja.Value) (*httpmodule.Response, error)
+)
+
+// NewClient instantiates a new tracing Client
+func NewClient(vu modules.VU, opts options) *Client {
+	rt := vu.Runtime()
+
+	// Instantiate the http module in our runtime and get its default exported object
+	httpModuleObj, ok := httpmodule.New().NewModuleInstance(vu).Exports().Default.(*goja.Object)
+	if !ok {
+		common.Throw(rt, errors.New("failed to initialize tracing client, unable to load http module"))
+	}
+
+	// Get the http module's request function
+	httpModuleRequest := httpModuleObj.Get("request")
+
+	// Export the http module's request function goja.Callable as a Go function
+	var requestFunc HTTPRequestFunc
+	if err := rt.ExportTo(httpModuleRequest, &requestFunc); err != nil {
+		common.Throw(
+			rt,
+			fmt.Errorf("failed initializing tracing client, unable to export http.request method; reason: %w", err),
+		)
+	}
+
+	client := &Client{vu: vu, requestFunc: requestFunc}
+	if err := client.Configure(opts); err != nil {
+		common.Throw(
+			rt,
+			fmt.Errorf("failed initializing tracing client, invalid configuration; reason: %w", err),
+		)
+	}
+
+	return client
+}
+
+// Configure configures the tracing client with the given options.
+func (c *Client) Configure(opts options) error {
+	if err := opts.validate(); err != nil {
+		return fmt.Errorf("invalid options: %w", err)
+	}
+
+	switch opts.Propagator {
+	case "w3c":
+		c.propagator = &W3CPropagator{}
+	case "b3":
+		c.propagator = &B3Propagator{}
+	case "jaeger":
+		c.propagator = &JaegerPropagator{}
+	default:
+		return fmt.Errorf("unknown propagator: %s", opts.Propagator)
+	}
+
+	c.opts = opts
+
+	return nil
+}
+
+// Request instruments the http module's request function with tracing headers,
+// and ensures the trace_id is emitted as part of the output's data points metadata.
+func (c *Client) Request(method string, url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	rt := c.vu.Runtime()
+
+	// Ensure the arguments have a params object, in which
+	// we can add the tracing headers at a later point in time.
+	args, params, err := c.getOrCreateParams(method, args...)
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("failed to normalize the params argument; reason: %w", err))
+	}
+
+	// Ensure that the params object contains a headers object.
+	// Create it if it doesn't.
+	headers, err := c.getOrCreateHeaders(params)
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("failed to normalize params argument headers property; reason: %w", err))
+	}
+
+	traceID := NewTraceID(k6Prefix, k6CloudCode, uint64(time.Now().UnixNano()))
+	encodedTraceID, _, err := traceID.Encode()
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("failed to encode the generated trace ID; reason: %w", err))
+	}
+
+	// Produce a trace header in the format defined by the
+	// configured propagator.
+	header, err := c.propagator.Propagate(encodedTraceID)
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("failed to propagate trace ID; reason: %w", err))
+	}
+
+	for key, value := range header {
+		err = headers.Set(key, value)
+		if err != nil {
+			common.Throw(rt, fmt.Errorf("failed to set the trace header; reason: %w", err))
+		}
+	}
+
+	// Add the trace ID to the VU's state, so that it can be
+	// used in the metrics emitted by the HTTP module.
+	c.vu.State().Tags.Modify(func(t *metrics.TagsAndMeta) {
+		t.SetMetadata(metadataTraceIDKeyName, encodedTraceID)
+	})
+
+	response, err := c.requestFunc(method, url, args...)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	// Remove the trace ID from the VU's state, so that it doesn't
+	// leak into other requests.
+	c.vu.State().Tags.Modify(func(t *metrics.TagsAndMeta) {
+		t.DeleteMetadata(metadataTraceIDKeyName)
+	})
+
+	return response, nil
+}
+
+// Delete instruments the http module's delete method.
+func (c *Client) Delete(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodDelete, url, args...)
+}
+
+// Get instruments the http module's get method.
+func (c *Client) Get(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	// Here we prepend a null value that stands for the body parameter,
+	// that the request function expects as a first argument implicitly
+	args = append([]goja.Value{goja.Null()}, args...)
+	return c.Request(http.MethodGet, url, args...)
+}
+
+// Head instruments the http module's head method.
+func (c *Client) Head(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	// NB: here we prepend a null value that stands for the body parameter,
+	// that the request function expects as a first argument implicitly
+	args = append([]goja.Value{goja.Null()}, args...)
+	return c.Request(http.MethodHead, url, args...)
+}
+
+// Options instruments the http module's options method.
+func (c *Client) Options(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodOptions, url, args...)
+}
+
+// Patch instruments the http module's patch method.
+func (c *Client) Patch(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodPatch, url, args...)
+}
+
+// Post instruments the http module's post method.
+func (c *Client) Post(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodPost, url, args...)
+}
+
+// Put instruments the http module's put method.
+func (c *Client) Put(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodPut, url, args...)
+}
+
+// getOrCreateParams ensures that the HTTP method arguments list contains
+// a params object. If it doesn't, it creates one.
+//
+// The method returns the normalized arguments list as well as its params
+// object.
+//
+// Note that as of k6 v0.42.0 the HTTP API can turn out to be a bit inconsistent,
+// as it can be called with 0, 1 or 2 arguments, and the second argument
+// can be either a request's body, or a params object.
+func (c *Client) getOrCreateParams(method string, args ...goja.Value) ([]goja.Value, *goja.Object, error) {
+	rt := c.vu.Runtime()
+	params := rt.NewObject()
+
+	// The first argument of http methods is the `this` argument, so we need to shift
+	// the arguments list by one. Thus, the cases below correspond to the effective
+	// argument count of the http method + 1.
+	switch len(args) {
+	case 2, 3:
+		// The second (or third) argument is the params object.
+		paramsValue := args[len(args)-1]
+		if !isNullish(paramsValue) {
+			params = paramsValue.ToObject(rt)
+			break
+		}
+
+		args[len(args)-1] = params
+	case 1:
+		// The http.get and the http.head methods take an optional params
+		// object as first argument. Whereas the other methods take a
+		// request's body as first argument, and an optional params object
+		// as second argument.
+		if method != http.MethodGet && method != http.MethodHead {
+			args = append(args, params)
+			break
+		}
+
+		// The first argument is the params object.
+		paramsValue := args[0]
+		if !isNullish(paramsValue) {
+			params = paramsValue.ToObject(rt)
+			break
+		}
+
+		args[0] = params
+	case 0:
+		// No arguments, we'll add a params object as the second argument.
+		args = []goja.Value{goja.Null(), params}
+	default:
+		return args, params, fmt.Errorf("unexpected number of arguments for http.%s method", method)
+	}
+
+	return args, params, nil
+}
+
+// getOrCreateHeaders ensures that a http method params object is properly
+// formed, and has the expected properties set.
+//
+// This method modifies the params object in place, and returns the headers object.
+func (c *Client) getOrCreateHeaders(params *goja.Object) (*goja.Object, error) {
+	rt := c.vu.Runtime()
+
+	headersValue := params.Get("headers")
+	if !isNullish(headersValue) {
+		return headersValue.ToObject(rt), nil
+	}
+
+	headers := rt.NewObject()
+	if err := params.Set("headers", headers); err != nil {
+		return nil, err
+	}
+
+	return headers, nil
+}

--- a/js/modules/k6/experimental/tracing/client_test.go
+++ b/js/modules/k6/experimental/tracing/client_test.go
@@ -1,0 +1,275 @@
+package tracing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/modulestest"
+)
+
+func TestClientGetOrCreateParams(t *testing.T) {
+	t.Parallel()
+
+	t.Run("a provided body and params fn(fst, body, {}) leaves params untouched", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := Client{vu: testSetup.VU}
+		wantBody := testSetup.VU.Runtime().NewObject()
+		wantParams := testSetup.VU.Runtime().NewObject()
+		headers := testSetup.VU.Runtime().NewObject()
+		err := headers.Set("Content-Type", "application/json")
+		require.NoError(t, err)
+		err = wantParams.Set("headers", headers)
+		require.NoError(t, err)
+
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodPost, wantBody, wantParams)
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, wantBody, gotArgs[0])
+		assert.Equal(t, wantParams, gotArgs[1])
+	})
+
+	t.Run("a provided body and null params arg fn(fst, body, null) intializes params", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+		wantBody := testSetup.VU.Runtime().NewObject()
+
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodPost, wantBody, goja.Null())
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, wantBody, gotArgs[0])
+		assert.Equal(t, gotParams, gotArgs[1])
+	})
+
+	t.Run("a provided body and undefined params arg fn(fst, body, undefined) intializes params", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+		wantBody := testSetup.VU.Runtime().NewObject()
+
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodPost, wantBody, goja.Undefined())
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, wantBody, gotArgs[0])
+		assert.Equal(t, gotParams, gotArgs[1])
+	})
+
+	t.Run("a provided body and nil params arg fn(fst, body) intializes params", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+		wantBody := testSetup.VU.Runtime().NewObject()
+
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodPost, wantBody, nil)
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, wantBody, gotArgs[0])
+		assert.Equal(t, gotParams, gotArgs[1])
+	})
+
+	t.Run("a provided body and no params arg fn(fst, body) intializes params", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+		wantBody := testSetup.VU.Runtime().NewObject()
+
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodPost, wantBody)
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, wantBody, gotArgs[0])
+		assert.Equal(t, gotParams, gotArgs[1])
+	})
+
+	t.Run("a provided nil body and no params arg fn(fst, null) intializes params", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodPost, nil)
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 2)
+		assert.Nil(t, gotArgs[0])
+		assert.Equal(t, gotParams, gotArgs[1])
+	})
+
+	t.Run("a provided null params argument fn(fst, null) should initialize it", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodGet, goja.Null())
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 1)
+		assert.Equal(t, gotParams, gotArgs[0])
+	})
+
+	t.Run("a provided undefined params argument fn(fst, undefined) should initialize it", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodGet, goja.Undefined())
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 1)
+		assert.Equal(t, gotParams, gotArgs[0])
+	})
+
+	t.Run("a provided nil params argument fn(fst) should initialize it", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodGet, nil)
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 1)
+		assert.Equal(t, gotParams, gotArgs[0])
+	})
+
+	t.Run("a provided params argument fn(fst, {}) should leave it untouched", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+		headers := testSetup.VU.Runtime().NewObject()
+		err := headers.Set("test-header", "test-value")
+		require.NoError(t, err)
+		wantParams := testSetup.VU.Runtime().NewObject()
+		err = wantParams.Set("headers", headers)
+		require.NoError(t, err)
+
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodGet, wantParams)
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 1)
+		assert.Equal(t, gotArgs[0], wantParams)
+		assert.True(t, gotParams == wantParams)
+	})
+
+	t.Run("no arguments beyond first fn(fst) should initialize a params argument", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+
+		// the http.get method has a single argument, besides url,
+		// which is the optional gotParams object. We use it here to
+		// verify that we create a default gotParams object under the
+		// hood.
+		gotArgs, gotParams, gotErr := client.getOrCreateParams(http.MethodGet)
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, gotParams)
+		assert.NotNil(t, gotArgs)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, gotArgs[0], goja.Null())
+		assert.Equal(t, gotArgs[1], gotParams)
+	})
+}
+
+func TestClientGetOrCreateHeaders(t *testing.T) {
+	t.Parallel()
+
+	t.Run("params object with headers fn(..., { headers: {...} }) should return them", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+		params := testSetup.VU.Runtime().NewObject()
+		headers := testSetup.VU.Runtime().NewObject()
+		err := params.Set("headers", headers)
+		require.NoError(t, err)
+
+		gotHeaders, gotErr := client.getOrCreateHeaders(params)
+
+		assert.NoError(t, gotErr)
+		assert.Equal(t, gotHeaders, params.Get("headers"))
+	})
+
+	t.Run("params object without headers fn(..., { }) should initialize some", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+		wantParams := testSetup.VU.Runtime().NewObject()
+
+		gotHeaders, gotErr := client.getOrCreateHeaders(wantParams)
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, wantParams.Get("headers"))
+		assert.NotNil(t, gotHeaders)
+	})
+
+	t.Run("params object with undefined headers fn(..., { headers: undefined }) should set some", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+		wantParams := testSetup.VU.Runtime().NewObject()
+		err := wantParams.Set("headers", goja.Undefined())
+		require.NoError(t, err)
+
+		gotHeaders, gotErr := client.getOrCreateHeaders(wantParams)
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, wantParams.Get("headers"))
+		assert.NotNil(t, gotHeaders)
+	})
+
+	t.Run("params object with null headers fn(..., { headers: null }) should set some", func(t *testing.T) {
+		t.Parallel()
+
+		testSetup := modulestest.NewRuntime(t)
+		client := &Client{vu: testSetup.VU}
+		wantParams := testSetup.VU.Runtime().NewObject()
+		err := wantParams.Set("headers", goja.Null())
+		require.NoError(t, err)
+
+		gotHeaders, gotErr := client.getOrCreateHeaders(wantParams)
+
+		assert.NoError(t, gotErr)
+		assert.NotNil(t, wantParams.Get("headers"))
+		assert.NotNil(t, gotHeaders)
+	})
+}

--- a/js/modules/k6/experimental/tracing/encoding.go
+++ b/js/modules/k6/experimental/tracing/encoding.go
@@ -1,0 +1,19 @@
+package tracing
+
+import (
+	"math/rand"
+)
+
+// randHexStringRunes returns a random string of n hex characters.
+//
+// Note that this function uses a non-cryptographic random number generator.
+func randHexString(n int) string {
+	hexRunes := []rune("123456789abcdef")
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = hexRunes[rand.Intn(len(hexRunes))] //nolint:gosec
+	}
+
+	return string(b)
+}

--- a/js/modules/k6/experimental/tracing/goja.go
+++ b/js/modules/k6/experimental/tracing/goja.go
@@ -1,0 +1,11 @@
+package tracing
+
+import "github.com/dop251/goja"
+
+// isNullish checks if the given value is nullish, i.e. nil, undefined or null.
+//
+// This helper function emulates the behavior of Javascript's nullish coalescing
+// operator (??).
+func isNullish(value goja.Value) bool {
+	return value == nil || goja.IsUndefined(value) || goja.IsNull(value)
+}

--- a/js/modules/k6/experimental/tracing/module.go
+++ b/js/modules/k6/experimental/tracing/module.go
@@ -1,0 +1,48 @@
+// Package tracing implements a k6 JS module for instrumenting k6 scripts with tracing context information.
+package tracing
+
+import (
+	"go.k6.io/k6/js/modules"
+
+	"github.com/dop251/goja"
+)
+
+type (
+	// RootModule is the global module instance that will create Client
+	// instances for each VU.
+	RootModule struct{}
+
+	// ModuleInstance represents an instance of the JS module.
+	ModuleInstance struct {
+		vu modules.VU
+	}
+)
+
+// Ensure the interfaces are implemented correctly
+var (
+	_ modules.Instance = &ModuleInstance{}
+	_ modules.Module   = &RootModule{}
+)
+
+// New returns a pointer to a new RootModule instance
+func New() *RootModule {
+	return &RootModule{}
+}
+
+// NewModuleInstance implements the modules.Module interface and returns
+// a new instance for each VU.
+func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
+	// Any goja.Value exported to a Go struct will be mapped
+	// to the matching fields using the `js:""` tags.
+	vu.Runtime().SetFieldNameMapper(goja.TagFieldNameMapper("js", true))
+
+	return &ModuleInstance{
+		vu: vu,
+	}
+}
+
+// Exports implements the modules.Instance interface and returns
+// the exports of the JS module.
+func (mi *ModuleInstance) Exports() modules.Exports {
+	return modules.Exports{}
+}

--- a/js/modules/k6/experimental/tracing/module.go
+++ b/js/modules/k6/experimental/tracing/module.go
@@ -51,7 +51,8 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{
 		Named: map[string]interface{}{
-			"Client": mi.NewClient,
+			"Client":         mi.NewClient,
+			"instrumentHTTP": mi.InstrumentHTTP,
 		},
 	}
 }

--- a/js/modules/k6/experimental/tracing/module.go
+++ b/js/modules/k6/experimental/tracing/module.go
@@ -15,6 +15,8 @@ type (
 	// ModuleInstance represents an instance of the JS module.
 	ModuleInstance struct {
 		vu modules.VU
+
+		*Tracing
 	}
 )
 
@@ -38,11 +40,18 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 
 	return &ModuleInstance{
 		vu: vu,
+		Tracing: &Tracing{
+			vu: vu,
+		},
 	}
 }
 
 // Exports implements the modules.Instance interface and returns
 // the exports of the JS module.
 func (mi *ModuleInstance) Exports() modules.Exports {
-	return modules.Exports{}
+	return modules.Exports{
+		Named: map[string]interface{}{
+			"Client": mi.NewClient,
+		},
+	}
 }

--- a/js/modules/k6/experimental/tracing/options.go
+++ b/js/modules/k6/experimental/tracing/options.go
@@ -1,0 +1,40 @@
+package tracing
+
+import (
+	"errors"
+	"fmt"
+)
+
+// options are the options that can be passed to the
+// tracing.instrumentHTTP() method.
+type options struct {
+	// Propagation is the propagation format to use for the tracer.
+	Propagator string `js:"propagator"`
+
+	// Sampling is the sampling rate to use for the tracer.
+	Sampling *float64 `js:"sampling"`
+
+	// Baggage is a map of baggage items to add to the tracer.
+	Baggage map[string]string `js:"baggage"`
+}
+
+func (i *options) validate() error {
+	var (
+		isW3C    = i.Propagator == W3CPropagatorName
+		isB3     = i.Propagator == B3PropagatorName
+		isJaeger = i.Propagator == JaegerPropagatorName
+	)
+	if !isW3C && !isB3 && !isJaeger {
+		return fmt.Errorf("unknown propagator: %s", i.Propagator)
+	}
+
+	if i.Sampling != nil {
+		return errors.New("sampling is not yet supported")
+	}
+
+	if i.Baggage != nil {
+		return errors.New("baggage is not yet supported")
+	}
+
+	return nil
+}

--- a/js/modules/k6/experimental/tracing/options_test.go
+++ b/js/modules/k6/experimental/tracing/options_test.go
@@ -1,0 +1,81 @@
+package tracing
+
+import "testing"
+
+func TestOptionsValidate(t *testing.T) {
+	t.Parallel()
+
+	testFloat := 10.0
+
+	type fields struct {
+		Propagator string
+		Sampling   *float64
+		Baggage    map[string]string
+	}
+	testCases := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "w3c propagator is valid",
+			fields: fields{
+				Propagator: "w3c",
+			},
+			wantErr: false,
+		},
+		{
+			name: "b3 propagator is valid",
+			fields: fields{
+				Propagator: "b3",
+			},
+			wantErr: false,
+		},
+		{
+			name: "jaeger propagator is valid",
+			fields: fields{
+				Propagator: "jaeger",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid propagator is invalid",
+			fields: fields{
+				Propagator: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "sampling is not yet supported",
+			fields: fields{
+				Sampling: &testFloat,
+			},
+			wantErr: true,
+		},
+		{
+			name: "baggage is not yet supported",
+			fields: fields{
+				Baggage: map[string]string{"key": "value"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			i := &options{
+				Propagator: tc.fields.Propagator,
+				Sampling:   tc.fields.Sampling,
+				Baggage:    tc.fields.Baggage,
+			}
+
+			if err := i.validate(); (err != nil) != tc.wantErr {
+				t.Errorf("instrumentationOptions.validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/js/modules/k6/experimental/tracing/propagator.go
+++ b/js/modules/k6/experimental/tracing/propagator.go
@@ -1,0 +1,90 @@
+package tracing
+
+import (
+	"net/http"
+)
+
+// Propagator is an interface for trace context propagation
+type Propagator interface {
+	Propagate(traceID string) (http.Header, error)
+}
+
+const (
+	// W3CPropagatorName is the name of the W3C trace context propagator
+	W3CPropagatorName = "w3c"
+
+	// W3CHeaderName is the name of the W3C trace context header
+	W3CHeaderName = "traceparent"
+
+	// W3CVersion is the version of the supported W3C trace context header.
+	// The current specification assumes the version is set to 00.
+	W3CVersion = "00"
+
+	// W3CUnsampledTraceFlag is the trace-flag value for an unsampled trace.
+	W3CUnsampledTraceFlag = "00"
+
+	// W3CSampledTraceFlag is the trace-flag value for a sampled trace.
+	W3CSampledTraceFlag = "01"
+)
+
+// W3CPropagator is a Propagator for the W3C trace context header
+type W3CPropagator struct{}
+
+// Propagate returns a header with a random trace ID in the W3C format
+func (p *W3CPropagator) Propagate(traceID string) (http.Header, error) {
+	parentID := randHexString(16)
+
+	return http.Header{
+		W3CHeaderName: {
+			W3CVersion + "-" + traceID + "-" + parentID + "-" + W3CSampledTraceFlag,
+		},
+	}, nil
+}
+
+const (
+	// B3PropagatorName is the name of the B3 trace context propagator
+	B3PropagatorName = "b3"
+
+	// B3HeaderName is the name of the B3 trace context header
+	B3HeaderName = B3PropagatorName
+)
+
+// B3Propagator is a Propagator for the B3 trace context header
+type B3Propagator struct{}
+
+// Propagate returns a header with a random trace ID in the B3 format
+func (p *B3Propagator) Propagate(traceID string) (http.Header, error) {
+	parentID := randHexString(8)
+	parentSpanID := "1"
+
+	return http.Header{
+		B3HeaderName: {traceID + "-" + parentID + "-" + parentSpanID},
+	}, nil
+}
+
+const (
+	// JaegerPropagatorName is the name of the Jaeger trace context propagator
+	JaegerPropagatorName = "jaeger"
+
+	// JaegerHeaderName is the name of the Jaeger trace context header
+	JaegerHeaderName = "uber-trace-id"
+
+	// JaegerRootSpanID is the universal span ID of the root span.
+	// Its value is zero, which is described in the Jaeger documentation as:
+	// "0 value is valid and means “root span” (when not ignored)"
+	JaegerRootSpanID = "0"
+)
+
+// JaegerPropagator is a Propagator for the Jaeger trace context header
+type JaegerPropagator struct{}
+
+// Propagate returns a header with a random trace ID in the Jaeger format
+func (p *JaegerPropagator) Propagate(traceID string) (http.Header, error) {
+	spanID := randHexString(8)
+	// flags set to 1 means the span is sampled
+	flags := "1"
+
+	return http.Header{
+		JaegerHeaderName: {traceID + ":" + spanID + ":" + JaegerRootSpanID + ":" + flags},
+	}, nil
+}

--- a/js/modules/k6/experimental/tracing/trace_id.go
+++ b/js/modules/k6/experimental/tracing/trace_id.go
@@ -1,0 +1,79 @@
+package tracing
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+)
+
+const (
+	// Being 075 the ASCII code for 'K' :)
+	k6Prefix = 0o756
+
+	// To ingest and process the related spans in k6 Cloud.
+	k6CloudCode = 12
+
+	// To not ingest and process the related spans, b/c they are part of a non-cloud run.
+	k6LocalCode = 33
+
+	// metadataTraceIDKeyName is the key name of the traceID in the output metadata.
+	metadataTraceIDKeyName = "trace_id"
+)
+
+// TraceID represents a trace-id as defined by the [W3c specification], and
+// used by w3c, b3 and jaeger propagators. See [Considerations for trace-id field generation]
+// for more information.
+//
+// [W3c specification]: https://www.w3.org/TR/trace-context/#trace-id
+// [Considerations for trace-id field generation]: https://www.w3.org/TR/trace-context/#considerations-for-trace-id-field-generation
+//
+//nolint:lll
+type TraceID struct {
+	Prefix            int16
+	Code              int8
+	UnixTimestampNano uint64
+}
+
+// NewTraceID returns a new TraceID with the given prefix, code and unix timestamp in nanoseconds.
+func NewTraceID(prefix int16, code int8, unixTimestampNano uint64) TraceID {
+	return TraceID{
+		Prefix:            prefix,
+		Code:              code,
+		UnixTimestampNano: unixTimestampNano,
+	}
+}
+
+// Encode encodes the TraceID into a hex string and a byte slice.
+func (t TraceID) Encode() (string, []byte, error) {
+	if !t.isValid() {
+		return "", nil, fmt.Errorf("failed to encode traceID: %v", t)
+	}
+
+	buf := make([]byte, 16)
+
+	n := binary.PutVarint(buf, int64(t.Prefix))
+	n += binary.PutVarint(buf[n:], int64(t.Code))
+	n += binary.PutUvarint(buf[n:], t.UnixTimestampNano)
+
+	randomness := make([]byte, 16-n)
+	err := binary.Read(rand.Reader, binary.BigEndian, randomness)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to read random bytes from os; reason: %w", err)
+	}
+
+	buf = append(buf[:n], randomness...)
+	hx := hex.EncodeToString(buf)
+
+	return hx, buf, nil
+}
+
+func (t TraceID) isValid() bool {
+	var (
+		isk6Prefix = t.Prefix == k6Prefix
+		isk6Cloud  = t.Code == k6CloudCode
+		isk6Local  = t.Code == k6LocalCode
+	)
+
+	return isk6Prefix && (isk6Cloud || isk6Local)
+}

--- a/js/modules/k6/experimental/tracing/trace_id_test.go
+++ b/js/modules/k6/experimental/tracing/trace_id_test.go
@@ -1,0 +1,72 @@
+package tracing
+
+import "testing"
+
+func TestTraceID_isValid(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Prefix            int16
+		Code              int8
+		UnixTimestampNano uint64
+	}
+	testCases := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "traceID with k6 cloud code is valid",
+			fields: fields{
+				Prefix:            k6Prefix,
+				Code:              k6CloudCode,
+				UnixTimestampNano: 123456789,
+			},
+			want: true,
+		},
+		{
+			name: "traceID with k6 local code is valid",
+			fields: fields{
+				Prefix:            k6Prefix,
+				Code:              k6LocalCode,
+				UnixTimestampNano: 123456789,
+			},
+			want: true,
+		},
+		{
+			name: "traceID with prefix != k6Prefix is invalid",
+			fields: fields{
+				Prefix:            0,
+				Code:              k6CloudCode,
+				UnixTimestampNano: 123456789,
+			},
+			want: false,
+		},
+		{
+			name: "traceID code with code != k6CloudCode and code != k6LocalCode is invalid",
+			fields: fields{
+				Prefix:            k6Prefix,
+				Code:              0,
+				UnixTimestampNano: 123456789,
+			},
+			want: false,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tr := &TraceID{
+				Prefix:            tc.fields.Prefix,
+				Code:              tc.fields.Code,
+				UnixTimestampNano: tc.fields.UnixTimestampNano,
+			}
+
+			if got := tr.isValid(); got != tc.want {
+				t.Errorf("TraceID.isValid() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/js/modules/k6/experimental/tracing/tracing.go
+++ b/js/modules/k6/experimental/tracing/tracing.go
@@ -1,0 +1,35 @@
+package tracing
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/js/modules"
+)
+
+// Tracing is the JS module instance that will be created for each VU.
+type Tracing struct {
+	vu modules.VU
+}
+
+// NewClient is the JS constructor for the tracing.Client
+//
+// It expects a single configuration object as argument, which
+// will be used to instantiate an `Object` instance internally,
+// and will be used by the client to configure itself.
+func (t *Tracing) NewClient(cc goja.ConstructorCall) *goja.Object {
+	rt := t.vu.Runtime()
+
+	if len(cc.Arguments) < 1 {
+		common.Throw(rt, errors.New("Client constructor expects a single configuration object as argument; none given"))
+	}
+
+	var opts options
+	if err := rt.ExportTo(cc.Arguments[0], &opts); err != nil {
+		common.Throw(rt, fmt.Errorf("unable to parse options object; reason: %w", err))
+	}
+
+	return rt.ToValue(NewClient(t.vu, opts)).ToObject(rt)
+}

--- a/js/modules/k6/experimental/tracing/tracing.go
+++ b/js/modules/k6/experimental/tracing/tracing.go
@@ -12,6 +12,8 @@ import (
 // Tracing is the JS module instance that will be created for each VU.
 type Tracing struct {
 	vu modules.VU
+
+	defaultClient *Client
 }
 
 // NewClient is the JS constructor for the tracing.Client
@@ -32,4 +34,62 @@ func (t *Tracing) NewClient(cc goja.ConstructorCall) *goja.Object {
 	}
 
 	return rt.ToValue(NewClient(t.vu, opts)).ToObject(rt)
+}
+
+// InstrumentHTTP instruments the HTTP module with tracing headers.
+//
+// When used in the context of a k6 script, it will automatically replace
+// the imported http module's methods with instrumented ones.
+func (t *Tracing) InstrumentHTTP(options options) {
+	rt := t.vu.Runtime()
+
+	// Initialize the tracing module's instance default client,
+	// and configure it using the user-supplied set of options.
+	t.defaultClient = NewClient(t.vu, options)
+
+	// Explicitly inject the http module in the VU's runtime.
+	// This allows us to later on override the http module's methods
+	// with instrumented ones.
+	httpModuleValue, err := rt.RunString(`require('k6/http')`)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	httpModuleObj := httpModuleValue.ToObject(rt)
+
+	// Closure overriding a method of the provided imported module object.
+	//
+	// The `onModule` argument should be a *goja.Object obtained by requiring
+	// or importing the 'k6/http' module and converting it to an object.
+	//
+	// The `value` argument is expected to be callable.
+	mustSetHTTPMethod := func(method string, onModule *goja.Object, value interface{}) {
+		// Inject the new get function, adding tracing headers
+		// to the request in the HTTP module object.
+		err = onModule.Set(method, value)
+		if err != nil {
+			common.Throw(
+				rt,
+				fmt.Errorf("unable to overwrite http.%s method with instrumented one; reason: %w", method, err),
+			)
+		}
+	}
+
+	// Overwrite the implementation of the http module's method with the instrumented
+	// ones exposed by the `tracing.Client` struct.
+	mustSetHTTPMethod("del", httpModuleObj, t.defaultClient.Delete)
+	mustSetHTTPMethod("get", httpModuleObj, t.defaultClient.Get)
+	mustSetHTTPMethod("head", httpModuleObj, t.defaultClient.Head)
+	mustSetHTTPMethod("options", httpModuleObj, t.defaultClient.Options)
+	mustSetHTTPMethod("patch", httpModuleObj, t.defaultClient.Patch)
+	mustSetHTTPMethod("post", httpModuleObj, t.defaultClient.Patch)
+	mustSetHTTPMethod("put", httpModuleObj, t.defaultClient.Patch)
+	mustSetHTTPMethod("request", httpModuleObj, t.defaultClient.Request)
+
+	// Inject the updated HTTP module object in the runtime,
+	// overriding any previously imported one in the process.
+	err = rt.Set("http", httpModuleObj)
+	if err != nil {
+		common.Throw(rt, err)
+	}
 }

--- a/samples/experimental/tracing-client.js
+++ b/samples/experimental/tracing-client.js
@@ -1,0 +1,46 @@
+import http from "k6/http";
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+
+// Explicitly instantiating a tracing client allows to distringuish
+// instrumented from non-instrumented HTTP calls, by keeping APIs separate.
+// It also allows for finer-grained configuration control, by letting
+// users changing the tracing configuration on the fly during their
+// script's execution.
+let instrumentedHTTP = new tracing.Client({
+	propagator: "w3c",
+});
+
+const testData = { name: "Bert" };
+
+export default () => {
+	// Using the tracing client instance, HTTP calls will have
+	// their trace context headers set.
+	let res = instrumentedHTTP.request("GET", "http://httpbin.org/get", null, {
+		headers: {
+			"X-Example-Header": "instrumented/request",
+		},
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+
+	// The tracing client offers more flexibility over
+	// the `instrumentHTTP` function, as it leaves the
+	// imported standard http module untouched. Thus,
+	// one can still perform non-instrumented HTTP calls
+	// using it.
+	res = http.post("http://httpbin.org/post", JSON.stringify(testData), {
+		headers: { "X-Example-Header": "noninstrumented/post" },
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+
+	res = instrumentedHTTP.delete("http://httpbin.org/delete", null, {
+		headers: { "X-Example-Header": "instrumented/delete" },
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+};

--- a/samples/experimental/tracing.js
+++ b/samples/experimental/tracing.js
@@ -1,0 +1,24 @@
+import http from "k6/http";
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+
+// instrumentHTTP will ensure that all requests made by the http module
+// will be traced. The first argument is a configuration object that
+// can be used to configure the tracer.
+//
+// Currently supported HTTP methods are: get, post, put, patch, head,
+// del, options, and request.
+tracing.instrumentHTTP({
+	propagator: "w3c",
+});
+
+export default () => {
+	let res = http.get("http://httpbin.org/get", {
+		headers: {
+			"X-Example-Header": "instrumented/get",
+		},
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+};


### PR DESCRIPTION
Hi folks 👋🏻 

## What
This PR adds a `k6/experimental/tracing` module to k6. It implements the public API specified and agreed upon during our internal design process. As we talked about internally, it is embedded directly in the repository rather than imported from an xk6 extension repository.

Using this module, users can transparently add tracing (trace context) headers to their HTTP calls and have k6 emit the used traced ids as part of the output's metadata. Calling the `instrumentHTTP` function exposed by the module will automatically wrap the imported `http` module's function to include tracing information without involving any changes from the user to their scripts. Each request will use a different trace id, and have a random span id.

A lot of the code in this PR is, in fact, an adaptation of what already existed in [xk6-distributed-tracing](https://github.com/grafana/xk6-distributed-tracing); so kudos @Blinkuu and @dgzlopes for that 🙇🏻 

Design note: this PR implements the logic in Go rather than executing JS directly. The main reason for that is convenience regarding debugging and the ability to set and delete metadata, which I believe is not yet exposed to our JS runtime.

## Scope

In the spirit of keeping PRs small, this one only implements support for:
- propagators: w3c, b3, and jaeger
- `instrumentHTTP` wraps the `delete`, `get`, `head`, `options`, `post`, `patch`, `put`, `request` functions.

Support for the `batch` functions shall be added in later iterations. As well as support for sampling control and the baggage headers specification.

## Support required ✋🏻 

In an ideal world, I'd like to add some tests for the `instrumentHTTP` function. I want to start a test HTTP server and assert that when running a test script using the `instrumentHTTP` function, the expected headers are received by the server. I'd also like to do the same for the output's metadata.

The main blocking challenge I've encountered has been to make the init context available in the `modulestest.Runtime`, so that the `require` function is available in the context of the test script. I think my attempts so far could have been more fruitful. If you have ideas or guidance to help me achieve that, I'd be grateful 🙇🏻 

## Demo

```javascript
// we import the HTTP module in a standard manner
import http from "k6/http";
import { check } from "k6";
import tracing from "k6/experimental/tracing";

// This is the only change users need to make to include tracing context to their requests
// instrumentHTTP will ensure that all requests made by the http module
// will be traced. The first argument is a configuration object that
// can be used to configure the tracer.
//
// Currently supported HTTP methods are: get, post, put, patch, head, del,
// and options.
tracing.instrumentHTTP({
	propagator: "w3c",
});

export default () => {
	const params = {
		headers: {
			"X-My-Header": "something",
		},
	};

        // this http.get call will automatically include a traceparent header
        // and the used trace id will be included in the related data points in
        // the output's metadata.
	let res = http.get("http://httpbin.org/get", params);
	check(res, {
		"status is 200": (r) => r.status === 200,
	});

	let data = { name: "Bert" };

         // this http.get call will automatically include a traceparent header
         // and the used trace id will be included in the related data points in
        // the output's metadata.
	res = http.post("http://httpbin.org/post", JSON.stringify(data), params);
	check(res, {
		"status is 200": (r) => r.status === 200,
	});
};

```

Produces the the following HTTP requests:
```
INFO[0000] Request:
GET /get HTTP/1.1
Host: httpbin.org
User-Agent: k6/0.42.0 (https://k6.io/)
Traceparent: 00-dc0718b190d7e2d730a6219538e16e47-28cf4f6cd985afbb-01
X-My-Header: something
Accept-Encoding: gzip

INFO[0003] Request:
POST /post HTTP/1.1
Host: httpbin.org
User-Agent: k6/0.42.0 (https://k6.io/)
Content-Length: 15
Traceparent: 00-dc0718b1a5d7e2d7300e957d6ec9fb8b-ff9f9edcbfa41b91-01
X-My-Header: something
Accept-Encoding: gzip
```

## Edit
- 5th of January 2023: added support for `http.request`, and added it to the description