### PR TITLE
Show actual binary name in the usage help (#2850)

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -1,9 +1,6 @@
 package cmd
 
 import (
-	"bytes"
-	"text/template"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -77,17 +74,12 @@ func getCmdArchive(gs *state.GlobalState) *cobra.Command {
 		archiveOut: "archive.tar",
 	}
 
-	var exampleText bytes.Buffer
-	exampleTemplate := template.Must(template.New("").Parse(`
+	exampleText := getExampleText(gs, `
   # Archive a test run.
   {{.}} archive -u 10 -d 10s -O myarchive.tar script.js
   
   # Run the resulting archive.
-  {{.}} run myarchive.tar`[1:]))
-
-	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
-		gs.Logger.WithError(err).Error("Error during help example generation")
-	}
+  {{.}} run myarchive.tar`[1:])
 
 	archiveCmd := &cobra.Command{
 		Use:   "archive",
@@ -95,7 +87,7 @@ func getCmdArchive(gs *state.GlobalState) *cobra.Command {
 		Long: `Create an archive.
 
 An archive is a fully self-contained test run, and can be executed identically elsewhere.`,
-		Example: exampleText.String(),
+		Example: exampleText,
 		Args:    cobra.ExactArgs(1),
 		RunE:    c.run,
 	}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
-	"text/template"
 	"time"
 
 	"github.com/fatih/color"
@@ -328,13 +327,8 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 		exitOnRunning: false,
 	}
 
-	var exampleText bytes.Buffer
-	exampleTemplate := template.Must(template.New("").Parse(`
-  {{.}} cloud script.js`[1:]))
-
-	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
-		gs.Logger.WithError(err).Error("Error during help example generation")
-	}
+	exampleText := getExampleText(gs, `
+  {{.}} cloud script.js`[1:])
 
 	cloudCmd := &cobra.Command{
 		Use:   "cloud",
@@ -342,7 +336,7 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 		Long: `Run a test on the cloud.
 
 This will execute the test on the k6 cloud service. Use "k6 login cloud" to authenticate.`,
-		Example: exampleText.String(),
+		Example: exampleText,
 		Args:    exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
 		PreRunE: c.preRun,
 		RunE:    c.run,

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/fatih/color"
@@ -327,14 +328,21 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 		exitOnRunning: false,
 	}
 
+	var exampleText bytes.Buffer
+	exampleTemplate := template.Must(template.New("").Parse(`
+  {{.}} cloud script.js`[1:]))
+
+	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
+		gs.Logger.WithError(err).Error("Error during help example generation")
+	}
+
 	cloudCmd := &cobra.Command{
 		Use:   "cloud",
 		Short: "Run a test on the cloud",
 		Long: `Run a test on the cloud.
 
 This will execute the test on the k6 cloud service. Use "k6 login cloud" to authenticate.`,
-		Example: `
-        k6 cloud script.js`[1:],
+		Example: exampleText.String(),
 		Args:    exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
 		PreRunE: c.preRun,
 		RunE:    c.run,

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"syscall"
+	"text/template"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -70,6 +72,17 @@ func printToStdout(gs *state.GlobalState, s string) {
 	if _, err := fmt.Fprint(gs.Stdout, s); err != nil {
 		gs.Logger.Errorf("could not print '%s' to stdout: %s", s, err.Error())
 	}
+}
+
+func getExampleText(gs *state.GlobalState, tpl string) string {
+	var exampleText bytes.Buffer
+	exampleTemplate := template.Must(template.New("").Parse(tpl))
+
+	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
+		gs.Logger.WithError(err).Error("Error during help example generation")
+	}
+
+	return exampleText.String()
 }
 
 // Trap Interrupts, SIGINTs and SIGTERMs and call the given.

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"bytes"
 	"encoding/json"
-	"html/template"
 	"io"
 
 	"github.com/spf13/afero"
@@ -33,8 +31,7 @@ func getCmdConvert(gs *state.GlobalState) *cobra.Command {
 		skip                []string
 	)
 
-	var exampleText bytes.Buffer
-	exampleTemplate := template.Must(template.New("").Parse(`
+	exampleText := getExampleText(gs, `
   # Convert a HAR file to a k6 script.
   {{.}} convert -O har-session.js session.har
   
@@ -45,18 +42,14 @@ func getCmdConvert(gs *state.GlobalState) *cobra.Command {
   {{.}} convert --batch-threshold 800 session.har
   
   # Run the k6 script.
-  {{.}} run har-session.js`[1:]))
-
-	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
-		gs.Logger.WithError(err).Error("Error during help example generation")
-	}
+  {{.}} run har-session.js`[1:])
 
 	convertCmd := &cobra.Command{
 		Use:        "convert",
 		Short:      "Convert a HAR file to a k6 script",
 		Long:       "Convert a HAR (HTTP Archive) file to a k6 script",
 		Deprecated: "please use har-to-k6 (https://github.com/grafana/har-to-k6) instead.",
-		Example:    exampleText.String(),
+		Example:    exampleText,
 		Args:       cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Parse the HAR file

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
+	"html/template"
 	"io"
 
 	"github.com/spf13/afero"
@@ -14,6 +16,7 @@ import (
 )
 
 // TODO: split apart like `k6 run` and `k6 archive`?
+//
 //nolint:funlen,gocognit
 func getCmdConvert(gs *state.GlobalState) *cobra.Command {
 	var (
@@ -29,24 +32,32 @@ func getCmdConvert(gs *state.GlobalState) *cobra.Command {
 		only                []string
 		skip                []string
 	)
+
+	var exampleText bytes.Buffer
+	exampleTemplate := template.Must(template.New("").Parse(`
+  # Convert a HAR file to a k6 script.
+  {{.}} convert -O har-session.js session.har
+  
+  # Convert a HAR file to a k6 script creating requests only for the given domain/s.
+  {{.}} convert -O har-session.js --only yourdomain.com,additionaldomain.com session.har
+  
+  # Convert a HAR file. Batching requests together as long as idle time between requests <800ms
+  {{.}} convert --batch-threshold 800 session.har
+  
+  # Run the k6 script.
+  {{.}} run har-session.js`[1:]))
+
+	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
+		gs.Logger.WithError(err).Error("Error during help example generation")
+	}
+
 	convertCmd := &cobra.Command{
 		Use:        "convert",
 		Short:      "Convert a HAR file to a k6 script",
 		Long:       "Convert a HAR (HTTP Archive) file to a k6 script",
 		Deprecated: "please use har-to-k6 (https://github.com/grafana/har-to-k6) instead.",
-		Example: `
-  # Convert a HAR file to a k6 script.
-  k6 convert -O har-session.js session.har
-
-  # Convert a HAR file to a k6 script creating requests only for the given domain/s.
-  k6 convert -O har-session.js --only yourdomain.com,additionaldomain.com session.har
-
-  # Convert a HAR file. Batching requests together as long as idle time between requests <800ms
-  k6 convert --batch-threshold 800 session.har
-
-  # Run the k6 script.
-  k6 run har-session.js`[1:],
-		Args: cobra.ExactArgs(1),
+		Example:    exampleText.String(),
+		Args:       cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// Parse the HAR file
 			r, err := gs.FS.Open(args[0])

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"syscall"
+	"text/template"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -20,22 +22,29 @@ import (
 //nolint:funlen,gocognit
 func getCmdLoginCloud(gs *state.GlobalState) *cobra.Command {
 	// loginCloudCommand represents the 'login cloud' command
+	var exampleText bytes.Buffer
+	exampleTemplate := template.Must(template.New("").Parse(`
+  # Show the stored token.
+  {{.}} login cloud -s
+  
+  # Store a token.
+  {{.}} login cloud -t YOUR_TOKEN
+  
+  # Log in with an email/password.
+  {{.}} login cloud`[1:]))
+
+	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
+		gs.Logger.WithError(err).Error("Error during help example generation")
+	}
+
 	loginCloudCommand := &cobra.Command{
 		Use:   "cloud",
 		Short: "Authenticate with Load Impact",
 		Long: `Authenticate with Load Impact.
 
 This will set the default token used when just "k6 run -o cloud" is passed.`,
-		Example: `
-  # Show the stored token.
-  k6 login cloud -s
-
-  # Store a token.
-  k6 login cloud -t YOUR_TOKEN
-
-  # Log in with an email/password.
-  k6 login cloud`[1:],
-		Args: cobra.NoArgs,
+		Example: exampleText.String(),
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			currentDiskConf, err := readDiskConfig(gs)
 			if err != nil {

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -1,12 +1,10 @@
 package cmd
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"syscall"
-	"text/template"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -22,8 +20,7 @@ import (
 //nolint:funlen,gocognit
 func getCmdLoginCloud(gs *state.GlobalState) *cobra.Command {
 	// loginCloudCommand represents the 'login cloud' command
-	var exampleText bytes.Buffer
-	exampleTemplate := template.Must(template.New("").Parse(`
+	exampleText := getExampleText(gs, `
   # Show the stored token.
   {{.}} login cloud -s
   
@@ -31,11 +28,7 @@ func getCmdLoginCloud(gs *state.GlobalState) *cobra.Command {
   {{.}} login cloud -t YOUR_TOKEN
   
   # Log in with an email/password.
-  {{.}} login cloud`[1:]))
-
-	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
-		gs.Logger.WithError(err).Error("Error during help example generation")
-	}
+  {{.}} login cloud`[1:])
 
 	loginCloudCommand := &cobra.Command{
 		Use:   "cloud",
@@ -43,7 +36,7 @@ func getCmdLoginCloud(gs *state.GlobalState) *cobra.Command {
 		Long: `Authenticate with Load Impact.
 
 This will set the default token used when just "k6 run -o cloud" is passed.`,
-		Example: exampleText.String(),
+		Example: exampleText,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			currentDiskConf, err := readDiskConfig(gs)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,7 +37,7 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 	}
 	// the base command when called without any subcommands.
 	rootCmd := &cobra.Command{
-		Use:               "k6",
+		Use:               gs.BinaryName,
 		Short:             "a next-generation load generator",
 		Long:              "\n" + getBanner(gs.Flags.NoColor || !gs.Stdout.IsTTY),
 		SilenceUsage:      true,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -12,7 +12,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"text/template"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -357,8 +356,7 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
 		gs: gs,
 	}
 
-	var exampleText bytes.Buffer
-	exampleTemplate := template.Must(template.New("").Parse(`
+	exampleText := getExampleText(gs, `
   # Run a single VU, once.
   {{.}} run script.js
   
@@ -375,11 +373,7 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
   {{.}} run -u 0 -s 10s:100 -s 60s -s 10s:0
   
   # Send metrics to an influxdb server
-  {{.}} run -o influxdb=http://1.2.3.4:8086/k6`[1:]))
-
-	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
-		gs.Logger.WithError(err).Error("Error during help example generation")
-	}
+  {{.}} run -o influxdb=http://1.2.3.4:8086/k6`[1:])
 
 	runCmd := &cobra.Command{
 		Use:   "run",
@@ -388,7 +382,7 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
 
 This also exposes a REST API to interact with it. Various k6 subcommands offer
 a commandline interface for interacting with it.`,
-		Example: exampleText.String(),
+		Example: exampleText,
 		Args:    exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
 		RunE:    c.run,
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"text/template"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -356,6 +357,30 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
 		gs: gs,
 	}
 
+	var exampleText bytes.Buffer
+	exampleTemplate := template.Must(template.New("").Parse(`
+  # Run a single VU, once.
+  {{.}} run script.js
+  
+  # Run a single VU, 10 times.
+  {{.}} run -i 10 script.js
+  
+  # Run 5 VUs, splitting 10 iterations between them.
+  {{.}} run -u 5 -i 10 script.js
+  
+  # Run 5 VUs for 10s.
+  {{.}} run -u 5 -d 10s script.js
+  
+  # Ramp VUs from 0 to 100 over 10s, stay there for 60s, then 10s down to 0.
+  {{.}} run -u 0 -s 10s:100 -s 60s -s 10s:0
+  
+  # Send metrics to an influxdb server
+  {{.}} run -o influxdb=http://1.2.3.4:8086/k6`))
+
+	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
+		gs.Logger.WithError(err).Error("Could not parse binary name")
+	}
+
 	runCmd := &cobra.Command{
 		Use:   "run",
 		Short: "Start a load test",
@@ -363,26 +388,9 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
 
 This also exposes a REST API to interact with it. Various k6 subcommands offer
 a commandline interface for interacting with it.`,
-		Example: `
-  # Run a single VU, once.
-  k6 run script.js
-
-  # Run a single VU, 10 times.
-  k6 run -i 10 script.js
-
-  # Run 5 VUs, splitting 10 iterations between them.
-  k6 run -u 5 -i 10 script.js
-
-  # Run 5 VUs for 10s.
-  k6 run -u 5 -d 10s script.js
-
-  # Ramp VUs from 0 to 100 over 10s, stay there for 60s, then 10s down to 0.
-  k6 run -u 0 -s 10s:100 -s 60s -s 10s:0
-
-  # Send metrics to an influxdb server
-  k6 run -o influxdb=http://1.2.3.4:8086/k6`[1:],
-		Args: exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
-		RunE: c.run,
+		Example: exampleText.String()[1:],
+		Args:    exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
+		RunE:    c.run,
 	}
 
 	runCmd.Flags().SortFlags = false

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -375,10 +375,10 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
   {{.}} run -u 0 -s 10s:100 -s 60s -s 10s:0
   
   # Send metrics to an influxdb server
-  {{.}} run -o influxdb=http://1.2.3.4:8086/k6`))
+  {{.}} run -o influxdb=http://1.2.3.4:8086/k6`[1:]))
 
 	if err := exampleTemplate.Execute(&exampleText, gs.BinaryName); err != nil {
-		gs.Logger.WithError(err).Error("Could not parse binary name")
+		gs.Logger.WithError(err).Error("Error during help example generation")
 	}
 
 	runCmd := &cobra.Command{
@@ -388,7 +388,7 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
 
 This also exposes a REST API to interact with it. Various k6 subcommands offer
 a commandline interface for interacting with it.`,
-		Example: exampleText.String()[1:],
+		Example: exampleText.String(),
 		Args:    exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
 		RunE:    c.run,
 	}

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -34,10 +34,11 @@ const defaultConfigFileName = "config.json"
 type GlobalState struct {
 	Ctx context.Context
 
-	FS      afero.Fs
-	Getwd   func() (string, error)
-	CmdArgs []string
-	Env     map[string]string
+	FS         afero.Fs
+	Getwd      func() (string, error)
+	BinaryName string
+	CmdArgs    []string
+	Env        map[string]string
 
 	DefaultFlags, Flags GlobalFlags
 
@@ -93,12 +94,18 @@ func NewGlobalState(ctx context.Context) *GlobalState {
 		confDir = ".config"
 	}
 
+	binary, err := os.Executable()
+	if err != nil {
+		binary = "k6"
+	}
+
 	defaultFlags := GetDefaultFlags(confDir)
 
 	return &GlobalState{
 		Ctx:          ctx,
 		FS:           afero.NewOsFs(),
 		Getwd:        os.Getwd,
+		BinaryName:   filepath.Base(binary),
 		CmdArgs:      os.Args,
 		Env:          env,
 		DefaultFlags: defaultFlags,

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -63,6 +63,35 @@ func TestSimpleTestStdin(t *testing.T) {
 	assert.Empty(t, ts.LoggerHook.Drain())
 }
 
+func TestBinaryNameStdout(t *testing.T) {
+	t.Parallel()
+
+	ts := NewGlobalTestState(t)
+	ts.BinaryName = "customBinaryName"
+	ts.CmdArgs = []string{ts.BinaryName}
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	assert.Contains(t, stdout, fmt.Sprintf("%s [command]", ts.BinaryName))
+	assert.Empty(t, ts.Stderr.Bytes())
+	assert.Empty(t, ts.LoggerHook.Drain())
+}
+
+func TestBinaryNameRunHelpStdout(t *testing.T) {
+	t.Parallel()
+
+	ts := NewGlobalTestState(t)
+	ts.BinaryName = "customBinaryName"
+	ts.CmdArgs = []string{ts.BinaryName, "help", "run"}
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	assert.Contains(t, stdout, fmt.Sprintf("%s run [flags]", ts.BinaryName))
+	assert.Contains(t, stdout, fmt.Sprintf("%s run -i 10 script.js", ts.BinaryName))
+	assert.Empty(t, ts.Stderr.Bytes())
+	assert.Empty(t, ts.LoggerHook.Drain())
+}
+
 // TODO: Remove this? It doesn't test anything AFAICT...
 func TestStdoutAndStderrAreEmptyWithQuietAndHandleSummary(t *testing.T) {
 	t.Parallel()

--- a/cmd/tests/test_state.go
+++ b/cmd/tests/test_state.go
@@ -87,6 +87,7 @@ func NewGlobalTestState(t *testing.T) *GlobalTestState {
 		Ctx:          ctx,
 		FS:           fs,
 		Getwd:        func() (string, error) { return ts.Cwd, nil },
+		BinaryName:   "k6",
 		CmdArgs:      []string{},
 		Env:          map[string]string{"K6_NO_USAGE_REPORT": "true"},
 		DefaultFlags: defaultFlags,


### PR DESCRIPTION
This should close #2850 

I have added some e2e tests in the `cmd_run_test` file, although, as discussed earlier in the issue, perhaps it should be moved to another file since the `run` command is not actually being checked.

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
