### PR TITLE
Experimental tracing module (3/3): define and expose a `instrumentHTTP` function

### DIFF
--- a/cmd/tests/tracing_module_test.go
+++ b/cmd/tests/tracing_module_test.go
@@ -112,7 +112,6 @@ func TestTracingInstrumentHTTP_W3C(t *testing.T) {
 
 	script := tb.Replacer.Replace(`
 		import http from "k6/http";
-		import { check } from "k6";
 		import tracing from "k6/experimental/tracing";
 
 		tracing.instrumentHTTP({

--- a/cmd/tests/tracing_module_test.go
+++ b/cmd/tests/tracing_module_test.go
@@ -56,37 +56,7 @@ func TestTracingModuleClient(t *testing.T) {
 	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
 	require.NoError(t, err)
 
-	gotHTTPDataPoints := false
-
-	for _, jsonLine := range bytes.Split(jsonResults, []byte("\n")) {
-		if len(jsonLine) == 0 {
-			continue
-		}
-
-		var line sampleEnvelope
-		require.NoError(t, json.Unmarshal(jsonLine, &line))
-
-		if line.Type != "Point" {
-			continue
-		}
-
-		// Filter metric samples which are not related to http
-		if !strings.HasPrefix(line.Metric, "http_") {
-			continue
-		}
-
-		gotHTTPDataPoints = true
-
-		anyTraceID, hasTraceID := line.Data.Metadata["trace_id"]
-		require.True(t, hasTraceID)
-
-		traceID, gotTraceID := anyTraceID.(string)
-		require.True(t, gotTraceID)
-
-		assert.Len(t, traceID, 32)
-	}
-
-	assert.True(t, gotHTTPDataPoints)
+	assertHasTraceIDMetadata(t, jsonResults)
 }
 
 func TestTracingClient_DoesNotInterfereWithHTTPModule(t *testing.T) {
@@ -126,6 +96,229 @@ func TestTracingClient_DoesNotInterfereWithHTTPModule(t *testing.T) {
 
 	assert.Equal(t, int64(3), atomic.LoadInt64(&gotRequests))
 	assert.Equal(t, int64(2), atomic.LoadInt64(&gotInstrumentedRequests))
+}
+
+func TestTracingInstrumentHTTP_W3C(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	var gotRequests int64
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&gotRequests, 1)
+		assert.NotEmpty(t, r.Header.Get("traceparent"))
+		assert.Len(t, r.Header.Get("traceparent"), 55)
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		tracing.instrumentHTTP({
+			propagator: "w3c",
+		})
+
+		export default function () {
+			http.del("HTTPBIN_IP_URL/tracing");
+			http.get("HTTPBIN_IP_URL/tracing");
+			http.head("HTTPBIN_IP_URL/tracing");
+			http.options("HTTPBIN_IP_URL/tracing");
+			http.patch("HTTPBIN_IP_URL/tracing");
+			http.post("HTTPBIN_IP_URL/tracing");
+			http.put("HTTPBIN_IP_URL/tracing");
+			http.request("GET", "HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, int64(8), atomic.LoadInt64(&gotRequests))
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	assertHasTraceIDMetadata(t, jsonResults)
+}
+
+func TestTracingInstrumentHTTP_Jaeger(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	var gotRequests int64
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&gotRequests, 1)
+		assert.NotEmpty(t, r.Header.Get("uber-trace-id"))
+		assert.Len(t, r.Header.Get("uber-trace-id"), 45)
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		tracing.instrumentHTTP({
+			propagator: "jaeger",
+		})
+
+		export default function () {
+			http.del("HTTPBIN_IP_URL/tracing");
+			http.get("HTTPBIN_IP_URL/tracing");
+			http.head("HTTPBIN_IP_URL/tracing");
+			http.options("HTTPBIN_IP_URL/tracing");
+			http.patch("HTTPBIN_IP_URL/tracing");
+			http.post("HTTPBIN_IP_URL/tracing");
+			http.put("HTTPBIN_IP_URL/tracing");
+			http.request("GET", "HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, int64(8), atomic.LoadInt64(&gotRequests))
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	assertHasTraceIDMetadata(t, jsonResults)
+}
+
+func TestTracingInstrumentHTTP_FillsParams(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	var gotRequests int64
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&gotRequests, 1)
+
+		assert.NotEmpty(t, r.Header.Get("traceparent"))
+		assert.Len(t, r.Header.Get("traceparent"), 55)
+
+		assert.NotEmpty(t, r.Header.Get("X-Test-Header"))
+		assert.Equal(t, "test", r.Header.Get("X-Test-Header"))
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		tracing.instrumentHTTP({
+			propagator: "w3c",
+		})
+
+		const testHeaders = {
+			"X-Test-Header": "test",
+		}
+
+		export default function () {
+			http.del("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.get("HTTPBIN_IP_URL/tracing", { headers: testHeaders });
+			http.head("HTTPBIN_IP_URL/tracing", { headers: testHeaders });
+			http.options("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.patch("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.post("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.put("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.request("GET", "HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, int64(8), atomic.LoadInt64(&gotRequests))
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	assertHasTraceIDMetadata(t, jsonResults)
+}
+
+func TestTracingInstrumentHTTP_FailsOutsideOfInitContext(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	script := tb.Replacer.Replace(`
+		import tracing from "k6/experimental/tracing";
+
+		export default function() {
+			tracing.instrumentHTTP({
+				propagator: "w3c",
+			})
+		}
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{}, 0)
+	ts.ExpectedExitCode = 0
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Contains(t, ts.Stderr.String(), "instrumentHTTP can only be called in the init context")
+}
+
+func TestTracingInstrumentHTTP_CannotBeCalledTwice(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	script := tb.Replacer.Replace(`
+		import tracing from "k6/experimental/tracing";
+
+		tracing.instrumentHTTP({
+			propagator: "w3c",
+		})
+
+		tracing.instrumentHTTP({
+			propagator: "w3c",
+		})
+
+		export default function() {
+		}
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{}, 0)
+	ts.ExpectedExitCode = 107
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Contains(t, ts.Stderr.String(), "instrumentHTTP can only be called once")
+}
+
+// assertHasTraceIDMetadata checks that the trace_id metadata is present and has the correct format
+// for all http metrics in the json results file.
+func assertHasTraceIDMetadata(t *testing.T, jsonResults []byte) {
+	gotHTTPDataPoints := false
+
+	for _, jsonLine := range bytes.Split(jsonResults, []byte("\n")) {
+		if len(jsonLine) == 0 {
+			continue
+		}
+
+		var line sampleEnvelope
+		require.NoError(t, json.Unmarshal(jsonLine, &line))
+
+		if line.Type != "Point" {
+			continue
+		}
+
+		// Filter metric samples which are not related to http
+		if !strings.HasPrefix(line.Metric, "http_") {
+			continue
+		}
+
+		gotHTTPDataPoints = true
+
+		anyTraceID, hasTraceID := line.Data.Metadata["trace_id"]
+		require.True(t, hasTraceID)
+
+		traceID, gotTraceID := anyTraceID.(string)
+		require.True(t, gotTraceID)
+
+		assert.Len(t, traceID, 32)
+	}
+
+	assert.True(t, gotHTTPDataPoints)
 }
 
 // sampleEnvelope is a trimmed version of the struct found

--- a/cmd/tests/tracing_module_test.go
+++ b/cmd/tests/tracing_module_test.go
@@ -261,7 +261,6 @@ func TestTracingInstrummentHTTP_SupportsMultipleTestScripts(t *testing.T) {
 		})
 
 		export default function() {
-			http.get("HTTPBIN_IP_URL/tracing");
 			iShouldBeInstrumented();
 		};
 	`)
@@ -286,7 +285,7 @@ func TestTracingInstrummentHTTP_SupportsMultipleTestScripts(t *testing.T) {
 	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
 	require.NoError(t, err)
 
-	assert.Equal(t, int64(2), atomic.LoadInt64(&gotRequests))
+	assert.Equal(t, int64(1), atomic.LoadInt64(&gotRequests))
 	assertHasTraceIDMetadata(t, jsonResults)
 }
 

--- a/cmd/tests/tracing_module_test.go
+++ b/cmd/tests/tracing_module_test.go
@@ -203,7 +203,6 @@ func TestTracingInstrumentHTTP_FillsParams(t *testing.T) {
 
 	script := tb.Replacer.Replace(`
 		import http from "k6/http";
-		import { check } from "k6";
 		import tracing from "k6/experimental/tracing";
 
 		tracing.instrumentHTTP({

--- a/js/modules/k6/experimental/tracing/module.go
+++ b/js/modules/k6/experimental/tracing/module.go
@@ -18,6 +18,9 @@ type (
 	// ModuleInstance represents an instance of the JS module.
 	ModuleInstance struct {
 		vu modules.VU
+
+		// Client holds the module's default tracing client.
+		*Client
 	}
 )
 
@@ -45,7 +48,8 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{
 		Named: map[string]interface{}{
-			"Client": mi.newClient,
+			"Client":         mi.newClient,
+			"instrumentHTTP": mi.instrumentHTTP,
 		},
 	}
 }
@@ -68,4 +72,68 @@ func (mi *ModuleInstance) newClient(cc goja.ConstructorCall) *goja.Object {
 	}
 
 	return rt.ToValue(NewClient(mi.vu, opts)).ToObject(rt)
+}
+
+// InstrumentHTTP instruments the HTTP module with tracing headers.
+//
+// When used in the context of a k6 script, it will automatically replace
+// the imported http module's methods with instrumented ones.
+func (mi *ModuleInstance) instrumentHTTP(options options) {
+	rt := mi.vu.Runtime()
+
+	if mi.vu.State() != nil {
+		common.Throw(rt, common.NewInitContextError("tracing module's instrumentHTTP can only be called in the init context"))
+	}
+
+	if mi.Client != nil {
+		err := errors.New(
+			"tracing module's instrumentHTTP can only be called once. " +
+				"if you were attempting to reconfigure the instrumentation, " +
+				"please consider using the tracing.Client instead",
+		)
+		common.Throw(rt, err)
+	}
+
+	// Initialize the tracing module's instance default client,
+	// and configure it using the user-supplied set of options.
+	mi.Client = NewClient(mi.vu, options)
+
+	// Explicitly inject the http module in the VU's runtime.
+	// This allows us to later on override the http module's methods
+	// with instrumented ones.
+	httpModuleValue, err := rt.RunString(`require('k6/http')`)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	httpModuleObj := httpModuleValue.ToObject(rt)
+
+	// Closure overriding a method of the provided imported module object.
+	//
+	// The `onModule` argument should be a *goja.Object obtained by requiring
+	// or importing the 'k6/http' module and converting it to an object.
+	//
+	// The `value` argument is expected to be callable.
+	mustSetHTTPMethod := func(method string, onModule *goja.Object, value interface{}) {
+		// Inject the new get function, adding tracing headers
+		// to the request in the HTTP module object.
+		err = onModule.Set(method, value)
+		if err != nil {
+			common.Throw(
+				rt,
+				fmt.Errorf("unable to overwrite http.%s method with instrumented one; reason: %w", method, err),
+			)
+		}
+	}
+
+	// Overwrite the implementation of the http module's method with the instrumented
+	// ones exposed by the `tracing.Client` struct.
+	mustSetHTTPMethod("del", httpModuleObj, mi.Client.Del)
+	mustSetHTTPMethod("get", httpModuleObj, mi.Client.Get)
+	mustSetHTTPMethod("head", httpModuleObj, mi.Client.Head)
+	mustSetHTTPMethod("options", httpModuleObj, mi.Client.Options)
+	mustSetHTTPMethod("patch", httpModuleObj, mi.Client.Patch)
+	mustSetHTTPMethod("post", httpModuleObj, mi.Client.Patch)
+	mustSetHTTPMethod("put", httpModuleObj, mi.Client.Patch)
+	mustSetHTTPMethod("request", httpModuleObj, mi.Client.Request)
 }

--- a/js/modules/k6/experimental/tracing/module_test.go
+++ b/js/modules/k6/experimental/tracing/module_test.go
@@ -1,0 +1,86 @@
+package tracing
+
+import (
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/modules/k6/http"
+	"go.k6.io/k6/js/modulestest"
+	"go.k6.io/k6/lib"
+)
+
+func TestInstrumentHTTP_SucceedsInInitContext(t *testing.T) {
+	t.Parallel()
+
+	ts := modulestest.NewRuntime(t)
+	m := new(RootModule).NewModuleInstance(ts.VU)
+
+	rt := ts.VU.Runtime()
+	require.NoError(t, rt.Set("instrumentHTTP", m.Exports().Named["instrumentHTTP"]))
+
+	require.NoError(t, rt.Set("require", func(module string) *goja.Object {
+		require.Equal(t, "k6/http", module)
+		export := http.New().NewModuleInstance(ts.VU).Exports().Default
+
+		return rt.ToValue(export).ToObject(rt)
+	}))
+
+	// Calling in the init context should succeed
+	_, err := ts.VU.Runtime().RunString(`
+		instrumentHTTP({propagator: 'w3c'})
+	`)
+
+	assert.NoError(t, err)
+}
+
+func TestInstrumentHTTP_FailsWhenCalledTwice(t *testing.T) {
+	t.Parallel()
+
+	ts := modulestest.NewRuntime(t)
+	m := new(RootModule).NewModuleInstance(ts.VU)
+
+	rt := ts.VU.Runtime()
+	require.NoError(t, rt.Set("instrumentHTTP", m.Exports().Named["instrumentHTTP"]))
+
+	require.NoError(t, rt.Set("require", func(module string) *goja.Object {
+		require.Equal(t, "k6/http", module)
+		export := http.New().NewModuleInstance(ts.VU).Exports().Default
+
+		return rt.ToValue(export).ToObject(rt)
+	}))
+
+	// Calling it twice in the init context should fail
+	_, err := ts.VU.Runtime().RunString(`
+		instrumentHTTP({propagator: 'w3c'})
+		instrumentHTTP({propagator: 'w3c'})
+	`)
+
+	assert.Error(t, err)
+}
+
+func TestInstrumentHTTP_FailsInVUContext(t *testing.T) {
+	t.Parallel()
+
+	ts := modulestest.NewRuntime(t)
+	ts.MoveToVUContext(&lib.State{})
+	m := new(RootModule).NewModuleInstance(ts.VU)
+
+	rt := ts.VU.Runtime()
+	require.NoError(t, rt.Set("instrumentHTTP", m.Exports().Named["instrumentHTTP"]))
+
+	require.NoError(t, rt.Set("require", func(module string) *goja.Object {
+		require.Equal(t, "k6/http", module)
+		export := http.New().NewModuleInstance(ts.VU).Exports().Default
+
+		return rt.ToValue(export).ToObject(rt)
+	}))
+
+	// Calling in the VU context should fail
+	_, err := ts.VU.Runtime().RunString(`
+		instrumentHTTP({propagator: 'w3c'})
+	`)
+
+	assert.Error(t, err)
+}

--- a/samples/experimental/tracing/tracing-instrumentHTTP.js
+++ b/samples/experimental/tracing/tracing-instrumentHTTP.js
@@ -1,0 +1,24 @@
+import http from "k6/http";
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+
+// instrumentHTTP will ensure that all requests made by the http module
+// will be traced. The first argument is a configuration object that
+// can be used to configure the tracer.
+//
+// Currently supported HTTP methods are: get, post, put, patch, head,
+// del, options, and request.
+tracing.instrumentHTTP({
+	propagator: "w3c",
+});
+
+export default () => {
+	let res = http.get("http://httpbin.org/get", {
+		headers: {
+			"X-Example-Header": "instrumented/get",
+		},
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+};


### PR DESCRIPTION
## About

To keep Pull Requests as small as possible and reduce the review burden, this PR is the third one in a chain of three implementing the decided API design for the experimental tracing module.

warning ✋🏻 This PR is part of a PR chain, and is based on https://github.com/grafana/k6/pull/2854

This second PR builds upon #2853 and #2854  and adds an `instrumentHTTP` function to k6/experimental/tracing.

Using this function in their k6 scripts, once, users can automatically have all their calls to the `http` module's methods (`http.{del,get,head,options,patch,post,put,request}`) automatically instrumented with tracing information, in the same fashion as described in #2854. Indeed, this function under the hood remaps the `http` module's method to use the `Client`'s methods instead.

The `instrumentHTTP` takes the same option set as the `Client` as input but does not allow for reconfiguration, nor does it allow to perform non instrumented calls. As it is the intended behavior, once called, the `http` module's methods are replaced with the instrumented ones. 

## In action

```javascript
import http from "k6/http";
import { check } from "k6";
import tracing from "k6/experimental/tracing";

// instrumentHTTP will ensure that all requests made by the http module
// will be traced. The first argument is a configuration object that
// can be used to configure the tracer.
//
// Currently supported HTTP methods are: get, post, put, patch, head,
// del, options, and request.
tracing.instrumentHTTP({
	propagator: "w3c",
});

export default () => {
	let res = http.get("http://httpbin.org/get", {
		headers: {
			"X-Example-Header": "instrumented/get",
		},
	});
	check(res, {
		"status is 200": (r) => r.status === 200,
	});
};
```

To observe this example in action, I recommend running it with the --http-debug too. That way, you'll be able to observe the Traceparent header being added (note that when using the b3 or jaeger propagators, the header is named differently.

```
go run go.k6.io/k6 run --http-debug samples/experimental/tracing.js
```

## Review

⚠️ Although this PR has >1000 lines addition, a considerable chunk of it is testing. I believe the amount of actual logic is somewhat limited ⚠️ 

The commits have been organized to be progressive and make sense as a sequence; thus, you should review them in order.

## References

Previous: #2853 #2854 