### PR TITLE
Add ability to display `testRunDetails` and logs from k6 cloud

### DIFF
--- a/cloudapi/api.go
+++ b/cloudapi/api.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/lib"
 )
 
@@ -28,9 +29,17 @@ type TestRun struct {
 	Duration int64 `json:"duration"`
 }
 
+// LogEntry can be used by the cloud to tell k6 to log something to the console,
+// so the user can see it.
+type LogEntry struct {
+	Level   string `json:"level"`
+	Message string `json:"message"`
+}
+
 type CreateTestRunResponse struct {
-	ReferenceID    string  `json:"reference_id"`
-	ConfigOverride *Config `json:"config"`
+	ReferenceID    string     `json:"reference_id"`
+	ConfigOverride *Config    `json:"config"`
+	Logs           []LogEntry `json:"logs"`
 }
 
 type TestProgressResponse struct {
@@ -44,6 +53,20 @@ type LoginResponse struct {
 	Token string `json:"token"`
 }
 
+func (c *Client) handleLogEntriesFromCloud(ctrr CreateTestRunResponse) {
+	logger := c.logger.WithField("source", "grafana-k6-cloud")
+	for _, logEntry := range ctrr.Logs {
+		level, err := logrus.ParseLevel(logEntry.Level)
+		if err != nil {
+			logger.Debugf("invalid message level '%s' for message '%s': %s", logEntry.Level, logEntry.Message, err)
+			level = logrus.ErrorLevel
+		}
+		logger.Log(level, logEntry.Message)
+	}
+}
+
+// CreateTestRun is used when a test run is being executed locally, while the
+// results are streamed to the cloud, i.e. `k6 run --out cloud script.js`.
 func (c *Client) CreateTestRun(testRun *TestRun) (*CreateTestRunResponse, error) {
 	url := fmt.Sprintf("%s/tests", c.baseURL)
 	req, err := c.NewRequest("POST", url, testRun)
@@ -57,6 +80,7 @@ func (c *Client) CreateTestRun(testRun *TestRun) (*CreateTestRunResponse, error)
 		return nil, err
 	}
 
+	c.handleLogEntriesFromCloud(ctrr)
 	if ctrr.ReferenceID == "" {
 		return nil, fmt.Errorf("failed to get a reference ID")
 	}
@@ -64,47 +88,49 @@ func (c *Client) CreateTestRun(testRun *TestRun) (*CreateTestRunResponse, error)
 	return &ctrr, nil
 }
 
-func (c *Client) StartCloudTestRun(name string, projectID int64, arc *lib.Archive) (string, error) {
+// StartCloudTestRun starts a cloud test run, i.e. `k6 cloud script.js`.
+func (c *Client) StartCloudTestRun(name string, projectID int64, arc *lib.Archive) (*CreateTestRunResponse, error) {
 	requestUrl := fmt.Sprintf("%s/archive-upload", c.baseURL)
 
 	var buf bytes.Buffer
 	mp := multipart.NewWriter(&buf)
 
 	if err := mp.WriteField("name", name); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if projectID != 0 {
 		if err := mp.WriteField("project_id", strconv.FormatInt(projectID, 10)); err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 
 	fw, err := mp.CreateFormFile("file", "archive.tar")
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if err := arc.Write(fw); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	if err := mp.Close(); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	req, err := http.NewRequest("POST", requestUrl, &buf)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	req.Header.Set("Content-Type", mp.FormDataContentType())
 
 	ctrr := CreateTestRunResponse{}
 	if err := c.Do(req, &ctrr); err != nil {
-		return "", err
+		return nil, err
 	}
-	return ctrr.ReferenceID, nil
+	c.handleLogEntriesFromCloud(ctrr)
+	return &ctrr, nil
 }
 
 func (c *Client) TestFinished(referenceID string, thresholds ThresholdResult, tained bool, runStatus lib.RunStatus) error {

--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -11,6 +11,7 @@ import (
 )
 
 // Config holds all the necessary data and options for sending metrics to the Load Impact cloud.
+//
 //nolint:lll
 type Config struct {
 	// TODO: refactor common stuff between cloud execution and output
@@ -21,11 +22,12 @@ type Config struct {
 	Host    null.String        `json:"host" envconfig:"K6_CLOUD_HOST"`
 	Timeout types.NullDuration `json:"timeout" envconfig:"K6_CLOUD_TIMEOUT"`
 
-	LogsTailURL null.String `json:"-" envconfig:"K6_CLOUD_LOGS_TAIL_URL"`
-	PushRefID   null.String `json:"pushRefID" envconfig:"K6_CLOUD_PUSH_REF_ID"`
-	WebAppURL   null.String `json:"webAppURL" envconfig:"K6_CLOUD_WEB_APP_URL"`
-	NoCompress  null.Bool   `json:"noCompress" envconfig:"K6_CLOUD_NO_COMPRESS"`
-	StopOnError null.Bool   `json:"stopOnError" envconfig:"K6_CLOUD_STOP_ON_ERROR"`
+	LogsTailURL    null.String `json:"-" envconfig:"K6_CLOUD_LOGS_TAIL_URL"`
+	PushRefID      null.String `json:"pushRefID" envconfig:"K6_CLOUD_PUSH_REF_ID"`
+	WebAppURL      null.String `json:"webAppURL" envconfig:"K6_CLOUD_WEB_APP_URL"`
+	TestRunDetails null.String `json:"testRunDetails" envconfig:"K6_CLOUD_TEST_RUN_DETAILS"`
+	NoCompress     null.Bool   `json:"noCompress" envconfig:"K6_CLOUD_NO_COMPRESS"`
+	StopOnError    null.Bool   `json:"stopOnError" envconfig:"K6_CLOUD_STOP_ON_ERROR"`
 
 	MaxMetricSamplesPerPackage null.Int `json:"maxMetricSamplesPerPackage" envconfig:"K6_CLOUD_MAX_METRIC_SAMPLES_PER_PACKAGE"`
 
@@ -185,6 +187,9 @@ func (c Config) Apply(cfg Config) Config {
 	}
 	if cfg.WebAppURL.Valid {
 		c.WebAppURL = cfg.WebAppURL
+	}
+	if cfg.TestRunDetails.Valid {
+		c.TestRunDetails = cfg.TestRunDetails
 	}
 	if cfg.NoCompress.Valid {
 		c.NoCompress = cfg.NoCompress

--- a/cloudapi/util.go
+++ b/cloudapi/util.go
@@ -2,5 +2,9 @@ package cloudapi
 
 // URLForResults returns the cloud URL with the test run results.
 func URLForResults(refID string, config Config) string {
+	if config.TestRunDetails.Valid {
+		return config.TestRunDetails.String
+	}
+
 	return config.WebAppURL.String + "/runs/" + refID
 }

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -161,9 +161,13 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	}
 
 	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Uploading archive"))
-	refID, err := client.StartCloudTestRun(name, cloudConfig.ProjectID.Int64, arc)
+	cloudTestRun, err := client.StartCloudTestRun(name, cloudConfig.ProjectID.Int64, arc)
 	if err != nil {
 		return err
+	}
+	refID := cloudTestRun.ReferenceID
+	if cloudTestRun.ConfigOverride != nil {
+		cloudConfig = cloudConfig.Apply(*cloudTestRun.ConfigOverride)
 	}
 
 	// Trap Interrupts, SIGINTs and SIGTERMs.

--- a/cmd/config_test.go
+++ b/cmd/config_test.go
@@ -53,9 +53,11 @@ func TestConfigCmd(t *testing.T) {
 	}
 
 	for _, data := range testdata {
+		data := data
 		t.Run(data.Name, func(t *testing.T) {
 			t.Parallel()
 			for _, test := range data.Tests {
+				test := test
 				t.Run(`"`+test.Name+`"`, func(t *testing.T) {
 					t.Parallel()
 					fs := configFlagSet()


### PR DESCRIPTION
This is built on top of https://github.com/grafana/k6/pull/2864