### PR TITLE
Update ui_unix.go with z/OS build flags

### DIFF
--- a/cmd/ui_unix.go
+++ b/cmd/ui_unix.go
@@ -1,5 +1,5 @@
-//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd
-// +build darwin dragonfly freebsd linux netbsd openbsd
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || zos
+// +build darwin dragonfly freebsd linux netbsd openbsd zos
 
 package cmd
 


### PR DESCRIPTION
Added z/OS build flags for IBM z/OS compatibility.

Enabling these build flags (along with the changes to afero mentioned here https://github.com/spf13/afero/pull/384) allows k6 to be compiled on z/OS Unix System Services. 

Closes #2888 
