### PR TITLE
Change env RegEx : support Cortex Tenant

### DIFF
--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -16,7 +16,7 @@ import (
 // https://github.com/k6io/k6/issues/883, since this code is fairly
 // self-contained and easily testable now, without any global dependencies...
 
-var userEnvVarName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+var userEnvVarName = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_-]*$`)
 
 func runtimeOptionFlagSet(includeSysEnv bool) *pflag.FlagSet {
 	flags := pflag.NewFlagSet("", 0)


### PR DESCRIPTION
When using Cortex as a prometheus remote storage, we have to add some http headers like,

* X-Scope-OrgID : for tenant

Cortex Guide Link : https://cortexmetrics.io/docs/guides/auth/

Current regEx for env variable does not contains hypen(-) so, cannot set above header using environment variable , as [this guide](https://k6.io/docs/results-output/real-time/prometheus-remote-write/#options) describe.

The env name for setting above header is 'K6_PROMETHEUS_RW_HEADERS_X-Scope-OrgID', and this cause the following error
```
time="2023-02-07T06:10:41Z" level=error msg="invalid environment variable name 'K6_PROMETHEUS_RW_HEADERS_X-Scope-OrgId'"

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
