### PR TITLE
js: Cache scripts by absolute not relative paths

### DIFF
--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -46,7 +46,7 @@ type InitContext struct {
 
 	// Cache of loaded programs and files.
 	programs map[string]programWithSource
-	// mege this and the above
+	// merge this and the above
 	k6ModulesCache map[string]goja.Value
 
 	compatibilityMode lib.CompatibilityMode

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -45,8 +45,9 @@ type InitContext struct {
 	pwd         *url.URL
 
 	// Cache of loaded programs and files.
-	programs     map[string]programWithSource
-	exportsCache map[string]goja.Value
+	programs map[string]programWithSource
+	// mege this and the above
+	k6ModulesCache map[string]goja.Value
 
 	compatibilityMode lib.CompatibilityMode
 
@@ -68,7 +69,7 @@ func NewInitContext(
 		compatibilityMode: compatMode,
 		logger:            logger,
 		moduleRegistry:    getJSModules(),
-		exportsCache:      make(map[string]goja.Value),
+		k6ModulesCache:    make(map[string]goja.Value),
 		moduleVUImpl: &moduleVUImpl{
 			// TODO: pass a real context as we did for https://github.com/grafana/k6/pull/2800,
 			// also see https://github.com/grafana/k6/issues/2804
@@ -96,7 +97,7 @@ func newBoundInitContext(base *InitContext, vuImpl *moduleVUImpl) *InitContext {
 
 		programs:          programs,
 		compatibilityMode: base.compatibilityMode,
-		exportsCache:      make(map[string]goja.Value),
+		k6ModulesCache:    make(map[string]goja.Value),
 		logger:            base.logger,
 		moduleRegistry:    base.moduleRegistry,
 		moduleVUImpl:      vuImpl,
@@ -105,13 +106,13 @@ func newBoundInitContext(base *InitContext, vuImpl *moduleVUImpl) *InitContext {
 
 // Require is called when a module/file needs to be loaded by a script
 func (i *InitContext) Require(arg string) (export goja.Value) {
-	var ok bool
-	if export, ok = i.exportsCache[arg]; ok {
-		return export
-	}
-	defer func() { i.exportsCache[arg] = export }()
 	switch {
 	case arg == "k6", strings.HasPrefix(arg, "k6/"):
+		var ok bool
+		if export, ok = i.k6ModulesCache[arg]; ok {
+			return export
+		}
+		defer func() { i.k6ModulesCache[arg] = export }()
 		// Builtin or external modules ("k6", "k6/*", or "k6/x/*") are handled
 		// specially, as they don't exist on the filesystem. This intentionally
 		// shadows attempts to name your own modules this.


### PR DESCRIPTION
This fixes a regression introduced in 2753196ab where in all imports are cached on the specifier that is provided for them. This is fine for k6 modules which happen to always have the same absolute names.

But source modules can have relative paths that resolve to different absolute ones depending on where they are imported from.

Fixes #2902
