### PR TITLE
Update the GitHub Actions to the latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install pandoc
-        uses: crazy-max/ghaction-chocolatey@b6061d587628735be315d74358228b83a7dba9a7
+        uses: crazy-max/ghaction-chocolatey@90deb87d9fbf0bb2f022b91e3bf11b4441cddda5 # v2.1.0
         with:
           args: install -y pandoc
       - name: Install wix tools

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -8,6 +8,6 @@ jobs:
     if: ${{ join(github.event.pull_request.requested_reviewers.*.login, ',') == '' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@19c336bfad4fcb61cab8dcb6b6a5fe3e62ac5cd8 #v1.2.0
+      - uses: kentaro-m/auto-assign-action@6d966a1f3bd73adfe44dd19dc42cc5845e39ebd3 # v1.2.4
         with:
           configuration-path: ".github/pr-auto-assign-config.yml"


### PR DESCRIPTION
# What?

These changes finalize the removalof the deprecated Node 12.X from our CI

Related to the:
* https://github.com/kentaro-m/auto-assign-action/issues/99
* https://github.com/kentaro-m/auto-assign-action/pull/98

# Why?

Resolves #2763