### PR TITLE
[PoC] Parse exported script options with lib.TestPreInitState access

### DIFF
--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -201,8 +201,8 @@ func TestNewBundle(t *testing.T) {
 			invalidOptions := map[string]struct {
 				Expr, Error string
 			}{
-				"Array":    {`[]`, "json: cannot unmarshal array into Go value of type lib.Options"},
-				"Function": {`function(){}`, "error parsing script options: json: unsupported type: func(goja.FunctionCall) goja.Value"},
+				"Array":    {`[]`, "the exported script options should be a JS object"},
+				"Function": {`function(){}`, "the exported script options should be a JS object"},
 			}
 			for name, data := range invalidOptions {
 				t.Run(name, func(t *testing.T) {
@@ -453,8 +453,7 @@ func TestNewBundle(t *testing.T) {
 			entries := hook.Drain()
 			require.Len(t, entries, 1)
 			assert.Equal(t, logrus.WarnLevel, entries[0].Level)
-			assert.Contains(t, entries[0].Message, "There were unknown fields")
-			assert.Contains(t, entries[0].Data["error"].(error).Error(), "unknown field \"something\"")
+			assert.Contains(t, entries[0].Message, "'something' is used in the exported script options, but it's not a valid k6 option")
 		})
 	})
 }


### PR DESCRIPTION
This is built on top of https://github.com/grafana/k6/pull/2999 and is a PoC of how we can parse exported script `options` while we have access to the `*lib.TestPreInitState`. 

Because of the changes in https://github.com/grafana/k6/pull/2999, JavaScript modules also have access to the `*lib.TestPreInitState`, so it can be used as a central place to coordinate things. For example, JS modules could presumably "register" scenario options specific to them, which could then be used when parsing and validating the options.

This is not intended for merging as it is, even though it slightly improves the UX (multiple errors when parsing the script options can now be returned at the same time), it's just a PoC that could be used for discussion. There are plenty of unresolved issues with it! For example, it doesn't handle .json config files or options that are in a .tar archive's `metadata.json` file. Both of these could presumably be made to work in a similar way, since we have the `*lib.TestPreInitState` in both cases, but it would require further refactoring. 