### PR TITLE
[gRPC] Set authority header as host

### DIFF
--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"strings"
 	"time"
 
@@ -133,6 +134,12 @@ func (c *Client) Connect(addr string, params map[string]interface{}) (bool, erro
 		tcred = insecure.NewCredentials()
 	}
 	opts = append(opts, grpc.WithTransportCredentials(tcred))
+
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false, err
+	}
+	opts = append(opts, grpc.WithAuthority(host))
 
 	if ua := state.Options.UserAgent; ua.Valid {
 		opts = append(opts, grpc.WithUserAgent(ua.ValueOrZero()))


### PR DESCRIPTION
* Description *

This PR contains a small fix to set the `authority` request header to the `host` rather than `host:port` for unary gRPC requests in k6. I believe this is a _strict_ improvement as an `authority` value of `host:port` is not meaningful at the point of TLS termination and some reverse proxies / load balancers that do TLS termination fail to do so if the `authority` header doesn't match the certificate.

* Testing *

Previously my reverse proxy (Ambassador Emissary Ingress 3.5) would fail match the certificate to the authority and fail to terminate TLS for a gRPC request from k6, and forward the request through, still encrypted:
````
':method', 'POST'
':scheme', 'https'
':path', '/foo/bar'
':authority', 'foo.bar.com:80'
'content-type', 'application/grpc'
'user-agent', 'grpc-go/1.53.0'
```

Now with this PR in place TLS termination and routing is successful:

```
':method', 'POST'
':scheme', 'http'
':path', '/foo/bar'
':authority', 'foo.bar.com'
'content-type', 'application/grpc'
'user-agent', 'grpc-go/1.53.0'
```
