### PR TITLE
Fix asyncWaitForStdoutAndRun error message

### DIFF
--- a/cmd/integration_test.go
+++ b/cmd/integration_test.go
@@ -700,7 +700,7 @@ func asyncWaitForStdoutAndRun(
 		ts.outMutex.Unlock()
 		t.Log(stdOut)
 		require.FailNow(
-			t, "did not find the text '%s' in the process stdout after %d attempts (%s)",
+			t, "expected output not found", "did not find the text '%s' in the process stdout after %d attempts (%s)",
 			expText, attempts, time.Duration(attempts)*interval,
 		)
 	}()


### PR DESCRIPTION
Unfortunately `require.Fail` first string argument isn't the format string, it is the second one. The first one is general error message string. Same goes for Failf, which just happens to require the actual format message as argument.

