### PR TITLE
Fix panic handling and add a new exit code and a test for panics

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"go.k6.io/k6/cmd/tests"
+	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/lib/testutils"
 )
 
@@ -36,4 +38,26 @@ func TestDeprecatedOptionWarning(t *testing.T) {
 	// and, ideally, through the log, not just print it...
 	assert.False(t, testutils.LogContains(logMsgs, logrus.InfoLevel, "logformat"))
 	assert.Contains(t, ts.Stdout.String(), `--logformat has been deprecated`)
+}
+
+func TestPanicHandling(t *testing.T) {
+	t.Parallel()
+
+	ts := tests.NewGlobalTestState(t)
+	ts.CmdArgs = []string{"k6", "panic"}
+	ts.ExpectedExitCode = int(exitcodes.GoPanic)
+
+	rootCmd := newRootCommand(ts.GlobalState)
+	rootCmd.cmd.AddCommand(&cobra.Command{
+		Use: "panic",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			panic("oh no, oh no, oh no,no,no,no,no")
+		},
+	})
+	rootCmd.execute()
+
+	t.Log(ts.Stderr.String())
+	logMsgs := ts.LoggerHook.Drain()
+	assert.True(t, testutils.LogContains(logMsgs, logrus.ErrorLevel, "unexpected k6 panic: oh no"))
+	assert.True(t, testutils.LogContains(logMsgs, logrus.ErrorLevel, "cmd.TestPanicHandling")) // check stacktrace
 }

--- a/errext/exitcodes/codes.go
+++ b/errext/exitcodes/codes.go
@@ -20,4 +20,5 @@ const (
 	CannotStartRESTAPI       ExitCode = 106
 	ScriptException          ExitCode = 107
 	ScriptAborted            ExitCode = 108
+	GoPanic                  ExitCode = 109
 )


### PR DESCRIPTION
In https://github.com/grafana/k6/pull/2833 we started calling `os.Exit()` in a `defer` statement, so we inadvertently circumvented the regular handling of panics that bubble up to the top by the Go runtime. 

I could have removed the `os.Exit()` call from the `defer`, but I think this is better. Handling panics ourselves in this way is explicit, simpler to understand, and it allows us to handle them exactly how we want - including assigning them their own unique exit code, and test the whole thing with an e2e test.