### PR TITLE
js: refactor how modules are loaded

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -101,7 +101,7 @@ func newBundle(
 	// TODO use a real context
 	vuImpl := &moduleVUImpl{ctx: context.Background(), runtime: goja.New()}
 	vuImpl.eventLoop = eventloop.New(vuImpl)
-	instance, err := bundle.instantiate(vuImpl, 0, c)
+	instance, err := bundle.instantiate(vuImpl, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (b *Bundle) Instantiate(ctx context.Context, vuID uint64) (*BundleInstance,
 	// runtime, but no state, to allow module-provided types to function within the init context.
 	vuImpl := &moduleVUImpl{ctx: ctx, runtime: goja.New()}
 	vuImpl.eventLoop = eventloop.New(vuImpl)
-	instance, err := b.instantiate(vuImpl, vuID, b.newCompiler(b.logger))
+	instance, err := b.instantiate(vuImpl, vuID)
 	if err != nil {
 		return nil, err
 	}
@@ -259,7 +259,7 @@ func (b *Bundle) newCompiler(logger logrus.FieldLogger) *compiler.Compiler {
 	return c
 }
 
-func (b *Bundle) instantiate(vuImpl *moduleVUImpl, vuID uint64, c *compiler.Compiler) (moduleInstance, error) {
+func (b *Bundle) instantiate(vuImpl *moduleVUImpl, vuID uint64) (moduleInstance, error) {
 	rt := vuImpl.runtime
 	err := b.setupJSRuntime(rt, int64(vuID), b.logger)
 	if err != nil {

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -123,7 +123,7 @@ func TestNewBundle(t *testing.T) {
 		t.Parallel()
 		b, err := getSimpleBundle(t, "-", `export default function() {};`)
 		require.NoError(t, err)
-		assert.Equal(t, "file://-", b.Filename.String())
+		assert.Equal(t, "file://-", b.sourceData.URL.String())
 		assert.Equal(t, "file:///", b.pwd.String())
 	})
 	t.Run("CompatibilityMode", func(t *testing.T) {

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -124,7 +124,7 @@ func TestNewBundle(t *testing.T) {
 		b, err := getSimpleBundle(t, "-", `export default function() {};`)
 		require.NoError(t, err)
 		assert.Equal(t, "file://-", b.Filename.String())
-		assert.Equal(t, "file:///", b.BaseInitContext.pwd.String())
+		assert.Equal(t, "file:///", b.pwd.String())
 	})
 	t.Run("CompatibilityMode", func(t *testing.T) {
 		t.Parallel()

--- a/js/cjsmodule.go
+++ b/js/cjsmodule.go
@@ -1,0 +1,70 @@
+package js
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/compiler"
+	"go.k6.io/k6/js/modules"
+)
+
+// cjsModule represents a commonJS module
+type cjsModule struct {
+	prg *goja.Program
+	url *url.URL
+}
+
+var _ module = &cjsModule{}
+
+type cjsModuleInstance struct {
+	mod       *cjsModule
+	moduleObj *goja.Object
+	vu        modules.VU
+}
+
+func (c *cjsModule) Instantiate(vu modules.VU) moduleInstance {
+	return &cjsModuleInstance{vu: vu, mod: c}
+}
+
+func (c *cjsModuleInstance) execute() error {
+	rt := c.vu.Runtime()
+	exports := rt.NewObject()
+	c.moduleObj = rt.NewObject()
+	err := c.moduleObj.Set("exports", exports)
+	if err != nil {
+		return fmt.Errorf("error while getting ready to import commonJS, couldn't set exports property of module: %w",
+			err)
+	}
+
+	// Run the program.
+	f, err := rt.RunProgram(c.mod.prg)
+	if err != nil {
+		return err
+	}
+	if call, ok := goja.AssertFunction(f); ok {
+		if _, err = call(exports, c.moduleObj, exports); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *cjsModuleInstance) exports() *goja.Object {
+	exportsV := c.moduleObj.Get("exports")
+	if goja.IsNull(exportsV) || goja.IsUndefined(exportsV) {
+		return nil
+	}
+	return exportsV.ToObject(c.vu.Runtime())
+}
+
+type cjsModuleLoader func(specifier *url.URL, name string) (*cjsModule, error)
+
+func cjsmoduleFromString(fileURL *url.URL, data []byte, c *compiler.Compiler) (*cjsModule, error) {
+	pgm, _, err := c.Compile(string(data), fileURL.String(), false)
+	if err != nil {
+		return nil, err
+	}
+	return &cjsModule{prg: pgm, url: fileURL}, nil
+}

--- a/js/gomodule.go
+++ b/js/gomodule.go
@@ -1,0 +1,93 @@
+package js
+
+import (
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/modules"
+)
+
+// baseGoModule is a go module that does not implement modules.Module interface
+// TODO maybe depracate those in the future
+type baseGoModule struct {
+	mod interface{}
+}
+
+var _ module = &baseGoModule{}
+
+func (b *baseGoModule) Instantiate(vu modules.VU) moduleInstance {
+	return &baseGoModuleInstance{mod: b.mod, vu: vu}
+}
+
+type baseGoModuleInstance struct {
+	mod      interface{}
+	vu       modules.VU
+	exportsO *goja.Object // this is so we only initialize the exports once per instance
+}
+
+func (b *baseGoModuleInstance) execute() error {
+	return nil
+}
+
+func (b *baseGoModuleInstance) exports() *goja.Object {
+	if b.exportsO == nil {
+		// TODO check this does not panic a lot
+		rt := b.vu.Runtime()
+		b.exportsO = rt.ToValue(b.mod).ToObject(rt)
+	}
+	return b.exportsO
+}
+
+// goModule is a go module which implements modules.Module
+type goModule struct {
+	modules.Module
+}
+
+var _ module = &goModule{}
+
+func (g *goModule) Instantiate(vu modules.VU) moduleInstance {
+	return &goModuleInstance{vu: vu, module: g}
+}
+
+type goModuleInstance struct {
+	modules.Instance
+	module   *goModule
+	vu       modules.VU
+	exportsO *goja.Object // this is so we only initialize the exports once per instance
+}
+
+var _ moduleInstance = &goModuleInstance{}
+
+func (gi *goModuleInstance) execute() error {
+	gi.Instance = gi.module.NewModuleInstance(gi.vu)
+	return nil
+}
+
+func (gi *goModuleInstance) exports() *goja.Object {
+	if gi.exportsO == nil {
+		rt := gi.vu.Runtime()
+		gi.exportsO = rt.ToValue(toESModuleExports(gi.Instance.Exports())).ToObject(rt)
+	}
+	return gi.exportsO
+}
+
+func toESModuleExports(exp modules.Exports) interface{} {
+	if exp.Named == nil {
+		return exp.Default
+	}
+	if exp.Default == nil {
+		return exp.Named
+	}
+
+	result := make(map[string]interface{}, len(exp.Named)+2)
+
+	for k, v := range exp.Named {
+		result[k] = v
+	}
+	// Maybe check that those weren't set
+	result["default"] = exp.Default
+	// this so babel works with the `default` when it transpiles from ESM to commonjs.
+	// This should probably be removed once we have support for ESM directly. So that require doesn't get support for
+	// that while ESM has.
+	result["__esModule"] = true
+
+	return result
+}

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -1,255 +1,37 @@
 package js
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/dop251/goja"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 
-	"go.k6.io/k6/js/common"
-	"go.k6.io/k6/js/compiler"
 	"go.k6.io/k6/js/modules"
-	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/loader"
 )
 
-type programWithSource struct {
-	pgm     *goja.Program
-	src     string
-	module  *goja.Object
-	exports *goja.Object
-}
-
-const openCantBeUsedOutsideInitContextMsg = `The "open()" function is only available in the init stage ` +
+const cantBeUsedOutsideInitContextMsg = `the "%s" function is only available in the init stage ` +
 	`(i.e. the global scope), see https://k6.io/docs/using-k6/test-life-cycle for more information`
 
-// InitContext provides APIs for use in the init context.
-//
-// TODO: refactor most/all of this state away, use common.InitEnvironment instead
-type InitContext struct {
-	// Bound runtime; used to instantiate objects.
-	compiler *compiler.Compiler
-
-	moduleVUImpl *moduleVUImpl
-
-	// Filesystem to load files and scripts from with the map key being the scheme
-	filesystems map[string]afero.Fs
-	pwd         *url.URL
-
-	// Cache of loaded programs and files.
-	programs map[string]programWithSource
-	// merge this and the above
-	k6ModulesCache map[string]goja.Value
-
-	compatibilityMode lib.CompatibilityMode
-
-	logger logrus.FieldLogger
-
-	moduleRegistry map[string]interface{}
-}
-
-// NewInitContext creates a new initcontext with the provided arguments
-func NewInitContext(
-	logger logrus.FieldLogger, rt *goja.Runtime, c *compiler.Compiler, compatMode lib.CompatibilityMode,
-	filesystems map[string]afero.Fs, pwd *url.URL,
-) *InitContext {
-	return &InitContext{
-		compiler:          c,
-		filesystems:       filesystems,
-		pwd:               pwd,
-		programs:          make(map[string]programWithSource),
-		compatibilityMode: compatMode,
-		logger:            logger,
-		moduleRegistry:    getJSModules(),
-		k6ModulesCache:    make(map[string]goja.Value),
-		moduleVUImpl: &moduleVUImpl{
-			// TODO: pass a real context as we did for https://github.com/grafana/k6/pull/2800,
-			// also see https://github.com/grafana/k6/issues/2804
-			ctx:     context.Background(),
-			runtime: rt,
-		},
-	}
-}
-
-func newBoundInitContext(base *InitContext, vuImpl *moduleVUImpl) *InitContext {
-	// we don't copy the exports as otherwise they will be shared and we don't want this.
-	// this means that all the files will be executed again but once again only once per compilation
-	// of the main file.
-	programs := make(map[string]programWithSource, len(base.programs))
-	for key, program := range base.programs {
-		programs[key] = programWithSource{
-			src: program.src,
-			pgm: program.pgm,
-		}
-	}
-	return &InitContext{
-		filesystems: base.filesystems,
-		pwd:         base.pwd,
-		compiler:    base.compiler,
-
-		programs:          programs,
-		compatibilityMode: base.compatibilityMode,
-		k6ModulesCache:    make(map[string]goja.Value),
-		logger:            base.logger,
-		moduleRegistry:    base.moduleRegistry,
-		moduleVUImpl:      vuImpl,
-	}
-}
-
-// Require is called when a module/file needs to be loaded by a script
-func (i *InitContext) Require(arg string) (export goja.Value) {
-	switch {
-	case arg == "k6", strings.HasPrefix(arg, "k6/"):
-		var ok bool
-		if export, ok = i.k6ModulesCache[arg]; ok {
-			return export
-		}
-		defer func() { i.k6ModulesCache[arg] = export }()
-		// Builtin or external modules ("k6", "k6/*", or "k6/x/*") are handled
-		// specially, as they don't exist on the filesystem. This intentionally
-		// shadows attempts to name your own modules this.
-		v, err := i.requireModule(arg)
-		if err != nil {
-			common.Throw(i.moduleVUImpl.runtime, err)
-		}
-		return v
-	default:
-		// Fall back to loading from the filesystem.
-		v, err := i.requireFile(arg)
-		if err != nil {
-			common.Throw(i.moduleVUImpl.runtime, err)
-		}
-		return v
-	}
-}
-
-func toESModuleExports(exp modules.Exports) interface{} {
-	if exp.Named == nil {
-		return exp.Default
-	}
-	if exp.Default == nil {
-		return exp.Named
-	}
-
-	result := make(map[string]interface{}, len(exp.Named)+2)
-
-	for k, v := range exp.Named {
-		result[k] = v
-	}
-	// Maybe check that those weren't set
-	result["default"] = exp.Default
-	// this so babel works with the `default` when it transpiles from ESM to commonjs.
-	// This should probably be removed once we have support for ESM directly. So that require doesn't get support for
-	// that while ESM has.
-	result["__esModule"] = true
-
-	return result
-}
-
-func (i *InitContext) requireModule(name string) (goja.Value, error) {
-	mod, ok := i.moduleRegistry[name]
-	if !ok {
-		return nil, fmt.Errorf("unknown module: %s", name)
-	}
-	if m, ok := mod.(modules.Module); ok {
-		instance := m.NewModuleInstance(i.moduleVUImpl)
-		return i.moduleVUImpl.runtime.ToValue(toESModuleExports(instance.Exports())), nil
-	}
-
-	return i.moduleVUImpl.runtime.ToValue(mod), nil
-}
-
-func (i *InitContext) requireFile(name string) (goja.Value, error) {
-	// Resolve the file path, push the target directory as pwd to make relative imports work.
-	pwd := i.pwd
-	fileURL, err := loader.Resolve(pwd, name)
-	if err != nil {
-		return nil, err
-	}
-
-	// First, check if we have a cached program already.
-	pgm, ok := i.programs[fileURL.String()]
-	if !ok || pgm.module == nil {
-		if filepath.IsAbs(name) && runtime.GOOS == "windows" {
-			i.logger.Warnf("'%s' was imported with an absolute path - this won't be cross-platform and won't work if"+
-				" you move the script between machines or run it with `k6 cloud`; if absolute paths are required,"+
-				" import them with the `file://` schema for slightly better compatibility",
-				name)
-		}
-		i.pwd = loader.Dir(fileURL)
-		defer func() { i.pwd = pwd }()
-		exports := i.moduleVUImpl.runtime.NewObject()
-		pgm.module = i.moduleVUImpl.runtime.NewObject()
-		_ = pgm.module.Set("exports", exports)
-
-		if pgm.pgm == nil {
-			// Load the sources; the loader takes care of remote loading, etc.
-			data, err := loader.Load(i.logger, i.filesystems, fileURL, name)
-			if err != nil {
-				return goja.Undefined(), err
-			}
-
-			pgm.src = string(data.Data)
-
-			// Compile the sources; this handles ES5 vs ES6 automatically.
-			pgm.pgm, err = i.compileImport(pgm.src, data.URL.String())
-			if err != nil {
-				return goja.Undefined(), err
-			}
-		}
-
-		i.programs[fileURL.String()] = pgm
-
-		// Run the program.
-		f, err := i.moduleVUImpl.runtime.RunProgram(pgm.pgm)
-		if err != nil {
-			delete(i.programs, fileURL.String())
-			return goja.Undefined(), err
-		}
-		if call, ok := goja.AssertFunction(f); ok {
-			if _, err = call(exports, pgm.module, exports); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return pgm.module.Get("exports"), nil
-}
-
-func (i *InitContext) compileImport(src, filename string) (*goja.Program, error) {
-	pgm, _, err := i.compiler.Compile(src, filename, false)
-	return pgm, err
-}
-
-// Open implements open() in the init context and will read and return the
+// openImpl implements openImpl() in the init context and will read and return the
 // contents of a file. If the second argument is "b" it returns an ArrayBuffer
 // instance, otherwise a string representation.
-func (i *InitContext) Open(filename string, args ...string) (goja.Value, error) {
-	if i.moduleVUImpl.State() != nil {
-		return nil, errors.New(openCantBeUsedOutsideInitContextMsg)
-	}
-
-	if filename == "" {
-		return nil, errors.New("open() can't be used with an empty filename")
-	}
-
+func openImpl(rt *goja.Runtime, fs afero.Fs, basePWD *url.URL, filename string, args ...string) (goja.Value, error) {
 	// Here IsAbs should be enough but unfortunately it doesn't handle absolute paths starting from
 	// the current drive on windows like `\users\noname\...`. Also it makes it more easy to test and
 	// will probably be need for archive execution under windows if always consider '/...' as an
 	// absolute path.
 	if filename[0] != '/' && filename[0] != '\\' && !filepath.IsAbs(filename) {
-		filename = filepath.Join(i.pwd.Path, filename)
+		filename = filepath.Join(basePWD.Path, filename)
 	}
 	filename = filepath.Clean(filename)
-	fs := i.filesystems["file"]
+
 	if filename[0:1] != afero.FilePathSeparator {
 		filename = afero.FilePathSeparator + filename
 	}
@@ -260,10 +42,10 @@ func (i *InitContext) Open(filename string, args ...string) (goja.Value, error) 
 	}
 
 	if len(args) > 0 && args[0] == "b" {
-		ab := i.moduleVUImpl.runtime.NewArrayBuffer(data)
-		return i.moduleVUImpl.runtime.ToValue(&ab), nil
+		ab := rt.NewArrayBuffer(data)
+		return rt.ToValue(&ab), nil
 	}
-	return i.moduleVUImpl.runtime.ToValue(string(data)), nil
+	return rt.ToValue(string(data)), nil
 }
 
 func readFile(fileSystem afero.Fs, filename string) (data []byte, err error) {
@@ -289,13 +71,68 @@ func readFile(fileSystem afero.Fs, filename string) (data []byte, err error) {
 }
 
 // allowOnlyOpenedFiles enables seen only files
-func (i *InitContext) allowOnlyOpenedFiles() {
-	fs := i.filesystems["file"]
-
+func allowOnlyOpenedFiles(fs afero.Fs) {
 	alreadyOpenedFS, ok := fs.(fsext.OnlyCachedEnabler)
 	if !ok {
 		return
 	}
 
 	alreadyOpenedFS.AllowOnlyCached()
+}
+
+type requireImpl struct {
+	vu      modules.VU
+	modules *moduleSystem
+	pwd     *url.URL
+}
+
+func (r *requireImpl) require(specifier string) (*goja.Object, error) {
+	// TODO remove this in the future when we address https://github.com/grafana/k6/issues/2674
+	// This is currently needed as each time require is called we need to record it's new pwd
+	// to be used if a require *or* open is used within the file as they are relative to the
+	// latest call to require.
+	// This is *not* the actual require behaviour defined in commonJS as it is actually always relative
+	// to the file it is in. This is unlikely to be an issue but this code is here to keep backwards
+	// compatibility *for now*.
+	// With native ESM this won't even be possible as `require` might not be called - instead an import
+	// might be used in which case we won't be able to be doing this hack. In that case we either will
+	// need some goja specific helper or to use stack traces as goja_nodejs does.
+	currentPWD := r.pwd
+	if specifier != "k6" && !strings.HasPrefix(specifier, "k6/") {
+		defer func() {
+			r.pwd = currentPWD
+		}()
+		// In theory we can give that downwards, but this makes the code more tightly coupled
+		// plus as explained above this will be removed in the future so the code reflects more
+		// closely what will be needed then
+		fileURL, err := loader.Resolve(r.pwd, specifier)
+		if err != nil {
+			return nil, err
+		}
+		r.pwd = loader.Dir(fileURL)
+	}
+
+	if r.vu.State() != nil { // fix
+		return nil, fmt.Errorf(cantBeUsedOutsideInitContextMsg, "require")
+	}
+	if specifier == "" {
+		return nil, errors.New("require() can't be used with an empty specifier")
+	}
+
+	return r.modules.Require(currentPWD, specifier)
+}
+
+func generateSourceMapLoader(logger logrus.FieldLogger, filesystems map[string]afero.Fs,
+) func(path string) ([]byte, error) {
+	return func(path string) ([]byte, error) {
+		u, err := url.Parse(path)
+		if err != nil {
+			return nil, err
+		}
+		data, err := loader.Load(logger, filesystems, u, path)
+		if err != nil {
+			return nil, err
+		}
+		return data.Data, nil
+	}
 }

--- a/js/modules.go
+++ b/js/modules.go
@@ -1,0 +1,122 @@
+package js
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/compiler"
+	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/loader"
+)
+
+type module interface {
+	Instantiate(vu modules.VU) moduleInstance
+}
+
+type moduleInstance interface {
+	execute() error
+	exports() *goja.Object
+}
+type moduleCacheElement struct {
+	mod module
+	err error
+}
+
+type modulesResolution struct {
+	cache     map[string]moduleCacheElement
+	goModules map[string]interface{}
+}
+
+func newModuleResolution(goModules map[string]interface{}) *modulesResolution {
+	return &modulesResolution{goModules: goModules, cache: make(map[string]moduleCacheElement)}
+}
+
+func (mr *modulesResolution) setMain(main *loader.SourceData, c *compiler.Compiler) error {
+	mod, err := cjsmoduleFromString(main.URL, main.Data, c)
+	mr.cache[main.URL.String()] = moduleCacheElement{mod: mod, err: err}
+	return err
+}
+
+func (mr *modulesResolution) resolveSpecifier(basePWD *url.URL, arg string) (*url.URL, error) {
+	specifier, err := loader.Resolve(basePWD, arg)
+	if err != nil {
+		return nil, err
+	}
+	return specifier, nil
+}
+
+func (mr *modulesResolution) requireModule(name string) (module, error) {
+	mod, ok := mr.goModules[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown module: %s", name)
+	}
+	if m, ok := mod.(modules.Module); ok {
+		return &goModule{Module: m}, nil
+	}
+
+	return &baseGoModule{mod: mod}, nil
+}
+
+func (mr *modulesResolution) resolve(basePWD *url.URL, arg string, loadCJS cjsModuleLoader) (module, error) {
+	if cached, ok := mr.cache[arg]; ok {
+		return cached.mod, cached.err
+	}
+	switch {
+	case arg == "k6", strings.HasPrefix(arg, "k6/"):
+		// Builtin or external modules ("k6", "k6/*", or "k6/x/*") are handled
+		// specially, as they don't exist on the filesystem.
+		mod, err := mr.requireModule(arg)
+		mr.cache[arg] = moduleCacheElement{mod: mod, err: err}
+		return mod, err
+	default:
+		specifier, err := mr.resolveSpecifier(basePWD, arg)
+		if err != nil {
+			return nil, err
+		}
+		// try cache with the final specifier
+		if cached, ok := mr.cache[specifier.String()]; ok {
+			return cached.mod, cached.err
+		}
+		// Fall back to loading from the filesystem.
+		mod, err := loadCJS(specifier, arg)
+		mr.cache[specifier.String()] = moduleCacheElement{mod: mod, err: err}
+		return mod, err
+	}
+}
+
+type moduleSystem struct {
+	vu            modules.VU
+	instanceCache map[module]moduleInstance
+	resolution    *modulesResolution
+	cjsLoad       cjsModuleLoader
+}
+
+func newModuleSystem(resolution *modulesResolution, vu modules.VU, cjsLoad cjsModuleLoader) *moduleSystem {
+	return &moduleSystem{
+		resolution:    resolution,
+		instanceCache: make(map[module]moduleInstance),
+		vu:            vu,
+		cjsLoad:       cjsLoad,
+	}
+}
+
+// Require is called when a module/file needs to be loaded by a script
+func (ms *moduleSystem) Require(pwd *url.URL, arg string) (*goja.Object, error) {
+	mod, err := ms.resolution.resolve(pwd, arg, ms.cjsLoad)
+	if err != nil {
+		return nil, err
+	}
+	if instance, ok := ms.instanceCache[mod]; ok {
+		return instance.exports(), nil
+	}
+
+	instance := mod.Instantiate(ms.vu)
+	ms.instanceCache[mod] = instance
+	if err = instance.execute(); err != nil {
+		return nil, err
+	}
+
+	return instance.exports(), nil
+}

--- a/js/modules.go
+++ b/js/modules.go
@@ -91,7 +91,6 @@ type moduleSystem struct {
 	vu            modules.VU
 	instanceCache map[module]moduleInstance
 	resolver      *moduleResolver
-	cjsLoad       cjsModuleLoader
 }
 
 func newModuleSystem(resolution *moduleResolver, vu modules.VU) *moduleSystem {

--- a/js/runner.go
+++ b/js/runner.go
@@ -252,7 +252,7 @@ func (r *Runner) newVU(
 	// instead of "Value is not an object: undefined  ..."
 	_ = vu.Runtime.GlobalObject().Set("open",
 		func() {
-			common.Throw(vu.Runtime, errors.New(openCantBeUsedOutsideInitContextMsg))
+			common.Throw(vu.Runtime, fmt.Errorf(cantBeUsedOutsideInitContextMsg, "open"))
 		})
 
 	return vu, nil
@@ -355,7 +355,7 @@ func (r *Runner) GetOptions() lib.Options {
 // IsExecutable returns whether the given name is an exported and
 // executable function in the script.
 func (r *Runner) IsExecutable(name string) bool {
-	_, exists := r.Bundle.exports[name]
+	_, exists := r.Bundle.callableExports[name]
 	return exists
 }
 


### PR DESCRIPTION
This refactor tries to simplify the implementation of `require` and
connected code by splitting it heavily into different parts.

These changes are similar to what will be needed for native ESM support
as shown in https://github.com/grafana/k6/pull/2563 , but without any of
the native parts and without doing anything that isn't currently needed.
This will hopefully make ESM PR much smaller and less intrusive.

This includes still keeping the wrong relativity of `require` as
explained in https://github.com/grafana/k6/issues/2674.

It also tries to simplify connected code, but due to this being very
sensitive code and the changes already being quite big, this is done
only to an extent.

The lack of new tests is mostly due to there not being really any new
code and the tests that were created along these changes already being
merged months ago with https://github.com/grafana/k6/pull/2782.

Future changes will try to address the above as well as potentially
moving the whole module types and logic in separate package to be reused
in tests.
