### PR TITLE
WIP: Refactor how cloud options are specified

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -113,10 +113,14 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Cloud config
-	cloudConfig, err := cloudapi.GetConsolidatedConfig(
-		test.derivedConfig.Collectors["cloud"], c.gs.Env, "", arc.Options.External)
+	cloudConfig, warn, err := cloudapi.GetConsolidatedConfig(
+		test.derivedConfig.Collectors["cloud"], c.gs.Env, "", arc.Options.Cloud, arc.Options.External)
 	if err != nil {
 		return err
+	}
+	// TODO: Temporarily support options.ext.loadimpact settings, plans to remove support for this in the future
+	if warn != nil {
+		modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, fmt.Sprintf("Warning: %s", warn.Error())))
 	}
 	if !cloudConfig.Token.Valid {
 		return errors.New("Not logged in, please use `k6 login cloud`.") //nolint:golint,revive,stylecheck

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -55,10 +55,13 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 
 			// We want to use this fully consolidated config for things like
 			// host addresses, so users can overwrite them with env vars.
-			consolidatedCurrentConfig, err := cloudapi.GetConsolidatedConfig(
-				currentJSONConfigRaw, gs.Env, "", nil)
+			consolidatedCurrentConfig, warn, err := cloudapi.GetConsolidatedConfig(
+				currentJSONConfigRaw, gs.Env, "", nil, nil)
 			if err != nil {
 				return err
+			}
+			if warn != nil {
+				gs.Logger.Warn(warn.Error())
 			}
 			// But we don't want to save them back to the JSON file, we only
 			// want to save what already existed there and the login details.

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -613,7 +613,7 @@ func TestSetupTeardownThresholds(t *testing.T) {
 
 	logMsgs := ts.LoggerHook.Drain()
 	for _, msg := range logMsgs {
-		if msg.Level != logrus.DebugLevel {
+		if (msg.Level != logrus.DebugLevel) && (msg.Level != logrus.WarnLevel) {
 			assert.Failf(t, "unexpected log message", "level %s, msg '%s'", msg.Level, msg.Message)
 		}
 	}

--- a/lib/options.go
+++ b/lib/options.go
@@ -303,6 +303,10 @@ type Options struct {
 	// Can't be set through env vars.
 	External map[string]json.RawMessage `json:"ext" ignored:"true"`
 
+	// These values are for third party collectors' benefit.
+	// Can't be set through env vars.
+	Cloud json.RawMessage `json:"cloud,omitempty" ignored:"true"`
+
 	// Summary trend stats for trend metrics (response times) in CLI output
 	SummaryTrendStats []string `json:"summaryTrendStats" envconfig:"K6_SUMMARY_TREND_STATS"`
 

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -79,7 +79,8 @@ func New(params output.Params) (output.Output, error) {
 func newOutput(params output.Params) (*Output, error) {
 	logger := params.Logger.WithFields(logrus.Fields{"output": "cloud"})
 	conf, warn, err := cloudapi.GetConsolidatedConfig(
-		params.JSONConfig, params.Environment, params.ConfigArgument, params.ScriptOptions.Cloud, params.ScriptOptions.External)
+		params.JSONConfig, params.Environment, params.ConfigArgument, params.ScriptOptions.Cloud,
+		params.ScriptOptions.External)
 	if err != nil {
 		return nil, err
 	}

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -77,17 +77,19 @@ func New(params output.Params) (output.Output, error) {
 
 // New creates a new cloud output.
 func newOutput(params output.Params) (*Output, error) {
-	conf, err := cloudapi.GetConsolidatedConfig(
-		params.JSONConfig, params.Environment, params.ConfigArgument, params.ScriptOptions.External)
+	logger := params.Logger.WithFields(logrus.Fields{"output": "cloud"})
+	conf, warn, err := cloudapi.GetConsolidatedConfig(
+		params.JSONConfig, params.Environment, params.ConfigArgument, params.ScriptOptions.Cloud, params.ScriptOptions.External)
 	if err != nil {
 		return nil, err
+	}
+	if warn != nil {
+		logger.Warn(warn.Error())
 	}
 
 	if err := validateRequiredSystemTags(params.ScriptOptions.SystemTags); err != nil {
 		return nil, err
 	}
-
-	logger := params.Logger.WithFields(logrus.Fields{"output": "cloud"})
 
 	if !conf.Name.Valid || conf.Name.String == "" {
 		scriptPath := params.ScriptPath.String()


### PR DESCRIPTION
Hi There! 👋 

I am new around here, so this is my first interaction with the project 😃 

I fancied trying to address issue https://github.com/grafana/k6/issues/1155 and submit a PR for it, and this one was of interest to many people so I decided to go for it. 

Keeping both options certainly makes things a bit messy. Having `options.cloud` and `options.ext.loadimpact`  accepted into the same function _seemed_ to remove the ability to pass them into the [`GetConsolidatedConfig` function](https://github.com/grafana/k6/compare/master...ChaosInTheCRD:k6:fix-cloud-loadimpact?expand=1#diff-55ae88ea92051c07942fe7b2477d0b5ee5c7889eb78825e8dd8db7fbf0f96e69L268) as the same variable (one is a map and the other is just a JSON raw message). Instead I had to add an extra parameter and put the decision logic of whether it was `cloud` or `loadimpact` outside of the [`MergeFromExternal` function](https://github.com/grafana/k6/compare/master...ChaosInTheCRD:k6:fix-cloud-loadimpact?expand=1#diff-55ae88ea92051c07942fe7b2477d0b5ee5c7889eb78825e8dd8db7fbf0f96e69R247). I am new around here, so I am unsure whether the way I have tried to add the warning to [`cloud.go`](https://github.com/grafana/k6/compare/master...ChaosInTheCRD:k6:fix-cloud-loadimpact?expand=1#diff-034babcea9f01cc4daa0dceffba8a79971137c0266ccf20371f342c545edd1aeR123) makes sense. But I figured that would be easy for someone to recommend an alternative in the PR if it is wrong 😄 .

I have tried to mark `TODO:`'s wherever the temporary `loadimpact`'ness is still lying around, so it will be easy to remove it when the time comes.

The only other thing is that one unit test was failing on my machine. This is cert related, and I decided to wait before deciding to debug. I figured it might be something to do with my local machine. I can work on this a bit more to address if need be 😄:

```
--- FAIL: TestVUIntegrationClientCerts (0.01s)
    --- FAIL: TestVUIntegrationClientCerts/VerifyServerCert (0.00s)
        --- FAIL: TestVUIntegrationClientCerts/VerifyServerCert/Archive (0.01s)
            runner_test.go:1846:
                	Error Trace:	/Users/tom.meadows/Git/k6-fork/js/runner_test.go:1846
                	Error:      	Error "GoError: Get \"https://127.0.0.1:49852\": x509: “127.0.0.1:6969” certificate is not standards compliant\n\tat go.k6.io/k6/js/modules/k6/http.(*RootModule).NewModuleInstance.func2 (native)\n\tat file:///script.js:7:25(4)\n" does not contain "certificate signed by unknown authority"
                	Test:       	TestVUIntegrationClientCerts/VerifyServerCert/Archive
        --- FAIL: TestVUIntegrationClientCerts/VerifyServerCert/Source (0.01s)
            runner_test.go:1846:
                	Error Trace:	/Users/tom.meadows/Git/k6-fork/js/runner_test.go:1846
                	Error:      	Error "GoError: Get \"https://127.0.0.1:49852\": x509: “127.0.0.1:6969” certificate is not standards compliant\n\tat go.k6.io/k6/js/modules/k6/http.(*RootModule).NewModuleInstance.func2 (native)\n\tat file:///script.js:7:25(4)\n" does not contain "certificate signed by unknown authority"
                	Test:       	TestVUIntegrationClientCerts/VerifyServerCert/Source
2023/03/09 01:02:49 http: TLS handshake error from [::1]:50048: remote error: tls: bad certificate
2023/03/09 01:02:49 http: TLS handshake error from [::1]:50049: remote error: tls: bad certificate
2023/03/09 01:02:49 http: TLS handshake error from [::1]:50052: remote error: tls: bad certificate
2023/03/09 01:02:49 http: TLS handshake error from [::1]:50053: remote error: tls: bad certificate
2023/03/09 01:02:49 http: TLS handshake error from [::1]:50056: tls: no cipher suite supported by both client and server
2023/03/09 01:02:49 http: TLS handshake error from [::1]:50057: tls: no cipher suite supported by both client and server
2023/03/09 01:02:49 http: TLS handshake error from [::1]:50058: EOF
2023/03/09 01:02:49 http: TLS handshake error from [::1]:50059: EOF
FAIL
```

I hope this was in some way helpful 😄 I am going to try and manually test my changes out, as I still haven't had time to do that. If this doesn't solve the problem and is off the mark, please let me know and I will try and find some time to move it towards done.



