### PR TITLE
Directly embed `lib.TestPreInitState` in `js/common.InitEnvironment`

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -223,11 +223,11 @@ func (b *Bundle) Instantiate(ctx context.Context, vuID uint64) (*BundleInstance,
 	// already pre-validated in cmd.validateScenarioConfig(), just get them here.
 	exports := instance.exports()
 
-	jsOptions := exports.Get("options")
+	jsOptions := exports.Get(consts.Options)
 	var jsOptionsObj *goja.Object
 	if jsOptions == nil || goja.IsNull(jsOptions) || goja.IsUndefined(jsOptions) {
 		jsOptionsObj = vuImpl.runtime.NewObject()
-		err := exports.Set("options", jsOptionsObj)
+		err := exports.Set(consts.Options, jsOptionsObj)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't set exported options with merged values: %w", err)
 		}
@@ -263,11 +263,9 @@ func (b *Bundle) instantiate(vuImpl *moduleVUImpl, vuID uint64) (moduleInstance,
 	}
 
 	initenv := &common.InitEnvironment{
-		Logger:      b.preInitState.Logger,
-		FileSystems: b.filesystems,
-		CWD:         b.pwd,
-		Registry:    b.preInitState.Registry,
-		LookupEnv:   b.preInitState.LookupEnv,
+		TestPreInitState: b.preInitState,
+		FileSystems:      b.filesystems,
+		CWD:              b.pwd,
 	}
 
 	modSys := newModuleSystem(b.moduleResolver, vuImpl)
@@ -293,7 +291,7 @@ func (b *Bundle) instantiate(vuImpl *moduleVUImpl, vuID uint64) (moduleInstance,
 	var instance moduleInstance
 	err = common.RunWithPanicCatching(b.preInitState.Logger, rt, func() error {
 		return vuImpl.eventLoop.Start(func() error {
-			//nolint:shadow,govet // here we shadow err on purpose
+			//nolint:govet // here we shadow err on purpose
 			mod, err := b.moduleResolver.resolve(b.pwd, b.sourceData.URL.String())
 			if err != nil {
 				return err // TODO wrap as this should never happen

--- a/js/common/initenv.go
+++ b/js/common/initenv.go
@@ -4,22 +4,18 @@ import (
 	"net/url"
 	"path/filepath"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/lib"
 )
 
 // InitEnvironment contains properties that can be accessed by Go code executed
 // in the k6 init context. It can be accessed by calling common.GetInitEnv().
 type InitEnvironment struct {
-	Logger      logrus.FieldLogger
+	*lib.TestPreInitState
 	FileSystems map[string]afero.Fs
 	CWD         *url.URL
-	Registry    *metrics.Registry
-	LookupEnv   func(key string) (val string, ok bool)
-	// TODO: add RuntimeOptions and other properties, goja sources, etc.
-	// ideally, we should leave this as the only data structure necessary for
-	// executing the init context for all JS modules
+	// TODO: get rid of this type altogether? we won't need it if we figure out
+	// how to handle .tar archive vs regular JS script differences in FileSystems
 }
 
 // GetAbsFilePath should be used to access the FileSystems, since afero has a

--- a/js/modules/k6/html/html_test.go
+++ b/js/modules/k6/html/html_test.go
@@ -10,6 +10,7 @@ import (
 
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modulestest"
+	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
 )
 
@@ -76,7 +77,9 @@ func getTestModuleInstance(t testing.TB) (*goja.Runtime, *ModuleInstance) {
 	mockVU := &modulestest.VU{
 		RuntimeField: rt,
 		InitEnvField: &common.InitEnvironment{
-			Registry: metrics.NewRegistry(),
+			TestPreInitState: &lib.TestPreInitState{
+				Registry: metrics.NewRegistry(),
+			},
 		},
 		CtxField:   ctx,
 		StateField: nil,
@@ -420,10 +423,10 @@ func TestParseHTML(t *testing.T) {
 			_, err := rt.RunString(`
 				const values = doc
 					.find("#select_multi option")
-					.map(function(idx, val) { 
+					.map(function(idx, val) {
 						return val.text()
 					})
-				
+
 				if (values.length !== 3) {
 					throw new Error('Expected 3 values, got ' + values.length)
 				}
@@ -477,25 +480,25 @@ func TestParseHTML(t *testing.T) {
 					})
 					return bucketObj
 				})
-		
+
 			if (buckets.length !== 2) {
 				throw new Error('Expected 2 buckets, got ' + buckets.length)
 			}
-		
+
 			if (buckets[0].name !== 'firstBucket') {
 				throw new Error('Expected bucket name to be "firstBucket", got ' + buckets[0].name)
 			}
-		
+
 			if (buckets[0].creationDate !== 1654852823) {
 				throw new Error(
 					'Expected bucket creation date to be 1654852823, got ' + buckets[0].creationDate
 				)
 			}
-		
+
 			if (buckets[1].name != 'secondBucket') {
 				throw new Error('Expected bucket name to be "secondBucket", got ' + buckets[1].name)
 			}
-		
+
 			if (buckets[1].creationDate !== 1654852825) {
 				throw new Error(
 					'Expected bucket creation date to be 1654852825, got ' + buckets[1].creationDate

--- a/js/modules/k6/metrics/metrics_test.go
+++ b/js/modules/k6/metrics/metrics_test.go
@@ -105,8 +105,10 @@ func TestMetrics(t *testing.T) {
 					registry := metrics.NewRegistry()
 					mii := &modulestest.VU{
 						RuntimeField: test.rt,
-						InitEnvField: &common.InitEnvironment{Registry: registry},
-						CtxField:     context.Background(),
+						InitEnvField: &common.InitEnvironment{
+							TestPreInitState: &lib.TestPreInitState{Registry: registry},
+						},
+						CtxField: context.Background(),
 					}
 					m, ok := New().NewModuleInstance(mii).(*ModuleInstance)
 					require.True(t, ok)
@@ -172,7 +174,7 @@ func TestMetricGetName(t *testing.T) {
 
 	mii := &modulestest.VU{
 		RuntimeField: rt,
-		InitEnvField: &common.InitEnvironment{Registry: metrics.NewRegistry()},
+		InitEnvField: &common.InitEnvironment{TestPreInitState: &lib.TestPreInitState{Registry: metrics.NewRegistry()}},
 		CtxField:     context.Background(),
 	}
 	m, ok := New().NewModuleInstance(mii).(*ModuleInstance)
@@ -200,7 +202,7 @@ func TestMetricDuplicates(t *testing.T) {
 
 	mii := &modulestest.VU{
 		RuntimeField: rt,
-		InitEnvField: &common.InitEnvironment{Registry: metrics.NewRegistry()},
+		InitEnvField: &common.InitEnvironment{TestPreInitState: &lib.TestPreInitState{Registry: metrics.NewRegistry()}},
 		CtxField:     context.Background(),
 	}
 	m, ok := New().NewModuleInstance(mii).(*ModuleInstance)

--- a/js/modulestest/runtime.go
+++ b/js/modulestest/runtime.go
@@ -31,8 +31,10 @@ func NewRuntime(t testing.TB) *Runtime {
 	}
 	vu.RuntimeField.SetFieldNameMapper(common.FieldNameMapper{})
 	vu.InitEnvField = &common.InitEnvironment{
-		Logger:   testutils.NewLogger(t),
-		Registry: metrics.NewRegistry(),
+		TestPreInitState: &lib.TestPreInitState{
+			Logger:   testutils.NewLogger(t),
+			Registry: metrics.NewRegistry(),
+		},
 	}
 
 	eventloop := eventloop.New(vu)


### PR DESCRIPTION
Instead of manually including most of its constituent parts, we can just embed the whole `*lib.TestPreInitState` in the struct. This will make any future changes much easier.

I also tried to move `FileSystems` and `CWD` in `lib.TestPreInitState`, so we can get rid of them in both `cmd.loadedTest` and `common.InitEnvironment` (at that point, we could basically replace it with `lib.TestPreInitState` directly): https://github.com/grafana/k6/blob/c09919b4961f9d93a32f482089a068d36f667ee2/cmd/test_load.go#L31-L39

Unfortunately, `FileSystems` is complicated, since when we are running .js files, its elements contain the "cache-on-read" overlay filesystems on top of the real FS (and on HTTPs), while for .tar archives we substitute them with the filesystems in the archive: https://github.com/grafana/k6/blob/c09919b4961f9d93a32f482089a068d36f667ee2/js/bundle.go#L134-L137

So, I decided to leave this for a future PR. With some further refactoring of the js test loading, it should be possible to handle in a nicer way than it currently is. Potentially before https://github.com/grafana/k6/issues/2975 :thinking: 