### PR TITLE
Disable async function as group and check callback

### DIFF
--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -95,7 +95,7 @@ func (mi *K6) Group(name string, val goja.Value) (goja.Value, error) {
 		return nil, ErrGroupInInitContext
 	}
 
-	if val == nil || goja.IsNull(val) {
+	if isNullish(val) {
 		return nil, errors.New("group() requires a callback as a second argument")
 	}
 	fn, ok := goja.AssertFunction(val)

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -24,7 +24,7 @@ var (
 )
 
 const asyncFunctionNotSupportedMsg = "%s: async functions are not supported as arguments, " +
-	"please see https://github.com/grafana/k6/issues/2728#issuecomment-1404747660 for more info"
+	"please see https://k6.io/docs/javascript-api/k6/group/#working-with-async-functions for more info"
 
 type (
 	// RootModule is the global module instance that will create module

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -3,6 +3,7 @@ package k6
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"sync/atomic"
 	"time"
@@ -21,6 +22,9 @@ var (
 	// ErrCheckInInitContext is returned when check() are using in the init context.
 	ErrCheckInInitContext = common.NewInitContextError("Using check() in the init context is not supported")
 )
+
+const asyncFunctionNotSupportedMsg = "%s: async functions are not supported as arguments, " +
+	"please see https://github.com/grafana/k6/issues/2728#issuecomment-1404747660 for more info"
 
 type (
 	// RootModule is the global module instance that will create module
@@ -85,16 +89,24 @@ func (mi *K6) RandomSeed(seed int64) {
 }
 
 // Group wraps a function call and executes it within the provided group name.
-func (mi *K6) Group(name string, fn goja.Callable) (goja.Value, error) {
+func (mi *K6) Group(name string, val goja.Value) (goja.Value, error) {
 	state := mi.vu.State()
 	if state == nil {
 		return nil, ErrGroupInInitContext
 	}
 
-	if fn == nil {
+	if val == nil || goja.IsNull(val) {
 		return nil, errors.New("group() requires a callback as a second argument")
 	}
-
+	fn, ok := goja.AssertFunction(val)
+	if !ok {
+		return nil, errors.New("group() requires a callback as a second argument")
+	}
+	rt := mi.vu.Runtime()
+	o := val.ToObject(rt)
+	if o.ClassName() == "AsyncFunction" {
+		return goja.Undefined(), fmt.Errorf(asyncFunctionNotSupportedMsg, "group")
+	}
 	g, err := state.Group.Group(name)
 	if err != nil {
 		return goja.Undefined(), err
@@ -137,7 +149,12 @@ func (mi *K6) Group(name string, fn goja.Callable) (goja.Value, error) {
 	return ret, err
 }
 
+func isNullish(val goja.Value) bool {
+	return val == nil || goja.IsNull(val) || goja.IsUndefined(val)
+}
+
 // Check will emit check metrics for the provided checks.
+//
 //nolint:cyclop
 func (mi *K6) Check(arg0, checks goja.Value, extras ...goja.Value) (bool, error) {
 	state := mi.vu.State()
@@ -174,6 +191,10 @@ func (mi *K6) Check(arg0, checks goja.Value, extras ...goja.Value) (bool, error)
 		tags := commonTagsAndMeta.Tags
 		if state.Options.SystemTags.Has(metrics.TagCheck) {
 			tags = tags.With("check", check.Name)
+		}
+
+		if !isNullish(val) && val.ToObject(rt).ClassName() == "AsyncFunction" {
+			return false, fmt.Errorf(asyncFunctionNotSupportedMsg, "check")
 		}
 
 		// Resolve callables into values.

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -23,7 +23,7 @@ var (
 	ErrCheckInInitContext = common.NewInitContextError("Using check() in the init context is not supported")
 )
 
-const asyncFunctionNotSupportedMsg = "%s: async functions are not supported as arguments, " +
+const asyncFunctionNotSupportedMsg = "%s() does not support async functions as arguments, " +
 	"please see https://k6.io/docs/javascript-api/k6/group/#working-with-async-functions for more info"
 
 type (

--- a/js/modules/k6/k6_test.go
+++ b/js/modules/k6/k6_test.go
@@ -191,14 +191,14 @@ func TestGroup(t *testing.T) {
 		t.Parallel()
 		rt, _, _ := setupGroupTest()
 		_, err := rt.RunString(`k6.group("something", async function() { })`)
-		assert.ErrorContains(t, err, "group: async functions are not supported as arguments")
+		assert.ErrorContains(t, err, "group() does not support async functions as arguments")
 	})
 
 	t.Run("async lambda", func(t *testing.T) {
 		t.Parallel()
 		rt, _, _ := setupGroupTest()
 		_, err := rt.RunString(`k6.group("something", async () => { })`)
-		assert.ErrorContains(t, err, "group: async functions are not supported as arguments")
+		assert.ErrorContains(t, err, "group() does not support async functions as arguments")
 	})
 }
 
@@ -290,14 +290,14 @@ func TestCheckObject(t *testing.T) {
 		t.Parallel()
 		rt, _, _ := checkTestRuntime(t)
 		_, err := rt.RunString(`k6.check("something", {"async": async function() { }})`)
-		assert.ErrorContains(t, err, "check: async functions are not supported as arguments")
+		assert.ErrorContains(t, err, "check() does not support async functions as arguments")
 	})
 
 	t.Run("async lambda", func(t *testing.T) {
 		t.Parallel()
 		rt, _, _ := checkTestRuntime(t)
 		_, err := rt.RunString(`k6.check("something", {"async": async () =>{ }})`)
-		assert.ErrorContains(t, err, "check: async functions are not supported as arguments")
+		assert.ErrorContains(t, err, "check() does not support async functions as arguments")
 	})
 }
 

--- a/js/modules/k6/k6_test.go
+++ b/js/modules/k6/k6_test.go
@@ -186,6 +186,20 @@ func TestGroup(t *testing.T) {
 		_, err := rt.RunString(`k6.group("::", function() { throw new Error("nooo") })`)
 		assert.Contains(t, err.Error(), "group and check names may not contain '::'")
 	})
+
+	t.Run("async function", func(t *testing.T) {
+		t.Parallel()
+		rt, _, _ := setupGroupTest()
+		_, err := rt.RunString(`k6.group("something", async function() { })`)
+		assert.ErrorContains(t, err, "group: async functions are not supported as arguments")
+	})
+
+	t.Run("async lambda", func(t *testing.T) {
+		t.Parallel()
+		rt, _, _ := setupGroupTest()
+		_, err := rt.RunString(`k6.group("something", async () => { })`)
+		assert.ErrorContains(t, err, "group: async functions are not supported as arguments")
+	})
 }
 
 func checkTestRuntime(t testing.TB) (*goja.Runtime, chan metrics.SampleContainer, *metrics.BuiltinMetrics) {
@@ -270,6 +284,20 @@ func TestCheckObject(t *testing.T) {
 		rt, _, _ := checkTestRuntime(t)
 		_, err := rt.RunString(`k6.check(null, { "::": true })`)
 		assert.Contains(t, err.Error(), "group and check names may not contain '::'")
+	})
+
+	t.Run("async function", func(t *testing.T) {
+		t.Parallel()
+		rt, _, _ := checkTestRuntime(t)
+		_, err := rt.RunString(`k6.check("something", {"async": async function() { }})`)
+		assert.ErrorContains(t, err, "check: async functions are not supported as arguments")
+	})
+
+	t.Run("async lambda", func(t *testing.T) {
+		t.Parallel()
+		rt, _, _ := checkTestRuntime(t)
+		_, err := rt.RunString(`k6.check("something", {"async": async () =>{ }})`)
+		assert.ErrorContains(t, err, "check: async functions are not supported as arguments")
 	})
 }
 


### PR DESCRIPTION
The general inconsistencies between group as an idea and asynchronous code makes it not great fit and such we will try to discourage users to mix them.

Updates #2728

