### PR TITLE
Reference 'k6 cloud' instead of 'Load Impact' in docs and errors

### DIFF
--- a/cloudapi/client.go
+++ b/cloudapi/client.go
@@ -23,7 +23,7 @@ const (
 	k6IdempotencyKeyHeader = "k6-Idempotency-Key"
 )
 
-// Client handles communication with Load Impact cloud API.
+// Client handles communication with k6 cloud API.
 type Client struct {
 	client  *http.Client
 	token   string
@@ -220,6 +220,7 @@ func shouldAddIdempotencyKey(req *http.Request) bool {
 
 // randomStrHex returns a hex string which can be used
 // for session token id or idempotency key.
+//
 //nolint:gosec
 func randomStrHex() string {
 	// 16 hex characters

--- a/cloudapi/client.go
+++ b/cloudapi/client.go
@@ -160,7 +160,7 @@ func (c *Client) do(req *http.Request, v interface{}, attempt int) (retry bool, 
 
 func checkResponse(r *http.Response) error {
 	if r == nil {
-		return ErrUnknown
+		return errUnknown
 	}
 
 	if c := r.StatusCode; c >= 200 && c <= 299 {
@@ -177,10 +177,10 @@ func checkResponse(r *http.Response) error {
 	}
 	if err := json.Unmarshal(data, &payload); err != nil {
 		if r.StatusCode == http.StatusUnauthorized {
-			return ErrNotAuthenticated
+			return errNotAuthenticated
 		}
 		if r.StatusCode == http.StatusForbidden {
-			return ErrNotAuthorized
+			return errNotAuthorized
 		}
 		return fmt.Errorf(
 			"unexpected HTTP error from %s: %d %s",

--- a/cloudapi/client.go
+++ b/cloudapi/client.go
@@ -23,7 +23,7 @@ const (
 	k6IdempotencyKeyHeader = "k6-Idempotency-Key"
 )
 
-// Client handles communication with k6 cloud API.
+// Client handles communication with the k6 Cloud API.
 type Client struct {
 	client  *http.Client
 	token   string

--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -10,7 +10,7 @@ import (
 	"go.k6.io/k6/lib/types"
 )
 
-// Config holds all the necessary data and options for sending metrics to the k6 cloud.
+// Config holds all the necessary data and options for sending metrics to the k6 Cloud.
 //
 //nolint:lll
 type Config struct {

--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -10,7 +10,7 @@ import (
 	"go.k6.io/k6/lib/types"
 )
 
-// Config holds all the necessary data and options for sending metrics to the Load Impact cloud.
+// Config holds all the necessary data and options for sending metrics to the k6 cloud.
 //
 //nolint:lll
 type Config struct {

--- a/cloudapi/errors.go
+++ b/cloudapi/errors.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	ErrNotAuthorized    = errors.New("Not allowed to upload result to Load Impact cloud")
-	ErrNotAuthenticated = errors.New("Failed to authenticate with Load Impact cloud")
-	ErrUnknown          = errors.New("An error occurred talking to Load Impact cloud")
+	ErrNotAuthorized    = errors.New("Not allowed to upload result to k6 cloud")
+	ErrNotAuthenticated = errors.New("Failed to authenticate with k6 cloud")
+	ErrUnknown          = errors.New("An error occurred talking to k6 cloud")
 )
 
 // ErrorResponse represents an error cause by talking to the API

--- a/cloudapi/errors.go
+++ b/cloudapi/errors.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	ErrNotAuthorized    = errors.New("Not allowed to upload result to k6 cloud")
-	ErrNotAuthenticated = errors.New("Failed to authenticate with k6 cloud")
-	ErrUnknown          = errors.New("An error occurred talking to k6 cloud")
+	errNotAuthorized    = errors.New("not allowed to upload result to k6 cloud")
+	errNotAuthenticated = errors.New("failed to authenticate with k6 cloud")
+	errUnknown          = errors.New("an error occurred talking to k6 cloud")
 )
 
 // ErrorResponse represents an error cause by talking to the API

--- a/cloudapi/errors.go
+++ b/cloudapi/errors.go
@@ -8,9 +8,9 @@ import (
 )
 
 var (
-	errNotAuthorized    = errors.New("not allowed to upload result to k6 cloud")
-	errNotAuthenticated = errors.New("failed to authenticate with k6 cloud")
-	errUnknown          = errors.New("an error occurred talking to k6 cloud")
+	errNotAuthorized    = errors.New("not allowed to upload result to k6 Cloud")
+	errNotAuthenticated = errors.New("failed to authenticate with k6 Cloud")
+	errUnknown          = errors.New("an error occurred communicating with k6 Cloud")
 )
 
 // ErrorResponse represents an error cause by talking to the API

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -22,8 +22,8 @@ func getCmdLoginCloud(gs *state.GlobalState) *cobra.Command {
 	// loginCloudCommand represents the 'login cloud' command
 	loginCloudCommand := &cobra.Command{
 		Use:   "cloud",
-		Short: "Authenticate with Load Impact",
-		Long: `Authenticate with Load Impact.
+		Short: "Authenticate with k6 Cloud",
+		Long: `Authenticate with k6 Cloud",
 
 This will set the default token used when just "k6 run -o cloud" is passed.`,
 		Example: `

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -354,8 +354,8 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
 
 	runCmd := &cobra.Command{
 		Use:   "run",
-		Short: "Start a load test",
-		Long: `Start a load test.
+		Short: "Start a test",
+		Long: `Start a test.
 
 This also exposes a REST API to interact with it. Various k6 subcommands offer
 a commandline interface for interacting with it.`,

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -25,10 +25,10 @@ import (
 	"go.k6.io/k6/metrics"
 )
 
-// TestName is the default Load Impact Cloud test name
+// TestName is the default k6 Cloud test name
 const TestName = "k6 test"
 
-// Output sends result data to the Load Impact cloud service.
+// Output sends result data to the k6 cloud service.
 type Output struct {
 	config      cloudapi.Config
 	referenceID string

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -28,7 +28,7 @@ import (
 // TestName is the default k6 Cloud test name
 const TestName = "k6 test"
 
-// Output sends result data to the k6 cloud service.
+// Output sends result data to the k6 Cloud service.
 type Output struct {
 	config      cloudapi.Config
 	referenceID string


### PR DESCRIPTION
triggered by https://github.com/grafana/k6/pull/2916/files#r1117146117 