### PR TITLE
Add sampling capabilities to the tracing module

### DIFF
--- a/js/modules/k6/experimental/tracing/encoding.go
+++ b/js/modules/k6/experimental/tracing/encoding.go
@@ -17,3 +17,22 @@ func randHexString(n int) string {
 
 	return string(b)
 }
+
+// chance returns true with a `percentage` chance, otherwise false.
+// the `percentage` argument is expected to be
+// within 0 <= percentage <= 100 range.
+//
+// The chance function works under the assumption that the
+// go rand module has been seeded with a non-deterministic
+// value.
+func chance(r *rand.Rand, percentage float64) bool {
+	if percentage == 0.0 {
+		return false
+	}
+
+	if percentage == 1.0 {
+		return true
+	}
+
+	return r.Float64() < percentage
+}

--- a/js/modules/k6/experimental/tracing/options.go
+++ b/js/modules/k6/experimental/tracing/options.go
@@ -3,19 +3,45 @@ package tracing
 import (
 	"errors"
 	"fmt"
+
+	"github.com/dop251/goja"
 )
 
 // options are the options that can be passed to the
 // tracing.instrumentHTTP() method.
 type options struct {
 	// Propagation is the propagation format to use for the tracer.
-	Propagator string `js:"propagator"`
+	Propagator string `json:"propagator"`
 
-	// Sampling is the sampling rate to use for the tracer.
-	Sampling *float64 `js:"sampling"`
+	// Sampling is the sampling rate to use for the
+	// tracer, expressed in percents within the
+	// bounds: 0.0 <= n <= 1.0.
+	Sampling float64 `json:"sampling"`
 
 	// Baggage is a map of baggage items to add to the tracer.
-	Baggage map[string]string `js:"baggage"`
+	Baggage map[string]string `json:"baggage"`
+}
+
+// defaultSamplingRate is the default sampling rate applied to options.
+const defaultSamplingRate float64 = 1.0
+
+// newOptions returns a new options object from the given goja.Value.
+//
+// Note that if the sampling field value is absent, or nullish, we'll
+// set it to the `defaultSamplingRate` value.
+func newOptions(rt *goja.Runtime, from goja.Value) (options, error) {
+	var opts options
+
+	if err := rt.ExportTo(from, &opts); err != nil {
+		return opts, fmt.Errorf("unable to parse options object; reason: %w", err)
+	}
+
+	fromSamplingValue := from.ToObject(rt).Get("sampling")
+	if fromSamplingValue == nil || isNullish(fromSamplingValue) {
+		opts.Sampling = defaultSamplingRate
+	}
+
+	return opts, nil
 }
 
 func (i *options) validate() error {
@@ -27,9 +53,8 @@ func (i *options) validate() error {
 		return fmt.Errorf("unknown propagator: %s", i.Propagator)
 	}
 
-	// TODO: implement sampling support
-	if i.Sampling != nil {
-		return errors.New("sampling is not yet supported")
+	if i.Sampling < 0.0 || i.Sampling > 1.0 {
+		return errors.New("sampling rate must be between 0.0 and 1.0")
 	}
 
 	// TODO: implement baggage support

--- a/js/modules/k6/experimental/tracing/options_test.go
+++ b/js/modules/k6/experimental/tracing/options_test.go
@@ -1,15 +1,84 @@
 package tracing
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewOptionsWithoutSamplingProperty(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+
+	_, err := ts.TestRuntime.VU.Runtime().RunString(`
+		const options = {
+			propagator: 'w3c',
+		}
+	`)
+	require.NoError(t, err)
+	optionsValue := ts.TestRuntime.VU.Runtime().Get("options")
+	gotOptions, gotOptionsErr := newOptions(ts.TestRuntime.VU.Runtime(), optionsValue)
+
+	assert.NoError(t, gotOptionsErr)
+	assert.Equal(t, 1.0, gotOptions.Sampling)
+}
+
+func TestNewOptionsWithSamplingPropertySetToNullish(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+
+	_, err := ts.TestRuntime.VU.Runtime().RunString(`
+		const options = {
+			propagator: 'w3c',
+			sampling: null,
+		}
+	`)
+	require.NoError(t, err)
+	optionsValue := ts.TestRuntime.VU.Runtime().Get("options")
+	gotOptions, gotOptionsErr := newOptions(ts.TestRuntime.VU.Runtime(), optionsValue)
+
+	assert.NoError(t, gotOptionsErr)
+	assert.Equal(t, 1.0, gotOptions.Sampling)
+}
+
+func TestNewOptionsWithSamplingPropertySet(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestSetup(t)
+
+	_, err := ts.TestRuntime.VU.Runtime().RunString(`
+		const options = {
+			propagator: 'w3c',
+			sampling: 0.5,
+		}
+	`)
+	require.NoError(t, err)
+	optionsValue := ts.TestRuntime.VU.Runtime().Get("options")
+	gotOptions, gotOptionsErr := newOptions(ts.TestRuntime.VU.Runtime(), optionsValue)
+
+	assert.NoError(t, gotOptionsErr)
+	assert.Equal(t, 0.5, gotOptions.Sampling)
+}
 
 func TestOptionsValidate(t *testing.T) {
 	t.Parallel()
 
-	testFloat := 10.0
+	// Note that we prefer variables over constants here
+	// as we need to be able to address them.
+	var (
+		validSampling            = 0.1
+		lowerBoundSampling       = 0.0
+		upperBoundSampling       = 1.0
+		lowerOutOfBoundsSampling = -1.0
+		upperOutOfBoundsSampling = 1.01
+	)
 
 	type fields struct {
 		Propagator string
-		Sampling   *float64
+		Sampling   float64
 		Baggage    map[string]string
 	}
 	testCases := []struct {
@@ -39,16 +108,50 @@ func TestOptionsValidate(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "sampling is not yet supported",
+			name: "sampling is not rate is valid",
 			fields: fields{
-				Sampling: &testFloat,
+				Propagator: "w3c",
+				Sampling:   validSampling,
+			},
+			wantErr: false,
+		},
+		{
+			name: "sampling rate = 0 is valid",
+			fields: fields{
+				Propagator: "w3c",
+				Sampling:   lowerBoundSampling,
+			},
+			wantErr: false,
+		},
+		{
+			name: "sampling rate = 1.0 is valid",
+			fields: fields{
+				Propagator: "w3c",
+				Sampling:   upperBoundSampling,
+			},
+			wantErr: false,
+		},
+		{
+			name: "sampling rate < 0 is invalid",
+			fields: fields{
+				Propagator: "w3c",
+				Sampling:   lowerOutOfBoundsSampling,
+			},
+			wantErr: true,
+		},
+		{
+			name: "sampling rater > 1.0 is invalid",
+			fields: fields{
+				Propagator: "w3c",
+				Sampling:   upperOutOfBoundsSampling,
 			},
 			wantErr: true,
 		},
 		{
 			name: "baggage is not yet supported",
 			fields: fields{
-				Baggage: map[string]string{"key": "value"},
+				Propagator: "w3c",
+				Baggage:    map[string]string{"key": "value"},
 			},
 			wantErr: true,
 		},

--- a/js/modules/k6/experimental/tracing/propagator.go
+++ b/js/modules/k6/experimental/tracing/propagator.go
@@ -57,13 +57,6 @@ func (p *W3CPropagator) Propagate(traceID string) (http.Header, error) {
 	}, nil
 }
 
-// Ensures that W3CPropagator implements the Propagator and
-// SampledPropagator interface
-var (
-	_ Propagator = &W3CPropagator{}
-	_ Sampler    = &W3CPropagator{}
-)
-
 const (
 	// JaegerPropagatorName is the name of the Jaeger trace context propagator
 	JaegerPropagatorName = "jaeger"
@@ -90,10 +83,6 @@ type JaegerPropagator struct {
 }
 
 // NewJaegerPropagator returns a new JaegerPropagator with the given sampler.
-//
-// Note that we allocate the propagator on the heap to ensure we conform
-// to the Sampler interface, as the [Sampler.SetSamplingRate]
-// method has a pointer receiver.
 func NewJaegerPropagator(s Sampler) *JaegerPropagator {
 	return &JaegerPropagator{
 		Sampler: s,
@@ -120,9 +109,16 @@ func pick[T any](decision bool, lhs, rhs T) T {
 	return rhs
 }
 
-// Ensure the JaegerPropagator implements the Propagator and
-// SampledPropagator interface
 var (
+	// Ensures that W3CPropagator implements the Propagator interface
+	_ Propagator = &W3CPropagator{}
+
+	// Ensures that W3CPropagator implements the Sampler interface
+	_ Sampler = &W3CPropagator{}
+
+	// Ensures the JaegerPropagator implements the Propagator interface
 	_ Propagator = &JaegerPropagator{}
-	_ Sampler    = &JaegerPropagator{}
+
+	// Ensures the JaegerPropagator implements the Sampler interface
+	_ Sampler = &JaegerPropagator{}
 )

--- a/js/modules/k6/experimental/tracing/propagator.go
+++ b/js/modules/k6/experimental/tracing/propagator.go
@@ -28,18 +28,41 @@ const (
 )
 
 // W3CPropagator is a Propagator for the W3C trace context header
-type W3CPropagator struct{}
+type W3CPropagator struct {
+	// Sampler is used to determine whether or not a trace should be sampled.
+	Sampler
+}
+
+// NewW3CPropagator returns a new W3CPropagator using the provided sampler
+// to base its sampling decision upon.
+//
+// Note that we allocate the propagator on the heap to ensure we conform
+// to the Sampler interface, as the [Sampler.SetSamplingRate]
+// method has a pointer receiver.
+func NewW3CPropagator(s Sampler) *W3CPropagator {
+	return &W3CPropagator{
+		Sampler: s,
+	}
+}
 
 // Propagate returns a header with a random trace ID in the W3C format
 func (p *W3CPropagator) Propagate(traceID string) (http.Header, error) {
 	parentID := randHexString(16)
+	flags := pick(p.ShouldSample(), W3CSampledTraceFlag, W3CUnsampledTraceFlag)
 
 	return http.Header{
 		W3CHeaderName: {
-			W3CVersion + "-" + traceID + "-" + parentID + "-" + W3CSampledTraceFlag,
+			W3CVersion + "-" + traceID + "-" + parentID + "-" + flags,
 		},
 	}, nil
 }
+
+// Ensures that W3CPropagator implements the Propagator and
+// SampledPropagator interface
+var (
+	_ Propagator = &W3CPropagator{}
+	_ Sampler    = &W3CPropagator{}
+)
 
 const (
 	// JaegerPropagatorName is the name of the Jaeger trace context propagator
@@ -52,18 +75,54 @@ const (
 	// Its value is zero, which is described in the Jaeger documentation as:
 	// "0 value is valid and means “root span” (when not ignored)"
 	JaegerRootSpanID = "0"
+
+	// JaegerSampledTraceFlag is the trace-flag value for an unsampled trace.
+	JaegerSampledTraceFlag = "0"
+
+	// JaegerUnsampledTraceFlag is the trace-flag value for a sampled trace.
+	JaegerUnsampledTraceFlag = "1"
 )
 
 // JaegerPropagator is a Propagator for the Jaeger trace context header
-type JaegerPropagator struct{}
+type JaegerPropagator struct {
+	// Sampler is used to determine whether or not a trace should be sampled.
+	Sampler
+}
+
+// NewJaegerPropagator returns a new JaegerPropagator with the given sampler.
+//
+// Note that we allocate the propagator on the heap to ensure we conform
+// to the Sampler interface, as the [Sampler.SetSamplingRate]
+// method has a pointer receiver.
+func NewJaegerPropagator(s Sampler) *JaegerPropagator {
+	return &JaegerPropagator{
+		Sampler: s,
+	}
+}
 
 // Propagate returns a header with a random trace ID in the Jaeger format
 func (p *JaegerPropagator) Propagate(traceID string) (http.Header, error) {
 	spanID := randHexString(8)
-	// flags set to 1 means the span is sampled
-	flags := "1"
+	flags := pick(p.ShouldSample(), JaegerSampledTraceFlag, JaegerUnsampledTraceFlag)
 
 	return http.Header{
 		JaegerHeaderName: {traceID + ":" + spanID + ":" + JaegerRootSpanID + ":" + flags},
 	}, nil
 }
+
+// Pick returns either the left or right value, depending on the value of the `decision`
+// boolean value.
+func pick[T any](decision bool, lhs, rhs T) T {
+	if decision {
+		return lhs
+	}
+
+	return rhs
+}
+
+// Ensure the JaegerPropagator implements the Propagator and
+// SampledPropagator interface
+var (
+	_ Propagator = &JaegerPropagator{}
+	_ Sampler    = &JaegerPropagator{}
+)

--- a/js/modules/k6/experimental/tracing/sampling.go
+++ b/js/modules/k6/experimental/tracing/sampling.go
@@ -1,0 +1,59 @@
+package tracing
+
+import (
+	"math/rand"
+)
+
+// Sampler is an interface defining probabilistic sampling strategies.
+type Sampler interface {
+	// ShouldSample returns true if the trace should be sampled
+	// false otherwise.
+	ShouldSample() bool
+}
+
+// ProbabilisticSampler implements the ProbabilisticSampler interface and allows
+// to take probabilistic sampling decisions based on a sampling rate.
+type ProbabilisticSampler struct {
+	// random is a random number generator used by the sampler.
+	random *rand.Rand
+
+	// samplingRate is a chance value defined as a percentage
+	// value within 0.0 <= samplingRate <= 1.0 bounds.
+	samplingRate float64
+}
+
+// NewProbabilisticSampler returns a new ProbablisticSampler with the provided sampling rate.
+func NewProbabilisticSampler(samplingRate float64) *ProbabilisticSampler {
+	return &ProbabilisticSampler{samplingRate: samplingRate}
+}
+
+// ShouldSample returns true if the trace should be sampled.
+//
+// Its return value is probabilistic, based on the selected
+// sampling rate S, there is S percent chance that the
+// returned value is true.
+func (ps ProbabilisticSampler) ShouldSample() bool {
+	return chance(ps.random, ps.samplingRate)
+}
+
+// Ensure that ProbabilisticSampler implements the Sampler interface.
+var _ Sampler = &ProbabilisticSampler{}
+
+// AlwaysOnSampler implements the Sampler interface and allows to bypass
+// sampling decisions by returning true for all Sampled() calls.
+//
+// This is useful in cases where the user either does not provide
+// the sampling option, or set it to 100% as it will avoid any
+// call to the random number generator.
+type AlwaysOnSampler struct{}
+
+// NewAlwaysOnSampler returns a new AlwaysSampledSampler.
+func NewAlwaysOnSampler() *AlwaysOnSampler {
+	return &AlwaysOnSampler{}
+}
+
+// ShouldSample always returns true.
+func (AlwaysOnSampler) ShouldSample() bool { return true }
+
+// Ensure that AlwaysOnSampler implements the Sampler interface.
+var _ Sampler = &AlwaysOnSampler{}

--- a/js/modules/k6/experimental/tracing/sampling.go
+++ b/js/modules/k6/experimental/tracing/sampling.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 )
 
-// Sampler is an interface defining probabilistic sampling strategies.
+// Sampler is an interface defining a sampling strategy.
 type Sampler interface {
 	// ShouldSample returns true if the trace should be sampled
 	// false otherwise.
@@ -23,7 +23,18 @@ type ProbabilisticSampler struct {
 }
 
 // NewProbabilisticSampler returns a new ProbablisticSampler with the provided sampling rate.
+//
+// Note that the sampling rate is a percentage value within 0.0 <= samplingRate <= 1.0 bounds.
+// If the provided sampling rate is outside of this range, it will be clamped to the closest
+// bound.
 func NewProbabilisticSampler(samplingRate float64) *ProbabilisticSampler {
+	// Ensure that the sampling rate is within the 0.0 <= samplingRate <= 1.0 bounds.
+	if samplingRate < 0.0 {
+		samplingRate = 0.0
+	} else if samplingRate > 1.0 {
+		samplingRate = 1.0
+	}
+
 	return &ProbabilisticSampler{samplingRate: samplingRate}
 }
 

--- a/samples/experimental/tracing/tracing-sampling.js
+++ b/samples/experimental/tracing/tracing-sampling.js
@@ -1,0 +1,31 @@
+import http from "k6/http";
+import { check } from "k6";
+import tracing from "k6/experimental/tracing";
+
+export const options = {
+	// As the number of sampled requests will converge towards
+	// the sampling percentage, we need to increase the number
+	// of iterations to get a more accurate result.
+	iterations: 10000,
+
+	vus: 100,
+};
+
+tracing.instrumentHTTP({
+	propagator: "w3c",
+
+	// Only 10% of the requests made will have their trace context
+	// header's sample flag set to activated.
+	sampling: 0.1,
+});
+
+export default () => {
+	let res = http.get("http://httpbin.org/get", {
+		headers: {
+			"X-Example-Header": "instrumented/get",
+		},
+	});
+	check(res, {
+		"status is 200": (r) => r.status === 200,
+	});
+};


### PR DESCRIPTION
## About

This Pull Request adds probabilistic sampling support to the tracing module. Using it, users can specify the percentage of their instrumented requests which should have their trace context header's sampled field set to true.

From a user-interface perspective, this feature is introduced as an option meant to be set during either the instantiation of a `tracing.Client`, or during a call to `instrumentHTTP`. It consists of a single integer field of the tracing options, whose value, within the `0 <= n <= 100` bounds, is meant to represent a percentage.

```javascript
// The sampling option is available when instantiating a Client
const sampledHTTP = new tracing.Client({
	propagator: "w3c",
	
	// Up to 55% of the requests emitted using the client instance's
	// methods will have their trace context header's sampled field
	// set to true.
	sampling: 55,
})

// It is also available when using the instrumentHTTP function
tracing.InstrumentHTTP({
	propagator: "w3c",
	
	// Up to 27% of the requests made with the HTTP module's functions
	// will have their trace context header's sampled field set to true
	// from this point onward 
	sampling: 27,
})
```

This feature is implemented using probabilistic sampling. Meaning that over an extensive series of iterations, the number of requests with their sampled flag set to true will tend to converge to the selected `sampling` rate value. It was a design choice without explicit constraints, preferring randomness over accuracy: each trace context generation evaluates its chance of being sampled independently. If you find an implementation emphasizing accuracy more suitable, I'm open to exploring that route; just let me know.

Note that regardless of the sampled header flag's value, the `trace_id` metadata will be attached to each output sample.