### PR TITLE
Fix panic with setInterval in k6/ws

### DIFF
--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -115,6 +115,7 @@ func (mi *WS) Exports() modules.Exports {
 }
 
 // Connect establishes a WebSocket connection based on the parameters provided.
+//
 //nolint:funlen
 func (mi *WS) Connect(url string, args ...goja.Value) (*HTTPResponse, error) {
 	ctx := mi.vu.Context()
@@ -453,7 +454,7 @@ func (s *Socket) SetInterval(fn goja.Callable, intervalMs float64) error {
 		return fmt.Errorf("setInterval requires a >0 timeout parameter, received %.2f", intervalMs)
 	}
 	go func() {
-		ticker := time.NewTicker(time.Duration(intervalMs) * time.Millisecond)
+		ticker := time.NewTicker(d)
 		defer ticker.Stop()
 
 		for {

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -217,7 +217,7 @@ func TestSessionInterval(t *testing.T) {
 	assertSessionMetricsEmitted(t, metrics.GetBufferedSamples(test.samples), "", sr("WSBIN_URL/ws-echo"), statusProtocolSwitch, "")
 }
 
-func TestSessionBadInterval(t *testing.T) {
+func TestSessionNegativeInterval(t *testing.T) {
 	t.Parallel()
 	tb := httpmultibin.NewHTTPMultiBin(t)
 	sr := tb.Replacer.Replace
@@ -234,6 +234,24 @@ func TestSessionBadInterval(t *testing.T) {
 		`))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "setInterval requires a >0 timeout parameter, received -1.23 ")
+}
+
+func TestSessionIntervalSub1(t *testing.T) {
+	t.Parallel()
+	tb := httpmultibin.NewHTTPMultiBin(t)
+	sr := tb.Replacer.Replace
+
+	test := newTestState(t)
+	_, err := test.VU.Runtime().RunString(sr(`
+		var counter = 0;
+		var res = ws.connect("WSBIN_URL/ws-echo", function(socket){
+			socket.setInterval(function () {
+				counter += 1;
+				if (counter > 2) { socket.close(); }
+			}, 0.3);
+		});
+		`))
+	require.NoError(t, err)
 }
 
 func TestSessionTimeout(t *testing.T) {


### PR DESCRIPTION
The panic happens when interval between 0 and 1 is given.

The code that tested whether the interval was > 0 correctly converted to
floats first and then back to time. And then checked it in order to
prevent this very panic.

Unfortunately it then did the same calculation again but this time by
converting the interval directly to int before multiplying by
milliseconds. Which ends up rounding it to 0. Making the whole result
zero and leading to time.NewTicker to panic.

This was already done correctly for setTimeout when the same panic was
found there and the wrong conversation was added for setInterval.

Previous commit https://github.com/grafana/k6/commit/df3ad1bd371ac6d0bd2d5a4c10887b08f4374eba