### PR TITLE
Fix active VU reporting by arrival-rate executors

### DIFF
--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -264,6 +264,10 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 	}()
 
 	returnVU := func(u lib.InitializedVU) {
+		// Return the VU without decreasing the global active VU counter, which
+		// is done in the goroutine started by activeVUPool.AddVU, whenever the
+		// VU finishes running an iteration. This results in a more accurate
+		// report of VUs that are _actually_ active.
 		car.executionState.ReturnVU(u, false)
 		activeVUsWg.Done()
 	}

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -217,7 +217,7 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 		<-waitOnProgressChannel
 	}()
 
-	vusPool := newActiveVUPool()
+	vusPool := newActiveVUPool(car.executionState)
 	defer func() {
 		// Make sure all VUs aren't executing iterations anymore, for the cancel()
 		// below to deactivate them.
@@ -264,7 +264,7 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 	}()
 
 	returnVU := func(u lib.InitializedVU) {
-		car.executionState.ReturnVU(u, true)
+		car.executionState.ReturnVU(u, false)
 		activeVUsWg.Done()
 	}
 
@@ -275,7 +275,6 @@ func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics
 			maxDurationCtx, car.config.BaseConfig, returnVU,
 			car.nextIterationCounters,
 		))
-		car.executionState.ModCurrentlyActiveVUsCount(+1)
 		atomic.AddUint64(&activeVUsCount, 1)
 		vusPool.AddVU(maxDurationCtx, activeVU, runIterationBasic)
 		return activeVU

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -390,4 +390,5 @@ func TestConstantArrivalRateActiveVUs(t *testing.T) {
 	require.NoError(t, test.executor.Run(test.ctx, engineOut))
 
 	assert.GreaterOrEqual(t, running, int64(5))
+	assert.LessOrEqual(t, running, int64(10))
 }

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -375,7 +375,8 @@ func TestConstantArrivalRateActiveVUs(t *testing.T) {
 
 	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
 		runMx.Lock()
-		assert.Equal(t, atomic.AddInt64(&running, 1), getCurrActiveVUs())
+		running++
+		assert.Equal(t, running, getCurrActiveVUs())
 		runMx.Unlock()
 		// Block the VU to cause the executor to schedule more
 		<-ctx.Done()

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -354,3 +354,40 @@ func TestConstantArrivalRateGlobalIters(t *testing.T) {
 		})
 	}
 }
+
+func TestConstantArrivalRateActiveVUs(t *testing.T) {
+	t.Parallel()
+
+	config := &ConstantArrivalRateConfig{
+		BaseConfig:      BaseConfig{GracefulStop: types.NullDurationFrom(0 * time.Second)},
+		TimeUnit:        types.NullDurationFrom(time.Second),
+		Rate:            null.IntFrom(10),
+		Duration:        types.NullDurationFrom(950 * time.Millisecond),
+		PreAllocatedVUs: null.IntFrom(5),
+		MaxVUs:          null.IntFrom(10),
+	}
+
+	var (
+		running          int64
+		getCurrActiveVUs func() int64
+		runMx            sync.Mutex
+	)
+
+	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+		runMx.Lock()
+		assert.Equal(t, atomic.AddInt64(&running, 1), getCurrActiveVUs())
+		runMx.Unlock()
+		// Block the VU to cause the executor to schedule more
+		<-ctx.Done()
+		return nil
+	})
+	test := setupExecutorTest(t, "", "", lib.Options{}, runner, config)
+	defer test.cancel()
+
+	getCurrActiveVUs = test.state.GetCurrentlyActiveVUsCount
+
+	engineOut := make(chan metrics.SampleContainer, 1000)
+	require.NoError(t, test.executor.Run(test.ctx, engineOut))
+
+	assert.GreaterOrEqual(t, running, int64(5))
+}

--- a/lib/executor/ramping_arrival_rate_test.go
+++ b/lib/executor/ramping_arrival_rate_test.go
@@ -760,7 +760,8 @@ func TestRampingArrivalRateActiveVUs(t *testing.T) {
 
 	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
 		runMx.Lock()
-		assert.Equal(t, atomic.AddInt64(&running, 1), getCurrActiveVUs())
+		running++
+		assert.Equal(t, running, getCurrActiveVUs())
 		runMx.Unlock()
 		// Block the VU to cause the executor to schedule more
 		<-ctx.Done()

--- a/lib/executor/ramping_arrival_rate_test.go
+++ b/lib/executor/ramping_arrival_rate_test.go
@@ -734,3 +734,45 @@ func TestRampingArrivalRateCornerCase(t *testing.T) {
 
 	require.False(t, config.HasWork(et))
 }
+
+func TestRampingArrivalRateActiveVUs(t *testing.T) {
+	t.Parallel()
+
+	config := &RampingArrivalRateConfig{
+		BaseConfig: BaseConfig{GracefulStop: types.NullDurationFrom(0 * time.Second)},
+		TimeUnit:   types.NullDurationFrom(time.Second),
+		StartRate:  null.IntFrom(10),
+		Stages: []Stage{
+			{
+				Duration: types.NullDurationFrom(950 * time.Millisecond),
+				Target:   null.IntFrom(20),
+			},
+		},
+		PreAllocatedVUs: null.IntFrom(5),
+		MaxVUs:          null.IntFrom(10),
+	}
+
+	var (
+		running          int64
+		getCurrActiveVUs func() int64
+		runMx            sync.Mutex
+	)
+
+	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+		runMx.Lock()
+		assert.Equal(t, atomic.AddInt64(&running, 1), getCurrActiveVUs())
+		runMx.Unlock()
+		// Block the VU to cause the executor to schedule more
+		<-ctx.Done()
+		return nil
+	})
+	test := setupExecutorTest(t, "", "", lib.Options{}, runner, config)
+	defer test.cancel()
+
+	getCurrActiveVUs = test.state.GetCurrentlyActiveVUsCount
+
+	engineOut := make(chan metrics.SampleContainer, 1000)
+	require.NoError(t, test.executor.Run(test.ctx, engineOut))
+
+	assert.GreaterOrEqual(t, running, int64(5))
+}

--- a/lib/executor/ramping_arrival_rate_test.go
+++ b/lib/executor/ramping_arrival_rate_test.go
@@ -775,4 +775,5 @@ func TestRampingArrivalRateActiveVUs(t *testing.T) {
 	require.NoError(t, test.executor.Run(test.ctx, engineOut))
 
 	assert.GreaterOrEqual(t, running, int64(5))
+	assert.LessOrEqual(t, running, int64(10))
 }


### PR DESCRIPTION
This is a somewhat quick and dirty fix of #1977, where instead of changing the global active VUs when the VU is activated, we change it when the VU is actually running. This synchronizes it with the running count of the internal `activeVUPool`, and reports the correct value everywhere the `ExecutionState` is used (the real-time total active VU count while the test is running, in all outputs, etc.).