### PR TITLE
Print the expected char with the default output

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -19,6 +19,7 @@ import (
 	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
+	"go.k6.io/k6/metrics/engine"
 	"go.k6.io/k6/output"
 	"go.k6.io/k6/ui/pb"
 )
@@ -109,11 +110,16 @@ func printExecutionDescription(
 	switch {
 	case outputOverride != "":
 		outputDescriptions = []string{outputOverride}
-	case len(outputs) == 0:
-		outputDescriptions = []string{"-"}
 	default:
 		for _, out := range outputs {
-			outputDescriptions = append(outputDescriptions, out.Description())
+			desc := out.Description()
+			if desc == engine.IngesterDescription {
+				if len(outputs) != 1 {
+					continue
+				}
+				desc = "-"
+			}
+			outputDescriptions = append(outputDescriptions, desc)
 		}
 	}
 

--- a/metrics/engine/ingester.go
+++ b/metrics/engine/ingester.go
@@ -11,6 +11,11 @@ const collectRate = 50 * time.Millisecond
 
 var _ output.Output = &outputIngester{}
 
+// IngesterDescription is a short description for ingester.
+// This variable is used from a function in cmd/ui file for matching this output
+// and print a special text.
+const IngesterDescription = "Internal Metrics Ingester"
+
 // outputIngester implements the output.Output interface and can be used to
 // "feed" the MetricsEngine data from a `k6 run` test run.
 type outputIngester struct {
@@ -23,7 +28,7 @@ type outputIngester struct {
 
 // Description returns a human-readable description of the output.
 func (oi *outputIngester) Description() string {
-	return "engine"
+	return IngesterDescription
 }
 
 // Start the engine by initializing a new output.PeriodicFlusher


### PR DESCRIPTION
It fixes the ui print `output: engine` restoring the expected text `output: -` when there isn't an explicit set from the user.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
