### PR TITLE
Split `Scheduler.Run()` into `Init()` and `Run()` again

### DIFF
--- a/api/v1/status_routes_test.go
+++ b/api/v1/status_routes_test.go
@@ -101,6 +101,7 @@ func TestPatchStatus(t *testing.T) {
 	}
 
 	for name, testCase := range testData {
+		name, testCase := name, testCase
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -136,6 +137,9 @@ func TestPatchStatus(t *testing.T) {
 				RunState:      testState,
 			}
 
+			stopEmission, err := execScheduler.Init(runCtx, samples)
+			require.NoError(t, err)
+
 			wg := &sync.WaitGroup{}
 			wg.Add(1)
 			defer func() {
@@ -146,6 +150,7 @@ func TestPatchStatus(t *testing.T) {
 
 			go func() {
 				assert.ErrorContains(t, execScheduler.Run(globalCtx, runCtx, samples), "custom cancel signal")
+				stopEmission()
 				close(samples)
 				wg.Done()
 			}()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -274,6 +274,13 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 	stopSignalHandling := handleTestAbortSignals(c.gs, gracefulStop, onHardStop)
 	defer stopSignalHandling()
 
+	// Initialize the VUs and executors
+	stopVUEmission, err := execScheduler.Init(runCtx, samples)
+	if err != nil {
+		return err
+	}
+	defer stopVUEmission()
+
 	if conf.Linger.Bool {
 		defer func() {
 			msg := "The test is done, but --linger was enabled, so k6 is waiting for Ctrl+C to continue..."
@@ -291,8 +298,8 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 		}()
 	}
 
-	// Initialize VUs and start the test! However, we won't immediately return
-	// if there was an error, we still have things to do.
+	// Start the test! However, we won't immediately return if there was an
+	// error, we still have things to do.
 	err = execScheduler.Run(globalCtx, runCtx, samples)
 
 	// Init has passed successfully, so unless disabled, make sure we send a

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -1020,15 +1020,7 @@ func TestAbortedByTestAbortInNonFirstInitCode(t *testing.T) {
 		export function handleSummary() { return {stdout: '\n\n\nbogus summary\n\n\n'};}
 	`
 
-	t.Run("noLinger", func(t *testing.T) {
-		t.Parallel()
-		testAbortedByScriptTestAbort(t, script, runTestWithNoLinger)
-	})
-
-	t.Run("withLinger", func(t *testing.T) {
-		t.Parallel()
-		testAbortedByScriptTestAbort(t, script, runTestWithLinger)
-	})
+	testAbortedByScriptTestAbort(t, script, runTestWithNoLinger)
 }
 
 func TestAbortedByScriptAbortInVUCode(t *testing.T) {

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -406,6 +406,9 @@ func TestDataIsolation(t *testing.T) {
 
 	require.Empty(t, runner.defaultGroup.Groups)
 
+	stopEmission, err := execScheduler.Init(runCtx, samples)
+	require.NoError(t, err)
+
 	errC := make(chan error)
 	go func() { errC <- execScheduler.Run(globalCtx, runCtx, samples) }()
 
@@ -414,6 +417,7 @@ func TestDataIsolation(t *testing.T) {
 		runAbort(fmt.Errorf("unexpected abort"))
 		t.Fatal("Test timed out")
 	case err := <-errC:
+		stopEmission()
 		close(samples)
 		require.NoError(t, err)
 		waitForMetricsFlushed()


### PR DESCRIPTION
This reverts a big part of https://github.com/grafana/k6/pull/2885 because, with all of the logic in `Run()`, k6 didn't know if it needed to wait when `--linger` was specified.

In general, if a script error or `test.abort()` occurs during init, `--linger` should not apply and k6 should exit immediately. But if `test.abort()` is called during the test run itself, or the test was stopped in some other way besides `Ctrl+C` (e.g. REST API, thresholds with `abortOnFail`), `--linger` means that k6 should not exit immediately after stopping the test.

https://github.com/grafana/k6/issues/2804 is a somewhat related issue, where I'll also document this somewhat hidden and implicit requirements.