### PR TITLE
Fix panic in `k6/execution`

### DIFF
--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -203,6 +203,11 @@ func (mi *ModuleInstance) newVUInfo() (*goja.Object, error) {
 		"idInTest":            func() interface{} { return vuState.VUIDGlobal },
 		"iterationInInstance": func() interface{} { return vuState.Iteration },
 		"iterationInScenario": func() interface{} {
+			if vuState.GetScenarioVUIter == nil {
+				// hasn't been set yet, no iteration stats available
+				return 0
+			}
+
 			return vuState.GetScenarioVUIter()
 		},
 	}

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -406,6 +406,34 @@ func TestScenarioNoAvailableInInitContext(t *testing.T) {
 	}
 }
 
+func TestVUDefaultDetails(t *testing.T) {
+	t.Parallel()
+
+	rt := goja.New()
+	m, ok := New().NewModuleInstance(
+		&modulestest.VU{
+			RuntimeField: rt,
+			CtxField:     context.Background(),
+			StateField: &lib.State{
+				Options: lib.Options{
+					Paused: null.BoolFrom(true),
+				},
+			},
+		},
+	).(*ModuleInstance)
+	require.True(t, ok)
+	require.NoError(t, rt.Set("exec", m.Exports().Default))
+
+	props := []string{"idInInstance", "idInTest", "iterationInInstance", "iterationInScenario"}
+
+	for _, code := range props {
+		prop := fmt.Sprintf("exec.vu.%s", code)
+		res, err := rt.RunString(prop)
+		require.NoError(t, err)
+		require.Equal(t, "0", res.String())
+	}
+}
+
 func TestTagsDynamicObjectGet(t *testing.T) {
 	t.Parallel()
 	rt := goja.New()


### PR DESCRIPTION
# What?

Fix a minor panic that could happen if try to get insides about the `exec.vu.iterationInScenario` in `setup` method

In that case, we will return `0` as all other `vu.*` properties do.

# Why?

Panics are bad.

Resolves: #2924