### PR TITLE
Add lint check for os and syscall usage and fix some of the issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,9 @@ issues:
    - linters:
      - paralleltest # false positive: https://github.com/kunwardeep/paralleltest/issues/8.
      text: "does not use range value in test Run"
+   - linters:
+     - forbidigo
+     text: 'use of `os\.(SyscallError|Signal|Interrupt)` forbidden'
 
 linters-settings:
   nolintlint:
@@ -48,6 +51,13 @@ linters-settings:
   funlen:
     lines: 80
     statements: 60
+  forbidigo:
+    forbid:
+      - '^(fmt\\.Print(|f|ln)|print|println)$'
+      # Forbid everything in os, except os.Signal and os.SyscalError
+      - '^os\.(.*)$(# Using anything except Signal and SyscallError from the os package is forbidden )?'
+      # Forbid everything in syscall except the uppercase constants
+      - '^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?'
 
 linters:
   enable-all: true

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
 	"time"
@@ -108,7 +108,7 @@ func getConfig(flags *pflag.FlagSet) (Config, error) {
 func readDiskConfig(gs *state.GlobalState) (Config, error) {
 	// Try to see if the file exists in the supplied filesystem
 	if _, err := gs.FS.Stat(gs.Flags.ConfigFilePath); err != nil {
-		if os.IsNotExist(err) && gs.Flags.ConfigFilePath == gs.DefaultFlags.ConfigFilePath {
+		if errors.Is(err, fs.ErrNotExist) && gs.Flags.ConfigFilePath == gs.DefaultFlags.ConfigFilePath {
 			// If the file doesn't exist, but it was the default config file (i.e. the user
 			// didn't specify anything), silence the error
 			err = nil

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -434,7 +435,7 @@ func handleSummaryResult(fs afero.Fs, stdOut, stdErr io.Writer, result map[strin
 		case "stderr":
 			return stdErr, nil
 		default:
-			return fs.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o666)
+			return fs.OpenFile(path, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_TRUNC, 0o666)
 		}
 	}
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"log"
-	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -39,20 +39,20 @@ func (fw mockWriter) Write(p []byte) (n int, err error) {
 
 var _ io.Writer = mockWriter{}
 
-func getFiles(t *testing.T, fs afero.Fs) map[string]*bytes.Buffer {
+func getFiles(t *testing.T, fileSystem afero.Fs) map[string]*bytes.Buffer {
 	result := map[string]*bytes.Buffer{}
-	walkFn := func(filePath string, _ os.FileInfo, err error) error {
+	walkFn := func(filePath string, _ fs.FileInfo, err error) error {
 		if filePath == "/" || filePath == "\\" {
 			return nil
 		}
 		require.NoError(t, err)
-		contents, err := afero.ReadFile(fs, filePath)
+		contents, err := afero.ReadFile(fileSystem, filePath)
 		require.NoError(t, err)
 		result[filePath] = bytes.NewBuffer(contents)
 		return nil
 	}
 
-	err := fsext.Walk(fs, afero.FilePathSeparator, filepath.WalkFunc(walkFn))
+	err := fsext.Walk(fileSystem, afero.FilePathSeparator, filepath.WalkFunc(walkFn))
 	require.NoError(t, err)
 
 	return result

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -58,6 +58,8 @@ type GlobalState struct {
 // global variables and functions from the os package. Anywhere else, things
 // like os.Stdout, os.Stderr, os.Stdin, os.Getenv(), etc. should be removed and
 // the respective properties of globalState used instead.
+//
+//nolint:forbidigo
 func NewGlobalState(ctx context.Context) *GlobalState {
 	isDumbTerm := os.Getenv("TERM") == "dumb"
 	stdoutTTY := !isDumbTerm && (isatty.IsTerminal(os.Stdout.Fd()) || isatty.IsCygwinTerminal(os.Stdout.Fd()))

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -6,9 +6,9 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
-	"os"
 	"path/filepath"
 	"sync"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -113,7 +113,7 @@ func (lt *loadedTest) initializeFirstRunner(gs *state.GlobalState) error {
 			// this is against our general approach of not using `os` directly and makes testing harder
 			keylogFilename = filepath.Join(lt.pwd, keylogFilename)
 		}
-		f, err := lt.fs.OpenFile(keylogFilename, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+		f, err := lt.fs.OpenFile(keylogFilename, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_APPEND, 0o600)
 		if err != nil {
 			return fmt.Errorf("couldn't get absolute path for keylog file: %w", err)
 		}

--- a/cmd/tests/tests.go
+++ b/cmd/tests/tests.go
@@ -28,6 +28,8 @@ func (bt *blockingTransport) RoundTrip(req *http.Request) (*http.Response, error
 // Main is a TestMain function that can be imported by other test packages that
 // want to use the blocking transport and other features useful for integration
 // tests.
+//
+//nolint:forbidigo
 func Main(m *testing.M) {
 	exitCode := 1 // error out by default
 	defer func() {
@@ -46,7 +48,7 @@ func Main(m *testing.M) {
 	http.DefaultTransport = bt
 	defer func() {
 		if bt.counter > 0 {
-			fmt.Printf("Expected blocking transport count to be 0 but was %d\n", bt.counter) //nolint:forbidigo
+			fmt.Printf("Expected blocking transport count to be 0 but was %d\n", bt.counter)
 			exitCode = 2
 		}
 	}()
@@ -56,7 +58,7 @@ func Main(m *testing.M) {
 		// around and remove this exception.
 		opt := goleak.IgnoreTopFunction("io.(*pipe).read")
 		if err := goleak.Find(opt); err != nil {
-			fmt.Println(err) //nolint:forbidigo
+			fmt.Println(err)
 			exitCode = 3
 		}
 	}()

--- a/js/modules/k6/html/gen/gen_elements.go
+++ b/js/modules/k6/html/gen/gen_elements.go
@@ -54,6 +54,7 @@ const (
 )
 
 // Some common TemplateArgs
+//
 //nolint:lll,gochecknoglobals
 var (
 	// Default return values for urlTemplate functions. Either an empty string or the current URL.
@@ -94,16 +95,18 @@ var (
 // TemplateArgs is a list of values to be interpolated in the template.
 
 // The number of TemplateArgs depends on the template type.
-//   stringTemplate: doesn't use any TemplateArgs
-//   boolTemplate: doesn't use any TemplateArgs
-//   constTemplate: uses 1 Template Arg, the generated function always returns that value
-//   intTemplate: needs 1 TemplateArg, used as the default return value (when the attribute was empty).
-//   urlTemplate: needs 1 TemplateArg, used as the default, either "defaultURLEmpty" or "defaultURLCurrent"
-//   enumTemplate: uses any number or more TemplateArg, the gen'd func always returns one of the values in
-//                 the TemplateArgs. The first item in the list is used as the default when the attribute
-//                 was invalid or unset.
-//   nullableEnumTemplate: similar to the enumTemplate except the default is goja.Undefined and the
-//                         return type is goja.Value
+//
+//	stringTemplate: doesn't use any TemplateArgs
+//	boolTemplate: doesn't use any TemplateArgs
+//	constTemplate: uses 1 Template Arg, the generated function always returns that value
+//	intTemplate: needs 1 TemplateArg, used as the default return value (when the attribute was empty).
+//	urlTemplate: needs 1 TemplateArg, used as the default, either "defaultURLEmpty" or "defaultURLCurrent"
+//	enumTemplate: uses any number or more TemplateArg, the gen'd func always returns one of the values in
+//	              the TemplateArgs. The first item in the list is used as the default when the attribute
+//	              was invalid or unset.
+//	nullableEnumTemplate: similar to the enumTemplate except the default is goja.Undefined and the
+//	                      return type is goja.Value
+//
 //nolint:gochecknoglobals
 var funcDefs = []struct {
 	Elem, Method, Attr string
@@ -345,7 +348,7 @@ func main() {
 		logrus.WithError(err).Fatal("format.Source on generated code failed")
 	}
 
-	f, err := os.Create("elements_gen.go")
+	f, err := os.Create("elements_gen.go") //nolint:forbidigo
 	if err != nil {
 		logrus.WithError(err).Fatal("Unable to create the file 'elements_gen.go'")
 	}
@@ -376,7 +379,7 @@ func selToElement(sel Selection) goja.Value {
 
 	elem := Element{sel.sel.Nodes[0], &sel}
 
-	switch elem.node.Data { 
+	switch elem.node.Data {
 {{- range $elemName, $elemInfo := .ElemInfos }}
 	case {{ $elemName }}TagName:
 		return sel.rt.ToValue({{ buildStruct $elemInfo }})
@@ -387,29 +390,29 @@ func selToElement(sel Selection) goja.Value {
  }
 
 {{ $templateTypes := .TemplateTypes }}
-{{ range $funcDef := .FuncDefs -}} 
+{{ range $funcDef := .FuncDefs -}}
 
 func (e {{$funcDef.Elem}}) {{$funcDef.Method}}() {{ returnType $funcDef.TemplateType }} {
 {{- if eq $funcDef.TemplateType $templateTypes.Int }}
 	return e.attrAsInt("{{ $funcDef.Attr }}", {{ index $funcDef.TemplateArgs 0 }})
 {{- else if eq $funcDef.TemplateType $templateTypes.Enum }}
 	attrVal := e.attrAsString("{{ $funcDef.Attr }}")
-	switch attrVal { 
+	switch attrVal {
 	{{- range $optIdx, $optVal := $funcDef.TemplateArgs }}
 	{{- if ne $optIdx 0 }}
 	case "{{$optVal}}":
 		return attrVal
 	{{- end }}
 	{{- end}}
-	default: 
-		return "{{ index $funcDef.TemplateArgs 0 }}" 
+	default:
+		return "{{ index $funcDef.TemplateArgs 0 }}"
 	}
 {{- else if eq $funcDef.TemplateType $templateTypes.GojaEnum }}
 	attrVal, exists := e.sel.sel.Attr("{{ $funcDef.Attr }}")
 	if !exists {
 		return goja.Undefined()
 	}
-	switch attrVal { 
+	switch attrVal {
 	{{- range $optVal := $funcDef.TemplateArgs }}
 	case "{{$optVal}}":
 		return e.sel.rt.ToValue(attrVal)

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"go/build"
+	"io/fs"
 	"io/ioutil"
 	stdlog "log"
 	"math/big"
@@ -18,7 +19,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -1474,8 +1474,8 @@ func TestVUDoesOpenUnderV0Condition(t *testing.T) {
 				console.log("hey")
 			}
 		`
-	require.NoError(t, afero.WriteFile(baseFS, "/home/somebody/test.json", []byte(`42`), os.ModePerm))
-	require.NoError(t, afero.WriteFile(baseFS, "/script.js", []byte(data), os.ModePerm))
+	require.NoError(t, afero.WriteFile(baseFS, "/home/somebody/test.json", []byte(`42`), fs.ModePerm))
+	require.NoError(t, afero.WriteFile(baseFS, "/script.js", []byte(data), fs.ModePerm))
 
 	fs := fsext.NewCacheOnReadFs(baseFS, afero.NewMemMapFs(), 0)
 
@@ -1498,8 +1498,8 @@ func TestVUDoesNotOpenUnderConditions(t *testing.T) {
 				console.log("hey")
 			}
 		`
-	require.NoError(t, afero.WriteFile(baseFS, "/home/somebody/test.json", []byte(`42`), os.ModePerm))
-	require.NoError(t, afero.WriteFile(baseFS, "/script.js", []byte(data), os.ModePerm))
+	require.NoError(t, afero.WriteFile(baseFS, "/home/somebody/test.json", []byte(`42`), fs.ModePerm))
+	require.NoError(t, afero.WriteFile(baseFS, "/script.js", []byte(data), fs.ModePerm))
 
 	fs := fsext.NewCacheOnReadFs(baseFS, afero.NewMemMapFs(), 0)
 
@@ -1523,7 +1523,7 @@ func TestVUDoesNonExistingPathnUnderConditions(t *testing.T) {
 				console.log("hey")
 			}
 		`
-	require.NoError(t, afero.WriteFile(baseFS, "/script.js", []byte(data), os.ModePerm))
+	require.NoError(t, afero.WriteFile(baseFS, "/script.js", []byte(data), fs.ModePerm))
 
 	fs := fsext.NewCacheOnReadFs(baseFS, afero.NewMemMapFs(), 0)
 
@@ -1961,7 +1961,7 @@ func TestInitContextForbidden(t *testing.T) {
 func TestArchiveRunningIntegrity(t *testing.T) {
 	t.Parallel()
 
-	fs := afero.NewMemMapFs()
+	fileSystem := afero.NewMemMapFs()
 	data := `
 			var fput = open("/home/somebody/test.json");
 			exports.options = { setupTimeout: "10s", teardownTimeout: "10s" };
@@ -1974,9 +1974,9 @@ func TestArchiveRunningIntegrity(t *testing.T) {
 				}
 			}
 		`
-	require.NoError(t, afero.WriteFile(fs, "/home/somebody/test.json", []byte(`42`), os.ModePerm))
-	require.NoError(t, afero.WriteFile(fs, "/script.js", []byte(data), os.ModePerm))
-	r1, err := getSimpleRunner(t, "/script.js", data, fs)
+	require.NoError(t, afero.WriteFile(fileSystem, "/home/somebody/test.json", []byte(`42`), fs.ModePerm))
+	require.NoError(t, afero.WriteFile(fileSystem, "/script.js", []byte(data), fs.ModePerm))
+	r1, err := getSimpleRunner(t, "/script.js", data, fileSystem)
 	require.NoError(t, err)
 
 	buf := bytes.NewBuffer(nil)
@@ -2019,12 +2019,12 @@ func TestArchiveRunningIntegrity(t *testing.T) {
 
 func TestArchiveNotPanicking(t *testing.T) {
 	t.Parallel()
-	fs := afero.NewMemMapFs()
-	require.NoError(t, afero.WriteFile(fs, "/non/existent", []byte(`42`), os.ModePerm))
+	fileSystem := afero.NewMemMapFs()
+	require.NoError(t, afero.WriteFile(fileSystem, "/non/existent", []byte(`42`), fs.ModePerm))
 	r1, err := getSimpleRunner(t, "/script.js", `
 			var fput = open("/non/existent");
 			exports.default = function(data) {}
-		`, fs)
+		`, fileSystem)
 	require.NoError(t, err)
 
 	arc := r1.MakeArchive()

--- a/js/tc39/tc39_test.go
+++ b/js/tc39/tc39_test.go
@@ -1,5 +1,6 @@
 // Heavily influenced by the fantastic work by @dop251 for https://github.com/dop251/goja
-
+//
+//nolint:forbidigo
 package tc39
 
 import (

--- a/lib/archive.go
+++ b/lib/archive.go
@@ -6,9 +6,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -162,13 +162,13 @@ func ReadArchive(in io.Reader) (*Archive, error) {
 			}
 			fallthrough
 		case "https", "file":
-			fs := arc.getFs(pfx)
+			fileSystem := arc.getFs(pfx)
 			name = filepath.FromSlash(name)
-			err = afero.WriteFile(fs, name, data, os.FileMode(hdr.Mode))
+			err = afero.WriteFile(fileSystem, name, data, fs.FileMode(hdr.Mode))
 			if err != nil {
 				return nil, err
 			}
-			err = fs.Chtimes(name, hdr.AccessTime, hdr.ModTime)
+			err = fileSystem.Chtimes(name, hdr.AccessTime, hdr.ModTime)
 			if err != nil {
 				return nil, err
 			}
@@ -278,10 +278,10 @@ func (arc *Archive) Write(out io.Writer) error {
 		//   anonymize paths before stuffing them in a shareable archive.
 		foundDirs := make(map[string]bool)
 		paths := make([]string, 0, 10)
-		infos := make(map[string]os.FileInfo) // ... fix this ?
+		infos := make(map[string]fs.FileInfo) // ... fix this ?
 		files := make(map[string][]byte)
 
-		walkFunc := filepath.WalkFunc(func(filePath string, info os.FileInfo, err error) error {
+		walkFunc := filepath.WalkFunc(func(filePath string, info fs.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}

--- a/lib/archive_test.go
+++ b/lib/archive_test.go
@@ -3,8 +3,8 @@ package lib
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -85,7 +85,7 @@ func diffFilesystems(t *testing.T, first, second afero.Fs) {
 	diffFilesystemsDir(t, first, second, "/")
 }
 
-func getInfoNames(infos []os.FileInfo) []string {
+func getInfoNames(infos []fs.FileInfo) []string {
 	names := make([]string, len(infos))
 	for i, info := range infos {
 		names[i] = info.Name()

--- a/lib/fsext/cacheonread.go
+++ b/lib/fsext/cacheonread.go
@@ -2,7 +2,7 @@ package fsext
 
 import (
 	"errors"
-	"os"
+	"io/fs"
 	"sync"
 	"time"
 
@@ -73,7 +73,7 @@ func (c *CacheOnReadFs) Open(name string) (afero.File, error) {
 // happens.
 // if CacheOnReadFs is in the opened only mode it should return
 // an error if path wasn't open before
-func (c *CacheOnReadFs) Stat(path string) (os.FileInfo, error) {
+func (c *CacheOnReadFs) Stat(path string) (fs.FileInfo, error) {
 	if err := c.checkOrRemember(path); err != nil {
 		return nil, err
 	}

--- a/lib/fsext/changepathfs.go
+++ b/lib/fsext/changepathfs.go
@@ -2,7 +2,7 @@ package fsext
 
 import (
 	"errors"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
 	"time"
@@ -39,7 +39,7 @@ type ChangePathFunc func(name string) (path string, err error)
 func NewTrimFilePathSeparatorFs(source afero.Fs) *ChangePathFs {
 	return &ChangePathFs{source: source, fn: ChangePathFunc(func(name string) (path string, err error) {
 		if !strings.HasPrefix(name, afero.FilePathSeparator) {
-			return name, os.ErrNotExist
+			return name, fs.ErrNotExist
 		}
 
 		return filepath.Clean(strings.TrimPrefix(name, afero.FilePathSeparator)), nil
@@ -60,16 +60,16 @@ func (b *ChangePathFs) Chown(name string, uid, gid int) error {
 func (b *ChangePathFs) Chtimes(name string, atime, mtime time.Time) (err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {
-		return &os.PathError{Op: "chtimes", Path: name, Err: err}
+		return &fs.PathError{Op: "chtimes", Path: name, Err: err}
 	}
 	return b.source.Chtimes(newName, atime, mtime)
 }
 
 // Chmod changes the mode of the named file to mode.
-func (b *ChangePathFs) Chmod(name string, mode os.FileMode) (err error) {
+func (b *ChangePathFs) Chmod(name string, mode fs.FileMode) (err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {
-		return &os.PathError{Op: "chmod", Path: name, Err: err}
+		return &fs.PathError{Op: "chmod", Path: name, Err: err}
 	}
 	return b.source.Chmod(newName, mode)
 }
@@ -81,10 +81,10 @@ func (b *ChangePathFs) Name() string {
 
 // Stat returns a FileInfo describing the named file, or an error, if any
 // happens.
-func (b *ChangePathFs) Stat(name string) (fi os.FileInfo, err error) {
+func (b *ChangePathFs) Stat(name string) (fi fs.FileInfo, err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {
-		return nil, &os.PathError{Op: "stat", Path: name, Err: err}
+		return nil, &fs.PathError{Op: "stat", Path: name, Err: err}
 	}
 	return b.source.Stat(newName)
 }
@@ -93,10 +93,10 @@ func (b *ChangePathFs) Stat(name string) (fi os.FileInfo, err error) {
 func (b *ChangePathFs) Rename(oldName, newName string) (err error) {
 	var newOldName, newNewName string
 	if newOldName, err = b.fn(oldName); err != nil {
-		return &os.PathError{Op: "rename", Path: oldName, Err: err}
+		return &fs.PathError{Op: "rename", Path: oldName, Err: err}
 	}
 	if newNewName, err = b.fn(newName); err != nil {
-		return &os.PathError{Op: "rename", Path: newName, Err: err}
+		return &fs.PathError{Op: "rename", Path: newName, Err: err}
 	}
 	return b.source.Rename(newOldName, newNewName)
 }
@@ -106,7 +106,7 @@ func (b *ChangePathFs) Rename(oldName, newName string) (err error) {
 func (b *ChangePathFs) RemoveAll(name string) (err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {
-		return &os.PathError{Op: "remove_all", Path: name, Err: err}
+		return &fs.PathError{Op: "remove_all", Path: name, Err: err}
 	}
 	return b.source.RemoveAll(newName)
 }
@@ -116,16 +116,16 @@ func (b *ChangePathFs) RemoveAll(name string) (err error) {
 func (b *ChangePathFs) Remove(name string) (err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {
-		return &os.PathError{Op: "remove", Path: name, Err: err}
+		return &fs.PathError{Op: "remove", Path: name, Err: err}
 	}
 	return b.source.Remove(newName)
 }
 
 // OpenFile opens a file using the given flags and the given mode.
-func (b *ChangePathFs) OpenFile(name string, flag int, mode os.FileMode) (f afero.File, err error) {
+func (b *ChangePathFs) OpenFile(name string, flag int, mode fs.FileMode) (f afero.File, err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {
-		return nil, &os.PathError{Op: "openfile", Path: name, Err: err}
+		return nil, &fs.PathError{Op: "openfile", Path: name, Err: err}
 	}
 	sourcef, err := b.source.OpenFile(newName, flag, mode)
 	if err != nil {
@@ -138,7 +138,7 @@ func (b *ChangePathFs) OpenFile(name string, flag int, mode os.FileMode) (f afer
 func (b *ChangePathFs) Open(name string) (f afero.File, err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {
-		return nil, &os.PathError{Op: "open", Path: name, Err: err}
+		return nil, &fs.PathError{Op: "open", Path: name, Err: err}
 	}
 	sourcef, err := b.source.Open(newName)
 	if err != nil {
@@ -149,20 +149,20 @@ func (b *ChangePathFs) Open(name string) (f afero.File, err error) {
 
 // Mkdir creates a directory in the filesystem, return an error if any
 // happens.
-func (b *ChangePathFs) Mkdir(name string, mode os.FileMode) (err error) {
+func (b *ChangePathFs) Mkdir(name string, mode fs.FileMode) (err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {
-		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+		return &fs.PathError{Op: "mkdir", Path: name, Err: err}
 	}
 	return b.source.Mkdir(newName, mode)
 }
 
 // MkdirAll creates a directory path and all parents that does not exist
 // yet.
-func (b *ChangePathFs) MkdirAll(name string, mode os.FileMode) (err error) {
+func (b *ChangePathFs) MkdirAll(name string, mode fs.FileMode) (err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {
-		return &os.PathError{Op: "mkdir", Path: name, Err: err}
+		return &fs.PathError{Op: "mkdir", Path: name, Err: err}
 	}
 	return b.source.MkdirAll(newName, mode)
 }
@@ -172,7 +172,7 @@ func (b *ChangePathFs) MkdirAll(name string, mode os.FileMode) (err error) {
 func (b *ChangePathFs) Create(name string) (f afero.File, err error) {
 	var newName string
 	if newName, err = b.fn(name); err != nil {
-		return nil, &os.PathError{Op: "create", Path: name, Err: err}
+		return nil, &fs.PathError{Op: "create", Path: name, Err: err}
 	}
 	sourcef, err := b.source.Create(newName)
 	if err != nil {
@@ -182,11 +182,11 @@ func (b *ChangePathFs) Create(name string) (f afero.File, err error) {
 }
 
 // LstatIfPossible implements the afero.Lstater interface
-func (b *ChangePathFs) LstatIfPossible(name string) (os.FileInfo, bool, error) {
+func (b *ChangePathFs) LstatIfPossible(name string) (fs.FileInfo, bool, error) {
 	var newName string
 	newName, err := b.fn(name)
 	if err != nil {
-		return nil, false, &os.PathError{Op: "lstat", Path: name, Err: err}
+		return nil, false, &fs.PathError{Op: "lstat", Path: name, Err: err}
 	}
 	if lstater, ok := b.source.(afero.Lstater); ok {
 		return lstater.LstatIfPossible(newName)

--- a/lib/fsext/trimpathseparator_test.go
+++ b/lib/fsext/trimpathseparator_test.go
@@ -1,7 +1,8 @@
 package fsext
 
 import (
-	"os"
+	"errors"
+	"io/fs"
 	"path/filepath"
 	"testing"
 
@@ -12,20 +13,20 @@ import (
 func TestTrimAferoPathSeparatorFs(t *testing.T) {
 	t.Parallel()
 	m := afero.NewMemMapFs()
-	fs := NewTrimFilePathSeparatorFs(m)
+	f := NewTrimFilePathSeparatorFs(m)
 	expecteData := []byte("something")
-	err := afero.WriteFile(fs, filepath.FromSlash("/path/to/somewhere"), expecteData, 0o644)
+	err := afero.WriteFile(f, filepath.FromSlash("/path/to/somewhere"), expecteData, 0o644)
 	require.NoError(t, err)
 	data, err := afero.ReadFile(m, "/path/to/somewhere")
 	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, fs.ErrNotExist))
 	require.Nil(t, data)
 
 	data, err = afero.ReadFile(m, "path/to/somewhere")
 	require.NoError(t, err)
 	require.Equal(t, expecteData, data)
 
-	err = afero.WriteFile(fs, filepath.FromSlash("path/without/separtor"), expecteData, 0o644)
+	err = afero.WriteFile(f, filepath.FromSlash("path/without/separtor"), expecteData, 0o644)
 	require.Error(t, err)
-	require.True(t, os.IsNotExist(err))
+	require.True(t, errors.Is(err, fs.ErrNotExist))
 }

--- a/lib/old_archive_test.go
+++ b/lib/old_archive_test.go
@@ -3,8 +3,8 @@ package lib
 import (
 	"archive/tar"
 	"bytes"
+	"io/fs"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"testing"
@@ -15,11 +15,11 @@ import (
 	"go.k6.io/k6/lib/fsext"
 )
 
-func dumpMemMapFsToBuf(fs afero.Fs) (*bytes.Buffer, error) {
+func dumpMemMapFsToBuf(fileSystem afero.Fs) (*bytes.Buffer, error) {
 	b := bytes.NewBuffer(nil)
 	w := tar.NewWriter(b)
-	err := fsext.Walk(fs, afero.FilePathSeparator,
-		filepath.WalkFunc(func(filePath string, info os.FileInfo, err error) error {
+	err := fsext.Walk(fileSystem, afero.FilePathSeparator,
+		filepath.WalkFunc(func(filePath string, info fs.FileInfo, err error) error {
 			if filePath == afero.FilePathSeparator {
 				return nil // skip the root
 			}
@@ -34,7 +34,7 @@ func dumpMemMapFsToBuf(fs afero.Fs) (*bytes.Buffer, error) {
 				})
 			}
 			var data []byte
-			data, err = afero.ReadFile(fs, filePath)
+			data, err = afero.ReadFile(fileSystem, filePath)
 			if err != nil {
 				return err
 			}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -5,10 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -185,7 +185,7 @@ func Load(
 	if err == nil {
 		return &SourceData{URL: moduleSpecifier, Data: data}, nil
 	}
-	if !os.IsNotExist(err) {
+	if !errors.Is(err, fs.ErrNotExist) {
 		return nil, err
 	}
 	if scheme == "https" {

--- a/log/file.go
+++ b/log/file.go
@@ -4,11 +4,13 @@ package log
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -96,11 +98,11 @@ func (h *fileHook) openFile(getCwd func() (string, error)) error {
 		path = filepath.Join(cwd, path)
 	}
 
-	if _, err := h.fs.Stat(filepath.Dir(path)); os.IsNotExist(err) {
+	if _, err := h.fs.Stat(filepath.Dir(path)); errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("provided directory '%s' does not exist", filepath.Dir(path))
 	}
 
-	file, err := h.fs.OpenFile(path, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o600)
+	file, err := h.fs.OpenFile(path, syscall.O_WRONLY|syscall.O_APPEND|syscall.O_CREAT, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to open logfile %s: %w", path, err)
 	}


### PR DESCRIPTION
Built on top of, https://github.com/grafana/k6/pull/2890, this PR adds linter rules that forbid the usage of most of the `os` and `syscall` packages. It also has the mechanical fixes to some of that previously improper usage in a bunch of places in the k6 codebase. I could safely replace a bunch of `os` usages with [the `fs` package introduced in Go 1.16](https://go.dev/doc/go1.16#fs) and the equivalent `syscall` constants, since the things in `os` are now [type aliases](https://yourbasic.org/golang/type-alias/) (see [this](https://github.com/golang/go/blob/56a14ad4bc19d5ee9d4257f370a570377e81e544/src/os/error.go#L21-L24), [this](https://github.com/golang/go/blob/56a14ad4bc19d5ee9d4257f370a570377e81e544/src/os/types.go#L20-L56) and [this](https://github.com/golang/go/blob/56a14ad4bc19d5ee9d4257f370a570377e81e544/src/os/file.go#L70-L83))