### PR TITLE
Add multi-arch docker image build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build
-        run: docker build -t $DOCKER_IMAGE_ID .
+        run: |
+          docker buildx create \
+            --name multibuilder \
+            --platform linux/amd64,linux/arm64 \
+            --bootstrap --use
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -t $DOCKER_IMAGE_ID .
       - name: Check
         run: |
             docker run $DOCKER_IMAGE_ID version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,23 @@
-FROM golang:1.20-alpine as builder
+# syntax=docker/dockerfile:1
+# Build
+FROM --platform=$BUILDPLATFORM golang:1.20-alpine AS builder
+
+ARG TARGETOS TARGETARCH
+
+ENV GOOS=$TARGETOS \
+  GOARCH=$TARGETARCH \
+  CGO_ENABLED=0
+
 WORKDIR $GOPATH/src/go.k6.io/k6
 COPY . .
 RUN apk --no-cache add git=~2
-RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"
+RUN go build -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)" -o /usr/bin/k6 .
 
+# Runtime stage
 FROM alpine:3.17
 RUN apk add --no-cache ca-certificates=~20220614 && \
     adduser -D -u 12345 -g 12345 k6
-COPY --from=builder /go/bin/k6 /usr/bin/k6
+COPY --from=builder /usr/bin/k6 /usr/bin/k6
 
 USER 12345
 WORKDIR /home/k6


### PR DESCRIPTION
Update the Dockerfile to support cross-compile via `GOOS` and `GOARCH`. To use docker buildx cross-compile feature, the `--platform=$BUILDPLATFORM` is included for the builder stage. `BUILDPLATFORM` matches the runner machine platform and `GOOS`+ `GOARCH` is used to tell Go to cross-compile for the specific combo passed.

Move from `go install` to `go build`, because it can't install a cross-compiled binary; instead the output is saved in `/usr/bin/k6` and copied from that path in the final stage.

Change the build workflow from docker build to docker buildx create and docker buildx build. For the build command the `--platform` flag is transformed as `TARGETOS` and `TARGETARCH` variables.

This provides a faster builder stage using the native architecture, with the slow part being left to the runtime stage which will only copy the final binary.

The resulting OCI image will provide a OCI Index that contains both architecture images. Adding support for more platform/arch combos is as simple as adding more entries to the docker buildx create and docker buildx build --platform flags.

More on this method of cross-compilation here:
https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/