### PR TITLE
metrics: Support Trend.Max with negative values

### DIFF
--- a/metrics/sink.go
+++ b/metrics/sink.go
@@ -80,18 +80,22 @@ type TrendSink struct {
 func (t *TrendSink) IsEmpty() bool { return t.Count == 0 }
 
 func (t *TrendSink) Add(s Sample) {
+	if t.Count == 0 {
+		t.Max, t.Min = s.Value, s.Value
+	} else {
+		if s.Value > t.Max {
+			t.Max = s.Value
+		}
+		if s.Value < t.Min {
+			t.Min = s.Value
+		}
+	}
+
 	t.Values = append(t.Values, s.Value)
 	t.sorted = false
 	t.Count += 1
 	t.Sum += s.Value
 	t.Avg = t.Sum / float64(t.Count)
-
-	if s.Value > t.Max {
-		t.Max = s.Value
-	}
-	if s.Value < t.Min || t.Count == 1 {
-		t.Min = s.Value
-	}
 }
 
 // P calculates the given percentile from sink values.


### PR DESCRIPTION
Max is not computed correctly when negative numbers are used.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
