### PR TITLE
lint: Use allowed list for linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,36 +50,70 @@ linters-settings:
     statements: 60
 
 linters:
-  enable-all: true
-  disable:
-  - nlreturn
-  - gci
-  - gochecknoinits
-  - godot
-  - godox
-  - gomodguard
-  - testpackage
-  - wsl
-  - gomnd
-  - goerr113 # most of the errors here are meant for humans
-  - goheader
-  - exhaustivestruct
-  - thelper
-  - gocyclo # replaced by cyclop since it also calculates the package complexity
-  - maligned # replaced by govet 'fieldalignment'
-  - interfacer # deprecated
-  - scopelint # deprecated, replaced by exportloopref
-  - wrapcheck # a little bit too much for k6, maybe after https://github.com/tomarrell/wrapcheck/issues/2 is fixed
-  - golint # this linter is deprecated
-  - varnamelen
-  - ireturn
-  - tagliatelle
-  - exhaustruct
-  - execinquery
-  - maintidx
-  - grouper
-  - decorder
-  - nonamedreturns
-  - nosnakecase
-  - containedctx
+  disable-all: true
+  enable:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - contextcheck
+    - cyclop
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - funlen
+    - gochecknoglobals
+    - gocognit
+    - goconst
+    - gocritic
+    - gofmt
+    - gofumpt
+    - goimports
+    - gomoddirectives
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ifshort
+    - importas
+    - ineffassign
+    - lll
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - paralleltest
+    - prealloc
+    - predeclared
+    - promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - tenv
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - wastedassign
+    - whitespace
   fast: false


### PR DESCRIPTION
It is a copy-paste of the enabled linters returned from the `make ci-like-lint` command used with `golangci-lint linters` on the master branch.
 
<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
