### PR TITLE
Experimental tracing module (4/3): support for sampling

### DIFF
--- a/cmd/tests/tracing_module_test.go
+++ b/cmd/tests/tracing_module_test.go
@@ -1,0 +1,140 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/cmd"
+	"go.k6.io/k6/lib/testutils/httpmultibin"
+)
+
+func TestTracingModuleClient(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	gotRequests := 0
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		gotRequests++
+		assert.NotEmpty(t, r.Header.Get("traceparent"))
+		assert.Len(t, r.Header.Get("traceparent"), 55)
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		const instrumentedHTTP = new tracing.Client({
+			propagator: "w3c",
+		})
+
+		export default function () {
+			instrumentedHTTP.del("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.get("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.head("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.options("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.patch("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.post("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.put("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.request("GET", "HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, 8, gotRequests)
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	gotHTTPDataPoints := false
+
+	for _, jsonLine := range bytes.Split(jsonResults, []byte("\n")) {
+		if len(jsonLine) == 0 {
+			continue
+		}
+
+		var line sampleEnvelope
+		require.NoError(t, json.Unmarshal(jsonLine, &line))
+
+		if line.Type != "Point" {
+			continue
+		}
+
+		// Filter metric samples which are not related to http
+		if !strings.HasPrefix(line.Metric, "http_") {
+			continue
+		}
+
+		gotHTTPDataPoints = true
+
+		anyTraceID, hasTraceID := line.Data.Metadata["trace_id"]
+		require.True(t, hasTraceID)
+
+		traceID, gotTraceID := anyTraceID.(string)
+		require.True(t, gotTraceID)
+
+		assert.Len(t, traceID, 32)
+	}
+
+	assert.True(t, gotHTTPDataPoints)
+}
+
+func TestTracingClient_DoesNotInterfereWithHTTPModule(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	gotRequests := 0
+	gotInstrumentedRequests := 0
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		gotRequests++
+
+		if r.Header.Get("traceparent") != "" {
+			gotInstrumentedRequests++
+			assert.Len(t, r.Header.Get("traceparent"), 55)
+		}
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		const instrumentedHTTP = new tracing.Client({
+			propagator: "w3c",
+		})
+
+		export default function () {
+			instrumentedHTTP.get("HTTPBIN_IP_URL/tracing");
+			http.get("HTTPBIN_IP_URL/tracing");
+			instrumentedHTTP.head("HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, 3, gotRequests)
+	assert.Equal(t, 2, gotInstrumentedRequests)
+}
+
+// sampleEnvelope is a trimmed version of the struct found
+// in output/json/wrapper.go
+// TODO: use the json output's wrapper struct instead if it's ever exported
+type sampleEnvelope struct {
+	Metric string `json:"metric"`
+	Type   string `json:"type"`
+	Data   struct {
+		Value    float64                `json:"value"`
+		Metadata map[string]interface{} `json:"metadata"`
+	} `json:"data"`
+}

--- a/cmd/tests/tracing_module_test.go
+++ b/cmd/tests/tracing_module_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/cmd"
+	"go.k6.io/k6/js/modules/k6/experimental/tracing"
 	"go.k6.io/k6/lib/testutils/httpmultibin"
 )
 
@@ -125,6 +126,236 @@ func TestTracingClient_DoesNotInterfereWithHTTPModule(t *testing.T) {
 
 	assert.Equal(t, 3, gotRequests)
 	assert.Equal(t, 2, gotInstrumentedRequests)
+}
+
+func TestTracingInstrumentHTTP_W3C(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	gotRequests := 0
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		gotRequests++
+		assert.NotEmpty(t, r.Header.Get("traceparent"))
+		assert.Len(t, r.Header.Get("traceparent"), 55)
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		tracing.instrumentHTTP({
+			propagator: "w3c",
+		})
+
+		export default function () {
+			http.del("HTTPBIN_IP_URL/tracing");
+			http.get("HTTPBIN_IP_URL/tracing");
+			http.head("HTTPBIN_IP_URL/tracing");
+			http.options("HTTPBIN_IP_URL/tracing");
+			http.patch("HTTPBIN_IP_URL/tracing");
+			http.post("HTTPBIN_IP_URL/tracing");
+			http.put("HTTPBIN_IP_URL/tracing");
+			http.request("GET", "HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, 8, gotRequests)
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	gotHTTPDataPoints := false
+
+	for _, jsonLine := range bytes.Split(jsonResults, []byte("\n")) {
+		if len(jsonLine) == 0 {
+			continue
+		}
+
+		var line sampleEnvelope
+		require.NoError(t, json.Unmarshal(jsonLine, &line))
+
+		if line.Type != "Point" {
+			continue
+		}
+
+		// Filter metric samples which are not related to http
+		if !strings.HasPrefix(line.Metric, "http_") {
+			continue
+		}
+
+		gotHTTPDataPoints = true
+
+		anyTraceID, hasTraceID := line.Data.Metadata["trace_id"]
+		require.True(t, hasTraceID)
+
+		traceID, gotTraceID := anyTraceID.(string)
+		require.True(t, gotTraceID)
+
+		assert.Len(t, traceID, 32)
+	}
+
+	assert.True(t, gotHTTPDataPoints)
+}
+
+func TestTracingInstrumentHTTP_Jaeger(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	gotRequests := 0
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		gotRequests++
+		assert.NotEmpty(t, r.Header.Get(tracing.JaegerHeaderName))
+		assert.Len(t, r.Header.Get(tracing.JaegerHeaderName), 45)
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		tracing.instrumentHTTP({
+			propagator: "jaeger",
+		})
+
+		export default function () {
+			http.del("HTTPBIN_IP_URL/tracing");
+			http.get("HTTPBIN_IP_URL/tracing");
+			http.head("HTTPBIN_IP_URL/tracing");
+			http.options("HTTPBIN_IP_URL/tracing");
+			http.patch("HTTPBIN_IP_URL/tracing");
+			http.post("HTTPBIN_IP_URL/tracing");
+			http.put("HTTPBIN_IP_URL/tracing");
+			http.request("GET", "HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, 8, gotRequests)
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	gotHTTPDataPoints := false
+
+	for _, jsonLine := range bytes.Split(jsonResults, []byte("\n")) {
+		if len(jsonLine) == 0 {
+			continue
+		}
+
+		var line sampleEnvelope
+		require.NoError(t, json.Unmarshal(jsonLine, &line))
+
+		if line.Type != "Point" {
+			continue
+		}
+
+		// Filter metric samples which are not related to http
+		if !strings.HasPrefix(line.Metric, "http_") {
+			continue
+		}
+
+		gotHTTPDataPoints = true
+
+		anyTraceID, hasTraceID := line.Data.Metadata["trace_id"]
+		require.True(t, hasTraceID)
+
+		traceID, gotTraceID := anyTraceID.(string)
+		require.True(t, gotTraceID)
+
+		assert.Len(t, traceID, 32)
+	}
+
+	assert.True(t, gotHTTPDataPoints)
+}
+
+func TestTracingInstrumentHTTP_FillsParams(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	gotRequests := 0
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		gotRequests++
+
+		assert.NotEmpty(t, r.Header.Get("traceparent"))
+		assert.Len(t, r.Header.Get("traceparent"), 55)
+
+		assert.NotEmpty(t, r.Header.Get("X-Test-Header"))
+		assert.Equal(t, "test", r.Header.Get("X-Test-Header"))
+	})
+
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		tracing.instrumentHTTP({
+			propagator: "w3c",
+		})
+
+		const testHeaders = {
+			"X-Test-Header": "test",
+		}
+
+		export default function () {
+			http.del("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.get("HTTPBIN_IP_URL/tracing", { headers: testHeaders });
+			http.head("HTTPBIN_IP_URL/tracing", { headers: testHeaders });
+			http.options("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.patch("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.post("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.put("HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+			http.request("GET", "HTTPBIN_IP_URL/tracing", null, { headers: testHeaders });
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, 8, gotRequests)
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	gotHTTPDataPoints := false
+
+	for _, jsonLine := range bytes.Split(jsonResults, []byte("\n")) {
+		if len(jsonLine) == 0 {
+			continue
+		}
+
+		var line sampleEnvelope
+		require.NoError(t, json.Unmarshal(jsonLine, &line))
+
+		if line.Type != "Point" {
+			continue
+		}
+
+		// Filter metric samples which are not related to http
+		if !strings.HasPrefix(line.Metric, "http_") {
+			continue
+		}
+
+		gotHTTPDataPoints = true
+
+		anyTraceID, hasTraceID := line.Data.Metadata["trace_id"]
+		require.True(t, hasTraceID)
+
+		traceID, gotTraceID := anyTraceID.(string)
+		require.True(t, gotTraceID)
+
+		assert.Len(t, traceID, 32)
+	}
+
+	assert.True(t, gotHTTPDataPoints)
 }
 
 // sampleEnvelope is a trimmed version of the struct found

--- a/cmd/tests/tracing_module_test.go
+++ b/cmd/tests/tracing_module_test.go
@@ -128,6 +128,99 @@ func TestTracingClient_DoesNotInterfereWithHTTPModule(t *testing.T) {
 	assert.Equal(t, 2, gotInstrumentedRequests)
 }
 
+func TestTracingClient_Sampling(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+
+	gotRequests := 0
+	gotSampledRequests := 0
+	gotNonsampledRequests := 0
+
+	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+		gotRequests++
+
+		if r.Header.Get("traceparent") != "" {
+			assert.Len(t, r.Header.Get("traceparent"), 55)
+
+			// Check if the sampled flag is set
+			if r.Header.Get("traceparent")[54] == '1' {
+				gotSampledRequests++
+			} else {
+				gotNonsampledRequests++
+			}
+		}
+	})
+
+	// The tracing client supports probabilistic sampling.
+	// Because of its very nature, it is hard (impossible) to test
+	// this in a satisfyingly deterministic way.
+	// Thus we will just test that the sampling flag is set according
+	// to sampling rates set to 0%, or 100%, and that the traceparent
+	// header is of the correct length.
+	script := tb.Replacer.Replace(`
+		import http from "k6/http";
+		import { check } from "k6";
+		import tracing from "k6/experimental/tracing";
+
+		const sampledHTTP = new tracing.Client({
+			propagator: "w3c",
+			sampling: 100,
+		})
+
+		const nonSampledHTTP = new tracing.Client({
+			propagator: "w3c",
+			sampling: 0,
+		})
+
+		export default function () {
+			sampledHTTP.get("HTTPBIN_IP_URL/tracing");
+			nonSampledHTTP.head("HTTPBIN_IP_URL/tracing");
+		};
+	`)
+
+	ts := getSingleFileTestState(t, script, []string{"--out", "json=results.json"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Equal(t, 2, gotRequests)
+	assert.Equal(t, 1, gotSampledRequests)
+	assert.Equal(t, 1, gotNonsampledRequests)
+
+	jsonResults, err := afero.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+
+	gotHTTPDataPoints := false
+
+	for _, jsonLine := range bytes.Split(jsonResults, []byte("\n")) {
+		if len(jsonLine) == 0 {
+			continue
+		}
+
+		var line sampleEnvelope
+		require.NoError(t, json.Unmarshal(jsonLine, &line))
+
+		if line.Type != "Point" {
+			continue
+		}
+
+		// Filter metric samples which are not related to http
+		if !strings.HasPrefix(line.Metric, "http_") {
+			continue
+		}
+
+		gotHTTPDataPoints = true
+
+		anyTraceID, hasTraceID := line.Data.Metadata["trace_id"]
+		require.True(t, hasTraceID)
+
+		traceID, gotTraceID := anyTraceID.(string)
+		require.True(t, gotTraceID)
+
+		assert.Len(t, traceID, 32)
+	}
+
+	assert.True(t, gotHTTPDataPoints)
+}
+
 func TestTracingInstrumentHTTP_W3C(t *testing.T) {
 	t.Parallel()
 	tb := httpmultibin.NewHTTPMultiBin(t)

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -8,6 +8,7 @@ import (
 	"go.k6.io/k6/js/modules/k6/data"
 	"go.k6.io/k6/js/modules/k6/encoding"
 	"go.k6.io/k6/js/modules/k6/execution"
+	"go.k6.io/k6/js/modules/k6/experimental/tracing"
 	"go.k6.io/k6/js/modules/k6/grpc"
 	"go.k6.io/k6/js/modules/k6/html"
 	"go.k6.io/k6/js/modules/k6/http"
@@ -30,6 +31,7 @@ func getInternalJSModules() map[string]interface{} {
 		"k6/experimental/redis":      redis.New(),
 		"k6/experimental/websockets": &expws.RootModule{},
 		"k6/experimental/timers":     timers.New(),
+		"k6/experimental/tracing":    tracing.New(),
 		"k6/net/grpc":                grpc.New(),
 		"k6/html":                    html.New(),
 		"k6/http":                    http.New(),

--- a/js/modules/k6/experimental/tracing/client.go
+++ b/js/modules/k6/experimental/tracing/client.go
@@ -23,7 +23,7 @@ type Client struct {
 	// propagator holds the client's trace propagator, used
 	// to produce trace context headers for each supported
 	// formats: w3c, b3, jaeger.
-	propagator Propagator
+	propagator SampledPropagator
 
 	// requestFunc holds the http module's request function
 	// used to emit HTTP requests in k6 script. The client
@@ -79,11 +79,18 @@ func (c *Client) Configure(opts options) error {
 		return fmt.Errorf("invalid options: %w", err)
 	}
 
+	// If the sampling option wasn't provided
+	// we default to 100% sampling rate.
+	samplingRate := 100
+	if opts.Sampling != nil {
+		samplingRate = *opts.Sampling
+	}
+
 	switch opts.Propagator {
 	case "w3c":
-		c.propagator = &W3CPropagator{}
+		c.propagator = NewW3CPropagator(samplingRate)
 	case "jaeger":
-		c.propagator = &JaegerPropagator{}
+		c.propagator = NewJaegerPropagator(samplingRate)
 	default:
 		return fmt.Errorf("unknown propagator: %s", opts.Propagator)
 	}

--- a/js/modules/k6/experimental/tracing/client.go
+++ b/js/modules/k6/experimental/tracing/client.go
@@ -1,0 +1,237 @@
+package tracing
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/js/modules"
+	httpmodule "go.k6.io/k6/js/modules/k6/http"
+	"go.k6.io/k6/metrics"
+)
+
+// Client represents a HTTP Client instrumenting the requests
+// it performs with tracing information.
+type Client struct {
+	vu modules.VU
+
+	// opts holds the client's configuration options.
+	opts options
+
+	// propagator holds the client's trace propagator, used
+	// to produce trace context headers for each supported
+	// formats: w3c, b3, jaeger.
+	propagator Propagator
+
+	// requestFunc holds the http module's request function
+	// used to emit HTTP requests in k6 script. The client
+	// uses it under the hood to emit the requests it
+	// instruments.
+	requestFunc HTTPRequestFunc
+}
+
+// HTTPRequestFunc is a type alias representing the prototype of
+// k6's http module's request function
+type HTTPRequestFunc func(method string, url goja.Value, args ...goja.Value) (*httpmodule.Response, error)
+
+// NewClient instantiates a new tracing Client
+func NewClient(vu modules.VU, opts options) *Client {
+	rt := vu.Runtime()
+
+	// Get the http module's request function
+	httpModuleRequest, err := rt.RunString("require('k6/http').request")
+	if err != nil {
+		common.Throw(
+			rt,
+			fmt.Errorf(
+				"failed initializing tracing client, "+
+					"unable to require http.request method; reason: %w",
+				err,
+			),
+		)
+	}
+
+	// Export the http module's request function goja.Callable as a Go function
+	var requestFunc HTTPRequestFunc
+	if err := rt.ExportTo(httpModuleRequest, &requestFunc); err != nil {
+		common.Throw(
+			rt,
+			fmt.Errorf("failed initializing tracing client, unable to export http.request method; reason: %w", err),
+		)
+	}
+
+	client := &Client{vu: vu, requestFunc: requestFunc}
+	if err := client.Configure(opts); err != nil {
+		common.Throw(
+			rt,
+			fmt.Errorf("failed initializing tracing client, invalid configuration; reason: %w", err),
+		)
+	}
+
+	return client
+}
+
+// Configure configures the tracing client with the given options.
+func (c *Client) Configure(opts options) error {
+	if err := opts.validate(); err != nil {
+		return fmt.Errorf("invalid options: %w", err)
+	}
+
+	switch opts.Propagator {
+	case "w3c":
+		c.propagator = &W3CPropagator{}
+	case "jaeger":
+		c.propagator = &JaegerPropagator{}
+	default:
+		return fmt.Errorf("unknown propagator: %s", opts.Propagator)
+	}
+
+	c.opts = opts
+
+	return nil
+}
+
+// Request instruments the http module's request function with tracing headers,
+// and ensures the trace_id is emitted as part of the output's data points metadata.
+func (c *Client) Request(method string, url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	rt := c.vu.Runtime()
+
+	// The http module's request function expects the first argument to be the
+	// request body. If no body is provided, we need to pass null to the function.
+	if len(args) == 0 {
+		args = []goja.Value{goja.Null()}
+	}
+
+	traceID := TraceID{
+		Prefix: k6Prefix,
+		Code:   k6CloudCode,
+		Time:   time.Now(),
+	}
+
+	encodedTraceID, err := traceID.Encode()
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("failed to encode the generated trace ID; reason: %w", err))
+	}
+
+	// Produce a trace header in the format defined by the
+	// configured propagator.
+	traceContextHeader, err := c.propagator.Propagate(encodedTraceID)
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("failed to propagate trace ID; reason: %w", err))
+	}
+
+	// update the `params` argument with the trace context header
+	// so that it can be used by the http module's request function.
+	args, err = c.instrumentArguments(traceContextHeader, args...)
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("failed to instrument request arguments; reason: %w", err))
+	}
+
+	// Add the trace ID to the VU's state, so that it can be
+	// used in the metrics emitted by the HTTP module.
+	c.vu.State().Tags.Modify(func(t *metrics.TagsAndMeta) {
+		t.SetMetadata(metadataTraceIDKeyName, encodedTraceID)
+	})
+
+	response, err := c.requestFunc(method, url, args...)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	// Remove the trace ID from the VU's state, so that it doesn't
+	// leak into other requests.
+	c.vu.State().Tags.Modify(func(t *metrics.TagsAndMeta) {
+		t.DeleteMetadata(metadataTraceIDKeyName)
+	})
+
+	return response, nil
+}
+
+// Del instruments the http module's delete method.
+func (c *Client) Del(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodDelete, url, args...)
+}
+
+// Get instruments the http module's get method.
+func (c *Client) Get(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	// Here we prepend a null value that stands for the body parameter,
+	// that the request function expects as a first argument implicitly
+	args = append([]goja.Value{goja.Null()}, args...)
+	return c.Request(http.MethodGet, url, args...)
+}
+
+// Head instruments the http module's head method.
+func (c *Client) Head(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	// NB: here we prepend a null value that stands for the body parameter,
+	// that the request function expects as a first argument implicitly
+	args = append([]goja.Value{goja.Null()}, args...)
+	return c.Request(http.MethodHead, url, args...)
+}
+
+// Options instruments the http module's options method.
+func (c *Client) Options(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodOptions, url, args...)
+}
+
+// Patch instruments the http module's patch method.
+func (c *Client) Patch(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodPatch, url, args...)
+}
+
+// Post instruments the http module's post method.
+func (c *Client) Post(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodPost, url, args...)
+}
+
+// Put instruments the http module's put method.
+func (c *Client) Put(url goja.Value, args ...goja.Value) (*httpmodule.Response, error) {
+	return c.Request(http.MethodPut, url, args...)
+}
+
+// instrumentArguments: expects args to be in the format expected by the
+// request method (body, params)
+func (c *Client) instrumentArguments(traceContext http.Header, args ...goja.Value) ([]goja.Value, error) {
+	rt := c.vu.Runtime()
+
+	var paramsObj *goja.Object
+
+	switch len(args) {
+	case 2:
+		// We received both a body and a params argument. In the
+		// event params would be nullish, we'll instantiate
+		// a new object.
+		if isNullish(args[1]) {
+			paramsObj = rt.NewObject()
+			args[1] = paramsObj
+		} else {
+			paramsObj = args[1].ToObject(rt)
+		}
+	case 1:
+		// We only received a body argument
+		paramsObj = rt.NewObject()
+		args = append(args, paramsObj)
+	default:
+		return nil, fmt.Errorf("invalid number of arguments; expected 1 or 2, got %d", len(args))
+	}
+
+	headersObj := rt.NewObject()
+
+	headersValue := paramsObj.Get("headers")
+	if !isNullish(headersValue) {
+		headersObj = headersValue.ToObject(rt)
+	}
+
+	if err := paramsObj.Set("headers", headersObj); err != nil {
+		return args, err
+	}
+
+	for key, value := range traceContext {
+		if err := headersObj.Set(key, value); err != nil {
+			return args, fmt.Errorf("failed to set the trace header; reason: %w", err)
+		}
+	}
+
+	return args, nil
+}

--- a/js/modules/k6/experimental/tracing/client_test.go
+++ b/js/modules/k6/experimental/tracing/client_test.go
@@ -1,0 +1,166 @@
+package tracing
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/dop251/goja"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/modulestest"
+)
+
+// traceParentHeaderName is the normalized trace header name.
+// Although the traceparent header is case insensitive, the
+// Go http.Header sets it capitalized.
+const traceparentHeaderName string = "Traceparent"
+
+// testTraceID is a valid trace ID used in tests.
+const testTraceID string = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-00"
+
+func TestClientInstrumentArguments(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no args should fail", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+
+		_, err := testCase.client.instrumentArguments(testCase.traceContextHeader)
+		require.Error(t, err)
+	})
+
+	t.Run("1 arg should initialize params successfully", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+		rt := testCase.testSetup.VU.Runtime()
+
+		gotArgs, gotErr := testCase.client.instrumentArguments(testCase.traceContextHeader, goja.Null())
+
+		assert.NoError(t, gotErr)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, goja.Null(), gotArgs[0])
+
+		gotParams := gotArgs[1].ToObject(rt)
+		assert.NotNil(t, gotParams)
+		gotHeaders := gotParams.Get("headers").ToObject(rt)
+		assert.NotNil(t, gotHeaders)
+		gotTraceParent := gotHeaders.Get(traceparentHeaderName)
+		assert.NotNil(t, gotTraceParent)
+		assert.Equal(t, testTraceID, gotTraceParent.String())
+	})
+
+	t.Run("2 args with null params should initialize it", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+		rt := testCase.testSetup.VU.Runtime()
+
+		gotArgs, gotErr := testCase.client.instrumentArguments(testCase.traceContextHeader, goja.Null(), goja.Null())
+
+		assert.NoError(t, gotErr)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, goja.Null(), gotArgs[0])
+
+		gotParams := gotArgs[1].ToObject(rt)
+		assert.NotNil(t, gotParams)
+		gotHeaders := gotParams.Get("headers").ToObject(rt)
+		assert.NotNil(t, gotHeaders)
+		gotTraceParent := gotHeaders.Get(traceparentHeaderName)
+		assert.NotNil(t, gotTraceParent)
+		assert.Equal(t, testTraceID, gotTraceParent.String())
+	})
+
+	t.Run("2 args with undefined params should initialize it", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+		rt := testCase.testSetup.VU.Runtime()
+
+		gotArgs, gotErr := testCase.client.instrumentArguments(testCase.traceContextHeader, goja.Null(), goja.Undefined())
+
+		assert.NoError(t, gotErr)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, goja.Null(), gotArgs[0])
+
+		gotParams := gotArgs[1].ToObject(rt)
+		assert.NotNil(t, gotParams)
+		gotHeaders := gotParams.Get("headers").ToObject(rt)
+		assert.NotNil(t, gotHeaders)
+		gotTraceParent := gotHeaders.Get(traceparentHeaderName)
+		assert.NotNil(t, gotTraceParent)
+		assert.Equal(t, testTraceID, gotTraceParent.String())
+	})
+
+	t.Run("2 args with predefined params and headers updates them successfully", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+		rt := testCase.testSetup.VU.Runtime()
+
+		wantHeaders := rt.NewObject()
+		require.NoError(t, wantHeaders.Set("X-Test-Header", "testvalue"))
+		wantParams := rt.NewObject()
+		require.NoError(t, wantParams.Set("headers", wantHeaders))
+
+		gotArgs, gotErr := testCase.client.instrumentArguments(testCase.traceContextHeader, goja.Null(), wantParams)
+
+		assert.NoError(t, gotErr)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, goja.Null(), gotArgs[0])
+		assert.Equal(t, wantParams, gotArgs[1])
+
+		gotHeaders := gotArgs[1].ToObject(rt).Get("headers").ToObject(rt)
+
+		gotTraceParent := gotHeaders.Get(traceparentHeaderName)
+		assert.NotNil(t, gotTraceParent)
+		assert.Equal(t, testTraceID, gotTraceParent.String())
+
+		gotTestHeader := gotHeaders.Get("X-Test-Header")
+		assert.NotNil(t, gotTestHeader)
+		assert.Equal(t, "testvalue", gotTestHeader.String())
+	})
+
+	t.Run("2 args with predefined params and no headers sets and updates them successfully", func(t *testing.T) {
+		t.Parallel()
+
+		testCase := newTestCase(t)
+		rt := testCase.testSetup.VU.Runtime()
+		wantParams := rt.NewObject()
+
+		gotArgs, gotErr := testCase.client.instrumentArguments(testCase.traceContextHeader, goja.Null(), wantParams)
+
+		assert.NoError(t, gotErr)
+		assert.Len(t, gotArgs, 2)
+		assert.Equal(t, goja.Null(), gotArgs[0])
+		assert.Equal(t, wantParams, gotArgs[1])
+
+		gotHeaders := gotArgs[1].ToObject(rt).Get("headers").ToObject(rt)
+
+		gotTraceParent := gotHeaders.Get(traceparentHeaderName)
+		assert.NotNil(t, gotTraceParent)
+		assert.Equal(t, testTraceID, gotTraceParent.String())
+	})
+}
+
+type tracingClientTestCase struct {
+	t                  *testing.T
+	testSetup          *modulestest.Runtime
+	client             Client
+	traceContextHeader http.Header
+}
+
+func newTestCase(t *testing.T) *tracingClientTestCase {
+	testSetup := modulestest.NewRuntime(t)
+	client := Client{vu: testSetup.VU}
+	traceContextHeader := http.Header{}
+	traceContextHeader.Add(traceparentHeaderName, testTraceID)
+
+	return &tracingClientTestCase{
+		t:                  t,
+		testSetup:          testSetup,
+		client:             client,
+		traceContextHeader: traceContextHeader,
+	}
+}

--- a/js/modules/k6/experimental/tracing/encoding.go
+++ b/js/modules/k6/experimental/tracing/encoding.go
@@ -1,0 +1,19 @@
+package tracing
+
+import (
+	"math/rand"
+)
+
+// randHexStringRunes returns a random string of n hex characters.
+//
+// Note that this function uses a non-cryptographic random number generator.
+func randHexString(n int) string {
+	hexRunes := []rune("123456789abcdef")
+
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = hexRunes[rand.Intn(len(hexRunes))] //nolint:gosec
+	}
+
+	return string(b)
+}

--- a/js/modules/k6/experimental/tracing/goja.go
+++ b/js/modules/k6/experimental/tracing/goja.go
@@ -1,0 +1,11 @@
+package tracing
+
+import "github.com/dop251/goja"
+
+// isNullish checks if the given value is nullish, i.e. nil, undefined or null.
+//
+// This helper function emulates the behavior of Javascript's nullish coalescing
+// operator (??).
+func isNullish(value goja.Value) bool {
+	return value == nil || goja.IsUndefined(value) || goja.IsNull(value)
+}

--- a/js/modules/k6/experimental/tracing/module.go
+++ b/js/modules/k6/experimental/tracing/module.go
@@ -1,0 +1,42 @@
+// Package tracing implements a k6 JS module for instrumenting k6 scripts with tracing context information.
+package tracing
+
+import (
+	"go.k6.io/k6/js/modules"
+)
+
+type (
+	// RootModule is the global module instance that will create Client
+	// instances for each VU.
+	RootModule struct{}
+
+	// ModuleInstance represents an instance of the JS module.
+	ModuleInstance struct {
+		vu modules.VU
+	}
+)
+
+// Ensure the interfaces are implemented correctly
+var (
+	_ modules.Instance = &ModuleInstance{}
+	_ modules.Module   = &RootModule{}
+)
+
+// New returns a pointer to a new RootModule instance
+func New() *RootModule {
+	return &RootModule{}
+}
+
+// NewModuleInstance implements the modules.Module interface and returns
+// a new instance for each VU.
+func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
+	return &ModuleInstance{
+		vu: vu,
+	}
+}
+
+// Exports implements the modules.Instance interface and returns
+// the exports of the JS module.
+func (mi *ModuleInstance) Exports() modules.Exports {
+	return modules.Exports{}
+}

--- a/js/modules/k6/experimental/tracing/module.go
+++ b/js/modules/k6/experimental/tracing/module.go
@@ -18,6 +18,9 @@ type (
 	// ModuleInstance represents an instance of the JS module.
 	ModuleInstance struct {
 		vu modules.VU
+
+		// Client holds the module's default tracing client.
+		*Client
 	}
 )
 
@@ -37,6 +40,9 @@ func New() *RootModule {
 func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	return &ModuleInstance{
 		vu: vu,
+		Client: &Client{
+			vu: vu,
+		},
 	}
 }
 
@@ -45,7 +51,8 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{
 		Named: map[string]interface{}{
-			"Client": mi.newClient,
+			"Client":         mi.newClient,
+			"instrumentHTTP": mi.instrumentHTTP,
 		},
 	}
 }
@@ -68,4 +75,55 @@ func (mi *ModuleInstance) newClient(cc goja.ConstructorCall) *goja.Object {
 	}
 
 	return rt.ToValue(NewClient(mi.vu, opts)).ToObject(rt)
+}
+
+// InstrumentHTTP instruments the HTTP module with tracing headers.
+//
+// When used in the context of a k6 script, it will automatically replace
+// the imported http module's methods with instrumented ones.
+func (mi *ModuleInstance) instrumentHTTP(options options) {
+	rt := mi.vu.Runtime()
+
+	// Initialize the tracing module's instance default client,
+	// and configure it using the user-supplied set of options.
+	mi.Client = NewClient(mi.vu, options)
+
+	// Explicitly inject the http module in the VU's runtime.
+	// This allows us to later on override the http module's methods
+	// with instrumented ones.
+	httpModuleValue, err := rt.RunString(`require('k6/http')`)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	httpModuleObj := httpModuleValue.ToObject(rt)
+
+	// Closure overriding a method of the provided imported module object.
+	//
+	// The `onModule` argument should be a *goja.Object obtained by requiring
+	// or importing the 'k6/http' module and converting it to an object.
+	//
+	// The `value` argument is expected to be callable.
+	mustSetHTTPMethod := func(method string, onModule *goja.Object, value interface{}) {
+		// Inject the new get function, adding tracing headers
+		// to the request in the HTTP module object.
+		err = onModule.Set(method, value)
+		if err != nil {
+			common.Throw(
+				rt,
+				fmt.Errorf("unable to overwrite http.%s method with instrumented one; reason: %w", method, err),
+			)
+		}
+	}
+
+	// Overwrite the implementation of the http module's method with the instrumented
+	// ones exposed by the `tracing.Client` struct.
+	mustSetHTTPMethod("del", httpModuleObj, mi.Client.Del)
+	mustSetHTTPMethod("get", httpModuleObj, mi.Client.Get)
+	mustSetHTTPMethod("head", httpModuleObj, mi.Client.Head)
+	mustSetHTTPMethod("options", httpModuleObj, mi.Client.Options)
+	mustSetHTTPMethod("patch", httpModuleObj, mi.Client.Patch)
+	mustSetHTTPMethod("post", httpModuleObj, mi.Client.Patch)
+	mustSetHTTPMethod("put", httpModuleObj, mi.Client.Patch)
+	mustSetHTTPMethod("request", httpModuleObj, mi.Client.Request)
 }

--- a/js/modules/k6/experimental/tracing/module.go
+++ b/js/modules/k6/experimental/tracing/module.go
@@ -2,6 +2,11 @@
 package tracing
 
 import (
+	"errors"
+	"fmt"
+
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
 )
 
@@ -38,5 +43,29 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 // Exports implements the modules.Instance interface and returns
 // the exports of the JS module.
 func (mi *ModuleInstance) Exports() modules.Exports {
-	return modules.Exports{}
+	return modules.Exports{
+		Named: map[string]interface{}{
+			"Client": mi.newClient,
+		},
+	}
+}
+
+// NewClient is the JS constructor for the tracing.Client
+//
+// It expects a single configuration object as argument, which
+// will be used to instantiate an `Object` instance internally,
+// and will be used by the client to configure itself.
+func (mi *ModuleInstance) newClient(cc goja.ConstructorCall) *goja.Object {
+	rt := mi.vu.Runtime()
+
+	if len(cc.Arguments) < 1 {
+		common.Throw(rt, errors.New("Client constructor expects a single configuration object as argument; none given"))
+	}
+
+	var opts options
+	if err := rt.ExportTo(cc.Arguments[0], &opts); err != nil {
+		common.Throw(rt, fmt.Errorf("unable to parse options object; reason: %w", err))
+	}
+
+	return rt.ToValue(NewClient(mi.vu, opts)).ToObject(rt)
 }

--- a/js/modules/k6/experimental/tracing/options.go
+++ b/js/modules/k6/experimental/tracing/options.go
@@ -1,0 +1,41 @@
+package tracing
+
+import (
+	"errors"
+	"fmt"
+)
+
+// options are the options that can be passed to the
+// tracing.instrumentHTTP() method.
+type options struct {
+	// Propagation is the propagation format to use for the tracer.
+	Propagator string `js:"propagator"`
+
+	// Sampling is the sampling rate to use for the tracer.
+	Sampling *float64 `js:"sampling"`
+
+	// Baggage is a map of baggage items to add to the tracer.
+	Baggage map[string]string `js:"baggage"`
+}
+
+func (i *options) validate() error {
+	var (
+		isW3C    = i.Propagator == W3CPropagatorName
+		isJaeger = i.Propagator == JaegerPropagatorName
+	)
+	if !isW3C && !isJaeger {
+		return fmt.Errorf("unknown propagator: %s", i.Propagator)
+	}
+
+	// TODO: implement sampling support
+	if i.Sampling != nil {
+		return errors.New("sampling is not yet supported")
+	}
+
+	// TODO: implement baggage support
+	if i.Baggage != nil {
+		return errors.New("baggage is not yet supported")
+	}
+
+	return nil
+}

--- a/js/modules/k6/experimental/tracing/options.go
+++ b/js/modules/k6/experimental/tracing/options.go
@@ -11,8 +11,9 @@ type options struct {
 	// Propagation is the propagation format to use for the tracer.
 	Propagator string `js:"propagator"`
 
-	// Sampling is the sampling rate to use for the tracer.
-	Sampling *float64 `js:"sampling"`
+	// Sampling is the sampling rate to use for the
+	// tracer, expressed in percents: 0 <= n <= 100.
+	Sampling *int `json:"sampling"`
 
 	// Baggage is a map of baggage items to add to the tracer.
 	Baggage map[string]string `js:"baggage"`
@@ -27,9 +28,8 @@ func (i *options) validate() error {
 		return fmt.Errorf("unknown propagator: %s", i.Propagator)
 	}
 
-	// TODO: implement sampling support
-	if i.Sampling != nil {
-		return errors.New("sampling is not yet supported")
+	if i.Sampling != nil && (*i.Sampling < 0 || *i.Sampling > 100) {
+		return errors.New("sampling rate must be between 0 and 100")
 	}
 
 	// TODO: implement baggage support

--- a/js/modules/k6/experimental/tracing/options_test.go
+++ b/js/modules/k6/experimental/tracing/options_test.go
@@ -1,0 +1,74 @@
+package tracing
+
+import "testing"
+
+func TestOptionsValidate(t *testing.T) {
+	t.Parallel()
+
+	testFloat := 10.0
+
+	type fields struct {
+		Propagator string
+		Sampling   *float64
+		Baggage    map[string]string
+	}
+	testCases := []struct {
+		name    string
+		fields  fields
+		wantErr bool
+	}{
+		{
+			name: "w3c propagator is valid",
+			fields: fields{
+				Propagator: "w3c",
+			},
+			wantErr: false,
+		},
+		{
+			name: "jaeger propagator is valid",
+			fields: fields{
+				Propagator: "jaeger",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid propagator is invalid",
+			fields: fields{
+				Propagator: "invalid",
+			},
+			wantErr: true,
+		},
+		{
+			name: "sampling is not yet supported",
+			fields: fields{
+				Sampling: &testFloat,
+			},
+			wantErr: true,
+		},
+		{
+			name: "baggage is not yet supported",
+			fields: fields{
+				Baggage: map[string]string{"key": "value"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			i := &options{
+				Propagator: tc.fields.Propagator,
+				Sampling:   tc.fields.Sampling,
+				Baggage:    tc.fields.Baggage,
+			}
+
+			if err := i.validate(); (err != nil) != tc.wantErr {
+				t.Errorf("instrumentationOptions.validate() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/js/modules/k6/experimental/tracing/options_test.go
+++ b/js/modules/k6/experimental/tracing/options_test.go
@@ -5,11 +5,19 @@ import "testing"
 func TestOptionsValidate(t *testing.T) {
 	t.Parallel()
 
-	testFloat := 10.0
+	// Note that we prefer variables over constants here
+	// as we need to be able to address them.
+	var (
+		validSampling            = 10
+		lowerBoundSampling       = 0
+		upperBoundSampling       = 100
+		lowerOutOfBoundsSampling = -1
+		upperOutOfBoundsSampling = 101
+	)
 
 	type fields struct {
 		Propagator string
-		Sampling   *float64
+		Sampling   *int
 		Baggage    map[string]string
 	}
 	testCases := []struct {
@@ -39,16 +47,58 @@ func TestOptionsValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "sampling is not yet supported",
+			name: "sampling rate is valid",
 			fields: fields{
-				Sampling: &testFloat,
+				Propagator: "w3c",
+				Sampling:   &validSampling,
+			},
+			wantErr: false,
+		},
+		{
+			name: "no sampling is valid",
+			fields: fields{
+				Propagator: "w3c",
+				Sampling:   nil,
+			},
+			wantErr: false,
+		},
+		{
+			name: "sampling rate = 0 is valid",
+			fields: fields{
+				Propagator: "w3c",
+				Sampling:   &lowerBoundSampling,
+			},
+			wantErr: false,
+		},
+		{
+			name: "sampling rate = 100 is valid",
+			fields: fields{
+				Propagator: "w3c",
+				Sampling:   &upperBoundSampling,
+			},
+			wantErr: false,
+		},
+		{
+			name: "sampling rate < 0 is invalid",
+			fields: fields{
+				Propagator: "w3c",
+				Sampling:   &lowerOutOfBoundsSampling,
+			},
+			wantErr: true,
+		},
+		{
+			name: "sampling rater > 100 is invalid",
+			fields: fields{
+				Propagator: "w3c",
+				Sampling:   &upperOutOfBoundsSampling,
 			},
 			wantErr: true,
 		},
 		{
 			name: "baggage is not yet supported",
 			fields: fields{
-				Baggage: map[string]string{"key": "value"},
+				Propagator: "w3c",
+				Baggage:    map[string]string{"key": "value"},
 			},
 			wantErr: true,
 		},

--- a/js/modules/k6/experimental/tracing/propagator.go
+++ b/js/modules/k6/experimental/tracing/propagator.go
@@ -1,0 +1,69 @@
+package tracing
+
+import (
+	"net/http"
+)
+
+// Propagator is an interface for trace context propagation
+type Propagator interface {
+	Propagate(traceID string) (http.Header, error)
+}
+
+const (
+	// W3CPropagatorName is the name of the W3C trace context propagator
+	W3CPropagatorName = "w3c"
+
+	// W3CHeaderName is the name of the W3C trace context header
+	W3CHeaderName = "traceparent"
+
+	// W3CVersion is the version of the supported W3C trace context header.
+	// The current specification assumes the version is set to 00.
+	W3CVersion = "00"
+
+	// W3CUnsampledTraceFlag is the trace-flag value for an unsampled trace.
+	W3CUnsampledTraceFlag = "00"
+
+	// W3CSampledTraceFlag is the trace-flag value for a sampled trace.
+	W3CSampledTraceFlag = "01"
+)
+
+// W3CPropagator is a Propagator for the W3C trace context header
+type W3CPropagator struct{}
+
+// Propagate returns a header with a random trace ID in the W3C format
+func (p *W3CPropagator) Propagate(traceID string) (http.Header, error) {
+	parentID := randHexString(16)
+
+	return http.Header{
+		W3CHeaderName: {
+			W3CVersion + "-" + traceID + "-" + parentID + "-" + W3CSampledTraceFlag,
+		},
+	}, nil
+}
+
+const (
+	// JaegerPropagatorName is the name of the Jaeger trace context propagator
+	JaegerPropagatorName = "jaeger"
+
+	// JaegerHeaderName is the name of the Jaeger trace context header
+	JaegerHeaderName = "uber-trace-id"
+
+	// JaegerRootSpanID is the universal span ID of the root span.
+	// Its value is zero, which is described in the Jaeger documentation as:
+	// "0 value is valid and means “root span” (when not ignored)"
+	JaegerRootSpanID = "0"
+)
+
+// JaegerPropagator is a Propagator for the Jaeger trace context header
+type JaegerPropagator struct{}
+
+// Propagate returns a header with a random trace ID in the Jaeger format
+func (p *JaegerPropagator) Propagate(traceID string) (http.Header, error) {
+	spanID := randHexString(8)
+	// flags set to 1 means the span is sampled
+	flags := "1"
+
+	return http.Header{
+		JaegerHeaderName: {traceID + ":" + spanID + ":" + JaegerRootSpanID + ":" + flags},
+	}, nil
+}

--- a/js/modules/k6/experimental/tracing/propagator.go
+++ b/js/modules/k6/experimental/tracing/propagator.go
@@ -9,6 +9,19 @@ type Propagator interface {
 	Propagate(traceID string) (http.Header, error)
 }
 
+// SampledPropagator is an interface for trace context propagation
+// with support for sampling.
+type SampledPropagator interface {
+	Propagator
+	ProbabilisticSampler
+
+	// SampleFlag should return the sampling flag to use
+	// as part of the trace context header, according to
+	// the sampler's decision of whether or not a given
+	// trace should be sampled.
+	SampleFlag() string
+}
+
 const (
 	// W3CPropagatorName is the name of the W3C trace context propagator
 	W3CPropagatorName = "w3c"
@@ -20,25 +33,61 @@ const (
 	// The current specification assumes the version is set to 00.
 	W3CVersion = "00"
 
-	// W3CUnsampledTraceFlag is the trace-flag value for an unsampled trace.
-	W3CUnsampledTraceFlag = "00"
-
 	// W3CSampledTraceFlag is the trace-flag value for a sampled trace.
 	W3CSampledTraceFlag = "01"
+
+	// W3CUnsampledTraceFlag is the trace-flag value for an unsampled trace.
+	W3CUnsampledTraceFlag = "00"
 )
 
 // W3CPropagator is a Propagator for the W3C trace context header
-type W3CPropagator struct{}
+type W3CPropagator struct {
+	Sampler
+}
+
+// Ensures that W3CPropagator implements the Propagator and
+// SampledPropagator interface
+var (
+	_ Propagator        = &W3CPropagator{}
+	_ SampledPropagator = &W3CPropagator{}
+)
+
+// NewW3CPropagator returns a new W3CPropagator with the given sampling rate.
+//
+// Note that we allocate the propagator on the heap to ensure we conform
+// to the Sampler interface, as the ProbabilisticSampler's SetSamplingRate
+// method has a pointer receiver.
+func NewW3CPropagator(samplingRate int) *W3CPropagator {
+	return &W3CPropagator{
+		NewSampler(samplingRate),
+	}
+}
 
 // Propagate returns a header with a random trace ID in the W3C format
-func (p *W3CPropagator) Propagate(traceID string) (http.Header, error) {
+func (p W3CPropagator) Propagate(traceID string) (http.Header, error) {
 	parentID := randHexString(16)
+	flags := p.SampleFlag()
 
 	return http.Header{
 		W3CHeaderName: {
-			W3CVersion + "-" + traceID + "-" + parentID + "-" + W3CSampledTraceFlag,
+			W3CVersion + "-" + traceID + "-" + parentID + "-" + flags,
 		},
 	}, nil
+}
+
+// SampleFlag returns the trace sample flag for the trace,
+// based on the current sampling rate.
+//
+// It uses under the `Sampled` method under the hood to
+// set the flag to either W3CSampledTraceFlag or W3CUnsampledTraceFlag,
+// with a percent of chance based on the propagator's sampling
+// rate.
+func (p W3CPropagator) SampleFlag() string {
+	if p.Sampled() {
+		return W3CSampledTraceFlag
+	}
+
+	return W3CUnsampledTraceFlag
 }
 
 const (
@@ -52,18 +101,58 @@ const (
 	// Its value is zero, which is described in the Jaeger documentation as:
 	// "0 value is valid and means “root span” (when not ignored)"
 	JaegerRootSpanID = "0"
+
+	// JaegerSampledTraceFlag is the trace-flag value for an unsampled trace.
+	JaegerSampledTraceFlag = "0"
+
+	// JaegerUnsampledTraceFlag is the trace-flag value for a sampled trace.
+	JaegerUnsampledTraceFlag = "1"
 )
 
 // JaegerPropagator is a Propagator for the Jaeger trace context header
-type JaegerPropagator struct{}
+type JaegerPropagator struct {
+	Sampler
+}
+
+// Ensure the JaegerPropagator implements the Propagator and
+// SampledPropagator interface
+var (
+	_ Propagator        = &JaegerPropagator{}
+	_ SampledPropagator = &JaegerPropagator{}
+)
+
+// NewJaegerPropagator returns a new JaegerPropagator with the given sampling rate.
+//
+// Note that we allocate the propagator on the heap to ensure we conform
+// to the Sampler interface, as the ProbabilisticSampler's SetSamplingRate
+// method has a pointer receiver.
+func NewJaegerPropagator(samplingRate int) *JaegerPropagator {
+	return &JaegerPropagator{
+		NewSampler(samplingRate),
+	}
+}
 
 // Propagate returns a header with a random trace ID in the Jaeger format
 func (p *JaegerPropagator) Propagate(traceID string) (http.Header, error) {
 	spanID := randHexString(8)
-	// flags set to 1 means the span is sampled
-	flags := "1"
+	flags := p.SampleFlag()
 
 	return http.Header{
 		JaegerHeaderName: {traceID + ":" + spanID + ":" + JaegerRootSpanID + ":" + flags},
 	}, nil
+}
+
+// SampleFlag returns the trace sample flag for the trace,
+// based on the current sampling rate.
+//
+// It uses under the `Sampled` method under the hood to
+// set the flag to either W3CSampledTraceFlag or W3CUnsampledTraceFlag,
+// with a percent of chance based on the propagator's sampling
+// rate.
+func (p *JaegerPropagator) SampleFlag() string {
+	if p.Sampled() {
+		return JaegerSampledTraceFlag
+	}
+
+	return JaegerUnsampledTraceFlag
 }

--- a/js/modules/k6/experimental/tracing/rand.go
+++ b/js/modules/k6/experimental/tracing/rand.go
@@ -17,3 +17,11 @@ func randHexString(n int) string {
 
 	return string(b)
 }
+
+// chance returns true with a `percentage` chance, otherwise false.
+// the `percentage` argument is expected to be
+// within 0 <= percentage <= 100 range.
+func chance(percentage int) bool {
+	//nolint:gosec
+	return rand.Intn(100) < percentage
+}

--- a/js/modules/k6/experimental/tracing/sampling.go
+++ b/js/modules/k6/experimental/tracing/sampling.go
@@ -1,0 +1,39 @@
+package tracing
+
+// ProbabilisticSampler is an interface defining probabilistic sampling strategies.
+type ProbabilisticSampler interface {
+	// SetSamplingRate sets the sampling rate for the sampler.
+	SetSamplingRate(percent int)
+
+	// Sampled returns true if the trace should be sampled
+	// false otherwise. The returned value is based on the
+	// sampling rate set by SetSamplingRate().
+	Sampled() bool
+}
+
+// Sampler implements the Sampler interface and allows
+// to take probabilistic sampling decisions based on a sampling rate.
+type Sampler struct {
+	// samplingRate is a chance value defined as a percentage
+	// value within 0 <= samplingRate <= 100 bounds.
+	samplingRate int
+}
+
+// NewSampler returns a new ProbablisticSampler with the provided sampling rate.
+func NewSampler(samplingRate int) Sampler {
+	return Sampler{samplingRate: samplingRate}
+}
+
+// SetSamplingRate sets the sampling rate for the sampler.
+func (ps *Sampler) SetSamplingRate(percent int) {
+	ps.samplingRate = percent
+}
+
+// Sampled returns true if the trace should be sampled.
+//
+// Its return value is probabilistic, based on the selected
+// sampling rate S, there is S percent chance that the
+// returned value is true.
+func (ps Sampler) Sampled() bool {
+	return chance(ps.samplingRate)
+}

--- a/js/modules/k6/experimental/tracing/trace_id.go
+++ b/js/modules/k6/experimental/tracing/trace_id.go
@@ -1,0 +1,95 @@
+package tracing
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+const (
+	// Being 075 the ASCII code for 'K' :)
+	k6Prefix = 0o756
+
+	// To ingest and process the related spans in k6 Cloud.
+	k6CloudCode = 12
+
+	// To not ingest and process the related spans, b/c they are part of a non-cloud run.
+	k6LocalCode = 33
+)
+
+// TraceID represents a trace-id as defined by the [W3c specification], and
+// used by w3c, b3 and jaeger propagators. See Considerations for trace-id field [generation]
+// for more information.
+//
+// [W3c specification]: https://www.w3.org/TR/trace-context/#trace-id
+// [generation]: https://www.w3.org/TR/trace-context/#considerations-for-trace-id-field-generation
+type TraceID struct {
+	// Prefix is the first 2 bytes of the trace-id, and is used to identify the
+	// vendor of the trace-id.
+	Prefix int16
+
+	// Code is the third byte of the trace-id, and is used to identify the
+	// vendor's specific trace-id format.
+	Code int8
+
+	// Time is the time at which the trace-id was generated.
+	//
+	// The time component is used as a source of randomness, and to ensure
+	// uniqueness of the trace-id.
+	//
+	// When encoded, it should be in a format occupying the last 8 bytes of
+	// the trace-id, and should ideally be encoded as nanoseconds.
+	Time time.Time
+}
+
+// Encode encodes the TraceID into a hex string.
+//
+// The trace id is first encoded as a 16 bytes sequence, as follows:
+// 1. Up to 2 bytes are encoded as the Prefix
+// 2. The third byte is the Code.
+// 3. Up to the following 8 bytes are UnixTimestampNano.
+// 4. The remaining bytes are filled with random bytes.
+//
+// The resulting 16 bytes sequence is then encoded as a hex string.
+func (t TraceID) Encode() (string, error) {
+	if !t.isValid() {
+		return "", fmt.Errorf("failed to encode traceID: %v", t)
+	}
+
+	// TraceID is specified to be 16 bytes long.
+	buf := make([]byte, 16)
+
+	// The `PutVarint` and `PutUvarint` functions encode the given value into
+	// the provided buffer, and return the number of bytes written. Thus, it
+	// allows us to keep track of the number of bytes written, as we go, and
+	// to pack the values to use as less space as possible.
+	n := binary.PutVarint(buf, int64(t.Prefix))
+	n += binary.PutVarint(buf[n:], int64(t.Code))
+	n += binary.PutVarint(buf[n:], t.Time.UnixNano())
+
+	// The rest of the space in the 16 bytes buffer, equivalent to the number
+	// of available bytes left after writing the prefix, code and timestamp (index n)
+	// is filled with random bytes.
+	randomness := make([]byte, 16-n)
+	err := binary.Read(rand.Reader, binary.BigEndian, randomness)
+	if err != nil {
+		return "", fmt.Errorf("failed to read random bytes from os; reason: %w", err)
+	}
+
+	buf = append(buf[:n], randomness...)
+	hx := hex.EncodeToString(buf)
+
+	return hx, nil
+}
+
+func (t TraceID) isValid() bool {
+	var (
+		isk6Prefix = t.Prefix == k6Prefix
+		isk6Cloud  = t.Code == k6CloudCode
+		isk6Local  = t.Code == k6LocalCode
+	)
+
+	return isk6Prefix && (isk6Cloud || isk6Local)
+}

--- a/js/modules/k6/experimental/tracing/trace_id.go
+++ b/js/modules/k6/experimental/tracing/trace_id.go
@@ -17,6 +17,9 @@ const (
 
 	// To not ingest and process the related spans, b/c they are part of a non-cloud run.
 	k6LocalCode = 33
+
+	// metadataTraceIDKeyName is the key name of the traceID in the output metadata.
+	metadataTraceIDKeyName = "trace_id"
 )
 
 // TraceID represents a trace-id as defined by the [W3c specification], and

--- a/js/modules/k6/experimental/tracing/trace_id_test.go
+++ b/js/modules/k6/experimental/tracing/trace_id_test.go
@@ -1,0 +1,75 @@
+package tracing
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTraceID_isValid(t *testing.T) {
+	t.Parallel()
+
+	type fields struct {
+		Prefix int16
+		Code   int8
+		Time   time.Time
+	}
+	testCases := []struct {
+		name   string
+		fields fields
+		want   bool
+	}{
+		{
+			name: "traceID with k6 cloud code is valid",
+			fields: fields{
+				Prefix: k6Prefix,
+				Code:   k6CloudCode,
+				Time:   time.Unix(123456789, 0),
+			},
+			want: true,
+		},
+		{
+			name: "traceID with k6 local code is valid",
+			fields: fields{
+				Prefix: k6Prefix,
+				Code:   k6LocalCode,
+				Time:   time.Unix(123456789, 0),
+			},
+			want: true,
+		},
+		{
+			name: "traceID with prefix != k6Prefix is invalid",
+			fields: fields{
+				Prefix: 0,
+				Code:   k6CloudCode,
+				Time:   time.Unix(123456789, 0),
+			},
+			want: false,
+		},
+		{
+			name: "traceID code with code != k6CloudCode and code != k6LocalCode is invalid",
+			fields: fields{
+				Prefix: k6Prefix,
+				Code:   0,
+				Time:   time.Unix(123456789, 0),
+			},
+			want: false,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tr := &TraceID{
+				Prefix: tc.fields.Prefix,
+				Code:   tc.fields.Code,
+				Time:   tc.fields.Time,
+			}
+
+			if got := tr.isValid(); got != tc.want {
+				t.Errorf("TraceID.isValid() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/samples/experimental/tracing-client.js
+++ b/samples/experimental/tracing-client.js
@@ -1,0 +1,46 @@
+import http from "k6/http";
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+
+// Explicitly instantiating a tracing client allows to distringuish
+// instrumented from non-instrumented HTTP calls, by keeping APIs separate.
+// It also allows for finer-grained configuration control, by letting
+// users changing the tracing configuration on the fly during their
+// script's execution.
+let instrumentedHTTP = new tracing.Client({
+	propagator: "w3c",
+});
+
+const testData = { name: "Bert" };
+
+export default () => {
+	// Using the tracing client instance, HTTP calls will have
+	// their trace context headers set.
+	let res = instrumentedHTTP.request("GET", "http://httpbin.org/get", null, {
+		headers: {
+			"X-Example-Header": "instrumented/request",
+		},
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+
+	// The tracing client offers more flexibility over
+	// the `instrumentHTTP` function, as it leaves the
+	// imported standard http module untouched. Thus,
+	// one can still perform non-instrumented HTTP calls
+	// using it.
+	res = http.post("http://httpbin.org/post", JSON.stringify(testData), {
+		headers: { "X-Example-Header": "noninstrumented/post" },
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+
+	res = instrumentedHTTP.del("http://httpbin.org/delete", null, {
+		headers: { "X-Example-Header": "instrumented/delete" },
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+};

--- a/samples/experimental/tracing-sampling.js
+++ b/samples/experimental/tracing-sampling.js
@@ -1,0 +1,31 @@
+import http from "k6/http";
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+
+export const options = {
+	// As the number of sampled requests will converge towards
+	// the sampling percentage, we need to increase the number
+	// of iterations to get a more accurate result.
+	iterations: 10000,
+
+	vus: 100,
+};
+
+tracing.instrumentHTTP({
+	propagator: "w3c",
+
+	// Only 10% of the requests made will have their trace context
+	// header's sample flag set to activated.
+	sampling: 10,
+});
+
+export default () => {
+	let res = http.get("http://httpbin.org/get", {
+		headers: {
+			"X-Example-Header": "instrumented/get",
+		},
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+};

--- a/samples/experimental/tracing/tracing-instrumentHTTP.js
+++ b/samples/experimental/tracing/tracing-instrumentHTTP.js
@@ -1,0 +1,24 @@
+import http from "k6/http";
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+
+// instrumentHTTP will ensure that all requests made by the http module
+// will be traced. The first argument is a configuration object that
+// can be used to configure the tracer.
+//
+// Currently supported HTTP methods are: get, post, put, patch, head,
+// del, options, and request.
+tracing.instrumentHTTP({
+	propagator: "w3c",
+});
+
+export default () => {
+	let res = http.get("http://httpbin.org/get", {
+		headers: {
+			"X-Example-Header": "instrumented/get",
+		},
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+};


### PR DESCRIPTION
## About

This Pull Request adds probabilistic sampling support to the tracing module. Using it, users can specify the percentage of their instrumented requests which should have their trace context header's sampled field set to true.

✋🏻 This Pull Request is a nice-to-have built on top of the initial PR chain meant to add a `k6/experimental/tracing` module to k6 (#2853, #2854, #2855) and should be treated separately and merged only once the initial PR chain is merged to master ✋🏻 

From a user-interface perspective, this feature is introduced as an option meant to be set during either the instantiation of a `tracing.Client`, or during a call to `instrumentHTTP`. It consists of a single integer field of the tracing options, whose value, within the `0 <= n <= 100` bounds, is meant to represent a percentage.

```javascript
// The sampling option is available when instantiating a Client
const sampledHTTP = new tracing.Client({
	propagator: "w3c",
	
	// Up to 55% of the requests emitted using the client instance's
	// methods will have their trace context header's sampled field
	// set to true.
	sampling: 55,
})

// It is also available when using the instrumentHTTP function
tracing.InstrumentHTTP({
	propagator: "w3c",
	
	// Up to 27% of the requests made with the HTTP module's functions
	// will have their trace context header's sampled field set to true
	// from this point onward 
	sampling: 27,
})
```

This feature is implemented using probabilistic sampling. Meaning that over a large series of iterations, the number of requests with their sampled flag set to true will tend to converge to the selected `sampling` rate value. That was a design choice without explicit constraints, preferring randomness over accuracy: each trace context generation evaluates its chance of being sampled independently. If you find an implementation emphasizing more accuracy, I'm open to going that route; just let me know.

Note that regardless of the sampled header flag's value, the `trace_id` metadata will be attached to each output sample.