### PR TITLE
Pin grafana version in docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - INFLUXDB_DB=k6
 
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:9.3.8
     networks:
       - grafana
     ports:


### PR DESCRIPTION
This due to our provisioning files not working with latest grafana

see #2969
