### PR TITLE
Add more context when script options can't be parsed

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -180,7 +180,7 @@ func (b *Bundle) getExports(logger logrus.FieldLogger, rt *goja.Runtime, updateO
 			}
 			data, err := json.Marshal(v.Export())
 			if err != nil {
-				return err
+				return fmt.Errorf("error parsing script options: %w", err)
 			}
 			dec := json.NewDecoder(bytes.NewReader(data))
 			dec.DisallowUnknownFields()

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -202,7 +202,7 @@ func TestNewBundle(t *testing.T) {
 				Expr, Error string
 			}{
 				"Array":    {`[]`, "json: cannot unmarshal array into Go value of type lib.Options"},
-				"Function": {`function(){}`, "json: unsupported type: func(goja.FunctionCall) goja.Value"},
+				"Function": {`function(){}`, "error parsing script options: json: unsupported type: func(goja.FunctionCall) goja.Value"},
 			}
 			for name, data := range invalidOptions {
 				t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
This only makes certain the error does actually specify it is about the options.

Updates #2909
