### PR TITLE
Bump golangci version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,8 +42,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          # up this to 1.19.x when we update the version of golangci-lint to latest
-          go-version: 1.18.x
+          go-version: 1.20.x
           check-latest: true
       - name: Retrieve golangci-lint version
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.47.2
+# v1.51.2
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   deadline: 5m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -68,7 +68,6 @@ linters:
     - bodyclose
     - contextcheck
     - cyclop
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -95,7 +94,6 @@ linters:
     - gosec
     - gosimple
     - govet
-    - ifshort
     - importas
     - ineffassign
     - lll
@@ -117,7 +115,6 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - tenv
     - tparallel
@@ -126,7 +123,6 @@ linters:
     - unparam
     - unused
     - usestdlibvars
-    - varcheck
     - wastedassign
     - whitespace
   fast: false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,6 +82,7 @@ linters:
     - forbidigo
     - forcetypeassert
     - funlen
+    - gocheckcompilerdirectives
     - gochecknoglobals
     - gocognit
     - goconst
@@ -112,6 +113,7 @@ linters:
     - predeclared
     - promlinter
     - revive
+    - reassign
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
@@ -123,6 +125,7 @@ linters:
     - unconvert
     - unparam
     - unused
+    - usestdlibvars
     - varcheck
     - wastedassign
     - whitespace

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -56,7 +56,7 @@ func TestPing(t *testing.T) {
 	mux := handlePing(logger)
 
 	rw := httptest.NewRecorder()
-	r := httptest.NewRequest("GET", "/ping", nil)
+	r := httptest.NewRequest(http.MethodGet, "/ping", nil)
 	mux.ServeHTTP(rw, r)
 
 	res := rw.Result()

--- a/cloudapi/api.go
+++ b/cloudapi/api.go
@@ -118,7 +118,7 @@ func (c *Client) StartCloudTestRun(name string, projectID int64, arc *lib.Archiv
 		return nil, err
 	}
 
-	req, err := http.NewRequest("POST", requestUrl, &buf)
+	req, err := http.NewRequest(http.MethodPost, requestUrl, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (c *Client) TestFinished(referenceID string, thresholds ThresholdResult, ta
 
 func (c *Client) GetTestProgress(referenceID string) (*TestProgressResponse, error) {
 	url := fmt.Sprintf("%s/test-progress/%s", c.baseURL, referenceID)
-	req, err := c.NewRequest("GET", url, nil)
+	req, err := c.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cloudapi/api.go
+++ b/cloudapi/api.go
@@ -118,7 +118,7 @@ func (c *Client) StartCloudTestRun(name string, projectID int64, arc *lib.Archiv
 		return nil, err
 	}
 
-	req, err := http.NewRequest(http.MethodPost, requestUrl, &buf)
+	req, err := http.NewRequest(http.MethodPost, requestUrl, &buf) //nolint:noctx
 	if err != nil {
 		return nil, err
 	}

--- a/cloudapi/api_test.go
+++ b/cloudapi/api_test.go
@@ -113,7 +113,7 @@ func TestClientRetry(t *testing.T) {
 		assert.NotEmpty(t, gotK6IdempotencyKey)
 		assert.Equal(t, idempotencyKey, gotK6IdempotencyKey)
 		called++
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
 
@@ -143,7 +143,7 @@ func TestClientRetrySuccessOnSecond(t *testing.T) {
 			fprintf(t, w, `{"reference_id": "1"}`)
 			return
 		}
-		w.WriteHeader(500)
+		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer server.Close()
 

--- a/converter/har/converter.go
+++ b/converter/har/converter.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"sort"
 	"strings"
@@ -183,7 +184,7 @@ func Convert(h HAR, options lib.Options, minSleep, maxSleep uint, enableChecks b
 					fprintf(w, "%q", e.Request.URL)
 				}
 
-				if e.Request.Method != "GET" {
+				if e.Request.Method != http.MethodGet {
 					if correlate && e.Request.PostData != nil && strings.Contains(e.Request.PostData.MimeType, "json") {
 						requestMap := map[string]interface{}{}
 

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -710,7 +710,7 @@ func TestRequest(t *testing.T) {
 						}
 
 						http.SetCookie(w, &cookie)
-						w.WriteHeader(200)
+						w.WriteHeader(http.StatusOK)
 					}))
 					cookieJar, err := cookiejar.New(nil)
 					require.NoError(t, err)
@@ -1721,11 +1721,11 @@ func TestErrorCodes(t *testing.T) {
 
 	// Handple paths with custom logic
 	tb.Mux.HandleFunc("/no-location-redirect", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(302)
+		w.WriteHeader(http.StatusFound)
 	}))
 	tb.Mux.HandleFunc("/bad-location-redirect", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Location", "h\t:/") // \n is forbidden
-		w.WriteHeader(302)
+		w.WriteHeader(http.StatusFound)
 	}))
 
 	testCases := []struct {
@@ -2338,7 +2338,7 @@ func GenerateTLSCertificate(t *testing.T, host string, notBefore time.Time, vali
 func GetTestServerWithCertificate(t *testing.T, certPem, key []byte, suitesIds ...uint16) (*httptest.Server, *http.Client) {
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 		}),
 		ReadHeaderTimeout: time.Second,
 		ReadTimeout:       time.Second,

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -83,7 +83,7 @@ func myFormHandler(w http.ResponseWriter, r *http.Request) {
 		body = []byte(testGetFormHTML)
 	}
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(body)
 }
 
@@ -91,7 +91,7 @@ func jsonHandler(w http.ResponseWriter, r *http.Request) {
 	body := []byte(jsonData)
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(body)
 }
 
@@ -99,7 +99,7 @@ func invalidJSONHandler(w http.ResponseWriter, r *http.Request) {
 	body := []byte(invalidJSONData)
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
-	w.WriteHeader(200)
+	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(body)
 }
 

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -961,7 +961,7 @@ func GenerateTLSCertificate(t *testing.T, host string, notBefore time.Time, vali
 func GetTestServerWithCertificate(t *testing.T, certPem, key []byte) *httptest.Server {
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 		}),
 		ReadHeaderTimeout: time.Second,
 		ReadTimeout:       time.Second,

--- a/lib/netext/httpext/error_codes_test.go
+++ b/lib/netext/httpext/error_codes_test.go
@@ -182,7 +182,7 @@ func TestHTTP2StreamError(t *testing.T) {
 
 	tb.Mux.HandleFunc("/tsr", func(rw http.ResponseWriter, req *http.Request) {
 		rw.Header().Set("Content-Length", "100000")
-		rw.WriteHeader(200)
+		rw.WriteHeader(http.StatusOK)
 
 		rw.(http.Flusher).Flush()
 		time.Sleep(time.Millisecond * 2)
@@ -222,7 +222,7 @@ func TestX509HostnameError(t *testing.T) {
 		badHostname: *badHost,
 	})
 	require.NoError(t, err)
-	req, err := http.NewRequestWithContext(context.Background(), "GET", tb.Replacer.Replace("https://"+badHostname+":HTTPSBIN_PORT/get"), nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tb.Replacer.Replace("https://"+badHostname+":HTTPSBIN_PORT/get"), nil)
 	require.NoError(t, err)
 	res, err := client.Do(req) //nolint:bodyclose
 	require.Nil(t, res)
@@ -243,7 +243,7 @@ func TestX509UnknownAuthorityError(t *testing.T) {
 			DialContext: tb.HTTPTransport.DialContext,
 		},
 	}
-	req, err := http.NewRequestWithContext(context.Background(), "GET", tb.Replacer.Replace("HTTPSBIN_URL/get"), nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, tb.Replacer.Replace("HTTPSBIN_URL/get"), nil)
 	require.NoError(t, err)
 	res, err := client.Do(req) //nolint:bodyclose
 	require.Nil(t, res)

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -88,7 +88,7 @@ func TestMakeRequestError(t *testing.T) {
 
 	t.Run("bad compression algorithm body", func(t *testing.T) {
 		t.Parallel()
-		req, err := http.NewRequest("GET", "https://wont.be.used", nil)
+		req, err := http.NewRequest(http.MethodGet, "https://wont.be.used", nil)
 
 		require.NoError(t, err)
 		badCompressionType := CompressionType(13)
@@ -125,7 +125,7 @@ func TestMakeRequestError(t *testing.T) {
 			Logger:    logger,
 			Tags:      lib.NewVUStateTags(metrics.NewRegistry().RootTagSet()),
 		}
-		req, _ := http.NewRequest("GET", srv.URL, nil)
+		req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 		preq := &ParsedHTTPRequest{
 			Req:         req,
 			URL:         &URL{u: req.URL},
@@ -178,7 +178,7 @@ func TestResponseStatus(t *testing.T) {
 					BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 					Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 				}
-				req, err := http.NewRequest("GET", server.URL, nil)
+				req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 				require.NoError(t, err)
 
 				preq := &ParsedHTTPRequest{
@@ -236,7 +236,7 @@ func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Add("Content-Length", "100000")
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		if f, ok := w.(http.Flusher); ok {
 			f.Flush()
 		}
@@ -260,7 +260,7 @@ func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
-	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	preq := &ParsedHTTPRequest{
 		Req:              req,
 		URL:              &URL{u: req.URL, URL: srv.URL},
@@ -338,7 +338,7 @@ func TestTrailFailed(t *testing.T) {
 				BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 				Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 			}
-			req, _ := http.NewRequest("GET", srv.URL, nil)
+			req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 			preq := &ParsedHTTPRequest{
 				Req:              req,
 				URL:              &URL{u: req.URL, URL: srv.URL},
@@ -405,7 +405,7 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
 
-	req, _ := http.NewRequest("GET", "http://"+addr.String(), nil)
+	req, _ := http.NewRequest(http.MethodGet, "http://"+addr.String(), nil)
 	preq := &ParsedHTTPRequest{
 		Req:              req,
 		URL:              &URL{u: req.URL, URL: req.URL.String()},
@@ -460,7 +460,7 @@ func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
-	req, _ := http.NewRequest("GET", srv.URL, nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
 	preq := &ParsedHTTPRequest{
 		Req:              req,
 		URL:              &URL{u: req.URL, URL: srv.URL},
@@ -541,7 +541,7 @@ func TestMakeRequestRPSLimit(t *testing.T) {
 			assert.InDelta(t, val, 3, 3)
 			return
 		default:
-			req, _ := http.NewRequest("GET", ts.URL, nil)
+			req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
 			preq := &ParsedHTTPRequest{
 				Req:         req,
 				URL:         &URL{u: req.URL, URL: ts.URL, Name: ts.URL},

--- a/lib/netext/httpext/tracer_test.go
+++ b/lib/netext/httpext/tracer_test.go
@@ -116,7 +116,7 @@ func TestTracer(t *testing.T) { //nolint:tparallel
 	for tnum, isReuse := range []bool{false, true, true} { //nolint:paralleltest
 		t.Run(fmt.Sprintf("Test #%d", tnum), func(t *testing.T) {
 			// Do not enable parallel testing, test relies on sequential execution
-			req, err := http.NewRequest("GET", srv.URL+"/get", nil)
+			req, err := http.NewRequest(http.MethodGet, srv.URL+"/get", nil)
 			require.NoError(t, err)
 
 			tracer, ct := getTestTracer(t)
@@ -204,7 +204,7 @@ func TestTracerNegativeHttpSendingValues(t *testing.T) {
 		return failingConn{conn}, err
 	}
 
-	req, err := http.NewRequest("GET", srv.URL+"/get", nil)
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/get", nil)
 	require.NoError(t, err)
 
 	{
@@ -242,7 +242,7 @@ func TestTracerError(t *testing.T) {
 	defer srv.Close()
 
 	tracer := &Tracer{}
-	req, err := http.NewRequest("GET", srv.URL+"/get", nil)
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/get", nil)
 	require.NoError(t, err)
 
 	_, err = http.DefaultTransport.RoundTrip(
@@ -261,7 +261,7 @@ func TestCancelledRequest(t *testing.T) {
 
 	cancelTest := func(t *testing.T) {
 		tracer := &Tracer{}
-		req, err := http.NewRequestWithContext(context.Background(), "GET", srv.URL+"/delay/1", nil)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL+"/delay/1", nil)
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(httptrace.WithClientTrace(req.Context(), tracer.Trace()))

--- a/lib/netext/httpext/transport_test.go
+++ b/lib/netext/httpext/transport_test.go
@@ -41,7 +41,7 @@ func BenchmarkMeasureAndEmitMetrics(b *testing.B) {
 	unfRequest := &unfinishedRequest{
 		tracer: &Tracer{},
 		response: &http.Response{
-			StatusCode: 200,
+			StatusCode: http.StatusOK,
 		},
 		request: &http.Request{
 			URL: &url.URL{

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -290,9 +290,9 @@ func fetch(logger logrus.FieldLogger, u string) ([]byte, error) {
 	}
 	defer func() { _ = res.Body.Close() }()
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		switch res.StatusCode {
-		case 404:
+		case http.StatusNotFound:
 			return nil, fmt.Errorf("not found: %s", u)
 		default:
 			return nil, fmt.Errorf("wrong status code (%d) for: %s", res.StatusCode, u)

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -109,7 +109,7 @@ func TestLoad(t *testing.T) {
 	const responseStr = "export function fn() {\r\n    return 1234;\r\n}"
 	tb.Mux.HandleFunc("/raw/something", func(w http.ResponseWriter, r *http.Request) {
 		if _, ok := r.URL.Query()["_k6"]; ok {
-			http.Error(w, "Internal server error", 500)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 		_, err := fmt.Fprint(w, responseStr)
@@ -117,7 +117,7 @@ func TestLoad(t *testing.T) {
 	})
 
 	tb.Mux.HandleFunc("/invalid", func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, "Internal server error", 500)
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
 	})
 
 	t.Run("Local", func(t *testing.T) {

--- a/output/cloud/metrics_client.go
+++ b/output/cloud/metrics_client.go
@@ -56,7 +56,7 @@ func (mc *MetricsClient) PushMetric(referenceID string, s []*Sample) error {
 	jsonTime := time.Since(jsonStart)
 
 	// TODO: change the context, maybe to one with a timeout
-	req, err := http.NewRequestWithContext(context.Background(), "POST", url, nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, nil)
 	if err != nil {
 		return err
 	}

--- a/output/influxdb/bench_test.go
+++ b/output/influxdb/bench_test.go
@@ -28,7 +28,7 @@ func benchmarkInfluxdb(b *testing.B, t time.Duration) {
 				break
 			}
 		}
-		rw.WriteHeader(204)
+		rw.WriteHeader(http.StatusNoContent)
 	}, func(tb testing.TB, c *Output) {
 		b = tb.(*testing.B)
 		b.ResetTimer()

--- a/output/influxdb/output_test.go
+++ b/output/influxdb/output_test.go
@@ -110,7 +110,7 @@ func TestOutput(t *testing.T) {
 			}
 		}
 
-		rw.WriteHeader(204)
+		rw.WriteHeader(http.StatusNoContent)
 	}, func(tb testing.TB, c *Output) {
 		samples := make(metrics.Samples, 10)
 		for i := 0; i < len(samples); i++ {


### PR DESCRIPTION
The diff for the disabled linters:

```
-dupword: checks for duplicate words in the source code
-ginkgolinter: enforces standards of using ginkgo and gomega
-gocheckcompilerdirectives: Checks that go compiler directive comments (//go:) are valid.
-interfacebloat: A linter that checks the number of methods inside an interface.
-loggercheck (logrlint): Checks key valur pairs for common logger libraries (kitlog,klog,logr,zap). 
-musttag: enforce field tags in (un)marshaled structs
-reassign: Checks that package variables are not reassigned
-testableexamples: linter checks if examples are testable (have an expected output)
-usestdlibvars: A linter that detect the possibility to use variables/constants from the Go standard library.
```

From the previous list this PR enables the following new linters:

- gocheckcompilerdirectives
- reassign
- usestdlibvars


It resolves points 2-3 from https://github.com/grafana/k6/issues/2715

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
