### PR TITLE
Support async functions for setup and handleSummary

### DIFF
--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -542,6 +542,26 @@ func TestSetupDataNoReturn(t *testing.T) {
 	};`)
 }
 
+func TestSetupDataPromise(t *testing.T) {
+	t.Parallel()
+	testSetupDataHelper(t, `
+	exports.options = { setupTimeout: "1s", teardownTimeout: "1s" };
+	exports.setup = async function() {
+        return await Promise.resolve({"data": "correct"})
+    }
+	exports.default = function(data) {
+		if (data.data !== "correct") {
+			throw new Error("default: wrong data: " + JSON.stringify(data))
+		}
+	};
+
+	exports.teardown = function(data) {
+		if (data.data !== "correct") {
+			throw new Error("teardown: wrong data: " + JSON.stringify(data))
+		}
+	};`)
+}
+
 func TestRunnerIntegrationImports(t *testing.T) {
 	t.Parallel()
 	t.Run("Modules", func(t *testing.T) {


### PR DESCRIPTION
This in practice just checks that a promise was not return and get's it result.

Async functions happen to just always return promises.

Fixes #2935 and #2959
