### PR TITLE
Add support for reporting DNS resolution times

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -78,6 +78,10 @@ func NewFromArchive(piState *lib.TestPreInitState, arc *lib.Archive) (*Runner, e
 	return NewFromBundle(piState, bundle)
 }
 
+func lookupIP(ctx context.Context, host string) ([]net.IP, error) {
+	return net.DefaultResolver.LookupIP(ctx, "ip", host)
+}
+
 // NewFromBundle returns a new Runner from the provided Bundle
 func NewFromBundle(piState *lib.TestPreInitState, b *Bundle) (*Runner, error) {
 	defaultGroup, err := lib.NewGroup("", nil)
@@ -97,8 +101,8 @@ func NewFromBundle(piState *lib.TestPreInitState, b *Bundle) (*Runner, error) {
 		},
 		console: newConsole(piState.Logger),
 		Resolver: netext.NewResolver(
-			net.LookupIP, 0, defDNS.Select.DNSSelect, defDNS.Policy.DNSPolicy),
-		ActualResolver: net.LookupIP,
+			lookupIP, 0, defDNS.Select.DNSSelect, defDNS.Policy.DNSPolicy),
+		ActualResolver: lookupIP,
 	}
 
 	err = r.SetOptions(r.Bundle.Options)

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -57,7 +57,7 @@ func (b BlockedHostError) Error() string {
 
 // DialContext wraps the net.Dialer.DialContext and handles the k6 specifics
 func (d *Dialer) DialContext(ctx context.Context, proto, addr string) (net.Conn, error) {
-	dialAddr, err := d.getDialAddr(addr)
+	dialAddr, err := d.getDialAddr(ctx, addr)
 	if err != nil {
 		return nil, err
 	}
@@ -133,8 +133,8 @@ func (d *Dialer) GetTrail(
 	}
 }
 
-func (d *Dialer) getDialAddr(addr string) (string, error) {
-	remote, err := d.findRemote(addr)
+func (d *Dialer) getDialAddr(ctx context.Context, addr string) (string, error) {
+	remote, err := d.findRemote(ctx, addr)
 	if err != nil {
 		return "", err
 	}
@@ -148,7 +148,7 @@ func (d *Dialer) getDialAddr(addr string) (string, error) {
 	return remote.String(), nil
 }
 
-func (d *Dialer) findRemote(addr string) (*types.Host, error) {
+func (d *Dialer) findRemote(ctx context.Context, addr string) (*types.Host, error) {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil {
 		return nil, err
@@ -172,7 +172,7 @@ func (d *Dialer) findRemote(addr string) (*types.Host, error) {
 		return types.NewHost(ip, port)
 	}
 
-	ip, err = d.Resolver.LookupIP(host)
+	ip, err = d.Resolver.LookupIP(ctx, host)
 	if err != nil {
 		return nil, err
 	}

--- a/metrics/builtin.go
+++ b/metrics/builtin.go
@@ -13,6 +13,7 @@ const (
 	HTTPReqsName              = "http_reqs"
 	HTTPReqFailedName         = "http_req_failed"
 	HTTPReqDurationName       = "http_req_duration"
+	HTTPReqResolveName        = "http_req_resolve"
 	HTTPReqBlockedName        = "http_req_blocked"
 	HTTPReqConnectingName     = "http_req_connecting"
 	HTTPReqTLSHandshakingName = "http_req_tls_handshaking"
@@ -49,6 +50,7 @@ type BuiltinMetrics struct {
 	HTTPReqs              *Metric
 	HTTPReqFailed         *Metric
 	HTTPReqDuration       *Metric
+	HTTPReqResolve        *Metric
 	HTTPReqBlocked        *Metric
 	HTTPReqConnecting     *Metric
 	HTTPReqTLSHandshaking *Metric
@@ -87,6 +89,7 @@ func RegisterBuiltinMetrics(registry *Registry) *BuiltinMetrics {
 		HTTPReqs:              registry.MustNewMetric(HTTPReqsName, Counter),
 		HTTPReqFailed:         registry.MustNewMetric(HTTPReqFailedName, Rate),
 		HTTPReqDuration:       registry.MustNewMetric(HTTPReqDurationName, Trend, Time),
+		HTTPReqResolve:        registry.MustNewMetric(HTTPReqResolveName, Trend, Time),
 		HTTPReqBlocked:        registry.MustNewMetric(HTTPReqBlockedName, Trend, Time),
 		HTTPReqConnecting:     registry.MustNewMetric(HTTPReqConnectingName, Trend, Time),
 		HTTPReqTLSHandshaking: registry.MustNewMetric(HTTPReqTLSHandshakingName, Trend, Time),


### PR DESCRIPTION
The time it takes to resolve hostnames is missing from the reported metrcs. Add support for recording that information thru the httptrace DNSStart and DNSDone hooks. This requires changing the signature of the netext.MultiResolver type because nettrace depends on having the hooks passed in a structure in the request context (they are wired up by httptrace).

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
