### PR TITLE
Experimental tracing module (2/3): define and expose a `tracing.Client`

### DIFF
--- a/cmd/tests/tracing_module_test.go
+++ b/cmd/tests/tracing_module_test.go
@@ -1,0 +1,140 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/cmd"
+	"go.k6.io/k6/lib/testutils/httpmultibin"
+)
+
+func TestTracingModuleClient(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	gotRequests := 0
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		gotRequests++
+		assert.NotEmpty(t, r.Header.Get("traceparent"))
+		assert.Len(t, r.Header.Get("traceparent"), 55)
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		const instrumentedHTTP = new tracing.Client({
+			propagator: "w3c",
+		})
+
+		export default function () {
+			instrumentedHTTP.del("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.get("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.head("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.options("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.patch("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.post("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.put("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.request("GET", "HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, 8, gotRequests)
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	gotHTTPDataPoints := false
+
+	for _, jsonLine := range bytes.Split(jsonResults, []byte("\n")) {
+		if len(jsonLine) == 0 {
+			continue
+		}
+
+		var line sampleEnvelope
+		require.NoError(t, json.Unmarshal(jsonLine, &line))
+
+		if line.Type != "Point" {
+			continue
+		}
+
+		// Filter metric samples which are not related to http
+		if !strings.HasPrefix(line.Metric, "http_") {
+			continue
+		}
+
+		gotHTTPDataPoints = true
+
+		anyTraceID, hasTraceID := line.Data.Metadata["trace_id"]
+		require.True(t, hasTraceID)
+
+		traceID, gotTraceID := anyTraceID.(string)
+		require.True(t, gotTraceID)
+
+		assert.Len(t, traceID, 32)
+	}
+
+	assert.True(t, gotHTTPDataPoints)
+}
+
+func TestTracingClient_DoesNotInterfereWithHTTPModule(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	gotRequests := 0
+	gotInstrumentedRequests := 0
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		gotRequests++
+
+		if r.Header.Get("traceparent") != "" {
+			gotInstrumentedRequests++
+			assert.Len(t, r.Header.Get("traceparent"), 55)
+		}
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		const instrumentedHTTP = new tracing.Client({
+			propagator: "w3c",
+		})
+
+		export default function () {
+			instrumentedHTTP.get("HTTPBIN_IP_URL/tracing");
+			http.get("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.head("HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, 3, gotRequests)
+	assert.Equal(t, 2, gotInstrumentedRequests)
+}
+
+// sampleEnvelope is a trimmed version of the struct found
+// in output/json/wrapper.go
+// TODO: use the json output's wrapper struct instead if it's ever exported
+type sampleEnvelope struct {
+	Metric string `json:"metric"`
+	Type   string `json:"type"`
+	Data   struct {
+		Value    float64                `json:"value"`
+		Metadata map[string]interface{} `json:"metadata"`
+	} `json:"data"`
+}

--- a/cmd/tests/tracing_module_test.go
+++ b/cmd/tests/tracing_module_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -56,37 +57,7 @@ func TestTracingModuleClient(t *testing.T) {
 	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
 	require.NoError(t, err)
 
-	gotHTTPDataPoints := false
-
-	for _, jsonLine := range bytes.Split(jsonResults, []byte("\n")) {
-		if len(jsonLine) == 0 {
-			continue
-		}
-
-		var line sampleEnvelope
-		require.NoError(t, json.Unmarshal(jsonLine, &line))
-
-		if line.Type != "Point" {
-			continue
-		}
-
-		// Filter metric samples which are not related to http
-		if !strings.HasPrefix(line.Metric, "http_") {
-			continue
-		}
-
-		gotHTTPDataPoints = true
-
-		anyTraceID, hasTraceID := line.Data.Metadata["trace_id"]
-		require.True(t, hasTraceID)
-
-		traceID, gotTraceID := anyTraceID.(string)
-		require.True(t, gotTraceID)
-
-		assert.Len(t, traceID, 32)
-	}
-
-	assert.True(t, gotHTTPDataPoints)
+	assertHasTraceIDMetadata(t, jsonResults)
 }
 
 func TestTracingClient_DoesNotInterfereWithHTTPModule(t *testing.T) {
@@ -126,6 +97,232 @@ func TestTracingClient_DoesNotInterfereWithHTTPModule(t *testing.T) {
 
 	assert.Equal(t, int64(3), atomic.LoadInt64(&gotRequests))
 	assert.Equal(t, int64(2), atomic.LoadInt64(&gotInstrumentedRequests))
+}
+
+func TestTracingInstrumentHTTP_W3C(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	var gotRequests int64
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&gotRequests, 1)
+		assert.NotEmpty(t, r.Header.Get("traceparent"))
+		assert.Len(t, r.Header.Get("traceparent"), 55)
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import tracing from "k6/experimental/tracing";
+
+		tracing.instrumentHTTP({
+			propagator: "w3c",
+		})
+
+		export default function () {
+			http.del("HTTPBIN_IP_URL/tracing");
+			http.get("HTTPBIN_IP_URL/tracing");
+			http.head("HTTPBIN_IP_URL/tracing");
+			http.options("HTTPBIN_IP_URL/tracing");
+			http.patch("HTTPBIN_IP_URL/tracing");
+			http.post("HTTPBIN_IP_URL/tracing");
+			http.put("HTTPBIN_IP_URL/tracing");
+			http.request("GET", "HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, int64(8), atomic.LoadInt64(&gotRequests))
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	assertHasTraceIDMetadata(t, jsonResults)
+}
+
+func TestTracingInstrumentHTTP_Jaeger(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	var gotRequests int64
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&gotRequests, 1)
+		assert.NotEmpty(t, r.Header.Get("uber-trace-id"))
+		assert.Len(t, r.Header.Get("uber-trace-id"), 45)
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		tracing.instrumentHTTP({
+			propagator: "jaeger",
+		})
+
+		export default function () {
+			http.del("HTTPBIN_IP_URL/tracing");
+			http.get("HTTPBIN_IP_URL/tracing");
+			http.head("HTTPBIN_IP_URL/tracing");
+			http.options("HTTPBIN_IP_URL/tracing");
+			http.patch("HTTPBIN_IP_URL/tracing");
+			http.post("HTTPBIN_IP_URL/tracing");
+			http.put("HTTPBIN_IP_URL/tracing");
+			http.request("GET", "HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, int64(8), atomic.LoadInt64(&gotRequests))
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	assertHasTraceIDMetadata(t, jsonResults)
+}
+
+func TestTracingInstrumentHTTP_FillsParams(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	var gotRequests int64
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&gotRequests, 1)
+
+		assert.NotEmpty(t, r.Header.Get("traceparent"))
+		assert.Len(t, r.Header.Get("traceparent"), 55)
+
+		assert.NotEmpty(t, r.Header.Get("X-Test-Header"))
+		assert.Equal(t, "test", r.Header.Get("X-Test-Header"))
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import tracing from "k6/experimental/tracing";
+
+		tracing.instrumentHTTP({
+			propagator: "w3c",
+		})
+
+		const testHeaders = {
+			"X-Test-Header": "test",
+		}
+
+		export default function () {
+			http.del("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.get("HTTPBIN_IP_URL/tracing", { headers: testHeaders });
+			http.head("HTTPBIN_IP_URL/tracing", { headers: testHeaders });
+			http.options("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.patch("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.post("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.put("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.request("GET", "HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, int64(8), atomic.LoadInt64(&gotRequests))
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	assertHasTraceIDMetadata(t, jsonResults)
+}
+
+func TestTracingInstrummentHTTP_SupportsMultipleTestScripts(t *testing.T) {
+	t.Parallel()
+
+	var gotRequests int64
+
+	tb := httpmultibin.NewHTTPMultiBin(t)
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&gotRequests, 1)
+
+		assert.NotEmpty(t, r.Header.Get("traceparent"))
+		assert.Len(t, r.Header.Get("traceparent"), 55)
+	})
+
+	mainScript := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import tracing from "k6/experimental/tracing";
+
+		import { iShouldBeInstrumented } from "./imported.js";
+		
+		tracing.instrumentHTTP({
+			propagator: "w3c",
+		})
+
+		export default function() {
+			iShouldBeInstrumented();
+		};
+	`)
+
+	importedScript := tb.Replacer.Replace(`
+		import http from "k6/http";
+
+		export function iShouldBeInstrumented() {
+			http.head("HTTPBIN_IP_URL/tracing");
+		}
+	`)
+
+	ts := NewGlobalTestState(t)
+	require.NoError(t, afero.WriteFile(ts.FS, filepath.Join(ts.Cwd, "main.js"), []byte(mainScript), 0o644))
+	require.NoError(t, afero.WriteFile(ts.FS, filepath.Join(ts.Cwd, "imported.js"), []byte(importedScript), 0o644))
+
+	ts.CmdArgs = []string{"k6", "run", "--out", "json=results.json", "main.js"}
+	ts.ExpectedExitCode = 0
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(1), atomic.LoadInt64(&gotRequests))
+	assertHasTraceIDMetadata(t, jsonResults)
+}
+
+// assertHasTraceIDMetadata checks that the trace_id metadata is present and has the correct format
+// for all http metrics in the json results file.
+func assertHasTraceIDMetadata(t *testing.T, jsonResults []byte) {
+	gotHTTPDataPoints := false
+
+	for _, jsonLine := range bytes.Split(jsonResults, []byte("\n")) {
+		if len(jsonLine) == 0 {
+			continue
+		}
+
+		var line sampleEnvelope
+		require.NoError(t, json.Unmarshal(jsonLine, &line))
+
+		if line.Type != "Point" {
+			continue
+		}
+
+		// Filter metric samples which are not related to http
+		if !strings.HasPrefix(line.Metric, "http_") {
+			continue
+		}
+
+		gotHTTPDataPoints = true
+
+		anyTraceID, hasTraceID := line.Data.Metadata["trace_id"]
+		require.True(t, hasTraceID)
+
+		traceID, gotTraceID := anyTraceID.(string)
+		require.True(t, gotTraceID)
+
+		assert.Len(t, traceID, 32)
+	}
+
+	assert.True(t, gotHTTPDataPoints)
 }
 
 // sampleEnvelope is a trimmed version of the struct found

--- a/js/modules/k6/experimental/tracing/client.go
+++ b/js/modules/k6/experimental/tracing/client.go
@@ -1,0 +1,237 @@
+package tracing
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/js/modules"
+	httpmodule "go.k6.io/k6/js/modules/k6/http"
+	"go.k6.io/k6/metrics"
+)
+
+// Client represents a HTTP Client instrumenting the requests
+// it performs with tracing information.
+type Client struct {
+	vu modules.VU
+
+	// opts holds the client's configuration options.
+	opts options
+
+	// propagator holds the client's trace propagator, used
+	// to produce trace context headers for each supported
+	// formats: w3c, b3, jaeger.
+	propagator Propagator
+
+	// requestFunc holds the http module's request function
+	// used to emit HTTP requests in k6 script. The client
+	// uses it under the hood to emit the requests it
+	// instruments.
+	requestFunc HTTPRequestFunc
+}
+
+// HTTPRequestFunc is a type alias representing the prototype of
+// k6's http module's request function
+type HTTPRequestFunc func(method string, url goja.Value, args ...goja.Value) (*httpmodule.Response, error)
+
+// NewClient instantiates a new tracing Client
+func NewClient(vu modules.VU, opts options) *Client {
+	rt := vu.Runtime()
+
+	// Get the http module's request function
+	httpModuleRequest, err := rt.RunString("require('k6/http').request")
+	if err != nil {
+		common.Throw(
+			rt,
+			fmt.Errorf(
+				"failed initializing tracing client, "+
+					"unable to require http.request method; reason: %w",
+				err,
+			),
+		)
+	}
+
+	// Export the http module's request function goja.Callable as a Go function
+	var requestFunc HTTPRequestFunc
+	if err := rt.ExportTo(httpModuleRequest, &requestFunc); err != nil {
+		common.Throw(
+			rt,
+			fmt.Errorf("failed initializing tracing client, unable to export http.request method; reason: %w", err),
+		)
+	}
+
+	client := &Client{vu: vu, requestFunc: requestFunc}
+	if err := client.Configure(opts); err != nil {
+		common.Throw(
+			rt,
+			fmt.Errorf("failed initializing tracing client, invalid configuration; reason: %w", err),
+		)
+	}
+
+	return client
+}
+
+// Configure configures the tracing client with the given options.
+func (c *Client) Configure(opts options) error {
+	if err := opts.validate(); err != nil {
+		return fmt.Errorf("invalid options: %w", err)
+	}
+
+	switch opts.Propagator {
+	case "w3c":
+		c.propagator = &W3CPropagator{}
+	case "jaeger":
+		c.propagator = &JaegerPropagator{}
+	default:
+		return fmt.Errorf("unknown propagator: %s", opts.Propagator)
+	}
+
+	c.opts = opts
+
+	return nil
+}
+
+// Request instruments the http module's request function with tracing headers,
+// and ensures the trace_id is emitted as part of the output's data points metadata.
+func (c *Client) Request(method string, url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	rt := c.vu.Runtime()
+
+	// The http module's request function expects the first argument to be the
+	// request body. If no body is provided, we need to pass null to the function.
+	if len(args) == 0 {
+		args = []goja.Value{goja.Null()}
+	}
+
+	traceID := TraceID{
+		Prefix: k6Prefix,
+		Code:   k6CloudCode,
+		Time:   time.Now(),
+	}
+
+	encodedTraceID, err := traceID.Encode()
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("failed to encode the generated trace ID; reason: %w", err))
+	}
+
+	// Produce a trace header in the format defined by the
+	// configured propagator.
+	traceContextHeader, err := c.propagator.Propagate(encodedTraceID)
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("failed to propagate trace ID; reason: %w", err))
+	}
+
+	// update the `params` argument with the trace context header
+	// so that it can be used by the http module's request function.
+	args, err = c.instrumentArguments(traceContextHeader, args...)
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("failed to instrument request arguments; reason: %w", err))
+	}
+
+	// Add the trace ID to the VU's state, so that it can be
+	// used in the metrics emitted by the HTTP module.
+	c.vu.State().Tags.Modify(func(t *metrics.TagsAndMeta) {
+		t.SetMetadata(metadataTraceIDKeyName, encodedTraceID)
+	})
+
+	response, err := c.requestFunc(method, url, args...)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	// Remove the trace ID from the VU's state, so that it doesn't
+	// leak into other requests.
+	c.vu.State().Tags.Modify(func(t *metrics.TagsAndMeta) {
+		t.DeleteMetadata(metadataTraceIDKeyName)
+	})
+
+	return response, nil
+}
+
+// Del instruments the http module's delete method.
+func (c *Client) Del(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodDelete, url, args...)
+}
+
+// Get instruments the http module's get method.
+func (c *Client) Get(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	// Here we prepend a null value that stands for the body parameter,
+	// that the request function expects as a first argument implicitly
+	args = append([]goja.Value{goja.Null()}, args...)
+	return c.Request(http.MethodGet, url, args...)
+}
+
+// Head instruments the http module's head method.
+func (c *Client) Head(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	// NB: here we prepend a null value that stands for the body parameter,
+	// that the request function expects as a first argument implicitly
+	args = append([]goja.Value{goja.Null()}, args...)
+	return c.Request(http.MethodHead, url, args...)
+}
+
+// Options instruments the http module's options method.
+func (c *Client) Options(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodOptions, url, args...)
+}
+
+// Patch instruments the http module's patch method.
+func (c *Client) Patch(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodPatch, url, args...)
+}
+
+// Post instruments the http module's post method.
+func (c *Client) Post(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodPost, url, args...)
+}
+
+// Put instruments the http module's put method.
+func (c *Client) Put(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodPut, url, args...)
+}
+
+// instrumentArguments: expects args to be in the format expected by the
+// request method (body, params)
+func (c *Client) instrumentArguments(traceContext http.Header, args ...goja.Value) ([]goja.Value, error) {
+	rt := c.vu.Runtime()
+
+	var paramsObj *goja.Object
+
+	switch len(args) {
+	case 2:
+		// We received both a body and a params argument. In the
+		// event params would be nullish, we'll instantiate
+		// a new object.
+		if isNullish(args[1]) {
+			paramsObj = rt.NewObject()
+			args[1] = paramsObj
+		} else {
+			paramsObj = args[1].ToObject(rt)
+		}
+	case 1:
+		// We only received a body argument
+		paramsObj = rt.NewObject()
+		args = append(args, paramsObj)
+	default:
+		return nil, fmt.Errorf("invalid number of arguments; expected 1 or 2, got %d", len(args))
+	}
+
+	headersObj := rt.NewObject()
+
+	headersValue := paramsObj.Get("headers")
+	if !isNullish(headersValue) {
+		headersObj = headersValue.ToObject(rt)
+	}
+
+	if err := paramsObj.Set("headers", headersObj); err != nil {
+		return args, err
+	}
+
+	for key, value := range traceContext {
+		if err := headersObj.Set(key, value); err != nil {
+			return args, fmt.Errorf("failed to set the trace header; reason: %w", err)
+		}
+	}
+
+	return args, nil
+}

--- a/js/modules/k6/experimental/tracing/client_test.go
+++ b/js/modules/k6/experimental/tracing/client_test.go
@@ -1,0 +1,166 @@
+package tracing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/modulestest"
+)
+
+// traceParentHeaderName is the normalized trace header name.
+// Although the traceparent header is case insensitive, the
+// Go http.Header sets it capitalized.
+const traceparentHeaderName string = "Traceparent"
+
+// testTraceID is a valid trace ID used in tests.
+const testTraceID string = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"
+
+func TestClientInstrumentArguments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no args should fail", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+
+		_, err := testCase.client.instrumentArguments(testCase.traceContextHeader)
+		require.Error(t, err)
+	})
+
+	t.Run("1 arg should initialize params successfully", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+		rt := testCase.testSetup.VU.Runtime()
+
+		gotArgs, gotErr := testCase.client.instrumentArguments(testCase.traceContextHeader, goja.Null())
+
+		assert.NoError(t, gotErr)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, goja.Null(), gotArgs[0])
+
+		gotParams := gotArgs[1].ToObject(rt)
+		assert.NotNil(t, gotParams)
+		gotHeaders := gotParams.Get("headers").ToObject(rt)
+		assert.NotNil(t, gotHeaders)
+		gotTraceParent := gotHeaders.Get(traceparentHeaderName)
+		assert.NotNil(t, gotTraceParent)
+		assert.Equal(t, testTraceID, gotTraceParent.String())
+	})
+
+	t.Run("2 args with null params should initialize it", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+		rt := testCase.testSetup.VU.Runtime()
+
+		gotArgs, gotErr := testCase.client.instrumentArguments(testCase.traceContextHeader, goja.Null(), goja.Null())
+
+		assert.NoError(t, gotErr)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, goja.Null(), gotArgs[0])
+
+		gotParams := gotArgs[1].ToObject(rt)
+		assert.NotNil(t, gotParams)
+		gotHeaders := gotParams.Get("headers").ToObject(rt)
+		assert.NotNil(t, gotHeaders)
+		gotTraceParent := gotHeaders.Get(traceparentHeaderName)
+		assert.NotNil(t, gotTraceParent)
+		assert.Equal(t, testTraceID, gotTraceParent.String())
+	})
+
+	t.Run("2 args with undefined params should initialize it", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+		rt := testCase.testSetup.VU.Runtime()
+
+		gotArgs, gotErr := testCase.client.instrumentArguments(testCase.traceContextHeader, goja.Null(), goja.Undefined())
+
+		assert.NoError(t, gotErr)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, goja.Null(), gotArgs[0])
+
+		gotParams := gotArgs[1].ToObject(rt)
+		assert.NotNil(t, gotParams)
+		gotHeaders := gotParams.Get("headers").ToObject(rt)
+		assert.NotNil(t, gotHeaders)
+		gotTraceParent := gotHeaders.Get(traceparentHeaderName)
+		assert.NotNil(t, gotTraceParent)
+		assert.Equal(t, testTraceID, gotTraceParent.String())
+	})
+
+	t.Run("2 args with predefined params and headers updates them successfully", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+		rt := testCase.testSetup.VU.Runtime()
+
+		wantHeaders := rt.NewObject()
+		require.NoError(t, wantHeaders.Set("X-Test-Header", "testvalue"))
+		wantParams := rt.NewObject()
+		require.NoError(t, wantParams.Set("headers", wantHeaders))
+
+		gotArgs, gotErr := testCase.client.instrumentArguments(testCase.traceContextHeader, goja.Null(), wantParams)
+
+		assert.NoError(t, gotErr)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, goja.Null(), gotArgs[0])
+		assert.Equal(t, wantParams, gotArgs[1])
+
+		gotHeaders := gotArgs[1].ToObject(rt).Get("headers").ToObject(rt)
+
+		gotTraceParent := gotHeaders.Get(traceparentHeaderName)
+		assert.NotNil(t, gotTraceParent)
+		assert.Equal(t, testTraceID, gotTraceParent.String())
+
+		gotTestHeader := gotHeaders.Get("X-Test-Header")
+		assert.NotNil(t, gotTestHeader)
+		assert.Equal(t, "testvalue", gotTestHeader.String())
+	})
+
+	t.Run("2 args with predefined params and no headers sets and updates them successfully", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+		rt := testCase.testSetup.VU.Runtime()
+		wantParams := rt.NewObject()
+
+		gotArgs, gotErr := testCase.client.instrumentArguments(testCase.traceContextHeader, goja.Null(), wantParams)
+
+		assert.NoError(t, gotErr)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, goja.Null(), gotArgs[0])
+		assert.Equal(t, wantParams, gotArgs[1])
+
+		gotHeaders := gotArgs[1].ToObject(rt).Get("headers").ToObject(rt)
+
+		gotTraceParent := gotHeaders.Get(traceparentHeaderName)
+		assert.NotNil(t, gotTraceParent)
+		assert.Equal(t, testTraceID, gotTraceParent.String())
+	})
+}
+
+type tracingClientTestCase struct {
+	t                  *testing.T
+	testSetup          *modulestest.Runtime
+	client             Client
+	traceContextHeader http.Header
+}
+
+func newTestCase(t *testing.T) *tracingClientTestCase {
+	testSetup := modulestest.NewRuntime(t)
+	client := Client{vu: testSetup.VU}
+	traceContextHeader := http.Header{}
+	traceContextHeader.Add(traceparentHeaderName, testTraceID)
+
+	return &tracingClientTestCase{
+		t:                  t,
+		testSetup:          testSetup,
+		client:             client,
+		traceContextHeader: traceContextHeader,
+	}
+}

--- a/js/modules/k6/experimental/tracing/goja.go
+++ b/js/modules/k6/experimental/tracing/goja.go
@@ -1,0 +1,11 @@
+package tracing
+
+import "github.com/dop251/goja"
+
+// isNullish checks if the given value is nullish, i.e. nil, undefined or null.
+//
+// This helper function emulates the behavior of Javascript's nullish coalescing
+// operator (??).
+func isNullish(value goja.Value) bool {
+	return value == nil || goja.IsUndefined(value) || goja.IsNull(value)
+}

--- a/js/modules/k6/experimental/tracing/module.go
+++ b/js/modules/k6/experimental/tracing/module.go
@@ -18,6 +18,9 @@ type (
 	// ModuleInstance represents an instance of the JS module.
 	ModuleInstance struct {
 		vu modules.VU
+
+		// Client holds the module's default tracing client.
+		*Client
 	}
 )
 
@@ -45,7 +48,8 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{
 		Named: map[string]interface{}{
-			"Client": mi.newClient,
+			"Client":         mi.newClient,
+			"instrumentHTTP": mi.instrumentHTTP,
 		},
 	}
 }
@@ -68,4 +72,68 @@ func (mi *ModuleInstance) newClient(cc goja.ConstructorCall) *goja.Object {
 	}
 
 	return rt.ToValue(NewClient(mi.vu, opts)).ToObject(rt)
+}
+
+// InstrumentHTTP instruments the HTTP module with tracing headers.
+//
+// When used in the context of a k6 script, it will automatically replace
+// the imported http module's methods with instrumented ones.
+func (mi *ModuleInstance) instrumentHTTP(options options) {
+	rt := mi.vu.Runtime()
+
+	if mi.vu.State() != nil {
+		common.Throw(rt, common.NewInitContextError("tracing module's instrumentHTTP can only be called in the init context"))
+	}
+
+	if mi.Client != nil {
+		err := errors.New(
+			"tracing module's instrumentHTTP can only be called once. " +
+				"if you were attempting to reconfigure the instrumentation, " +
+				"please consider using the tracing.Client instead",
+		)
+		common.Throw(rt, err)
+	}
+
+	// Initialize the tracing module's instance default client,
+	// and configure it using the user-supplied set of options.
+	mi.Client = NewClient(mi.vu, options)
+
+	// Explicitly inject the http module in the VU's runtime.
+	// This allows us to later on override the http module's methods
+	// with instrumented ones.
+	httpModuleValue, err := rt.RunString(`require('k6/http')`)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	httpModuleObj := httpModuleValue.ToObject(rt)
+
+	// Closure overriding a method of the provided imported module object.
+	//
+	// The `onModule` argument should be a *goja.Object obtained by requiring
+	// or importing the 'k6/http' module and converting it to an object.
+	//
+	// The `value` argument is expected to be callable.
+	mustSetHTTPMethod := func(method string, onModule *goja.Object, value interface{}) {
+		// Inject the new get function, adding tracing headers
+		// to the request in the HTTP module object.
+		err = onModule.Set(method, value)
+		if err != nil {
+			common.Throw(
+				rt,
+				fmt.Errorf("unable to overwrite http.%s method with instrumented one; reason: %w", method, err),
+			)
+		}
+	}
+
+	// Overwrite the implementation of the http module's method with the instrumented
+	// ones exposed by the `tracing.Client` struct.
+	mustSetHTTPMethod("del", httpModuleObj, mi.Client.Del)
+	mustSetHTTPMethod("get", httpModuleObj, mi.Client.Get)
+	mustSetHTTPMethod("head", httpModuleObj, mi.Client.Head)
+	mustSetHTTPMethod("options", httpModuleObj, mi.Client.Options)
+	mustSetHTTPMethod("patch", httpModuleObj, mi.Client.Patch)
+	mustSetHTTPMethod("post", httpModuleObj, mi.Client.Patch)
+	mustSetHTTPMethod("put", httpModuleObj, mi.Client.Patch)
+	mustSetHTTPMethod("request", httpModuleObj, mi.Client.Request)
 }

--- a/js/modules/k6/experimental/tracing/module.go
+++ b/js/modules/k6/experimental/tracing/module.go
@@ -2,6 +2,11 @@
 package tracing
 
 import (
+	"errors"
+	"fmt"
+
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
 )
 
@@ -38,5 +43,29 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 // Exports implements the modules.Instance interface and returns
 // the exports of the JS module.
 func (mi *ModuleInstance) Exports() modules.Exports {
-	return modules.Exports{}
+	return modules.Exports{
+		Named: map[string]interface{}{
+			"Client": mi.newClient,
+		},
+	}
+}
+
+// NewClient is the JS constructor for the tracing.Client
+//
+// It expects a single configuration object as argument, which
+// will be used to instantiate an `Object` instance internally,
+// and will be used by the client to configure itself.
+func (mi *ModuleInstance) newClient(cc goja.ConstructorCall) *goja.Object {
+	rt := mi.vu.Runtime()
+
+	if len(cc.Arguments) < 1 {
+		common.Throw(rt, errors.New("Client constructor expects a single configuration object as argument; none given"))
+	}
+
+	var opts options
+	if err := rt.ExportTo(cc.Arguments[0], &opts); err != nil {
+		common.Throw(rt, fmt.Errorf("unable to parse options object; reason: %w", err))
+	}
+
+	return rt.ToValue(NewClient(mi.vu, opts)).ToObject(rt)
 }

--- a/js/modules/k6/experimental/tracing/module_test.go
+++ b/js/modules/k6/experimental/tracing/module_test.go
@@ -1,0 +1,78 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/modules/k6/http"
+	"go.k6.io/k6/js/modulestest"
+	"go.k6.io/k6/lib"
+)
+
+func TestInstrumentHTTP_SucceedsInInitContext(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+
+	// Calling in the init context should succeed
+	_, err := ts.TestRuntime.VU.Runtime().RunString(`
+		instrumentHTTP({propagator: 'w3c'})
+	`)
+
+	assert.NoError(t, err)
+}
+
+func TestInstrumentHTTP_FailsWhenCalledTwice(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+
+	// Calling it twice in the init context should fail
+	_, err := ts.TestRuntime.VU.Runtime().RunString(`
+		instrumentHTTP({propagator: 'w3c'})
+		instrumentHTTP({propagator: 'w3c'})
+	`)
+
+	assert.Error(t, err)
+}
+
+func TestInstrumentHTTP_FailsInVUContext(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+	ts.TestRuntime.MoveToVUContext(&lib.State{})
+
+	// Calling in the VU context should fail
+	_, err := ts.TestRuntime.VU.Runtime().RunString(`
+		instrumentHTTP({propagator: 'w3c'})
+	`)
+
+	assert.Error(t, err)
+}
+
+type testSetup struct {
+	t           *testing.T
+	TestRuntime *modulestest.Runtime
+}
+
+func newTestSetup(t *testing.T) testSetup {
+	ts := modulestest.NewRuntime(t)
+	m := new(RootModule).NewModuleInstance(ts.VU)
+
+	rt := ts.VU.Runtime()
+	require.NoError(t, rt.Set("instrumentHTTP", m.Exports().Named["instrumentHTTP"]))
+
+	require.NoError(t, rt.Set("require", func(module string) *goja.Object {
+		require.Equal(t, "k6/http", module)
+		export := http.New().NewModuleInstance(ts.VU).Exports().Default
+
+		return rt.ToValue(export).ToObject(rt)
+	}))
+
+	return testSetup{
+		t:           t,
+		TestRuntime: ts,
+	}
+}

--- a/js/modules/k6/experimental/tracing/options.go
+++ b/js/modules/k6/experimental/tracing/options.go
@@ -1,0 +1,41 @@
+package tracing
+
+import (
+	"errors"
+	"fmt"
+)
+
+// options are the options that can be passed to the
+// tracing.instrumentHTTP() method.
+type options struct {
+	// Propagation is the propagation format to use for the tracer.
+	Propagator string `js:"propagator"`
+
+	// Sampling is the sampling rate to use for the tracer.
+	Sampling *float64 `js:"sampling"`
+
+	// Baggage is a map of baggage items to add to the tracer.
+	Baggage map[string]string `js:"baggage"`
+}
+
+func (i *options) validate() error {
+	var (
+		isW3C    = i.Propagator == W3CPropagatorName
+		isJaeger = i.Propagator == JaegerPropagatorName
+	)
+	if !isW3C && !isJaeger {
+		return fmt.Errorf("unknown propagator: %s", i.Propagator)
+	}
+
+	// TODO: implement sampling support
+	if i.Sampling != nil {
+		return errors.New("sampling is not yet supported")
+	}
+
+	// TODO: implement baggage support
+	if i.Baggage != nil {
+		return errors.New("baggage is not yet supported")
+	}
+
+	return nil
+}

--- a/js/modules/k6/experimental/tracing/options_test.go
+++ b/js/modules/k6/experimental/tracing/options_test.go
@@ -1,0 +1,74 @@
+package tracing
+
+import "testing"
+
+func TestOptionsValidate(t *testing.T) {
+	t.Parallel()
+
+	testFloat := 10.0
+
+	type fields struct {
+		Propagator string
+		Sampling   *float64
+		Baggage    map[string]string
+	}
+	testCases := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "w3c propagator is valid",
+			fields: fields{
+				Propagator: "w3c",
+			},
+			wantErr: false,
+		},
+		{
+			name: "jaeger propagator is valid",
+			fields: fields{
+				Propagator: "jaeger",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid propagator is invalid",
+			fields: fields{
+				Propagator: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "sampling is not yet supported",
+			fields: fields{
+				Sampling: &testFloat,
+			},
+			wantErr: true,
+		},
+		{
+			name: "baggage is not yet supported",
+			fields: fields{
+				Baggage: map[string]string{"key": "value"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			i := &options{
+				Propagator: tc.fields.Propagator,
+				Sampling:   tc.fields.Sampling,
+				Baggage:    tc.fields.Baggage,
+			}
+
+			if err := i.validate(); (err != nil) != tc.wantErr {
+				t.Errorf("instrumentationOptions.validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/js/modules/k6/experimental/tracing/trace_id.go
+++ b/js/modules/k6/experimental/tracing/trace_id.go
@@ -17,6 +17,9 @@ const (
 
 	// To not ingest and process the related spans, b/c they are part of a non-cloud run.
 	k6LocalCode = 33
+
+	// metadataTraceIDKeyName is the key name of the traceID in the output metadata.
+	metadataTraceIDKeyName = "trace_id"
 )
 
 // TraceID represents a trace-id as defined by the [W3c specification], and

--- a/samples/experimental/tracing-client.js
+++ b/samples/experimental/tracing-client.js
@@ -1,0 +1,46 @@
+import http from "k6/http";
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+
+// Explicitly instantiating a tracing client allows to distringuish
+// instrumented from non-instrumented HTTP calls, by keeping APIs separate.
+// It also allows for finer-grained configuration control, by letting
+// users changing the tracing configuration on the fly during their
+// script's execution.
+let instrumentedHTTP = new tracing.Client({
+	propagator: "w3c",
+});
+
+const testData = { name: "Bert" };
+
+export default () => {
+	// Using the tracing client instance, HTTP calls will have
+	// their trace context headers set.
+	let res = instrumentedHTTP.request("GET", "http://httpbin.org/get", null, {
+		headers: {
+			"X-Example-Header": "instrumented/request",
+		},
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+
+	// The tracing client offers more flexibility over
+	// the `instrumentHTTP` function, as it leaves the
+	// imported standard http module untouched. Thus,
+	// one can still perform non-instrumented HTTP calls
+	// using it.
+	res = http.post("http://httpbin.org/post", JSON.stringify(testData), {
+		headers: { "X-Example-Header": "noninstrumented/post" },
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+
+	res = instrumentedHTTP.del("http://httpbin.org/delete", null, {
+		headers: { "X-Example-Header": "instrumented/delete" },
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+};

--- a/samples/experimental/tracing/tracing-instrumentHTTP.js
+++ b/samples/experimental/tracing/tracing-instrumentHTTP.js
@@ -1,0 +1,24 @@
+import http from "k6/http";
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+
+// instrumentHTTP will ensure that all requests made by the http module
+// will be traced. The first argument is a configuration object that
+// can be used to configure the tracer.
+//
+// Currently supported HTTP methods are: get, post, put, patch, head,
+// del, options, and request.
+tracing.instrumentHTTP({
+	propagator: "w3c",
+});
+
+export default () => {
+	let res = http.get("http://httpbin.org/get", {
+		headers: {
+			"X-Example-Header": "instrumented/get",
+		},
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+};


### PR DESCRIPTION
## About

To keep Pull Requests as small as possible and reduce the review burden, this PR is the second in a chain of three implementing the decided API design for the experimental tracing module.

⚠️ ✋🏻 This PR is part of a PR chain, and is based on #2853  

This second PR builds upon #2853 and adds a `Client` type to `k6/experimental/tracing`. This type mimics the relevant part of the HTTP module to allow users to perform HTTP requests embedding a trace context while also attaching the produced trace id as output metadata on the HTTP-related samples. In the larger context of the module's goal, the `Client` should hold the underlying logic for the `instrumentHTTP` function that's to come in the third PR. Still, it also allows users to selectively trace requests and reconfigure their tracing configuration on the fly if they wish.

To achieve that, it is built upon the HTTP module's request function, which wraps with *hooking* logic to ensure the expected headers are produced and present and emit the output metadata. 

The `Client` is configured using an options object that lets the user select the propagation format they use. Other options, such as sampling rate, and baggage, have been added for forward compatibility and convenience but will lead to "not implemented" errors if used.

## Example of it in action

```javascript
import http from "k6/http";
import { check } from "k6";
import tracing from "k6/experimental/tracing";

// Explicitly instantiating a tracing client allows to distringuish
// instrumented from non-instrumented HTTP calls, by keeping APIs separate.
// It also allows for finer-grained configuration control, by letting
// users changing the tracing configuration on the fly during their
// script's execution.
let instrumentedHTTP = new tracing.Client({
	propagator: "w3c",
});

const testData = { name: "Bert" };

export default () => {
	// Using the tracing client instance, HTTP calls will have
	// their trace context headers set.
	let res = instrumentedHTTP.request("GET", "http://httpbin.org/get", null, {
		headers: {
			"X-Example-Header": "instrumented/request",
		},
	});
	check(res, {
		"status is 200": (r) => r.status === 200,
	});

	// The tracing client offers more flexibility over
	// the `instrumentHTTP` function, as it leaves the
	// imported standard http module untouched. Thus,
	// one can still perform non-instrumented HTTP calls
	// using it.
	res = http.post("http://httpbin.org/post", JSON.stringify(testData), {
		headers: { "X-Example-Header": "noninstrumented/post" },
	});
	check(res, {
		"status is 200": (r) => r.status === 200,
	});

	res = instrumentedHTTP.del("http://httpbin.org/delete", null, {
		headers: { "X-Example-Header": "instrumented/delete" },
	});
	check(res, {
		"status is 200": (r) => r.status === 200,
	});
};
```

In order to observe this example in action, I recommend to run it with the `--http-debug` too. That way you'll be able to observe the `Traceparent` header being added (note that when using the `b3` or `jaeger` propagators, the header is named differently.

```
go run go.k6.io/k6 run --http-debug samples/experimental/tracing-client.js
```

## Review

⚠️ Although this PR has >1000 lines addition, a considerable chunk of it is testing. I believe the amount of actual logic is somewhat limited ⚠️ 

The commits have been organized to be progressive, and make sense as a sequence; thus, you should review them in order. 

## References

Previous PR: #2853 