### PR TITLE
Update to xk6-websockets v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/grafana/xk6-output-prometheus-remote v0.1.0
 	github.com/grafana/xk6-redis v0.1.1
 	github.com/grafana/xk6-timers v0.1.2
-	github.com/grafana/xk6-websockets v0.1.6
+	github.com/grafana/xk6-websockets v0.2.0
 	github.com/influxdata/influxdb1-client v0.0.0-20190402204710-8ff2fc3824fc
 	github.com/jhump/protoreflect v1.15.0
 	github.com/klauspost/compress v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -176,8 +176,8 @@ github.com/grafana/xk6-redis v0.1.1 h1:rvWnLanRB2qzDwuY6NMBe6PXei3wJ3kjYvfCwRJ+q
 github.com/grafana/xk6-redis v0.1.1/go.mod h1:z7el1Tz8advY+ex419KfLbENzSQYgaA2lQYwMlt9yMM=
 github.com/grafana/xk6-timers v0.1.2 h1:YVM6hPDgvy4SkdZQpd+/r9M0kDi1g+QdbSxW5ClfwDk=
 github.com/grafana/xk6-timers v0.1.2/go.mod h1:XHmDIXAKe30NJMXrxKIKMFXx98etsCl0jBYktjsSURc=
-github.com/grafana/xk6-websockets v0.1.6 h1:WeVXiNWjOous82jldyHzNmBSS8XygMPkqVp0GgXMhEA=
-github.com/grafana/xk6-websockets v0.1.6/go.mod h1:rqb9U/KERxR3CUL1k8bSAJLn1eHjNHQXvIhxXaAFKpI=
+github.com/grafana/xk6-websockets v0.2.0 h1:oZcq4lm/p/Tc94ZMMNeYDML0DjU39jasC6kTyc6iF+8=
+github.com/grafana/xk6-websockets v0.2.0/go.mod h1:4SaWAP+ZVHoWn8oOcq6m38lDLjEWikAWDZhJi5XZ1ms=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,8 +161,8 @@ github.com/grafana/xk6-redis/redis
 # github.com/grafana/xk6-timers v0.1.2
 ## explicit; go 1.17
 github.com/grafana/xk6-timers/timers
-# github.com/grafana/xk6-websockets v0.1.6
-## explicit; go 1.17
+# github.com/grafana/xk6-websockets v0.2.0
+## explicit; go 1.18
 github.com/grafana/xk6-websockets/websockets
 github.com/grafana/xk6-websockets/websockets/events
 # github.com/inconshreveable/mousetrap v1.0.0


### PR DESCRIPTION
This "fixes" a potential lock up, but that was already fixed in k6 in #3004.

So this is mostly a somewhat of refactor and simplying PR. 

As well as make `ping` throw an exception if used with a closed connection.