### PR TITLE
Fix xk6-browser v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4-0.20211119122758-180fcef48034+incompatible
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.5.0
-	github.com/grafana/xk6-browser v0.8.1-0.20230131153655-c347eae1e46a
+	github.com/grafana/xk6-browser v0.8.1-0.20230207135343-cfd6a83dfc42
 	github.com/grafana/xk6-output-prometheus-remote v0.1.0
 	github.com/grafana/xk6-redis v0.1.1
 	github.com/grafana/xk6-timers v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/websocket v1.5.0 h1:PPwGk2jz7EePpoHN/+ClbZu8SPxiqlu12wZP/3sWmnc=
 github.com/gorilla/websocket v1.5.0/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
-github.com/grafana/xk6-browser v0.8.1-0.20230131153655-c347eae1e46a h1:KWu67+49qu24PvzoRj+qVTsDfhY51m0WMFMUZolqcXE=
-github.com/grafana/xk6-browser v0.8.1-0.20230131153655-c347eae1e46a/go.mod h1:elvssKBUHI8rLShlWb+lOUhkaGcn0RcipKE6MRcezVw=
+github.com/grafana/xk6-browser v0.8.1-0.20230207135343-cfd6a83dfc42 h1:y62cvumZOkhwh5p4bOcURP3J/DceFUsbOjFSds7+NMs=
+github.com/grafana/xk6-browser v0.8.1-0.20230207135343-cfd6a83dfc42/go.mod h1:elvssKBUHI8rLShlWb+lOUhkaGcn0RcipKE6MRcezVw=
 github.com/grafana/xk6-output-prometheus-remote v0.1.0 h1:yJc09O6TeBYLFfNG/dqBDtvHmM9P1B2ZFTyr0HgvsHY=
 github.com/grafana/xk6-output-prometheus-remote v0.1.0/go.mod h1:R4o0VbIfbQNNPSGkeeiCBLzwNfG+DEdfKYNsV1oww1Y=
 github.com/grafana/xk6-redis v0.1.1 h1:rvWnLanRB2qzDwuY6NMBe6PXei3wJ3kjYvfCwRJ+q+8=

--- a/vendor/github.com/grafana/xk6-browser/api/browser_context.go
+++ b/vendor/github.com/grafana/xk6-browser/api/browser_context.go
@@ -6,23 +6,23 @@ import (
 
 // BrowserContext is the public interface of a CDP browser context.
 type BrowserContext interface {
-	AddCookies(cookies goja.Value) *goja.Promise
+	AddCookies(cookies goja.Value)
 	AddInitScript(script goja.Value, arg goja.Value)
 	Browser() Browser
 	ClearCookies()
 	ClearPermissions()
 	Close()
-	Cookies() *goja.Promise
-	ExposeBinding(name string, callback goja.Callable, opts goja.Value) *goja.Promise
-	ExposeFunction(name string, callback goja.Callable) *goja.Promise
+	Cookies() []any // TODO: make it []Cookie later on
+	ExposeBinding(name string, callback goja.Callable, opts goja.Value)
+	ExposeFunction(name string, callback goja.Callable)
 	GrantPermissions(permissions []string, opts goja.Value)
-	NewCDPSession() *goja.Promise
+	NewCDPSession() CDPSession
 	NewPage() Page
 	Pages() []Page
-	Route(url goja.Value, handler goja.Callable) *goja.Promise
+	Route(url goja.Value, handler goja.Callable)
 	SetDefaultNavigationTimeout(timeout int64)
 	SetDefaultTimeout(timeout int64)
-	SetExtraHTTPHeaders(headers map[string]string) *goja.Promise
+	SetExtraHTTPHeaders(headers map[string]string)
 	SetGeolocation(geolocation goja.Value)
 	// SetHTTPCredentials sets username/password credentials to use for HTTP authentication.
 	//
@@ -32,7 +32,7 @@ type BrowserContext interface {
 	// - https://github.com/microsoft/playwright/pull/2763
 	SetHTTPCredentials(httpCredentials goja.Value)
 	SetOffline(offline bool)
-	StorageState(opts goja.Value) *goja.Promise
-	Unroute(url goja.Value, handler goja.Callable) *goja.Promise
+	StorageState(opts goja.Value)
+	Unroute(url goja.Value, handler goja.Callable)
 	WaitForEvent(event string, optsOrPredicate goja.Value) any
 }

--- a/vendor/github.com/grafana/xk6-browser/api/browser_type.go
+++ b/vendor/github.com/grafana/xk6-browser/api/browser_type.go
@@ -6,9 +6,9 @@ import (
 
 // BrowserType is the public interface of a CDP browser client.
 type BrowserType interface {
-	Connect(opts goja.Value) *goja.Promise
+	Connect(opts goja.Value)
 	ExecutablePath() string
 	Launch(opts goja.Value) Browser
-	LaunchPersistentContext(userDataDir string, opts goja.Value) *goja.Promise
+	LaunchPersistentContext(userDataDir string, opts goja.Value) Browser
 	Name() string
 }

--- a/vendor/github.com/grafana/xk6-browser/api/element_handle.go
+++ b/vendor/github.com/grafana/xk6-browser/api/element_handle.go
@@ -33,7 +33,7 @@ type ElementHandle interface {
 	ScrollIntoViewIfNeeded(opts goja.Value)
 	SelectOption(values goja.Value, opts goja.Value) []string
 	SelectText(opts goja.Value)
-	SetInputFiles(files goja.Value, opts goja.Value) *goja.Promise
+	SetInputFiles(files goja.Value, opts goja.Value)
 	Tap(opts goja.Value)
 	TextContent() string
 	Type(text string, opts goja.Value)

--- a/vendor/github.com/grafana/xk6-browser/api/frame.go
+++ b/vendor/github.com/grafana/xk6-browser/api/frame.go
@@ -4,8 +4,8 @@ import "github.com/dop251/goja"
 
 // Frame is the interface of a CDP target frame.
 type Frame interface {
-	AddScriptTag(opts goja.Value) *goja.Promise
-	AddStyleTag(opts goja.Value) *goja.Promise
+	AddScriptTag(opts goja.Value)
+	AddStyleTag(opts goja.Value)
 	Check(selector string, opts goja.Value)
 	ChildFrames() []Frame
 	Click(selector string, opts goja.Value) error
@@ -42,7 +42,7 @@ type Frame interface {
 	Press(selector string, key string, opts goja.Value)
 	SelectOption(selector string, values goja.Value, opts goja.Value) []string
 	SetContent(html string, opts goja.Value)
-	SetInputFiles(selector string, files goja.Value, opts goja.Value) *goja.Promise
+	SetInputFiles(selector string, files goja.Value, opts goja.Value)
 	Tap(selector string, opts goja.Value)
 	TextContent(selector string, opts goja.Value) string
 	Title() string

--- a/vendor/github.com/grafana/xk6-browser/api/page.go
+++ b/vendor/github.com/grafana/xk6-browser/api/page.go
@@ -4,9 +4,9 @@ import "github.com/dop251/goja"
 
 // Page is the interface of a single browser tab.
 type Page interface {
-	AddInitScript(script goja.Value, arg goja.Value) *goja.Promise
-	AddScriptTag(opts goja.Value) *goja.Promise
-	AddStyleTag(opts goja.Value) *goja.Promise
+	AddInitScript(script goja.Value, arg goja.Value)
+	AddScriptTag(opts goja.Value)
+	AddStyleTag(opts goja.Value)
 	BringToFront()
 	Check(selector string, opts goja.Value)
 	Click(selector string, opts goja.Value) error
@@ -15,20 +15,23 @@ type Page interface {
 	Context() BrowserContext
 	Dblclick(selector string, opts goja.Value)
 	DispatchEvent(selector string, typ string, eventInit goja.Value, opts goja.Value)
-	DragAndDrop(source string, target string, opts goja.Value) *goja.Promise
+	DragAndDrop(source string, target string, opts goja.Value)
 	EmulateMedia(opts goja.Value)
 	EmulateVisionDeficiency(typ string)
 	Evaluate(pageFunc goja.Value, arg ...goja.Value) any
 	EvaluateHandle(pageFunc goja.Value, arg ...goja.Value) JSHandle
-	ExposeBinding(name string, callback goja.Callable, opts goja.Value) *goja.Promise
-	ExposeFunction(name string, callback goja.Callable) *goja.Promise
+	ExposeBinding(name string, callback goja.Callable, opts goja.Value)
+	ExposeFunction(name string, callback goja.Callable)
 	Fill(selector string, value string, opts goja.Value)
 	Focus(selector string, opts goja.Value)
-	Frame(frameSelector goja.Value) *goja.Promise
+	Frame(frameSelector goja.Value) Frame
 	Frames() []Frame
 	GetAttribute(selector string, name string, opts goja.Value) goja.Value
-	GoBack(opts goja.Value) *goja.Promise
-	GoForward(opts goja.Value) *goja.Promise
+	GetKeyboard() Keyboard
+	GetMouse() Mouse
+	GetTouchscreen() Touchscreen
+	GoBack(opts goja.Value) Response
+	GoForward(opts goja.Value) Response
 	Goto(url string, opts goja.Value) (Response, error)
 	Hover(selector string, opts goja.Value)
 	InnerHTML(selector string, opts goja.Value) string
@@ -45,36 +48,36 @@ type Page interface {
 	Locator(selector string, opts goja.Value) Locator
 	MainFrame() Frame
 	Opener() Page
-	Pause() *goja.Promise
-	Pdf(opts goja.Value) *goja.Promise
+	Pause()
+	Pdf(opts goja.Value) []byte
 	Press(selector string, key string, opts goja.Value)
 	Query(selector string) ElementHandle
 	QueryAll(selector string) []ElementHandle
 	Reload(opts goja.Value) Response
-	Route(url goja.Value, handler goja.Callable) *goja.Promise
+	Route(url goja.Value, handler goja.Callable)
 	Screenshot(opts goja.Value) goja.ArrayBuffer
 	SelectOption(selector string, values goja.Value, opts goja.Value) []string
 	SetContent(html string, opts goja.Value)
 	SetDefaultNavigationTimeout(timeout int64)
 	SetDefaultTimeout(timeout int64)
 	SetExtraHTTPHeaders(headers map[string]string)
-	SetInputFiles(selector string, files goja.Value, opts goja.Value) *goja.Promise
+	SetInputFiles(selector string, files goja.Value, opts goja.Value)
 	SetViewportSize(viewportSize goja.Value)
 	Tap(selector string, opts goja.Value)
 	TextContent(selector string, opts goja.Value) string
 	Title() string
 	Type(selector string, text string, opts goja.Value)
 	Uncheck(selector string, opts goja.Value)
-	Unroute(url goja.Value, handler goja.Callable) *goja.Promise
+	Unroute(url goja.Value, handler goja.Callable)
 	URL() string
-	Video() *goja.Promise
+	Video() Video
 	ViewportSize() map[string]float64
-	WaitForEvent(event string, optsOrPredicate goja.Value) *goja.Promise
+	WaitForEvent(event string, optsOrPredicate goja.Value) any
 	WaitForFunction(fn, opts goja.Value, args ...goja.Value) (any, error)
 	WaitForLoadState(state string, opts goja.Value)
 	WaitForNavigation(opts goja.Value) (Response, error)
-	WaitForRequest(urlOrPredicate, opts goja.Value) *goja.Promise
-	WaitForResponse(urlOrPredicate, opts goja.Value) *goja.Promise
+	WaitForRequest(urlOrPredicate, opts goja.Value) Request
+	WaitForResponse(urlOrPredicate, opts goja.Value) Response
 	WaitForSelector(selector string, opts goja.Value) ElementHandle
 	WaitForTimeout(timeout int64)
 	Workers() []Worker

--- a/vendor/github.com/grafana/xk6-browser/api/response.go
+++ b/vendor/github.com/grafana/xk6-browser/api/response.go
@@ -6,7 +6,7 @@ import "github.com/dop251/goja"
 type Response interface {
 	AllHeaders() map[string]string
 	Body() goja.ArrayBuffer
-	Finished() *goja.Promise
+	Finished() bool
 	Frame() Frame
 	HeaderValue(string) goja.Value
 	HeaderValues(string) []string

--- a/vendor/github.com/grafana/xk6-browser/browser/mapping.go
+++ b/vendor/github.com/grafana/xk6-browser/browser/mapping.go
@@ -14,6 +14,24 @@ import (
 	k6modules "go.k6.io/k6/js/modules"
 )
 
+// moduleVU carries module specific VU information.
+//
+// Currently, it is used to carry the VU object to the
+// inner objects and promises.
+type moduleVU struct {
+	k6modules.VU
+}
+
+func (vu moduleVU) Context() context.Context {
+	// promises and inner objects need the VU object to be
+	// able to use k6-core specific functionality.
+	//
+	// We should not cache the context (especially the init
+	// context from the vu that is received from k6 in
+	// NewModuleInstance).
+	return k6ext.WithVU(vu.VU.Context(), vu.VU)
+}
+
 // mapping is a type of mapping between our API (api/) and the JS
 // module. It acts like a bridge and allows adding wildcard methods
 // and customization over our API.
@@ -24,29 +42,17 @@ import (
 // https://github.com/dop251/goja/issues/469
 type mapping = map[string]any
 
-// wildcards is a list of extra mappings for our API (api/).
-func wildcards() map[string]string {
-	return map[string]string{
-		"Page.query":             "$",
-		"Page.queryAll":          "$$",
-		"Frame.query":            "$",
-		"Frame.queryAll":         "$$",
-		"ElementHandle.query":    "$",
-		"ElementHandle.queryAll": "$$",
-	}
-}
-
 // mapBrowserToGoja maps the browser API to the JS module.
 // The motivation of this mapping was to support $ and $$ wildcard
 // methods.
 // See issue #661 for more details.
-func mapBrowserToGoja(ctx context.Context, vu k6modules.VU) *goja.Object {
+func mapBrowserToGoja(vu moduleVU) *goja.Object {
 	var (
 		rt          = vu.Runtime()
 		obj         = rt.NewObject()
 		browserType = chromium.NewBrowserType(vu)
 	)
-	for k, v := range mapBrowserType(ctx, vu, browserType) {
+	for k, v := range mapBrowserType(vu, browserType) {
 		err := obj.Set(k, rt.ToValue(v))
 		if err != nil {
 			k6common.Throw(rt, fmt.Errorf("mapping: %w", err))
@@ -57,13 +63,13 @@ func mapBrowserToGoja(ctx context.Context, vu k6modules.VU) *goja.Object {
 }
 
 // mapRequest to the JS module.
-func mapRequest(ctx context.Context, vu k6modules.VU, r api.Request) mapping {
+func mapRequest(vu moduleVU, r api.Request) mapping {
 	rt := vu.Runtime()
 	maps := mapping{
 		"allHeaders": r.AllHeaders,
 		"failure":    r.Failure,
 		"frame": func() *goja.Object {
-			mf := mapFrame(ctx, vu, r.Frame())
+			mf := mapFrame(vu, r.Frame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"headerValue":         r.HeaderValue,
@@ -75,16 +81,16 @@ func mapRequest(ctx context.Context, vu k6modules.VU, r api.Request) mapping {
 		"postDataBuffer":      r.PostDataBuffer,
 		"postDataJSON":        r.PostDataJSON,
 		"redirectedFrom": func() *goja.Object {
-			mr := mapRequest(ctx, vu, r.RedirectedFrom())
+			mr := mapRequest(vu, r.RedirectedFrom())
 			return rt.ToValue(mr).ToObject(rt)
 		},
 		"redirectedTo": func() *goja.Object {
-			mr := mapRequest(ctx, vu, r.RedirectedTo())
+			mr := mapRequest(vu, r.RedirectedTo())
 			return rt.ToValue(mr).ToObject(rt)
 		},
 		"resourceType": r.ResourceType,
 		"response": func() *goja.Object {
-			mr := mapResponse(ctx, vu, r.Response())
+			mr := mapResponse(vu, r.Response())
 			return rt.ToValue(mr).ToObject(rt)
 		},
 		"size":   r.Size,
@@ -96,7 +102,7 @@ func mapRequest(ctx context.Context, vu k6modules.VU, r api.Request) mapping {
 }
 
 // mapResponse to the JS module.
-func mapResponse(ctx context.Context, vu k6modules.VU, r api.Response) mapping {
+func mapResponse(vu moduleVU, r api.Response) mapping {
 	if r == nil {
 		return nil
 	}
@@ -106,7 +112,7 @@ func mapResponse(ctx context.Context, vu k6modules.VU, r api.Response) mapping {
 		"body":       r.Body,
 		"finished":   r.Finished,
 		"frame": func() *goja.Object {
-			mf := mapFrame(ctx, vu, r.Frame())
+			mf := mapFrame(vu, r.Frame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"headerValue":  r.HeaderValue,
@@ -116,7 +122,7 @@ func mapResponse(ctx context.Context, vu k6modules.VU, r api.Response) mapping {
 		"jSON":         r.JSON,
 		"ok":           r.Ok,
 		"request": func() *goja.Object {
-			mr := mapRequest(ctx, vu, r.Request())
+			mr := mapRequest(vu, r.Request())
 			return rt.ToValue(mr).ToObject(rt)
 		},
 		"securityDetails": r.SecurityDetails,
@@ -131,11 +137,11 @@ func mapResponse(ctx context.Context, vu k6modules.VU, r api.Response) mapping {
 }
 
 // mapJSHandle to the JS module.
-func mapJSHandle(ctx context.Context, vu k6modules.VU, jsh api.JSHandle) mapping {
+func mapJSHandle(vu moduleVU, jsh api.JSHandle) mapping {
 	rt := vu.Runtime()
 	return mapping{
 		"asElement": func() *goja.Object {
-			m := mapElementHandle(ctx, vu, jsh.AsElement())
+			m := mapElementHandle(vu, jsh.AsElement())
 			return rt.ToValue(m).ToObject(rt)
 		},
 		"dispose":  jsh.Dispose,
@@ -143,21 +149,21 @@ func mapJSHandle(ctx context.Context, vu k6modules.VU, jsh api.JSHandle) mapping
 		"evaluateHandle": func(pageFunc goja.Value, args ...goja.Value) *goja.Object {
 			var (
 				h = jsh.EvaluateHandle(pageFunc, args...)
-				m = mapJSHandle(ctx, vu, h)
+				m = mapJSHandle(vu, h)
 			)
 			return rt.ToValue(m).ToObject(rt)
 		},
 		"getProperties": func() *goja.Object {
 			dst := make(map[string]any)
 			for k, v := range jsh.GetProperties() {
-				dst[k] = mapJSHandle(ctx, vu, v)
+				dst[k] = mapJSHandle(vu, v)
 			}
 			return rt.ToValue(dst).ToObject(rt)
 		},
 		"getProperty": func(propertyName string) *goja.Object {
 			var (
 				h = jsh.GetProperty(propertyName)
-				m = mapJSHandle(ctx, vu, h)
+				m = mapJSHandle(vu, h)
 			)
 			return rt.ToValue(m).ToObject(rt)
 		},
@@ -169,20 +175,20 @@ func mapJSHandle(ctx context.Context, vu k6modules.VU, jsh api.JSHandle) mapping
 // mapElementHandle to the JS module.
 //
 //nolint:funlen
-func mapElementHandle(ctx context.Context, vu k6modules.VU, eh api.ElementHandle) mapping {
+func mapElementHandle(vu moduleVU, eh api.ElementHandle) mapping {
 	rt := vu.Runtime()
 	maps := mapping{
 		"boundingBox": eh.BoundingBox,
 		"check":       eh.Check,
 		"click": func(opts goja.Value) *goja.Promise {
-			return k6ext.Promise(ctx, func() (any, error) {
+			return k6ext.Promise(vu.Context(), func() (any, error) {
 				err := eh.Click(opts)
 				return nil, err //nolint:wrapcheck
 			})
 		},
 		"contentFrame": func() *goja.Object {
 			f := eh.ContentFrame()
-			mf := mapFrame(ctx, vu, f)
+			mf := mapFrame(vu, f)
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"dblclick":      eh.Dblclick,
@@ -202,7 +208,7 @@ func mapElementHandle(ctx context.Context, vu k6modules.VU, eh api.ElementHandle
 		"isVisible":     eh.IsVisible,
 		"ownerFrame": func() *goja.Object {
 			f := eh.OwnerFrame()
-			mf := mapFrame(ctx, vu, f)
+			mf := mapFrame(vu, f)
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"press":                  eh.Press,
@@ -218,13 +224,13 @@ func mapElementHandle(ctx context.Context, vu k6modules.VU, eh api.ElementHandle
 		"waitForElementState":    eh.WaitForElementState,
 		"waitForSelector": func(selector string, opts goja.Value) *goja.Object {
 			eh := eh.WaitForSelector(selector, opts)
-			ehm := mapElementHandle(ctx, vu, eh)
+			ehm := mapElementHandle(vu, eh)
 			return rt.ToValue(ehm).ToObject(rt)
 		},
 	}
 	maps["$"] = func(selector string) *goja.Object {
 		eh := eh.Query(selector)
-		ehm := mapElementHandle(ctx, vu, eh)
+		ehm := mapElementHandle(vu, eh)
 		return rt.ToValue(ehm).ToObject(rt)
 	}
 	maps["$$"] = func(selector string) *goja.Object {
@@ -233,13 +239,13 @@ func mapElementHandle(ctx context.Context, vu k6modules.VU, eh api.ElementHandle
 			ehs  = eh.QueryAll(selector)
 		)
 		for _, eh := range ehs {
-			ehm := mapElementHandle(ctx, vu, eh)
+			ehm := mapElementHandle(vu, eh)
 			mehs = append(mehs, ehm)
 		}
 		return rt.ToValue(mehs).ToObject(rt)
 	}
 
-	jsHandleMap := mapJSHandle(ctx, vu, eh)
+	jsHandleMap := mapJSHandle(vu, eh)
 	for k, v := range jsHandleMap {
 		maps[k] = v
 	}
@@ -250,7 +256,7 @@ func mapElementHandle(ctx context.Context, vu k6modules.VU, eh api.ElementHandle
 // mapFrame to the JS module.
 //
 //nolint:funlen
-func mapFrame(ctx context.Context, vu k6modules.VU, f api.Frame) mapping {
+func mapFrame(vu moduleVU, f api.Frame) mapping {
 	rt := vu.Runtime()
 	maps := mapping{
 		"addScriptTag": f.AddScriptTag,
@@ -262,12 +268,12 @@ func mapFrame(ctx context.Context, vu k6modules.VU, f api.Frame) mapping {
 				cfs  = f.ChildFrames()
 			)
 			for _, fr := range cfs {
-				mcfs = append(mcfs, mapFrame(ctx, vu, fr))
+				mcfs = append(mcfs, mapFrame(vu, fr))
 			}
 			return rt.ToValue(mcfs).ToObject(rt)
 		},
 		"click": func(selector string, opts goja.Value) *goja.Promise {
-			return k6ext.Promise(ctx, func() (any, error) {
+			return k6ext.Promise(vu.Context(), func() (any, error) {
 				err := f.Click(selector, opts)
 				return nil, err //nolint:wrapcheck
 			})
@@ -278,24 +284,24 @@ func mapFrame(ctx context.Context, vu k6modules.VU, f api.Frame) mapping {
 		"evaluate":      f.Evaluate,
 		"evaluateHandle": func(pageFunction goja.Value, args ...goja.Value) *goja.Object {
 			jsh := f.EvaluateHandle(pageFunction, args...)
-			ehm := mapJSHandle(ctx, vu, jsh)
+			ehm := mapJSHandle(vu, jsh)
 			return rt.ToValue(ehm).ToObject(rt)
 		},
 		"fill":  f.Fill,
 		"focus": f.Focus,
 		"frameElement": func() *goja.Object {
-			eh := mapElementHandle(ctx, vu, f.FrameElement())
+			eh := mapElementHandle(vu, f.FrameElement())
 			return rt.ToValue(eh).ToObject(rt)
 		},
 		"getAttribute": f.GetAttribute,
 		"goto": func(url string, opts goja.Value) *goja.Promise {
-			return k6ext.Promise(ctx, func() (any, error) {
+			return k6ext.Promise(vu.Context(), func() (any, error) {
 				resp, err := f.Goto(url, opts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
 
-				return mapResponse(ctx, vu, resp), nil
+				return mapResponse(vu, resp), nil
 			})
 		},
 		"hover":      f.Hover,
@@ -314,11 +320,11 @@ func mapFrame(ctx context.Context, vu k6modules.VU, f api.Frame) mapping {
 		"locator":    f.Locator,
 		"name":       f.Name,
 		"page": func() *goja.Object {
-			mp := mapPage(ctx, vu, f.Page())
+			mp := mapPage(vu, f.Page())
 			return rt.ToValue(mp).ToObject(rt)
 		},
 		"parentFrame": func() *goja.Object {
-			mf := mapFrame(ctx, vu, f.ParentFrame())
+			mf := mapFrame(vu, f.ParentFrame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
 		"press":         f.Press,
@@ -332,30 +338,30 @@ func mapFrame(ctx context.Context, vu k6modules.VU, f api.Frame) mapping {
 		"uncheck":       f.Uncheck,
 		"url":           f.URL,
 		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) *goja.Promise {
-			return k6ext.Promise(ctx, func() (result any, reason error) {
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
 				return f.WaitForFunction(pageFunc, opts, args...) //nolint:wrapcheck
 			})
 		},
 		"waitForLoadState": f.WaitForLoadState,
 		"waitForNavigation": func(opts goja.Value) *goja.Promise {
-			return k6ext.Promise(ctx, func() (result any, reason error) {
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
 				resp, err := f.WaitForNavigation(opts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
-				return mapResponse(ctx, vu, resp), nil
+				return mapResponse(vu, resp), nil
 			})
 		},
 		"waitForSelector": func(selector string, opts goja.Value) *goja.Object {
 			eh := f.WaitForSelector(selector, opts)
-			ehm := mapElementHandle(ctx, vu, eh)
+			ehm := mapElementHandle(vu, eh)
 			return rt.ToValue(ehm).ToObject(rt)
 		},
 		"waitForTimeout": f.WaitForTimeout,
 	}
 	maps["$"] = func(selector string) *goja.Object {
 		eh := f.Query(selector)
-		ehm := mapElementHandle(ctx, vu, eh)
+		ehm := mapElementHandle(vu, eh)
 		return rt.ToValue(ehm).ToObject(rt)
 	}
 	maps["$$"] = func(selector string) *goja.Object {
@@ -364,7 +370,7 @@ func mapFrame(ctx context.Context, vu k6modules.VU, f api.Frame) mapping {
 			ehs  = f.QueryAll(selector)
 		)
 		for _, eh := range ehs {
-			ehm := mapElementHandle(ctx, vu, eh)
+			ehm := mapElementHandle(vu, eh)
 			mehs = append(mehs, ehm)
 		}
 		return rt.ToValue(mehs).ToObject(rt)
@@ -376,7 +382,7 @@ func mapFrame(ctx context.Context, vu k6modules.VU, f api.Frame) mapping {
 // mapPage to the JS module.
 //
 //nolint:funlen
-func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
+func mapPage(vu moduleVU, p api.Page) mapping {
 	rt := vu.Runtime()
 	maps := mapping{
 		"addInitScript": p.AddInitScript,
@@ -385,7 +391,7 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 		"bringToFront":  p.BringToFront,
 		"check":         p.Check,
 		"click": func(selector string, opts goja.Value) *goja.Promise {
-			return k6ext.Promise(ctx, func() (any, error) {
+			return k6ext.Promise(vu.Context(), func() (any, error) {
 				err := p.Click(selector, opts)
 				return nil, err //nolint:wrapcheck
 			})
@@ -402,7 +408,7 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 		"evaluateHandle": func(pageFunc goja.Value, args ...goja.Value) *goja.Object {
 			var (
 				jsh = p.EvaluateHandle(pageFunc, args...)
-				m   = mapJSHandle(ctx, vu, jsh)
+				m   = mapJSHandle(vu, jsh)
 			)
 			return rt.ToValue(m).ToObject(rt)
 		},
@@ -417,7 +423,7 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 				frs  = p.Frames()
 			)
 			for _, fr := range frs {
-				mfrs = append(mfrs, mapFrame(ctx, vu, fr))
+				mfrs = append(mfrs, mapFrame(vu, fr))
 			}
 			return rt.ToValue(mfrs).ToObject(rt)
 		},
@@ -425,13 +431,13 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 		"goBack":       p.GoBack,
 		"goForward":    p.GoForward,
 		"goto": func(url string, opts goja.Value) *goja.Promise {
-			return k6ext.Promise(ctx, func() (any, error) {
+			return k6ext.Promise(vu.Context(), func() (any, error) {
 				resp, err := p.Goto(url, opts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
 
-				return mapResponse(ctx, vu, resp), nil
+				return mapResponse(vu, resp), nil
 			})
 		},
 		"hover":      p.Hover,
@@ -445,17 +451,19 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 		"isEnabled":  p.IsEnabled,
 		"isHidden":   p.IsHidden,
 		"isVisible":  p.IsVisible,
+		"keyboard":   rt.ToValue(p.GetKeyboard()).ToObject(rt),
 		"locator":    p.Locator,
 		"mainFrame": func() *goja.Object {
-			mf := mapFrame(ctx, vu, p.MainFrame())
+			mf := mapFrame(vu, p.MainFrame())
 			return rt.ToValue(mf).ToObject(rt)
 		},
+		"mouse":  rt.ToValue(p.GetMouse()).ToObject(rt),
 		"opener": p.Opener,
 		"pause":  p.Pause,
 		"pdf":    p.Pdf,
 		"press":  p.Press,
 		"reload": func(opts goja.Value) *goja.Object {
-			r := mapResponse(ctx, vu, p.Reload(opts))
+			r := mapResponse(vu, p.Reload(opts))
 			return rt.ToValue(r).ToObject(rt)
 		},
 		"route":                       p.Route,
@@ -470,6 +478,7 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 		"tap":                         p.Tap,
 		"textContent":                 p.TextContent,
 		"title":                       p.Title,
+		"touchscreen":                 rt.ToValue(p.GetTouchscreen()).ToObject(rt),
 		"type":                        p.Type,
 		"uncheck":                     p.Uncheck,
 		"unroute":                     p.Unroute,
@@ -478,18 +487,18 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 		"viewportSize":                p.ViewportSize,
 		"waitForEvent":                p.WaitForEvent,
 		"waitForFunction": func(pageFunc, opts goja.Value, args ...goja.Value) *goja.Promise {
-			return k6ext.Promise(ctx, func() (result any, reason error) {
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
 				return p.WaitForFunction(pageFunc, opts, args...) //nolint:wrapcheck
 			})
 		},
 		"waitForLoadState": p.WaitForLoadState,
 		"waitForNavigation": func(opts goja.Value) *goja.Promise {
-			return k6ext.Promise(ctx, func() (result any, reason error) {
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
 				resp, err := p.WaitForNavigation(opts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
-				return mapResponse(ctx, vu, resp), nil
+				return mapResponse(vu, resp), nil
 			})
 		},
 		"waitForRequest":  p.WaitForRequest,
@@ -499,7 +508,7 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 		"workers": func() *goja.Object {
 			var mws []mapping
 			for _, w := range p.Workers() {
-				mw := mapWorker(ctx, vu, w)
+				mw := mapWorker(vu, w)
 				mws = append(mws, mw)
 			}
 			return rt.ToValue(mws).ToObject(rt)
@@ -507,7 +516,7 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 	}
 	maps["$"] = func(selector string) *goja.Object {
 		eh := p.Query(selector)
-		ehm := mapElementHandle(ctx, vu, eh)
+		ehm := mapElementHandle(vu, eh)
 		return rt.ToValue(ehm).ToObject(rt)
 	}
 	maps["$$"] = func(selector string) *goja.Object {
@@ -516,7 +525,7 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 			ehs  = p.QueryAll(selector)
 		)
 		for _, eh := range ehs {
-			ehm := mapElementHandle(ctx, vu, eh)
+			ehm := mapElementHandle(vu, eh)
 			mehs = append(mehs, ehm)
 		}
 		return rt.ToValue(mehs).ToObject(rt)
@@ -526,13 +535,13 @@ func mapPage(ctx context.Context, vu k6modules.VU, p api.Page) mapping {
 }
 
 // mapWorker to the JS module.
-func mapWorker(ctx context.Context, vu k6modules.VU, w api.Worker) mapping {
+func mapWorker(vu moduleVU, w api.Worker) mapping {
 	rt := vu.Runtime()
 	return mapping{
 		"evaluate": w.Evaluate,
 		"evaluateHandle": func(pageFunc goja.Value, args ...goja.Value) *goja.Object {
 			h := w.EvaluateHandle(pageFunc, args...)
-			m := mapJSHandle(ctx, vu, h)
+			m := mapJSHandle(vu, h)
 			return rt.ToValue(m).ToObject(rt)
 		},
 		"url": w.URL(),
@@ -540,7 +549,7 @@ func mapWorker(ctx context.Context, vu k6modules.VU, w api.Worker) mapping {
 }
 
 // mapBrowserContext to the JS module.
-func mapBrowserContext(ctx context.Context, vu k6modules.VU, bc api.BrowserContext) mapping {
+func mapBrowserContext(vu moduleVU, bc api.BrowserContext) mapping {
 	rt := vu.Runtime()
 	return mapping{
 		"addCookies":                  bc.AddCookies,
@@ -573,7 +582,7 @@ func mapBrowserContext(ctx context.Context, vu k6modules.VU, bc api.BrowserConte
 				if page == nil {
 					continue
 				}
-				m := mapPage(ctx, vu, page)
+				m := mapPage(vu, page)
 				mpages = append(mpages, m)
 			}
 
@@ -581,21 +590,21 @@ func mapBrowserContext(ctx context.Context, vu k6modules.VU, bc api.BrowserConte
 		},
 		"newPage": func() *goja.Object {
 			page := bc.NewPage()
-			m := mapPage(ctx, vu, page)
+			m := mapPage(vu, page)
 			return rt.ToValue(m).ToObject(rt)
 		},
 	}
 }
 
 // mapBrowser to the JS module.
-func mapBrowser(ctx context.Context, vu k6modules.VU, b api.Browser) mapping {
+func mapBrowser(vu moduleVU, b api.Browser) mapping {
 	rt := vu.Runtime()
 	return mapping{
 		"close":       b.Close,
 		"contexts":    b.Contexts,
 		"isConnected": b.IsConnected,
 		"on": func(event string) *goja.Promise {
-			return k6ext.Promise(ctx, func() (result any, reason error) {
+			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
 				return b.On(event) //nolint:wrapcheck
 			})
 		},
@@ -603,19 +612,19 @@ func mapBrowser(ctx context.Context, vu k6modules.VU, b api.Browser) mapping {
 		"version":   b.Version,
 		"newContext": func(opts goja.Value) *goja.Object {
 			bctx := b.NewContext(opts)
-			m := mapBrowserContext(ctx, vu, bctx)
+			m := mapBrowserContext(vu, bctx)
 			return rt.ToValue(m).ToObject(rt)
 		},
 		"newPage": func(opts goja.Value) *goja.Object {
 			page := b.NewPage(opts)
-			m := mapPage(ctx, vu, page)
+			m := mapPage(vu, page)
 			return rt.ToValue(m).ToObject(rt)
 		},
 	}
 }
 
 // mapBrowserType to the JS module.
-func mapBrowserType(ctx context.Context, vu k6modules.VU, bt api.BrowserType) mapping {
+func mapBrowserType(vu moduleVU, bt api.BrowserType) mapping {
 	rt := vu.Runtime()
 	return mapping{
 		"connect":                 bt.Connect,
@@ -623,7 +632,7 @@ func mapBrowserType(ctx context.Context, vu k6modules.VU, bt api.BrowserType) ma
 		"launchPersistentContext": bt.LaunchPersistentContext,
 		"name":                    bt.Name,
 		"launch": func(opts goja.Value) *goja.Object {
-			m := mapBrowser(ctx, vu, bt.Launch(opts))
+			m := mapBrowser(vu, bt.Launch(opts))
 			return rt.ToValue(m).ToObject(rt)
 		},
 	}

--- a/vendor/github.com/grafana/xk6-browser/browser/module.go
+++ b/vendor/github.com/grafana/xk6-browser/browser/module.go
@@ -5,7 +5,6 @@ import (
 	"github.com/dop251/goja"
 
 	"github.com/grafana/xk6-browser/common"
-	"github.com/grafana/xk6-browser/k6ext"
 
 	k6modules "go.k6.io/k6/js/modules"
 )
@@ -43,13 +42,9 @@ func New() *RootModule {
 // NewModuleInstance implements the k6modules.Module interface to return
 // a new instance for each VU.
 func (*RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
-	// promises and inner objects need the VU object to be
-	// able to use k6-core specific functionality.
-	ctx := k6ext.WithVU(vu.Context(), vu)
-
 	return &ModuleInstance{
 		mod: &JSModule{
-			Chromium: mapBrowserToGoja(ctx, vu),
+			Chromium: mapBrowserToGoja(moduleVU{vu}),
 			Devices:  common.GetDevices(),
 			Version:  version,
 		},

--- a/vendor/github.com/grafana/xk6-browser/chromium/browser_type.go
+++ b/vendor/github.com/grafana/xk6-browser/chromium/browser_type.go
@@ -63,10 +63,9 @@ func NewBrowserType(vu k6modules.VU) api.BrowserType {
 }
 
 // Connect attaches k6 browser to an existing browser instance.
-func (b *BrowserType) Connect(opts goja.Value) *goja.Promise {
+func (b *BrowserType) Connect(opts goja.Value) {
 	rt := b.vu.Runtime()
 	k6common.Throw(rt, errors.New("BrowserType.connect() has not been implemented yet"))
-	return nil
 }
 
 // ExecutablePath returns the path where the extension expects to find the browser executable.
@@ -205,7 +204,7 @@ func (b *BrowserType) launch(ctx context.Context, opts *common.LaunchOptions) (*
 }
 
 // LaunchPersistentContext launches the browser with persistent storage.
-func (b *BrowserType) LaunchPersistentContext(userDataDir string, opts goja.Value) *goja.Promise {
+func (b *BrowserType) LaunchPersistentContext(userDataDir string, opts goja.Value) api.Browser {
 	rt := b.vu.Runtime()
 	k6common.Throw(rt, errors.New("BrowserType.LaunchPersistentContext(userDataDir, opts) has not been implemented yet"))
 	return nil

--- a/vendor/github.com/grafana/xk6-browser/common/browser.go
+++ b/vendor/github.com/grafana/xk6-browser/common/browser.go
@@ -28,7 +28,6 @@ var _ api.Browser = &Browser{}
 
 const (
 	BrowserStateOpen int64 = iota
-	BrowserStateClosing
 	BrowserStateClosed
 )
 
@@ -399,12 +398,6 @@ func (b *Browser) Close() {
 	}()
 
 	b.logger.Debugf("Browser:Close", "")
-	if !atomic.CompareAndSwapInt64(&b.state, b.state, BrowserStateClosing) {
-		// If we're already in a closing state then no need to continue.
-		b.logger.Debugf("Browser:Close", "already in a closing state")
-		return
-	}
-
 	atomic.CompareAndSwapInt64(&b.state, b.state, BrowserStateClosed)
 
 	// Signal to the connection and the process that we're gracefully closing.

--- a/vendor/github.com/grafana/xk6-browser/common/browser_context.go
+++ b/vendor/github.com/grafana/xk6-browser/common/browser_context.go
@@ -64,9 +64,8 @@ func NewBrowserContext(
 }
 
 // AddCookies is not implemented.
-func (b *BrowserContext) AddCookies(cookies goja.Value) *goja.Promise {
+func (b *BrowserContext) AddCookies(cookies goja.Value) {
 	k6ext.Panic(b.ctx, "BrowserContext.addCookies(cookies) has not been implemented yet")
-	return nil
 }
 
 // AddInitScript adds a script that will be initialized on all new pages.
@@ -143,21 +142,19 @@ func (b *BrowserContext) Close() {
 }
 
 // Cookies is not implemented.
-func (b *BrowserContext) Cookies() *goja.Promise {
+func (b *BrowserContext) Cookies() []any {
 	k6ext.Panic(b.ctx, "BrowserContext.cookies() has not been implemented yet")
 	return nil
 }
 
 // ExposeBinding is not implemented.
-func (b *BrowserContext) ExposeBinding(name string, callback goja.Callable, opts goja.Value) *goja.Promise {
+func (b *BrowserContext) ExposeBinding(name string, callback goja.Callable, opts goja.Value) {
 	k6ext.Panic(b.ctx, "BrowserContext.exposeBinding(name, callback, opts) has not been implemented yet")
-	return nil
 }
 
 // ExposeFunction is not implemented.
-func (b *BrowserContext) ExposeFunction(name string, callback goja.Callable) *goja.Promise {
+func (b *BrowserContext) ExposeFunction(name string, callback goja.Callable) {
 	k6ext.Panic(b.ctx, "BrowserContext.exposeFunction(name, callback) has not been implemented yet")
-	return nil
 }
 
 // GrantPermissions enables the specified permissions, all others will be disabled.
@@ -206,7 +203,7 @@ func (b *BrowserContext) GrantPermissions(permissions []string, opts goja.Value)
 }
 
 // NewCDPSession returns a new CDP session attached to this target.
-func (b *BrowserContext) NewCDPSession() *goja.Promise {
+func (b *BrowserContext) NewCDPSession() api.CDPSession {
 	k6ext.Panic(b.ctx, "BrowserContext.newCDPSession() has not been implemented yet")
 	return nil
 }
@@ -245,9 +242,8 @@ func (b *BrowserContext) Pages() []api.Page {
 }
 
 // Route is not implemented.
-func (b *BrowserContext) Route(url goja.Value, handler goja.Callable) *goja.Promise {
+func (b *BrowserContext) Route(url goja.Value, handler goja.Callable) {
 	k6ext.Panic(b.ctx, "BrowserContext.route(url, handler) has not been implemented yet")
-	return nil
 }
 
 // SetDefaultNavigationTimeout sets the default navigation timeout in milliseconds.
@@ -265,9 +261,8 @@ func (b *BrowserContext) SetDefaultTimeout(timeout int64) {
 }
 
 // SetExtraHTTPHeaders is not implemented.
-func (b *BrowserContext) SetExtraHTTPHeaders(headers map[string]string) *goja.Promise {
+func (b *BrowserContext) SetExtraHTTPHeaders(headers map[string]string) {
 	k6ext.Panic(b.ctx, "BrowserContext.setExtraHTTPHeaders(headers) has not been implemented yet")
-	return nil
 }
 
 // SetGeolocation overrides the geo location of the user.
@@ -320,15 +315,13 @@ func (b *BrowserContext) SetOffline(offline bool) {
 }
 
 // StorageState is not implemented.
-func (b *BrowserContext) StorageState(opts goja.Value) *goja.Promise {
+func (b *BrowserContext) StorageState(opts goja.Value) {
 	k6ext.Panic(b.ctx, "BrowserContext.storageState(opts) has not been implemented yet")
-	return nil
 }
 
 // Unroute is not implemented.
-func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) *goja.Promise {
+func (b *BrowserContext) Unroute(url goja.Value, handler goja.Callable) {
 	k6ext.Panic(b.ctx, "BrowserContext.unroute(url, handler) has not been implemented yet")
-	return nil
 }
 
 // WaitForEvent waits for event.

--- a/vendor/github.com/grafana/xk6-browser/common/element_handle.go
+++ b/vendor/github.com/grafana/xk6-browser/common/element_handle.go
@@ -1233,10 +1233,9 @@ func (h *ElementHandle) SelectText(opts goja.Value) {
 }
 
 // SetInputFiles is not implemented.
-func (h *ElementHandle) SetInputFiles(files goja.Value, opts goja.Value) *goja.Promise {
+func (h *ElementHandle) SetInputFiles(files goja.Value, opts goja.Value) {
 	// TODO: implement
 	k6ext.Panic(h.ctx, "ElementHandle.setInputFiles() has not been implemented yet")
-	return nil
 }
 
 func (h *ElementHandle) Tap(opts goja.Value) {

--- a/vendor/github.com/grafana/xk6-browser/common/frame.go
+++ b/vendor/github.com/grafana/xk6-browser/common/frame.go
@@ -486,17 +486,15 @@ func (f *Frame) waitForSelector(selector string, opts *FrameWaitForSelectorOptio
 }
 
 // AddScriptTag is not implemented.
-func (f *Frame) AddScriptTag(opts goja.Value) *goja.Promise {
+func (f *Frame) AddScriptTag(opts goja.Value) {
 	k6ext.Panic(f.ctx, "Frame.AddScriptTag() has not been implemented yet")
 	applySlowMo(f.ctx)
-	return nil
 }
 
 // AddStyleTag is not implemented.
-func (f *Frame) AddStyleTag(opts goja.Value) *goja.Promise {
+func (f *Frame) AddStyleTag(opts goja.Value) {
 	k6ext.Panic(f.ctx, "Frame.AddStyleTag() has not been implemented yet")
 	applySlowMo(f.ctx)
-	return nil
 }
 
 // ChildFrames returns a list of child frames.
@@ -1460,9 +1458,8 @@ func (f *Frame) SetContent(html string, opts goja.Value) {
 }
 
 // SetInputFiles is not implemented.
-func (f *Frame) SetInputFiles(selector string, files goja.Value, opts goja.Value) *goja.Promise {
+func (f *Frame) SetInputFiles(selector string, files goja.Value, opts goja.Value) {
 	k6ext.Panic(f.ctx, "Frame.setInputFiles(selector, files, opts) has not been implemented yet")
-	return nil
 	// TODO: needs slowMo
 }
 
@@ -1537,11 +1534,12 @@ func (f *Frame) textContent(selector string, opts *FrameTextContentOptions) (str
 	return gv.String(), nil
 }
 
+// Title returns the title of the frame.
 func (f *Frame) Title() string {
 	f.log.Debugf("Frame:Title", "fid:%s furl:%q", f.ID(), f.URL())
 
-	rt := f.vu.Runtime()
-	return f.Evaluate(rt.ToValue("document.title")).(string)
+	v := f.vu.Runtime().ToValue(`() => document.title`)
+	return gojaValueToString(f.ctx, f.Evaluate(v))
 }
 
 // Type text on the first element found matches the selector.

--- a/vendor/github.com/grafana/xk6-browser/common/page.go
+++ b/vendor/github.com/grafana/xk6-browser/common/page.go
@@ -23,16 +23,18 @@ import (
 )
 
 // Ensure page implements the EventEmitter, Target and Page interfaces.
-var _ EventEmitter = &Page{}
-var _ api.Page = &Page{}
+var (
+	_ EventEmitter = &Page{}
+	_ api.Page     = &Page{}
+)
 
 // Page stores Page/tab related context.
 type Page struct {
 	BaseEventEmitter
 
-	Keyboard    *Keyboard    `js:"keyboard"`    // Public JS API
-	Mouse       *Mouse       `js:"mouse"`       // Public JS API
-	Touchscreen *Touchscreen `js:"touchscreen"` // Public JS API
+	Keyboard    *Keyboard
+	Mouse       *Mouse
+	Touchscreen *Touchscreen
 
 	ctx context.Context
 
@@ -345,21 +347,18 @@ func (p *Page) viewportSize() Size {
 }
 
 // AddInitScript adds script to run in all new frames.
-func (p *Page) AddInitScript(script goja.Value, arg goja.Value) *goja.Promise {
+func (p *Page) AddInitScript(script goja.Value, arg goja.Value) {
 	k6ext.Panic(p.ctx, "Page.addInitScript(script, arg) has not been implemented yet")
-	return nil
 }
 
 // AddScriptTag is not implemented.
-func (p *Page) AddScriptTag(opts goja.Value) *goja.Promise {
+func (p *Page) AddScriptTag(opts goja.Value) {
 	k6ext.Panic(p.ctx, "Page.addScriptTag(opts) has not been implemented yet")
-	return nil
 }
 
 // AddStyleTag is not implemented.
-func (p *Page) AddStyleTag(opts goja.Value) *goja.Promise {
+func (p *Page) AddStyleTag(opts goja.Value) {
 	k6ext.Panic(p.ctx, "Page.addStyleTag(opts) has not been implemented yet")
-	return nil
 }
 
 // BringToFront activates the browser tab for this page.
@@ -434,9 +433,8 @@ func (p *Page) DispatchEvent(selector string, typ string, eventInit goja.Value, 
 }
 
 // DragAndDrop is not implemented.
-func (p *Page) DragAndDrop(source string, target string, opts goja.Value) *goja.Promise {
+func (p *Page) DragAndDrop(source string, target string, opts goja.Value) {
 	k6ext.Panic(p.ctx, "Page.DragAndDrop(source, target, opts) has not been implemented yet")
-	return nil
 }
 
 func (p *Page) EmulateMedia(opts goja.Value) {
@@ -499,15 +497,13 @@ func (p *Page) EvaluateHandle(pageFunc goja.Value, args ...goja.Value) api.JSHan
 }
 
 // ExposeBinding is not implemented.
-func (p *Page) ExposeBinding(name string, callback goja.Callable, opts goja.Value) *goja.Promise {
+func (p *Page) ExposeBinding(name string, callback goja.Callable, opts goja.Value) {
 	k6ext.Panic(p.ctx, "Page.exposeBinding(name, callback) has not been implemented yet")
-	return nil
 }
 
 // ExposeFunction is not implemented.
-func (p *Page) ExposeFunction(name string, callback goja.Callable) *goja.Promise {
+func (p *Page) ExposeFunction(name string, callback goja.Callable) {
 	k6ext.Panic(p.ctx, "Page.exposeFunction(name, callback) has not been implemented yet")
-	return nil
 }
 
 func (p *Page) Fill(selector string, value string, opts goja.Value) {
@@ -523,7 +519,7 @@ func (p *Page) Focus(selector string, opts goja.Value) {
 }
 
 // Frame is not implemented.
-func (p *Page) Frame(frameSelector goja.Value) *goja.Promise {
+func (p *Page) Frame(frameSelector goja.Value) api.Frame {
 	k6ext.Panic(p.ctx, "Page.frame(frameSelector) has not been implemented yet")
 	return nil
 }
@@ -540,14 +536,29 @@ func (p *Page) GetAttribute(selector string, name string, opts goja.Value) goja.
 	return p.MainFrame().GetAttribute(selector, name, opts)
 }
 
+// GetKeyboard returns the keyboard for the page.
+func (p *Page) GetKeyboard() api.Keyboard {
+	return p.Keyboard
+}
+
+// GetMouse returns the mouse for the page.
+func (p *Page) GetMouse() api.Mouse {
+	return p.Mouse
+}
+
+// GetTouchscreen returns the touchscreen for the page.
+func (p *Page) GetTouchscreen() api.Touchscreen {
+	return p.Touchscreen
+}
+
 // GoBack is not implemented.
-func (p *Page) GoBack(opts goja.Value) *goja.Promise {
+func (p *Page) GoBack(opts goja.Value) api.Response {
 	k6ext.Panic(p.ctx, "Page.goBack(opts) has not been implemented yet")
 	return nil
 }
 
 // GoForward is not implemented.
-func (p *Page) GoForward(opts goja.Value) *goja.Promise {
+func (p *Page) GoForward(opts goja.Value) api.Response {
 	k6ext.Panic(p.ctx, "Page.goForward(opts) has not been implemented yet")
 	return nil
 }
@@ -648,13 +659,12 @@ func (p *Page) Opener() api.Page {
 }
 
 // Pause is not implemented.
-func (p *Page) Pause() *goja.Promise {
+func (p *Page) Pause() {
 	k6ext.Panic(p.ctx, "Page.pause() has not been implemented yet")
-	return nil
 }
 
 // Pdf is not implemented.
-func (p *Page) Pdf(opts goja.Value) *goja.Promise {
+func (p *Page) Pdf(opts goja.Value) []byte {
 	k6ext.Panic(p.ctx, "Page.pdf(opts) has not been implemented yet")
 	return nil
 }
@@ -754,9 +764,8 @@ func (p *Page) Reload(opts goja.Value) api.Response {
 }
 
 // Route is not implemented.
-func (p *Page) Route(url goja.Value, handler goja.Callable) *goja.Promise {
+func (p *Page) Route(url goja.Value, handler goja.Callable) {
 	k6ext.Panic(p.ctx, "Page.route(url, handler) has not been implemented yet")
-	return nil
 }
 
 // Screenshot will instruct Chrome to save a screenshot of the current page and save it to specified file.
@@ -809,9 +818,8 @@ func (p *Page) SetExtraHTTPHeaders(headers map[string]string) {
 }
 
 // SetInputFiles is not implemented.
-func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value) *goja.Promise {
+func (p *Page) SetInputFiles(selector string, files goja.Value, opts goja.Value) {
 	k6ext.Panic(p.ctx, "Page.textContent(selector, opts) has not been implemented yet")
-	return nil
 	// TODO: needs slowMo
 }
 
@@ -855,19 +863,20 @@ func (p *Page) Type(selector string, text string, opts goja.Value) {
 }
 
 // Unroute is not implemented.
-func (p *Page) Unroute(url goja.Value, handler goja.Callable) *goja.Promise {
+func (p *Page) Unroute(url goja.Value, handler goja.Callable) {
 	k6ext.Panic(p.ctx, "Page.unroute(url, handler) has not been implemented yet")
-	return nil
 }
 
 // URL returns the location of the page.
 func (p *Page) URL() string {
-	rt := p.vu.Runtime()
-	return p.Evaluate(rt.ToValue("document.location.toString()")).(string)
+	p.logger.Debugf("Page:URL", "sid:%v", p.sessionID())
+
+	v := p.vu.Runtime().ToValue(`() => document.location.toString()`)
+	return gojaValueToString(p.ctx, p.Evaluate(v))
 }
 
 // Video returns information of recorded video.
-func (p *Page) Video() *goja.Promise {
+func (p *Page) Video() api.Video {
 	k6ext.Panic(p.ctx, "Page.video() has not been implemented yet")
 	return nil
 }
@@ -884,7 +893,7 @@ func (p *Page) ViewportSize() map[string]float64 {
 }
 
 // WaitForEvent waits for the specified event to trigger.
-func (p *Page) WaitForEvent(event string, optsOrPredicate goja.Value) *goja.Promise {
+func (p *Page) WaitForEvent(event string, optsOrPredicate goja.Value) any {
 	k6ext.Panic(p.ctx, "Page.waitForEvent(event, optsOrPredicate) has not been implemented yet")
 	return nil
 }
@@ -911,13 +920,13 @@ func (p *Page) WaitForNavigation(opts goja.Value) (api.Response, error) {
 }
 
 // WaitForRequest is not implemented.
-func (p *Page) WaitForRequest(urlOrPredicate, opts goja.Value) *goja.Promise {
+func (p *Page) WaitForRequest(urlOrPredicate, opts goja.Value) api.Request {
 	k6ext.Panic(p.ctx, "Page.waitForRequest(urlOrPredicate, opts) has not been implemented yet")
 	return nil
 }
 
 // WaitForResponse is not implemented.
-func (p *Page) WaitForResponse(urlOrPredicate, opts goja.Value) *goja.Promise {
+func (p *Page) WaitForResponse(urlOrPredicate, opts goja.Value) api.Response {
 	k6ext.Panic(p.ctx, "Page.waitForResponse(urlOrPredicate, opts) has not been implemented yet")
 	return nil
 }

--- a/vendor/github.com/grafana/xk6-browser/common/response.go
+++ b/vendor/github.com/grafana/xk6-browser/common/response.go
@@ -189,10 +189,10 @@ func (r *Response) bodySize() int64 {
 }
 
 // Finished waits for response to finish, return error if request failed.
-func (r *Response) Finished() *goja.Promise {
+func (r *Response) Finished() bool {
 	// TODO: should return nil|Error
 	k6ext.Panic(r.ctx, "Response.finished() has not been implemented yet")
-	return nil
+	return false
 }
 
 // Frame returns the frame within which the response was received.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -131,7 +131,7 @@ github.com/golang/snappy
 # github.com/gorilla/websocket v1.5.0
 ## explicit; go 1.12
 github.com/gorilla/websocket
-# github.com/grafana/xk6-browser v0.8.1-0.20230131153655-c347eae1e46a
+# github.com/grafana/xk6-browser v0.8.1-0.20230207135343-cfd6a83dfc42
 ## explicit; go 1.19
 github.com/grafana/xk6-browser/api
 github.com/grafana/xk6-browser/browser


### PR DESCRIPTION
This is a hot-fix update for xk6-browser. We noticed some of our APIs might not work as expected and fixed the issues.

Details:
- https://github.com/grafana/xk6-browser/issues/749
- https://github.com/grafana/xk6-browser/pull/754
- https://github.com/grafana/xk6-browser/pull/758
- https://github.com/grafana/xk6-browser/pull/761
- https://github.com/grafana/xk6-browser/pull/746

Question:
- Should this fix be in a k6 hotfix release after releasing k6 v0.43.0?