### PR TITLE
github: Bump go version for test-current-cov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         platform: [ubuntu-latest, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/js/common/initenv.go
+++ b/js/common/initenv.go
@@ -3,6 +3,7 @@ package common
 import (
 	"net/url"
 	"path/filepath"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
@@ -36,6 +37,9 @@ func (ie *InitEnvironment) GetAbsFilePath(filename string) string {
 	// absolute path.
 	if filename[0] != '/' && filename[0] != '\\' && !filepath.IsAbs(filename) {
 		filename = filepath.Join(ie.CWD.Path, filename)
+	}
+	if strings.HasPrefix(filename, `\\`) {
+		filename = filename[1:]
 	}
 	filename = filepath.Clean(filename)
 	if filename[0:1] != afero.FilePathSeparator {

--- a/lib/archive_test.go
+++ b/lib/archive_test.go
@@ -35,6 +35,8 @@ func TestNormalizeAndAnonymizePath(t *testing.T) {
 		"D:\\Documents and Settings\\myname\\dir\\myfile.txt": "/D/Documents and Settings/nobody/dir/myfile.txt",
 		"C:\\uSers\\myname\\dir\\myfile.txt":                  "/C/uSers/nobody/dir/myfile.txt",
 		"D:\\doCUMENts aND Settings\\myname\\dir\\myfile.txt": "/D/doCUMENts aND Settings/nobody/dir/myfile.txt",
+		"c:\\test":      "/c/test",
+		"/C:/Users/joe": "/C/Users/nobody",
 	}
 	// TODO: fix this - the issue is that filepath.Clean replaces `/` with whatever the path
 	// separator is on the current OS and as such this gets confused for shared folder on
@@ -102,7 +104,7 @@ func diffFilesystemsDir(t *testing.T, first, second afero.Fs, dirname string) {
 
 	require.ElementsMatch(t, getInfoNames(firstInfos), getInfoNames(secondInfos), "directory: "+dirname)
 	for _, info := range firstInfos {
-		path := filepath.Join(dirname, info.Name())
+		path := filepath.Join(dirname, path.Clean("/"+info.Name()))
 		if info.IsDir() {
 			diffFilesystemsDir(t, first, second, path)
 			continue

--- a/lib/fsext/walk.go
+++ b/lib/fsext/walk.go
@@ -2,6 +2,7 @@ package fsext
 
 import (
 	"io/fs"
+	"path"
 	"path/filepath"
 	"sort"
 
@@ -46,8 +47,8 @@ func readDirNames(fs afero.Fs, dirname string) ([]string, error) {
 
 // walk recursively descends path, calling walkFn
 // adapted from https://github.com/spf13/afero/blob/master/path.go#L27
-func walk(fileSystem afero.Fs, path string, info fs.FileInfo, walkFn filepath.WalkFunc) error {
-	err := walkFn(path, info, nil)
+func walk(fileSystem afero.Fs, targetPath string, info fs.FileInfo, walkFn filepath.WalkFunc) error {
+	err := walkFn(targetPath, info, nil)
 	if err != nil {
 		if info.IsDir() && err == filepath.SkipDir {
 			return nil
@@ -59,13 +60,13 @@ func walk(fileSystem afero.Fs, path string, info fs.FileInfo, walkFn filepath.Wa
 		return nil
 	}
 
-	names, err := readDirNames(fileSystem, path)
+	names, err := readDirNames(fileSystem, targetPath)
 	if err != nil {
-		return walkFn(path, info, err)
+		return walkFn(targetPath, info, err)
 	}
 
 	for _, name := range names {
-		filename := filepath.Join(path, name)
+		filename := filepath.Join(targetPath, path.Clean("/"+name))
 		fileInfo, err := fileSystem.Stat(filename)
 		if err != nil {
 			if err = walkFn(filename, fileInfo, err); err != nil && err != filepath.SkipDir {


### PR DESCRIPTION
Unfortunately I missed it during #2920. Fixing.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
