### PR TITLE
k6 v0.43.1 bugfix release

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -306,22 +306,17 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 	// Init has passed successfully, so unless disabled, make sure we send a
 	// usage report after the context is done.
 	if !conf.NoUsageReport.Bool {
-		backgroundProcesses.Add(2)
-		reportCtx, reportCancel := context.WithCancel(globalCtx)
-		reportDone := make(chan error)
+		backgroundProcesses.Add(1)
 		go func() {
+			defer backgroundProcesses.Done()
+			reportCtx, reportCancel := context.WithTimeout(globalCtx, 3*time.Second)
+			defer reportCancel()
 			logger.Debug("Sending usage report...")
-			reportDone <- reportUsage(reportCtx, execScheduler)
-			close(reportDone)
-			backgroundProcesses.Done()
-		}()
-		go func() {
-			select {
-			case <-reportDone:
-			case <-time.After(3 * time.Second):
+			if rerr := reportUsage(reportCtx, execScheduler); rerr != nil {
+				logger.WithError(rerr).Debug("Error sending usage report")
+			} else {
+				logger.Debug("Usage report sent successfully")
 			}
-			reportCancel()
-			backgroundProcesses.Done()
 		}()
 	}
 

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -19,6 +19,7 @@ import (
 	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
+	"go.k6.io/k6/metrics/engine"
 	"go.k6.io/k6/output"
 	"go.k6.io/k6/ui/pb"
 )
@@ -109,11 +110,16 @@ func printExecutionDescription(
 	switch {
 	case outputOverride != "":
 		outputDescriptions = []string{outputOverride}
-	case len(outputs) == 0:
-		outputDescriptions = []string{"-"}
 	default:
 		for _, out := range outputs {
-			outputDescriptions = append(outputDescriptions, out.Description())
+			desc := out.Description()
+			if desc == engine.IngesterDescription {
+				if len(outputs) != 1 {
+					continue
+				}
+				desc = "-"
+			}
+			outputDescriptions = append(outputDescriptions, desc)
 		}
 	}
 

--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -203,6 +203,11 @@ func (mi *ModuleInstance) newVUInfo() (*goja.Object, error) {
 		"idInTest":            func() interface{} { return vuState.VUIDGlobal },
 		"iterationInInstance": func() interface{} { return vuState.Iteration },
 		"iterationInScenario": func() interface{} {
+			if vuState.GetScenarioVUIter == nil {
+				// hasn't been set yet, no iteration stats available
+				return 0
+			}
+
 			return vuState.GetScenarioVUIter()
 		},
 	}

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -406,6 +406,34 @@ func TestScenarioNoAvailableInInitContext(t *testing.T) {
 	}
 }
 
+func TestVUDefaultDetails(t *testing.T) {
+	t.Parallel()
+
+	rt := goja.New()
+	m, ok := New().NewModuleInstance(
+		&modulestest.VU{
+			RuntimeField: rt,
+			CtxField:     context.Background(),
+			StateField: &lib.State{
+				Options: lib.Options{
+					Paused: null.BoolFrom(true),
+				},
+			},
+		},
+	).(*ModuleInstance)
+	require.True(t, ok)
+	require.NoError(t, rt.Set("exec", m.Exports().Default))
+
+	props := []string{"idInInstance", "idInTest", "iterationInInstance", "iterationInScenario"}
+
+	for _, code := range props {
+		prop := fmt.Sprintf("exec.vu.%s", code)
+		res, err := rt.RunString(prop)
+		require.NoError(t, err)
+		require.Equal(t, "0", res.String())
+	}
+}
+
 func TestTagsDynamicObjectGet(t *testing.T) {
 	t.Parallel()
 	rt := goja.New()

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.43.0"
+const Version = "0.43.1"
 
 // VersionDetails can be set externally as part of the build process
 var VersionDetails = "" //nolint:gochecknoglobals

--- a/metrics/engine/ingester.go
+++ b/metrics/engine/ingester.go
@@ -11,6 +11,11 @@ const collectRate = 50 * time.Millisecond
 
 var _ output.Output = &outputIngester{}
 
+// IngesterDescription is a short description for ingester.
+// This variable is used from a function in cmd/ui file for matching this output
+// and print a special text.
+const IngesterDescription = "Internal Metrics Ingester"
+
 // outputIngester implements the output.Output interface and can be used to
 // "feed" the MetricsEngine data from a `k6 run` test run.
 type outputIngester struct {
@@ -23,7 +28,7 @@ type outputIngester struct {
 
 // Description returns a human-readable description of the output.
 func (oi *outputIngester) Description() string {
-	return "engine"
+	return IngesterDescription
 }
 
 // Start the engine by initializing a new output.PeriodicFlusher

--- a/release notes/v0.43.1.md
+++ b/release notes/v0.43.1.md
@@ -1,0 +1,4 @@
+k6 v0.43.1 is a patch release containing a few bugfixes:
+- [#2926](https://github.com/grafana/k6/pull/2926) fixed a panic in `setup()` code when `vu.iterationInScenario` from `k6/execution` was used.
+- [#2934](https://github.com/grafana/k6/pull/2934) fixed a wrongly printed internal output ID to the `stdout` UI.
+- [#2938](https://github.com/grafana/k6/pull/2938) fixed a synchronization bug that caused k6 to get stuck after the end-of-test summary when sending the usage report took more than 3s. Thanks for [reporting this](https://github.com/grafana/k6/issues/2937), @ichasepucks!


### PR DESCRIPTION
 https://github.com/grafana/k6/issues/2937 / https://github.com/grafana/k6/pull/2938 is the main reason for needing to make a bugfix release :disappointed: However, since we'd be making one anyway, we can also release the more minor https://github.com/grafana/k6/pull/2926 and https://github.com/grafana/k6/pull/2934 bugfixes earlier than expected.