### PR TITLE
Pass `LookupEnv()` to `js/` modules

### DIFF
--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -70,6 +70,10 @@ func loadTest(gs *state.GlobalState, cmd *cobra.Command, args []string) (*loaded
 		RuntimeOptions: runtimeOptions,
 		Registry:       registry,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+		LookupEnv: func(key string) (string, bool) {
+			val, ok := gs.Env[key]
+			return val, ok
+		},
 	}
 
 	test := &loadedTest{

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -813,8 +813,8 @@ func TestBundleEnv(t *testing.T) {
 		b := b
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			require.Equal(t, "1", b.RuntimeOptions.Env["TEST_A"])
-			require.Equal(t, "", b.RuntimeOptions.Env["TEST_B"])
+			require.Equal(t, "1", b.preInitState.RuntimeOptions.Env["TEST_A"])
+			require.Equal(t, "", b.preInitState.RuntimeOptions.Env["TEST_B"])
 
 			bi, err := b.Instantiate(context.Background(), 0)
 			require.NoError(t, err)

--- a/js/common/initenv.go
+++ b/js/common/initenv.go
@@ -16,6 +16,7 @@ type InitEnvironment struct {
 	FileSystems map[string]afero.Fs
 	CWD         *url.URL
 	Registry    *metrics.Registry
+	LookupEnv   func(key string) (val string, ok bool)
 	// TODO: add RuntimeOptions and other properties, goja sources, etc.
 	// ideally, we should leave this as the only data structure necessary for
 	// executing the init context for all JS modules

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -72,6 +72,7 @@ func getSimpleRunner(tb testing.TB, filename, data string, opts ...interface{}) 
 			RuntimeOptions: rtOpts,
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
+			LookupEnv:      func(key string) (val string, ok bool) { return "", false },
 		},
 		&loader.SourceData{
 			URL:  &url.URL{Path: filename, Scheme: "file"},

--- a/lib/test_state.go
+++ b/lib/test_state.go
@@ -14,6 +14,7 @@ type TestPreInitState struct {
 	Registry       *metrics.Registry
 	BuiltinMetrics *metrics.BuiltinMetrics
 	KeyLogger      io.Writer
+	LookupEnv      func(key string) (val string, ok bool)
 
 	// TODO: replace with logrus.FieldLogger when all of the tests can be fixed
 	Logger *logrus.Logger


### PR DESCRIPTION
This PR threads a way for JS modules to lookup environment variables without directly accessing the `os` package. That ended up quite simple to do, with some additional simplification as a bonus, and it would be nice to have it before https://github.com/grafana/k6/pull/2884