### PR TITLE
Add tests ensuring the tracing module sets and cleans up metadata properly

### DIFF
--- a/js/modules/k6/experimental/tracing/client_test.go
+++ b/js/modules/k6/experimental/tracing/client_test.go
@@ -1,6 +1,7 @@
 package tracing
 
 import (
+	"math/rand"
 	"net/http"
 	"testing"
 
@@ -8,6 +9,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/js/modulestest"
+	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/testutils/httpmultibin"
+	"go.k6.io/k6/metrics"
 )
 
 // traceParentHeaderName is the normalized trace header name.
@@ -142,6 +146,105 @@ func TestClientInstrumentArguments(t *testing.T) {
 		assert.NotNil(t, gotTraceParent)
 		assert.Equal(t, testTraceID, gotTraceParent.String())
 	})
+}
+
+func TestClientInstrumentedCall(t *testing.T) {
+	t.Parallel()
+
+	testCase := newTestCase(t)
+	testCase.testSetup.MoveToVUContext(&lib.State{
+		Tags: lib.NewVUStateTags(&metrics.TagSet{}),
+	})
+	testCase.client.propagator = NewW3CPropagator(NewAlwaysOnSampler())
+
+	callFn := func(args ...goja.Value) error {
+		gotMetadataTraceID, gotTraceIDKey := testCase.client.vu.State().Tags.GetCurrentValues().Metadata["trace_id"]
+		assert.True(t, gotTraceIDKey)
+		assert.NotEmpty(t, gotMetadataTraceID)
+		return nil
+	}
+
+	// Assert there is no trace_id key in vu metadata before using intrumentedCall
+	_, hasTraceIDKey := testCase.client.vu.State().Tags.GetCurrentValues().Metadata["trace_id"]
+	assert.False(t, hasTraceIDKey)
+
+	// The callFn will assert that the trace_id key is present in vu metadata
+	// before returning
+	_ = testCase.client.instrumentedCall(callFn)
+
+	// Assert there is no trace_id key in vu metadata after using intrumentedCall
+	_, hasTraceIDKey = testCase.client.vu.State().Tags.GetCurrentValues().Metadata["trace_id"]
+	assert.False(t, hasTraceIDKey)
+}
+
+// This test ensures that the trace_id is added to the vu metadata when
+// and instrumented request is called; and that we can find it in the
+// produced samples.
+//
+// It also ensures that the trace_id is removed from the vu metadata
+// after the request is done.
+func TestCallingInstrumentedRequestEmitsTraceIdMetadata(t *testing.T) {
+	t.Parallel()
+
+	testCase := newTestSetup(t)
+	rt := testCase.TestRuntime.VU.Runtime()
+
+	// Making sure the instrumentHTTP is called in the init context
+	// before the test.
+	_, err := rt.RunString(`
+		let http = require('k6/http')
+		instrumentHTTP({propagator: 'w3c'})
+	`)
+	require.NoError(t, err)
+
+	// Move to VU context. Setup in way that the produced samples are
+	// written to a channel we own.
+	samples := make(chan metrics.SampleContainer, 1000)
+	httpBin := httpmultibin.NewHTTPMultiBin(t)
+	testCase.TestRuntime.MoveToVUContext(&lib.State{
+		BuiltinMetrics: metrics.RegisterBuiltinMetrics(testCase.TestRuntime.VU.InitEnvField.Registry),
+		Tags:           lib.NewVUStateTags(testCase.TestRuntime.VU.InitEnvField.Registry.RootTagSet()),
+		Transport:      httpBin.HTTPTransport,
+		BufferPool:     lib.NewBufferPool(),
+		Samples:        samples,
+		Options:        lib.Options{SystemTags: &metrics.DefaultSystemTagSet},
+	})
+
+	// Inject a function in the JS runtime to assert the trace_id key
+	// is present in the vu metadata.
+	err = rt.Set("assert_has_trace_id_metadata", func(expected bool, expectedTraceID string) {
+		gotTraceID, hasTraceID := testCase.TestRuntime.VU.State().Tags.GetCurrentValues().Metadata["trace_id"]
+		require.Equal(t, expected, hasTraceID)
+
+		if expectedTraceID != "" {
+			require.Equal(t, expectedTraceID, gotTraceID)
+		}
+	})
+	require.NoError(t, err)
+
+	// Assert there is no trace_id key in vu metadata before calling an instrumented
+	// function, and that it's cleaned up after the call.
+	t.Cleanup(testCase.TestRuntime.EventLoop.WaitOnRegistered)
+	err = testCase.TestRuntime.EventLoop.Start(func() error {
+		_, err = rt.RunString(httpBin.Replacer.Replace(`
+        	assert_has_trace_id_metadata(false)
+        	http.request("GET", "HTTPBIN_URL")
+        	assert_has_trace_id_metadata(false)
+        `))
+
+		return err
+	})
+	require.NoError(t, err)
+	close(samples)
+
+	var sampleRead bool
+	for sampleContainer := range samples {
+		for _, sample := range sampleContainer.GetSamples() {
+			require.NotEmpty(t, sample.Metadata["trace_id"])
+			sampleRead = true
+		}
+	}
+	require.True(t, sampleRead)
 }
 
 type tracingClientTestCase struct {

--- a/js/modules/k6/experimental/tracing/client_test.go
+++ b/js/modules/k6/experimental/tracing/client_test.go
@@ -153,7 +153,9 @@ type tracingClientTestCase struct {
 
 func newTestCase(t *testing.T) *tracingClientTestCase {
 	testSetup := modulestest.NewRuntime(t)
-	client := Client{vu: testSetup.VU}
+	// Here we provide the client with a fixed seed to ensure that the
+	// generated trace IDs random part is deterministic.
+	client := Client{vu: testSetup.VU, randSource: rand.New(rand.NewSource(0))} //nolint:gosec
 	traceContextHeader := http.Header{}
 	traceContextHeader.Add(traceparentHeaderName, testTraceID)
 

--- a/js/modules/k6/experimental/tracing/module_test.go
+++ b/js/modules/k6/experimental/tracing/module_test.go
@@ -64,10 +64,9 @@ func newTestSetup(t *testing.T) testSetup {
 	rt := ts.VU.Runtime()
 	require.NoError(t, rt.Set("instrumentHTTP", m.Exports().Named["instrumentHTTP"]))
 
+	export := http.New().NewModuleInstance(ts.VU).Exports().Default
 	require.NoError(t, rt.Set("require", func(module string) *goja.Object {
 		require.Equal(t, "k6/http", module)
-		export := http.New().NewModuleInstance(ts.VU).Exports().Default
-
 		return rt.ToValue(export).ToObject(rt)
 	}))
 

--- a/js/modules/k6/experimental/tracing/trace_id.go
+++ b/js/modules/k6/experimental/tracing/trace_id.go
@@ -1,7 +1,6 @@
 package tracing
 
 import (
-	"crypto/rand"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -51,18 +50,6 @@ type TraceID struct {
 	// trace-id. The `rand.Reader` should be your default pick. But
 	// you can replace it with a different source for testing purposes.
 	randSource io.Reader
-}
-
-// NewTraceID produces a new TraceID with the given prefix, code and time.
-//
-// It sets the traceID randomness source to the `rand.Reader` as a default.
-func NewTraceID(prefix int16, code int8, t time.Time, randSource io.Reader) TraceID {
-	return TraceID{
-		Prefix:     prefix,
-		Code:       code,
-		Time:       t,
-		randSource: rand.Reader,
-	}
 }
 
 // Encode encodes the TraceID into a hex string.


### PR DESCRIPTION
This Pull Request addresses #2889, and adds tests ensuring that the tracing module does add a `trace_id` metadata entry when performing a request and cleans it up afterward.

To make it possible, I had to wrap a bunch of existing behaviors throughout the module in interfaces. That way I could easily swap them with mocked/controllable behaviors: trace id generation and randomness generation.

Let me know what you think 🤝 

closes #2889 