### PR TITLE
Remove the fixed patch version for Go

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ env:
   LI_DOCKER_IMAGE_ID: "loadimpact/k6"
   DOCKER_IMAGE_ID: "grafana/k6"
   GHCR_IMAGE_ID: ${{ github.repository }}
-  DEFAULT_GO_VERSION: "1.19.3"
+  DEFAULT_GO_VERSION: "1.19.x"
 
 jobs:
   configure:


### PR DESCRIPTION
Removed the old hack added for releasing k6 v0.41.0 with a specific Go version.

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
