### PR TITLE
`github.com/sirupsen/logrus` usage refactoring

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,7 @@ linters-settings:
       - '^os\.(.*)$(# Using anything except Signal and SyscallError from the os package is forbidden )?'
       # Forbid everything in syscall except the uppercase constants
       - '^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?'
+      - '^logrus\.Logger$'
 
 linters:
   disable-all: true

--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -22,7 +21,6 @@ import (
 func getTestPreInitState(tb testing.TB) *lib.TestPreInitState {
 	reg := metrics.NewRegistry()
 	logger := testutils.NewLogger(tb)
-	logger.SetLevel(logrus.DebugLevel)
 	return &lib.TestPreInitState{
 		Logger:         logger,
 		RuntimeOptions: lib.RuntimeOptions{},

--- a/cloudapi/logs_test.go
+++ b/cloudapi/logs_test.go
@@ -92,7 +92,7 @@ func TestMSGLog(t *testing.T) {
 
 	logger := logrus.New()
 	logger.Out = ioutil.Discard
-	hook := &testutils.SimpleLogrusHook{HookedLevels: logrus.AllLevels}
+	hook := testutils.NewLogHook()
 	logger.AddHook(hook)
 	expectMsg.Log(logger)
 	logLines := hook.Drain()
@@ -250,7 +250,7 @@ func TestStreamLogsToLogger(t *testing.T) {
 
 		logger := logrus.New()
 		logger.Out = ioutil.Discard
-		hook := &testutils.SimpleLogrusHook{HookedLevels: logrus.AllLevels}
+		hook := testutils.NewLogHook()
 		logger.AddHook(hook)
 
 		c := configFromHTTPMultiBin(tb)
@@ -322,7 +322,7 @@ func TestStreamLogsToLogger(t *testing.T) {
 
 		logger := logrus.New()
 		logger.Out = ioutil.Discard
-		hook := &testutils.SimpleLogrusHook{HookedLevels: logrus.AllLevels}
+		hook := testutils.NewLogHook()
 		logger.AddHook(hook)
 
 		c := configFromHTTPMultiBin(tb)
@@ -390,7 +390,7 @@ func TestStreamLogsToLogger(t *testing.T) {
 
 		logger := logrus.New()
 		logger.Out = ioutil.Discard
-		hook := &testutils.SimpleLogrusHook{HookedLevels: logrus.AllLevels}
+		hook := testutils.NewLogHook()
 		logger.AddHook(hook)
 
 		c := configFromHTTPMultiBin(tb)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -355,19 +355,19 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
 	exampleText := getExampleText(gs, `
   # Run a single VU, once.
   {{.}} run script.js
-  
+
   # Run a single VU, 10 times.
   {{.}} run -i 10 script.js
-  
+
   # Run 5 VUs, splitting 10 iterations between them.
   {{.}} run -u 5 -i 10 script.js
-  
+
   # Run 5 VUs for 10s.
   {{.}} run -u 5 -d 10s script.js
-  
+
   # Ramp VUs from 0 to 100 over 10s, stay there for 60s, then 10s down to 0.
   {{.}} run -u 0 -s 10s:100 -s 60s -s 10s:0
-  
+
   # Send metrics to an influxdb server
   {{.}} run -o influxdb=http://1.2.3.4:8086/k6`[1:])
 

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"io/fs"
 	"io/ioutil"
-	"log"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -318,7 +317,7 @@ func TestThresholdsRuntimeBehavior(t *testing.T) {
 			}
 
 			if tc.expStdoutNotContains != "" {
-				log.Println(ts.Stdout.String())
+				t.Log(ts.Stdout.String())
 				assert.NotContains(t, ts.Stdout.String(), tc.expStdoutNotContains)
 			}
 		})

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -248,7 +248,7 @@ func loadAndConfigureTest(
 }
 
 // loadSystemCertPool attempts to load system certificates.
-func loadSystemCertPool(logger *logrus.Logger) {
+func loadSystemCertPool(logger logrus.FieldLogger) {
 	if _, err := x509.SystemCertPool(); err != nil {
 		logger.WithError(err).Warning("Unable to load system cert pool")
 	}

--- a/cmd/tests/test_state.go
+++ b/cmd/tests/test_state.go
@@ -49,7 +49,7 @@ func NewGlobalTestState(tb testing.TB) *GlobalTestState {
 	logger := logrus.New()
 	logger.SetLevel(logrus.InfoLevel)
 	logger.Out = testutils.NewTestOutput(tb)
-	hook := &testutils.SimpleLogrusHook{HookedLevels: logrus.AllLevels}
+	hook := testutils.NewLogHook()
 	logger.AddHook(hook)
 
 	ts := &GlobalTestState{

--- a/execution/scheduler_ext_exec_test.go
+++ b/execution/scheduler_ext_exec_test.go
@@ -64,8 +64,8 @@ func TestExecutionInfoVUSharing(t *testing.T) {
 
 	logger := logrus.New()
 	logger.SetOutput(ioutil.Discard)
-	logHook := testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.InfoLevel}}
-	logger.AddHook(&logHook)
+	logHook := testutils.NewLogHook(logrus.InfoLevel)
+	logger.AddHook(logHook)
 
 	registry := metrics.NewRegistry()
 	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
@@ -177,8 +177,8 @@ func TestExecutionInfoScenarioIter(t *testing.T) {
 
 	logger := logrus.New()
 	logger.SetOutput(ioutil.Discard)
-	logHook := testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.InfoLevel}}
-	logger.AddHook(&logHook)
+	logHook := testutils.NewLogHook(logrus.InfoLevel)
+	logger.AddHook(logHook)
 
 	registry := metrics.NewRegistry()
 	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
@@ -259,8 +259,8 @@ func TestSharedIterationsStable(t *testing.T) {
 
 	logger := logrus.New()
 	logger.SetOutput(ioutil.Discard)
-	logHook := testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.InfoLevel}}
-	logger.AddHook(&logHook)
+	logHook := testutils.NewLogHook(logrus.InfoLevel)
+	logger.AddHook(logHook)
 
 	registry := metrics.NewRegistry()
 	builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
@@ -394,8 +394,8 @@ func TestExecutionInfoAll(t *testing.T) {
 
 			logger := logrus.New()
 			logger.SetOutput(ioutil.Discard)
-			logHook := testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.InfoLevel}}
-			logger.AddHook(&logHook)
+			logHook := testutils.NewLogHook(logrus.InfoLevel)
+			logger.AddHook(logHook)
 
 			registry := metrics.NewRegistry()
 			builtinMetrics := metrics.RegisterBuiltinMetrics(registry)

--- a/execution/scheduler_ext_test.go
+++ b/execution/scheduler_ext_test.go
@@ -58,7 +58,7 @@ func getTestRunState(
 }
 
 func newTestScheduler(
-	t *testing.T, runner lib.Runner, logger *logrus.Logger, opts lib.Options,
+	t *testing.T, runner lib.Runner, logger logrus.FieldLogger, opts lib.Options,
 ) (ctx context.Context, cancel func(), execScheduler *execution.Scheduler, samples chan metrics.SampleContainer) {
 	if runner == nil {
 		runner = &minirunner.MiniRunner{}
@@ -1083,8 +1083,8 @@ func TestDNSResolver(t *testing.T) {
 				t.Parallel()
 				logger := logrus.New()
 				logger.SetOutput(ioutil.Discard)
-				logHook := testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
-				logger.AddHook(&logHook)
+				logHook := testutils.NewLogHook(logrus.WarnLevel)
+				logger.AddHook(logHook)
 
 				registry := metrics.NewRegistry()
 				builtinMetrics := metrics.RegisterBuiltinMetrics(registry)

--- a/js/compiler/compiler_test.go
+++ b/js/compiler/compiler_test.go
@@ -168,10 +168,8 @@ func TestCorruptSourceMap(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.DebugLevel)
 	logger.Out = ioutil.Discard
-	hook := testutils.SimpleLogrusHook{
-		HookedLevels: []logrus.Level{logrus.InfoLevel, logrus.WarnLevel},
-	}
-	logger.AddHook(&hook)
+	hook := testutils.NewLogHook(logrus.InfoLevel, logrus.WarnLevel)
+	logger.AddHook(hook)
 
 	compiler := New(logger)
 	compiler.Options = Options{
@@ -199,10 +197,8 @@ func TestCorruptSourceMapOnlyForBabel(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.DebugLevel)
 	logger.Out = ioutil.Discard
-	hook := testutils.SimpleLogrusHook{
-		HookedLevels: []logrus.Level{logrus.InfoLevel, logrus.WarnLevel},
-	}
-	logger.AddHook(&hook)
+	hook := testutils.NewLogHook(logrus.InfoLevel, logrus.WarnLevel)
+	logger.AddHook(hook)
 
 	compiler := New(logger)
 	compiler.Options = Options{
@@ -231,10 +227,8 @@ func TestMinimalSourceMap(t *testing.T) {
 	logger := logrus.New()
 	logger.SetLevel(logrus.DebugLevel)
 	logger.Out = ioutil.Discard
-	hook := testutils.SimpleLogrusHook{
-		HookedLevels: []logrus.Level{logrus.InfoLevel, logrus.WarnLevel},
-	}
-	logger.AddHook(&hook)
+	hook := testutils.NewLogHook(logrus.InfoLevel, logrus.WarnLevel)
+	logger.AddHook(hook)
 
 	compiler := New(logger)
 	compiler.Options = Options{

--- a/js/console.go
+++ b/js/console.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// console represents a JS console implemented as a logrus.Logger.
+// console represents a JS console implemented as a logrus.FieldLogger.
 type console struct {
 	logger logrus.FieldLogger
 }

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -58,7 +58,7 @@ func getSimpleRunner(tb testing.TB, filename, data string, opts ...interface{}) 
 			fsResolvers = opt
 		case lib.RuntimeOptions:
 			rtOpts = opt
-		case *logrus.Logger:
+		case logrus.FieldLogger:
 			logger = opt
 		default:
 			tb.Fatalf("unknown test option %q", opt)
@@ -82,6 +82,7 @@ func getSimpleRunner(tb testing.TB, filename, data string, opts ...interface{}) 
 	)
 }
 
+// TODO: remove the need for this function, see https://github.com/grafana/k6/issues/2968
 func extractLogger(fl logrus.FieldLogger) *logrus.Logger {
 	switch e := fl.(type) {
 	case *logrus.Entry:
@@ -103,8 +104,7 @@ func TestConsoleLogWithGojaNativeObject(t *testing.T) {
 	err := obj.Set("text", "nativeObject")
 	require.NoError(t, err)
 
-	logger := testutils.NewLogger(t)
-	hook := logtest.NewLocal(logger)
+	logger, hook := testutils.NewLoggerWithHook(t)
 
 	c := newConsole(logger)
 	c.Log(obj)
@@ -160,8 +160,7 @@ func TestConsoleLogObjectsWithGoTypes(t *testing.T) {
 			rt.SetFieldNameMapper(common.FieldNameMapper{})
 			obj := rt.ToValue(tt.in)
 
-			logger := testutils.NewLogger(t)
-			hook := logtest.NewLocal(logger)
+			logger, hook := testutils.NewLoggerWithHook(t)
 
 			c := newConsole(logger)
 			c.Log(obj)

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -119,7 +119,7 @@ func TestVUTagsSuccessOverwriteSystemTag(t *testing.T) {
 func TestVUTagsErrorOutOnInvalidValues(t *testing.T) {
 	t.Parallel()
 
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
+	logHook := testutils.NewLogHook(logrus.WarnLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(ioutil.Discard)

--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -949,9 +949,7 @@ func TestClientInvokeHeadersDeprecated(t *testing.T) {
 
 	registry := metrics.NewRegistry()
 
-	logHook := &testutils.SimpleLogrusHook{
-		HookedLevels: []logrus.Level{logrus.WarnLevel},
-	}
+	logHook := testutils.NewLogHook(logrus.WarnLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(ioutil.Discard)

--- a/js/modules/k6/http/batch_test.go
+++ b/js/modules/k6/http/batch_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/metrics"
@@ -80,9 +79,6 @@ func TestBatchError(t *testing.T) {
 			state.Options.Throw.Bool = tc.throw
 			defer func() { state.Options.Throw.Bool = oldThrow }()
 
-			hook := logtest.NewLocal(state.Logger)
-			defer hook.Reset()
-
 			ret, err := rt.RunString(fmt.Sprintf(`
 						(function(){
 							var r = http.batch(%s);
@@ -104,7 +100,7 @@ func TestBatchError(t *testing.T) {
 				require.Equal(t, int64(1020), retobj["error_code"])
 				require.Equal(t, invalidURLerr, retobj["error"])
 
-				logEntry := hook.LastEntry()
+				logEntry := ts.hook.LastEntry()
 				require.NotNil(t, logEntry)
 				assert.Equal(t, logrus.WarnLevel, logEntry.Level)
 				e, ok := logEntry.Data["error"].(error)
@@ -144,9 +140,6 @@ func TestBatchErrorNoPanic(t *testing.T) {
 			state.Options.Throw.Bool = false
 			defer func() { state.Options.Throw.Bool = oldThrow }()
 
-			hook := logtest.NewLocal(state.Logger)
-			defer hook.Reset()
-
 			ret, err := rt.RunString(fmt.Sprintf(`
 						(function(){
 							var r = http.batch(%s);
@@ -160,7 +153,7 @@ func TestBatchErrorNoPanic(t *testing.T) {
 			require.Error(t, err)
 			assert.Nil(t, ret)
 			assert.Contains(t, err.Error(), "unexpected end of JSON input")
-			logEntry := hook.LastEntry()
+			logEntry := ts.hook.LastEntry()
 			require.NotNil(t, logEntry)
 			assert.Equal(t, logrus.WarnLevel, logEntry.Level)
 			e, ok := logEntry.Data["error"].(error)

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -136,7 +136,7 @@ func TestMetrics(t *testing.T) {
 					mii.StateField = state
 					logger := logrus.New()
 					logger.Out = ioutil.Discard
-					test.hook = &testutils.SimpleLogrusHook{HookedLevels: logrus.AllLevels}
+					test.hook = testutils.NewLogHook()
 					logger.AddHook(test.hook)
 					state.Logger = logger
 

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -1191,7 +1191,7 @@ func TestCookieJar(t *testing.T) {
 
 func TestWSConnectEnableThrowErrorOption(t *testing.T) {
 	t.Parallel()
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
+	logHook := testutils.NewLogHook(logrus.WarnLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(io.Discard)
@@ -1211,7 +1211,7 @@ func TestWSConnectEnableThrowErrorOption(t *testing.T) {
 
 func TestWSConnectDisableThrowErrorOption(t *testing.T) {
 	t.Parallel()
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
+	logHook := testutils.NewLogHook(logrus.WarnLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(io.Discard)

--- a/js/runner.go
+++ b/js/runner.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/dop251/goja"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"golang.org/x/net/http2"
 	"golang.org/x/time/rate"
@@ -440,7 +441,13 @@ func (r *Runner) SetOptions(opts lib.Options) error {
 	// TODO: validate that all exec values are either nil or valid exported methods (or HTTP requests in the future)
 
 	if opts.ConsoleOutput.Valid {
-		c, err := newFileConsole(opts.ConsoleOutput.String, r.preInitState.Logger.Formatter)
+		// TODO: fix logger hack, see https://github.com/grafana/k6/issues/2958
+		// and https://github.com/grafana/k6/issues/2968
+		var formatter logrus.Formatter = &logrus.JSONFormatter{}
+		if l, ok := r.preInitState.Logger.(*logrus.Logger); ok { //nolint: forbidigo
+			formatter = l.Formatter
+		}
+		c, err := newFileConsole(opts.ConsoleOutput.String, formatter)
 		if err != nil {
 			return err
 		}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -2288,10 +2288,10 @@ func TestVUPanic(t *testing.T) {
 			logger := logrus.New()
 			logger.SetLevel(logrus.InfoLevel)
 			logger.Out = ioutil.Discard
-			hook := testutils.SimpleLogrusHook{
-				HookedLevels: []logrus.Level{logrus.InfoLevel, logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel},
-			}
-			logger.AddHook(&hook)
+			hook := testutils.NewLogHook(
+				logrus.InfoLevel, logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel,
+			)
+			logger.AddHook(hook)
 
 			vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 			vu.(*ActiveVU).Runtime.Set("panic", func(str string) { panic(str) })

--- a/js/share_test.go
+++ b/js/share_test.go
@@ -50,10 +50,10 @@ exports.default = function() {
 	logger := logrus.New()
 	logger.SetLevel(logrus.InfoLevel)
 	logger.Out = ioutil.Discard
-	hook := testutils.SimpleLogrusHook{
-		HookedLevels: []logrus.Level{logrus.InfoLevel, logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel},
-	}
-	logger.AddHook(&hook)
+	hook := testutils.NewLogHook(
+		logrus.InfoLevel, logrus.ErrorLevel, logrus.FatalLevel, logrus.PanicLevel,
+	)
+	logger.AddHook(hook)
 
 	r1, err := getSimpleRunner(t, "/script.js", data, logger)
 	require.NoError(t, err)

--- a/js/summary_test.go
+++ b/js/summary_test.go
@@ -671,8 +671,8 @@ func TestExceptionInHandleSummaryFallsBackToTextSummary(t *testing.T) {
 
 	logger := logrus.New()
 	logger.SetOutput(ioutil.Discard)
-	logHook := testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.ErrorLevel}}
-	logger.AddHook(&logHook)
+	logHook := testutils.NewLogHook(logrus.ErrorLevel)
+	logger.AddHook(logHook)
 
 	runner, err := getSimpleRunner(t, "/script.js", `
 			exports.default = function() {/* we don't run this, metrics are mocked */};

--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -47,7 +47,7 @@ func setupExecutor(t testing.TB, config lib.ExecutorConfig, es *lib.ExecutionSta
 	ctx, cancel := context.WithCancel(context.Background())
 	engineOut := make(chan metrics.SampleContainer, 100) // TODO: return this for more complicated tests?
 
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
+	logHook := testutils.NewLogHook(logrus.WarnLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(ioutil.Discard)

--- a/lib/executor/execution_test.go
+++ b/lib/executor/execution_test.go
@@ -83,7 +83,7 @@ func TestExecutionStateGettingVUsWhenNonAreAvailable(t *testing.T) {
 	et, err := lib.NewExecutionTuple(nil, nil)
 	require.NoError(t, err)
 	es := lib.NewExecutionState(nil, et, 0, 0)
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
+	logHook := testutils.NewLogHook(logrus.WarnLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(ioutil.Discard)
@@ -100,7 +100,7 @@ func TestExecutionStateGettingVUsWhenNonAreAvailable(t *testing.T) {
 
 func TestExecutionStateGettingVUs(t *testing.T) {
 	t.Parallel()
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel, logrus.DebugLevel}}
+	logHook := testutils.NewLogHook(logrus.WarnLevel, logrus.DebugLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(ioutil.Discard)

--- a/lib/executor/vu_handle_test.go
+++ b/lib/executor/vu_handle_test.go
@@ -27,7 +27,7 @@ func TestVUHandleRace(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
+	logHook := testutils.NewLogHook(logrus.DebugLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(testutils.NewTestOutput(t))
@@ -116,7 +116,7 @@ func TestVUHandleStartStopRace(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
+	logHook := testutils.NewLogHook(logrus.DebugLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(testutils.NewTestOutput(t))
@@ -225,7 +225,7 @@ func TestVUHandleSimple(t *testing.T) {
 
 	t.Run("start before gracefulStop finishes", func(t *testing.T) {
 		t.Parallel()
-		logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
+		logHook := testutils.NewLogHook(logrus.DebugLevel)
 		testLog := logrus.New()
 		testLog.AddHook(logHook)
 		testLog.SetOutput(testutils.NewTestOutput(t))
@@ -265,7 +265,7 @@ func TestVUHandleSimple(t *testing.T) {
 
 	t.Run("start after gracefulStop finishes", func(t *testing.T) {
 		t.Parallel()
-		logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
+		logHook := testutils.NewLogHook(logrus.DebugLevel)
 		testLog := logrus.New()
 		testLog.AddHook(logHook)
 		testLog.SetOutput(testutils.NewTestOutput(t))
@@ -306,7 +306,7 @@ func TestVUHandleSimple(t *testing.T) {
 
 	t.Run("start after hardStop", func(t *testing.T) {
 		t.Parallel()
-		logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
+		logHook := testutils.NewLogHook(logrus.DebugLevel)
 		testLog := logrus.New()
 		testLog.AddHook(logHook)
 		testLog.SetOutput(testutils.NewTestOutput(t))
@@ -347,7 +347,7 @@ func TestVUHandleSimple(t *testing.T) {
 }
 
 func BenchmarkVUHandleIterations(b *testing.B) {
-	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.DebugLevel}}
+	logHook := testutils.NewLogHook(logrus.DebugLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	// testLog.Level = logrus.DebugLevel

--- a/lib/netext/grpcext/conn.go
+++ b/lib/netext/grpcext/conn.go
@@ -9,11 +9,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
 
 	protov1 "github.com/golang/protobuf/proto" //nolint:staticcheck,nolintlint // this is the old v1 version
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"

--- a/lib/netext/httpext/httpdebug_transport.go
+++ b/lib/netext/httpext/httpdebug_transport.go
@@ -18,9 +18,9 @@ type httpDebugTransport struct {
 // RoundTrip prints passing HTTP requests and received responses
 //
 // TODO: massively improve this, because the printed information can be wrong:
-//  - https://github.com/k6io/k6/issues/986
-//  - https://github.com/k6io/k6/issues/1042
-//  - https://github.com/k6io/k6/issues/774
+//   - https://github.com/k6io/k6/issues/986
+//   - https://github.com/k6io/k6/issues/1042
+//   - https://github.com/k6io/k6/issues/774
 func (t httpDebugTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	id, _ := uuid.NewV4()
 	t.debugRequest(req, id.String())

--- a/lib/test_state.go
+++ b/lib/test_state.go
@@ -15,9 +15,7 @@ type TestPreInitState struct {
 	BuiltinMetrics *metrics.BuiltinMetrics
 	KeyLogger      io.Writer
 	LookupEnv      func(key string) (val string, ok bool)
-
-	// TODO: replace with logrus.FieldLogger when all of the tests can be fixed
-	Logger *logrus.Logger
+	Logger         logrus.FieldLogger
 }
 
 // TestRunState contains the pre-init state as well as all of the state and

--- a/lib/testutils/logrus_hook.go
+++ b/lib/testutils/logrus_hook.go
@@ -1,7 +1,6 @@
 package testutils
 
 import (
-	"io"
 	"strings"
 	"sync"
 
@@ -48,7 +47,35 @@ func (smh *SimpleLogrusHook) Lines() []string {
 	return lines
 }
 
+// Reset clears the internal entry buffer.
+func (smh *SimpleLogrusHook) Reset() {
+	smh.mutex.Lock()
+	defer smh.mutex.Unlock()
+	smh.messageCache = []logrus.Entry{}
+}
+
+// LastEntry returns the last entry that was logged (or nil, if no messages were
+// logged or remain).
+func (smh *SimpleLogrusHook) LastEntry() *logrus.Entry {
+	smh.mutex.Lock()
+	defer smh.mutex.Unlock()
+	i := len(smh.messageCache) - 1
+	if i < 0 {
+		return nil
+	}
+	return &smh.messageCache[i]
+}
+
 var _ logrus.Hook = &SimpleLogrusHook{}
+
+// NewLogHook creates a new SimpleLogrusHook with the given levels and returns
+// it. If no levels are specified, then logrus.AllLevels will be used.
+func NewLogHook(levels ...logrus.Level) *SimpleLogrusHook {
+	if len(levels) == 0 {
+		levels = logrus.AllLevels
+	}
+	return &SimpleLogrusHook{HookedLevels: levels}
+}
 
 // LogContains is a helper function that checks the provided list of log entries
 // for a message matching the provided level and contents.
@@ -59,19 +86,4 @@ func LogContains(logEntries []logrus.Entry, expLevel logrus.Level, expContents s
 		}
 	}
 	return false
-}
-
-// NewMemLogger creates a Logrus logger mocked by SimpleLogrusHook.
-func NewMemLogger(levels ...logrus.Level) (*logrus.Logger, *SimpleLogrusHook) {
-	if len(levels) == 0 {
-		levels = logrus.AllLevels
-	}
-	logger := logrus.New()
-	logger.SetLevel(logrus.InfoLevel)
-	logger.Out = io.Discard
-	hook := &SimpleLogrusHook{
-		HookedLevels: levels,
-	}
-	logger.AddHook(hook)
-	return logger, hook
 }

--- a/lib/testutils/test_output.go
+++ b/lib/testutils/test_output.go
@@ -23,10 +23,44 @@ func NewTestOutput(t testing.TB) io.Writer {
 	return testOutput{t}
 }
 
-// NewLogger Returns new logger that will log to the testing.TB.Logf
-func NewLogger(t testing.TB) *logrus.Logger {
+func newLogger(t testing.TB, level logrus.Level) *logrus.Logger { //nolint:forbidigo
 	l := logrus.New()
-	logrus.SetOutput(NewTestOutput(t))
-
+	l.SetLevel(level)
+	var w io.Writer
+	if t == nil {
+		w = io.Discard
+	} else {
+		w = NewTestOutput(t)
+	}
+	logrus.SetOutput(w)
 	return l
+}
+
+// NewLogger returns a new logger instance. If the given argument is not nil,
+// the logger will log everything using its t.Logf() method. If its nil, all
+// messages will be discarded.
+func NewLogger(t testing.TB) logrus.FieldLogger {
+	return newLogger(t, logrus.InfoLevel)
+}
+
+// NewLoggerWithHook calls NewLogger() and attaches a hook with the given
+// levels. If no levels are specified, then logrus.AllLevels will be used and
+// the lowest log level will be Debug.
+func NewLoggerWithHook(t testing.TB, levels ...logrus.Level) (logrus.FieldLogger, *SimpleLogrusHook) {
+	maxLevel := logrus.PanicLevel
+	if len(levels) == 0 {
+		levels = logrus.AllLevels
+		maxLevel = logrus.DebugLevel
+	} else {
+		for _, l := range levels {
+			if l > maxLevel {
+				maxLevel = l
+			}
+		}
+	}
+
+	l := newLogger(t, maxLevel)
+	hook := NewLogHook(levels...)
+	l.AddHook(hook)
+	return l, hook
 }

--- a/lib/vu_state.go
+++ b/lib/vu_state.go
@@ -33,9 +33,8 @@ type State struct {
 	Options        Options
 	BuiltinMetrics *metrics.BuiltinMetrics
 
-	// Logger. Avoid using the global logger.
-	// TODO: change to logrus.FieldLogger when there is time to fix all the tests
-	Logger *logrus.Logger
+	// Logger instance for every VU.
+	Logger logrus.FieldLogger
 
 	// Current group; all emitted metrics are tagged with this.
 	Group *Group

--- a/metrics/engine/ingester_test.go
+++ b/metrics/engine/ingester_test.go
@@ -106,7 +106,7 @@ func TestOutputFlushMetricsTimeSeriesWarning(t *testing.T) {
 	testMetric, err := piState.Registry.NewMetric("test_metric", metrics.Gauge)
 	require.NoError(t, err)
 
-	logger, hook := testutils.NewMemLogger()
+	logger, hook := testutils.NewLoggerWithHook(nil)
 	ingester := outputIngester{
 		logger: logger,
 		metricsEngine: &MetricsEngine{
@@ -199,7 +199,6 @@ func TestCardinalityControlLimitHit(t *testing.T) {
 func newTestPreInitState(tb testing.TB) *lib.TestPreInitState {
 	reg := metrics.NewRegistry()
 	logger := testutils.NewLogger(tb)
-	logger.SetLevel(logrus.DebugLevel)
 	return &lib.TestPreInitState{
 		Logger:         logger,
 		RuntimeOptions: lib.RuntimeOptions{},

--- a/output/csv/config.go
+++ b/output/csv/config.go
@@ -60,7 +60,7 @@ func (c Config) Apply(cfg Config) Config {
 }
 
 // ParseArg takes an arg string and converts it to a config
-func ParseArg(arg string, logger *logrus.Logger) (Config, error) {
+func ParseArg(arg string, logger logrus.FieldLogger) (Config, error) {
 	c := NewConfig()
 
 	if !strings.Contains(arg, "=") {
@@ -102,7 +102,7 @@ func ParseArg(arg string, logger *logrus.Logger) (Config, error) {
 // GetConsolidatedConfig combines {default config values + JSON config +
 // environment vars + arg config values}, and returns the final result.
 func GetConsolidatedConfig(
-	jsonRawConf json.RawMessage, env map[string]string, arg string, logger *logrus.Logger,
+	jsonRawConf json.RawMessage, env map[string]string, arg string, logger logrus.FieldLogger,
 ) (Config, error) {
 	result := NewConfig()
 	if jsonRawConf != nil {

--- a/ui/pb/progressbar_test.go
+++ b/ui/pb/progressbar_test.go
@@ -9,7 +9,7 @@ import (
 // TODO(imiric): Consider adding logging tests for 100% pb coverage.
 // Unfortunately the following introduces an import cycle: pb -> lib -> pb
 // func getTestLogger() *logger.Entry {
-// 	logHook := &testutils.SimpleLogrusHook{HookedLevels: []logrus.Level{logrus.WarnLevel}}
+// 	logHook := testutils.NewLogHook(logrus.WarnLevel)
 // 	testLog := logrus.New()
 // 	testLog.AddHook(logHook)
 // 	testLog.SetOutput(ioutil.Discard)


### PR DESCRIPTION
For some reason, my very sleep-deprived brain got stuck on these logging minutia today :man_facepalming: Still, the zombie state somewhat good at slogging through repetitive code modifications, so at least something semi-useful might come out of it in the long run... :sweat_smile: :crossed_fingers: 

This is one small part of https://github.com/grafana/k6/issues/2958. Because of https://github.com/grafana/xk6-browser/issues/818, this PR requires https://github.com/grafana/k6/pull/2994 to be merged first.

The important parts here are replacement of the `*logrus.Logger` concrete type usage with `logrus.FieldLogger` interface in a bunch of places, most importantly in the the VU `lib.State` and the `lib.TestPreInitState` :tada: The `testutils` refactoring from manually constructed objects to constructor functions + removing any usage of `github.com/sirupsen/logrus/hooks/test` is both making it easier to write tests now, and hopefully also making it easier to remove logrus in the future.
