### PR TITLE
Too many time series warning

### DIFF
--- a/lib/testutils/logrus_hook.go
+++ b/lib/testutils/logrus_hook.go
@@ -1,6 +1,7 @@
 package testutils
 
 import (
+	"io"
 	"strings"
 	"sync"
 
@@ -58,4 +59,19 @@ func LogContains(logEntries []logrus.Entry, expLevel logrus.Level, expContents s
 		}
 	}
 	return false
+}
+
+// NewMemLogger creates a Logrus logger mocked by SimpleLogrusHook.
+func NewMemLogger(levels ...logrus.Level) (*logrus.Logger, *SimpleLogrusHook) {
+	if len(levels) == 0 {
+		levels = logrus.AllLevels
+	}
+	logger := logrus.New()
+	logger.SetLevel(logrus.InfoLevel)
+	logger.Out = io.Discard
+	hook := &SimpleLogrusHook{
+		HookedLevels: levels,
+	}
+	logger.AddHook(hook)
+	return logger, hook
 }

--- a/metrics/engine/engine.go
+++ b/metrics/engine/engine.go
@@ -67,6 +67,7 @@ func (me *MetricsEngine) CreateIngester() output.Output {
 	me.outputIngester = &outputIngester{
 		logger:        me.logger.WithField("component", "metrics-engine-ingester"),
 		metricsEngine: me,
+		cardinality:   newCardinalityControl(),
 	}
 	return me.outputIngester
 }


### PR DESCRIPTION
Closes #2765

At the moment the implementation doesn't support turning it off, we may consider using 0 for it in the future.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
