### PR TITLE
Restore the exit codes to the v0.42.0 values

### DIFF
--- a/errext/exitcodes/codes.go
+++ b/errext/exitcodes/codes.go
@@ -14,10 +14,10 @@ const (
 	SetupTimeout             ExitCode = 100
 	TeardownTimeout          ExitCode = 101
 	GenericTimeout           ExitCode = 102 // TODO: remove?
-	CannotStartRESTAPI       ExitCode = 103
+	ScriptStoppedFromRESTAPI ExitCode = 103
 	InvalidConfig            ExitCode = 104
 	ExternalAbort            ExitCode = 105
-	ScriptStoppedFromRESTAPI ExitCode = 106
+	CannotStartRESTAPI       ExitCode = 106
 	ScriptException          ExitCode = 107
 	ScriptAborted            ExitCode = 108
 )


### PR DESCRIPTION
I messed up the exit codes in https://github.com/grafana/k6/pull/2815, so this PR now restores the old ones. The only thing different from v0.42.0 is the meaning of the 103 exit code. It used to be `GenericEngine`, i.e. "the test died from an unknown cause", and will now be used for the well-defined `ScriptStoppedFromRESTAPI` error.

This is the `git diff v0.42.0...restore-exit-codes -- errext/exitcodes/codes.go`, for easier review: 
```diff
diff --git a/errext/exitcodes/codes.go b/errext/exitcodes/codes.go
index abcb602f..8efc0578 100644
--- a/errext/exitcodes/codes.go
+++ b/errext/exitcodes/codes.go
@@ -1,4 +1,5 @@
 // Package exitcodes contains the constants representing possible k6 exit error codes.
+//
 //nolint:golint
 package exitcodes
 
@@ -13,7 +14,7 @@ const (
 	SetupTimeout             ExitCode = 100
 	TeardownTimeout          ExitCode = 101
 	GenericTimeout           ExitCode = 102 // TODO: remove?
-	GenericEngine            ExitCode = 103
+	ScriptStoppedFromRESTAPI ExitCode = 103
 	InvalidConfig            ExitCode = 104
 	ExternalAbort            ExitCode = 105
 	CannotStartRESTAPI       ExitCode = 106
```