### PR TITLE
Hide afero behind fsext package

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mstoykov/envconfig"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/pflag"
 	"gopkg.in/guregu/null.v3"
 
@@ -20,6 +19,7 @@ import (
 	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/executor"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/metrics"
 )
@@ -116,7 +116,7 @@ func readDiskConfig(gs *state.GlobalState) (Config, error) {
 		return Config{}, err
 	}
 
-	data, err := afero.ReadFile(gs.FS, gs.Flags.ConfigFilePath)
+	data, err := fsext.ReadFile(gs.FS, gs.Flags.ConfigFilePath)
 	if err != nil {
 		return Config{}, fmt.Errorf("couldn't load the configuration from %q: %w", gs.Flags.ConfigFilePath, err)
 	}
@@ -140,7 +140,7 @@ func writeDiskConfig(gs *state.GlobalState, conf Config) error {
 		return err
 	}
 
-	return afero.WriteFile(gs.FS, gs.Flags.ConfigFilePath, data, 0o644)
+	return fsext.WriteFile(gs.FS, gs.Flags.ConfigFilePath, data, 0o644)
 }
 
 // Reads configuration variables from the environment.

--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
@@ -14,6 +13,7 @@ import (
 	"go.k6.io/k6/cmd/tests"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/executor"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/metrics"
 )
@@ -109,10 +109,10 @@ type file struct {
 	filepath, contents string
 }
 
-func getFS(files []file) afero.Fs {
-	fs := afero.NewMemMapFs()
+func getFS(files []file) fsext.Fs {
+	fs := fsext.NewMemMapFs()
 	for _, f := range files {
-		must(afero.WriteFile(fs, f.filepath, []byte(f.contents), 0o644)) // modes don't matter in the afero.MemMapFs
+		must(fsext.WriteFile(fs, f.filepath, []byte(f.contents), 0o644)) // modes don't matter in the afero.MemMapFs
 	}
 	return fs
 }
@@ -121,7 +121,7 @@ type opts struct {
 	cli    []string
 	env    []string
 	runner *lib.Options
-	fs     afero.Fs
+	fs     fsext.Fs
 	cmds   []string
 }
 
@@ -145,7 +145,7 @@ type configConsolidationTestCase struct {
 
 func getConfigConsolidationTestCases() []configConsolidationTestCase {
 	defaultFlags := state.GetDefaultFlags(".config")
-	defaultConfig := func(jsonConfig string) afero.Fs {
+	defaultConfig := func(jsonConfig string) fsext.Fs {
 		return getFS([]file{{defaultFlags.ConfigFilePath, jsonConfig}})
 	}
 	I := null.IntFrom // shortcut for "Valid" (i.e. user-specified) ints

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"io"
 
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/converter/har"
 	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/fsext"
 )
 
 // TODO: split apart like `k6 run` and `k6 archive`?
@@ -34,13 +34,13 @@ func getCmdConvert(gs *state.GlobalState) *cobra.Command {
 	exampleText := getExampleText(gs, `
   # Convert a HAR file to a k6 script.
   {{.}} convert -O har-session.js session.har
-  
+
   # Convert a HAR file to a k6 script creating requests only for the given domain/s.
   {{.}} convert -O har-session.js --only yourdomain.com,additionaldomain.com session.har
-  
+
   # Convert a HAR file. Batching requests together as long as idle time between requests <800ms
   {{.}} convert --batch-threshold 800 session.har
-  
+
   # Run the k6 script.
   {{.}} run har-session.js`[1:])
 
@@ -69,7 +69,7 @@ func getCmdConvert(gs *state.GlobalState) *cobra.Command {
 			options := lib.Options{MaxRedirects: null.IntFrom(0)}
 
 			if optionsFilePath != "" {
-				optionsFileContents, readErr := afero.ReadFile(gs.FS, optionsFilePath)
+				optionsFileContents, readErr := fsext.ReadFile(gs.FS, optionsFilePath)
 				if readErr != nil {
 					return readErr
 				}

--- a/cmd/convert_test.go
+++ b/cmd/convert_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/pmezard/go-difflib/difflib"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/cmd/tests"
+	"go.k6.io/k6/lib/fsext"
 )
 
 const testHAR = `
@@ -109,7 +109,7 @@ func TestConvertCmdCorrelate(t *testing.T) {
 	require.NoError(t, err)
 
 	ts := tests.NewGlobalTestState(t)
-	require.NoError(t, afero.WriteFile(ts.FS, "correlate.har", har, 0o644))
+	require.NoError(t, fsext.WriteFile(ts.FS, "correlate.har", har, 0o644))
 	ts.CmdArgs = []string{
 		"k6", "convert", "--output=result.js", "--correlate=true", "--no-batch=true",
 		"--enable-status-code-checks=true", "--return-on-failed-check=true", "correlate.har",
@@ -117,7 +117,7 @@ func TestConvertCmdCorrelate(t *testing.T) {
 
 	newRootCommand(ts.GlobalState).execute()
 
-	result, err := afero.ReadFile(ts.FS, "result.js")
+	result, err := fsext.ReadFile(ts.FS, "result.js")
 	require.NoError(t, err)
 
 	// Sanitizing to avoid windows problems with carriage returns
@@ -144,7 +144,7 @@ func TestConvertCmdCorrelate(t *testing.T) {
 func TestConvertCmdStdout(t *testing.T) {
 	t.Parallel()
 	ts := tests.NewGlobalTestState(t)
-	require.NoError(t, afero.WriteFile(ts.FS, "stdout.har", []byte(testHAR), 0o644))
+	require.NoError(t, fsext.WriteFile(ts.FS, "stdout.har", []byte(testHAR), 0o644))
 	ts.CmdArgs = []string{"k6", "convert", "stdout.har"}
 
 	newRootCommand(ts.GlobalState).execute()
@@ -155,12 +155,12 @@ func TestConvertCmdOutputFile(t *testing.T) {
 	t.Parallel()
 
 	ts := tests.NewGlobalTestState(t)
-	require.NoError(t, afero.WriteFile(ts.FS, "output.har", []byte(testHAR), 0o644))
+	require.NoError(t, fsext.WriteFile(ts.FS, "output.har", []byte(testHAR), 0o644))
 	ts.CmdArgs = []string{"k6", "convert", "--output", "result.js", "output.har"}
 
 	newRootCommand(ts.GlobalState).execute()
 
-	output, err := afero.ReadFile(ts.FS, "result.js")
+	output, err := fsext.ReadFile(ts.FS, "result.js")
 	assert.NoError(t, err)
 	assert.Equal(t, testHARConvertResult, string(output))
 }

--- a/cmd/panic_integration_test.go
+++ b/cmd/panic_integration_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/cmd/tests"
 	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/testutils"
 )
 
@@ -86,7 +86,7 @@ func TestRunScriptPanicsErrorsAndAbort(t *testing.T) {
 
 			testFilename := "script.js"
 			ts := tests.NewGlobalTestState(t)
-			require.NoError(t, afero.WriteFile(ts.FS, filepath.Join(ts.Cwd, testFilename), []byte(tc.testScript), 0o644))
+			require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, testFilename), []byte(tc.testScript), 0o644))
 			ts.CmdArgs = []string{"k6", "run", testFilename}
 
 			ts.ExpectedExitCode = int(exitcodes.ScriptAborted)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -28,6 +27,7 @@ import (
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/metrics"
 	"go.k6.io/k6/metrics/engine"
 	"go.k6.io/k6/output"
@@ -422,7 +422,7 @@ func reportUsage(ctx context.Context, execScheduler *execution.Scheduler) error 
 	return err
 }
 
-func handleSummaryResult(fs afero.Fs, stdOut, stdErr io.Writer, result map[string]io.Reader) error {
+func handleSummaryResult(fs fsext.Fs, stdOut, stdErr io.Writer, result map[string]io.Reader) error {
 	var errs []error
 
 	getWriter := func(path string) (io.Writer, error) {

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -6,13 +6,13 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/cmd/tests"
 	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
 )
@@ -56,15 +56,15 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 	}
 	fmt.Fprint(jsCode, "}")
 
-	fs := afero.NewMemMapFs()
-	require.NoError(t, afero.WriteFile(fs, "/script.js", jsCode.Bytes(), 0o644))
+	fs := fsext.NewMemMapFs()
+	require.NoError(t, fsext.WriteFile(fs, "/script.js", jsCode.Bytes(), 0o644))
 
 	ts := tests.NewGlobalTestState(t) // TODO: move upwards, make this into an almost full integration test
 	registry := metrics.NewRegistry()
 	test := &loadedTest{
 		sourceRootPath: "script.js",
 		source:         &loader.SourceData{Data: jsCode.Bytes(), URL: &url.URL{Path: "/script.js", Scheme: "file"}},
-		fileSystems:    map[string]afero.Fs{"file": fs},
+		fileSystems:    map[string]fsext.Fs{"file": fs},
 		preInitState: &lib.TestPreInitState{
 			Logger:         ts.Logger,
 			RuntimeOptions: rtOpts,
@@ -83,7 +83,7 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 		return &loadedTest{
 			sourceRootPath: "script.tar",
 			source:         &loader.SourceData{Data: archiveBuf.Bytes(), URL: &url.URL{Path: "/script.tar", Scheme: "file"}},
-			fileSystems:    map[string]afero.Fs{"file": fs},
+			fileSystems:    map[string]fsext.Fs{"file": fs},
 			preInitState: &lib.TestPreInitState{
 				Logger:         ts.Logger,
 				RuntimeOptions: rtOpts,

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -11,8 +11,8 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/mattn/go-isatty"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/ui/console"
 )
 
@@ -34,7 +34,7 @@ const defaultConfigFileName = "config.json"
 type GlobalState struct {
 	Ctx context.Context
 
-	FS         afero.Fs
+	FS         fsext.Fs
 	Getwd      func() (string, error)
 	BinaryName string
 	CmdArgs    []string
@@ -105,7 +105,7 @@ func NewGlobalState(ctx context.Context) *GlobalState {
 
 	return &GlobalState{
 		Ctx:          ctx,
-		FS:           afero.NewOsFs(),
+		FS:           fsext.NewOsFs(),
 		Getwd:        os.Getwd,
 		BinaryName:   filepath.Base(binary),
 		CmdArgs:      os.Args,

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"go.k6.io/k6/cmd/state"
@@ -19,6 +18,7 @@ import (
 	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/js"
 	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
 )
@@ -34,8 +34,8 @@ type loadedTest struct {
 	sourceRootPath string // contains the raw string the user supplied
 	pwd            string
 	source         *loader.SourceData
-	fs             afero.Fs
-	fileSystems    map[string]afero.Fs
+	fs             fsext.Fs
+	fileSystems    map[string]fsext.Fs
 	preInitState   *lib.TestPreInitState
 	initRunner     lib.Runner // TODO: rename to something more appropriate
 	keyLogger      io.Closer
@@ -159,7 +159,7 @@ func (lt *loadedTest) initializeFirstRunner(gs *state.GlobalState) error {
 
 // readSource is a small wrapper around loader.ReadSource returning
 // result of the load and filesystems map
-func readSource(gs *state.GlobalState, filename string) (*loader.SourceData, map[string]afero.Fs, string, error) {
+func readSource(gs *state.GlobalState, filename string) (*loader.SourceData, map[string]fsext.Fs, string, error) {
 	pwd, err := gs.Getwd()
 	if err != nil {
 		return nil, nil, "", err

--- a/cmd/tests/cmd_cloud_test.go
+++ b/cmd/tests/cmd_cloud_test.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/cmd"
+	"go.k6.io/k6/lib/fsext"
 )
 
 func cloudTestStartSimple(tb testing.TB, testRunID int) http.Handler {
@@ -72,7 +72,7 @@ func getSimpleCloudTestState(
 	srv := getMockCloud(t, 123, archiveUpload, progressCallback)
 
 	ts := NewGlobalTestState(t)
-	require.NoError(t, afero.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), script, 0o644))
+	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), script, 0o644))
 	ts.CmdArgs = append(append([]string{"k6", "cloud"}, cliFlags...), "test.js")
 	ts.Env["K6_SHOW_CLOUD_LOGS"] = "false" // no mock for the logs yet
 	ts.Env["K6_CLOUD_HOST"] = srv.URL

--- a/cmd/tests/test_state.go
+++ b/cmd/tests/test_state.go
@@ -12,10 +12,10 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/cmd/state"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/ui/console"
 )
@@ -39,7 +39,7 @@ func NewGlobalTestState(tb testing.TB) *GlobalTestState {
 	ctx, cancel := context.WithCancel(context.Background())
 	tb.Cleanup(cancel)
 
-	fs := &afero.MemMapFs{}
+	fs := fsext.NewMemMapFs()
 	cwd := "/test/" // TODO: Make this relative to the test?
 	if runtime.GOOS == "windows" {
 		cwd = "c:\\test\\"

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/js/common"
@@ -20,6 +19,7 @@ import (
 	"go.k6.io/k6/js/eventloop"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/loader"
 )
 
@@ -32,7 +32,7 @@ type Bundle struct {
 	CompatibilityMode lib.CompatibilityMode // parsed value
 	preInitState      *lib.TestPreInitState
 
-	filesystems map[string]afero.Fs
+	filesystems map[string]fsext.Fs
 	pwd         *url.URL
 
 	callableExports map[string]struct{}
@@ -62,13 +62,13 @@ func (bi *BundleInstance) getExported(name string) goja.Value {
 
 // NewBundle creates a new bundle from a source file and a filesystem.
 func NewBundle(
-	piState *lib.TestPreInitState, src *loader.SourceData, filesystems map[string]afero.Fs,
+	piState *lib.TestPreInitState, src *loader.SourceData, filesystems map[string]fsext.Fs,
 ) (*Bundle, error) {
 	return newBundle(piState, src, filesystems, lib.Options{}, true)
 }
 
 func newBundle(
-	piState *lib.TestPreInitState, src *loader.SourceData, filesystems map[string]afero.Fs,
+	piState *lib.TestPreInitState, src *loader.SourceData, filesystems map[string]fsext.Fs,
 	options lib.Options, updateOptions bool, // TODO: try to figure out a way to not need both
 ) (*Bundle, error) {
 	compatMode, err := lib.ValidateCompatibilityMode(piState.RuntimeOptions.CompatibilityMode.String)

--- a/js/common/initenv.go
+++ b/js/common/initenv.go
@@ -4,15 +4,15 @@ import (
 	"net/url"
 	"path/filepath"
 
-	"github.com/spf13/afero"
 	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/fsext"
 )
 
 // InitEnvironment contains properties that can be accessed by Go code executed
 // in the k6 init context. It can be accessed by calling common.GetInitEnv().
 type InitEnvironment struct {
 	*lib.TestPreInitState
-	FileSystems map[string]afero.Fs
+	FileSystems map[string]fsext.Fs
 	CWD         *url.URL
 	// TODO: get rid of this type altogether? we won't need it if we figure out
 	// how to handle .tar archive vs regular JS script differences in FileSystems
@@ -34,8 +34,8 @@ func (ie *InitEnvironment) GetAbsFilePath(filename string) string {
 		filename = filepath.Join(ie.CWD.Path, filename)
 	}
 	filename = filepath.Clean(filename)
-	if filename[0:1] != afero.FilePathSeparator {
-		filename = afero.FilePathSeparator + filename
+	if filename[0:1] != fsext.FilePathSeparator {
+		filename = fsext.FilePathSeparator + filename
 	}
 	return filename
 }

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -12,13 +12,13 @@ import (
 	"github.com/dop251/goja"
 	"github.com/sirupsen/logrus"
 	logtest "github.com/sirupsen/logrus/hooks/test"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
@@ -49,13 +49,13 @@ func getSimpleRunner(tb testing.TB, filename, data string, opts ...interface{}) 
 	var (
 		rtOpts      = lib.RuntimeOptions{CompatibilityMode: null.NewString("base", true)}
 		logger      = testutils.NewLogger(tb)
-		fsResolvers = map[string]afero.Fs{"file": afero.NewMemMapFs(), "https": afero.NewMemMapFs()}
+		fsResolvers = map[string]fsext.Fs{"file": fsext.NewMemMapFs(), "https": fsext.NewMemMapFs()}
 	)
 	for _, o := range opts {
 		switch opt := o.(type) {
-		case afero.Fs:
+		case fsext.Fs:
 			fsResolvers["file"] = opt
-		case map[string]afero.Fs:
+		case map[string]fsext.Fs:
 			fsResolvers = opt
 		case lib.RuntimeOptions:
 			rtOpts = opt

--- a/js/init_and_modules_test.go
+++ b/js/init_and_modules_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
@@ -16,6 +15,7 @@ import (
 	"go.k6.io/k6/js"
 	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
@@ -69,7 +69,7 @@ func TestNewJSRunnerWithCustomModule(t *testing.T) {
 			URL:  &url.URL{Path: "blah", Scheme: "file"},
 			Data: []byte(script),
 		},
-		map[string]afero.Fs{"file": afero.NewMemMapFs(), "https": afero.NewMemMapFs()},
+		map[string]fsext.Fs{"file": fsext.NewMemMapFs(), "https": fsext.NewMemMapFs()},
 	)
 	require.NoError(t, err)
 	assert.Equal(t, checkModule.initCtxCalled, 1)

--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/dop251/goja"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -73,12 +72,12 @@ func TestClient(t *testing.T) {
 
 		cwd, err := os.Getwd()
 		require.NoError(t, err)
-		fs := afero.NewOsFs()
+		fs := fsext.NewOsFs()
 		if isWindows {
 			fs = fsext.NewTrimFilePathSeparatorFs(fs)
 		}
 		testRuntime.VU.InitEnvField.CWD = &url.URL{Path: cwd}
-		testRuntime.VU.InitEnvField.FileSystems = map[string]afero.Fs{"file": fs}
+		testRuntime.VU.InitEnvField.FileSystems = map[string]fsext.Fs{"file": fs}
 
 		return testState{
 			Runtime: testRuntime,

--- a/js/path_resolution_test.go
+++ b/js/path_resolution_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/lib/fsext"
 )
 
 // This whole file is about tests around https://github.com/grafana/k6/issues/2674
@@ -14,8 +14,8 @@ func TestOpenPathResolution(t *testing.T) {
 	t.Parallel()
 	t.Run("simple", func(t *testing.T) {
 		t.Parallel()
-		fs := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fs, "/path/to/data.txt", []byte("data file"), 0o644))
+		fs := fsext.NewMemMapFs()
+		require.NoError(t, fsext.WriteFile(fs, "/path/to/data.txt", []byte("data file"), 0o644))
 		data := `
 		export let data = open("../to/data.txt");
 		if (data != "data file") {
@@ -32,9 +32,9 @@ func TestOpenPathResolution(t *testing.T) {
 
 	t.Run("intermediate", func(t *testing.T) {
 		t.Parallel()
-		fs := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fs, "/path/to/data.txt", []byte("data file"), 0o644))
-		require.NoError(t, afero.WriteFile(fs, "/path/another/script/script.js", []byte(`
+		fs := fsext.NewMemMapFs()
+		require.NoError(t, fsext.WriteFile(fs, "/path/to/data.txt", []byte("data file"), 0o644))
+		require.NoError(t, fsext.WriteFile(fs, "/path/another/script/script.js", []byte(`
             module.exports = open("../../to/data.txt");
         `), 0o644))
 		data := `
@@ -53,12 +53,12 @@ func TestOpenPathResolution(t *testing.T) {
 
 	t.Run("complex", func(t *testing.T) {
 		t.Parallel()
-		fs := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fs, "/path/to/data.txt", []byte("data file"), 0o644))
-		require.NoError(t, afero.WriteFile(fs, "/path/another/script/script.js", []byte(`
+		fs := fsext.NewMemMapFs()
+		require.NoError(t, fsext.WriteFile(fs, "/path/to/data.txt", []byte("data file"), 0o644))
+		require.NoError(t, fsext.WriteFile(fs, "/path/another/script/script.js", []byte(`
         module.exports = () =>  open("./../data.txt"); // Here the path is relative to this module but to the one calling
         `), 0o644))
-		require.NoError(t, afero.WriteFile(fs, "/path/to/script/script.js", []byte(`
+		require.NoError(t, fsext.WriteFile(fs, "/path/to/script/script.js", []byte(`
         module.exports = require("./../../another/script/script.js")();
         `), 0o644))
 		data := `
@@ -80,8 +80,8 @@ func TestRequirePathResolution(t *testing.T) {
 	t.Parallel()
 	t.Run("simple", func(t *testing.T) {
 		t.Parallel()
-		fs := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fs, "/path/to/data.js", []byte("module.exports='export content'"), 0o644))
+		fs := fsext.NewMemMapFs()
+		require.NoError(t, fsext.WriteFile(fs, "/path/to/data.js", []byte("module.exports='export content'"), 0o644))
 		data := `
 		let data = require("../to/data.js");
 		if (data != "export content") {
@@ -98,9 +98,9 @@ func TestRequirePathResolution(t *testing.T) {
 
 	t.Run("intermediate", func(t *testing.T) {
 		t.Parallel()
-		fs := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fs, "/path/to/data.js", []byte("module.exports='export content'"), 0o644))
-		require.NoError(t, afero.WriteFile(fs, "/path/another/script/script.js", []byte(`
+		fs := fsext.NewMemMapFs()
+		require.NoError(t, fsext.WriteFile(fs, "/path/to/data.js", []byte("module.exports='export content'"), 0o644))
+		require.NoError(t, fsext.WriteFile(fs, "/path/another/script/script.js", []byte(`
             module.exports = require("../../to/data.js");
         `), 0o644))
 		data := `
@@ -119,12 +119,12 @@ func TestRequirePathResolution(t *testing.T) {
 
 	t.Run("complex", func(t *testing.T) {
 		t.Parallel()
-		fs := afero.NewMemMapFs()
-		require.NoError(t, afero.WriteFile(fs, "/path/to/data.js", []byte("module.exports='export content'"), 0o644))
-		require.NoError(t, afero.WriteFile(fs, "/path/another/script/script.js", []byte(`
+		fs := fsext.NewMemMapFs()
+		require.NoError(t, fsext.WriteFile(fs, "/path/to/data.js", []byte("module.exports='export content'"), 0o644))
+		require.NoError(t, fsext.WriteFile(fs, "/path/another/script/script.js", []byte(`
         module.exports = () =>  require("./../data.js"); // Here the path is relative to this module but to the one calling
         `), 0o644))
-		require.NoError(t, afero.WriteFile(fs, "/path/to/script/script.js", []byte(`
+		require.NoError(t, fsext.WriteFile(fs, "/path/to/script/script.js", []byte(`
         module.exports = require("./../../another/script/script.js")();
         `), 0o644))
 		data := `

--- a/js/runner.go
+++ b/js/runner.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/dop251/goja"
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"golang.org/x/net/http2"
 	"golang.org/x/time/rate"
 
@@ -28,6 +27,7 @@ import (
 	"go.k6.io/k6/js/eventloop"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/netext"
 	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/loader"
@@ -61,7 +61,7 @@ type Runner struct {
 }
 
 // New returns a new Runner for the provided source
-func New(piState *lib.TestPreInitState, src *loader.SourceData, filesystems map[string]afero.Fs) (*Runner, error) {
+func New(piState *lib.TestPreInitState, src *loader.SourceData, filesystems map[string]fsext.Fs) (*Runner, error) {
 	bundle, err := NewBundle(piState, src, filesystems)
 	if err != nil {
 		return nil, err

--- a/lib/fsext/afero_links.go
+++ b/lib/fsext/afero_links.go
@@ -1,0 +1,56 @@
+package fsext
+
+import (
+	"io/fs"
+
+	"github.com/spf13/afero"
+)
+
+// TODO: reimplement this while tackling https://github.com/grafana/k6/issues/1079
+
+// Fs represents a file system
+type Fs = afero.Fs
+
+// FilePathSeparator is the FilePathSeparator to be used within a file system
+const FilePathSeparator = afero.FilePathSeparator
+
+// NewMemMapFs returns a Fs that is in memory
+func NewMemMapFs() Fs {
+	return afero.NewMemMapFs()
+}
+
+// NewReadOnlyFs returns a Fs wrapping the provided one and returning error on any not read operation.
+func NewReadOnlyFs(fs Fs) Fs {
+	return afero.NewReadOnlyFs(fs)
+}
+
+// WriteFile writes the provided data to the provided fs in the provided filename
+func WriteFile(fs Fs, filename string, data []byte, perm fs.FileMode) error {
+	return afero.WriteFile(fs, filename, data, perm)
+}
+
+// ReadFile reads the whole file from the filesystem
+func ReadFile(fs Fs, filename string) ([]byte, error) {
+	return afero.ReadFile(fs, filename)
+}
+
+// ReadDir reads the info for each file in the provided dirname
+func ReadDir(fs Fs, dirname string) ([]fs.FileInfo, error) {
+	return afero.ReadDir(fs, dirname)
+}
+
+// NewOsFs returns a new wrapps os.Fs
+func NewOsFs() Fs {
+	return afero.NewOsFs()
+}
+
+// Exists checks if the provided path exists on the filesystem
+func Exists(fs Fs, path string) (bool, error) {
+	return afero.Exists(fs, path)
+}
+
+// IsDir checks if the provided path is a directory
+func IsDir(fs Fs, path string) (bool, error) {
+	// TODO move fix here
+	return afero.IsDir(fs, path)
+}

--- a/lib/old_archive_test.go
+++ b/lib/old_archive_test.go
@@ -9,18 +9,17 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/lib/fsext"
 )
 
-func dumpMemMapFsToBuf(fileSystem afero.Fs) (*bytes.Buffer, error) {
+func dumpMemMapFsToBuf(fileSystem fsext.Fs) (*bytes.Buffer, error) {
 	b := bytes.NewBuffer(nil)
 	w := tar.NewWriter(b)
-	err := fsext.Walk(fileSystem, afero.FilePathSeparator,
+	err := fsext.Walk(fileSystem, fsext.FilePathSeparator,
 		filepath.WalkFunc(func(filePath string, info fs.FileInfo, err error) error {
-			if filePath == afero.FilePathSeparator {
+			if filePath == fsext.FilePathSeparator {
 				return nil // skip the root
 			}
 			if err != nil {
@@ -34,7 +33,7 @@ func dumpMemMapFsToBuf(fileSystem afero.Fs) (*bytes.Buffer, error) {
 				})
 			}
 			var data []byte
-			data, err = afero.ReadFile(fileSystem, filePath)
+			data, err = fsext.ReadFile(fileSystem, filePath)
 			if err != nil {
 				return err
 			}
@@ -94,7 +93,7 @@ func TestOldArchive(t *testing.T) {
 			buf, err := dumpMemMapFsToBuf(fs)
 			require.NoError(t, err)
 
-			expectedFilesystems := map[string]afero.Fs{
+			expectedFilesystems := map[string]fsext.Fs{
 				"file": makeMemMapFs(t, map[string][]byte{
 					"/C:/something/path":  []byte(`windows file`),
 					"/absolulte/path":     []byte(`unix file`),

--- a/loader/cdnjs_test.go
+++ b/loader/cdnjs_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/testutils"
 )
 
@@ -70,7 +70,7 @@ func TestCDNJS(t *testing.T) {
 			require.Empty(t, resolvedURL.Scheme)
 			require.Equal(t, path, resolvedURL.Opaque)
 
-			data, err := Load(logger, map[string]afero.Fs{"https": afero.NewMemMapFs()}, resolvedURL, path)
+			data, err := Load(logger, map[string]fsext.Fs{"https": fsext.NewMemMapFs()}, resolvedURL, path)
 			require.NoError(t, err)
 			assert.Equal(t, resolvedURL, data.URL)
 			assert.NotEmpty(t, data.Data)
@@ -100,7 +100,7 @@ func TestCDNJS(t *testing.T) {
 		pathURL, err := url.Parse(src)
 		require.NoError(t, err)
 
-		_, err = Load(logger, map[string]afero.Fs{"https": afero.NewMemMapFs()}, pathURL, path)
+		_, err = Load(logger, map[string]fsext.Fs{"https": fsext.NewMemMapFs()}, pathURL, path)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "not found: https://cdnjs.cloudflare.com/ajax/libs/Faker/3.1.0/nonexistent.js")
 	})

--- a/loader/filesystems.go
+++ b/loader/filesystems.go
@@ -3,13 +3,11 @@ package loader
 import (
 	"runtime"
 
-	"github.com/spf13/afero"
-
 	"go.k6.io/k6/lib/fsext"
 )
 
 // CreateFilesystems creates the correct filesystem map for the current OS
-func CreateFilesystems(osfs afero.Fs) map[string]afero.Fs {
+func CreateFilesystems(osfs fsext.Fs) map[string]fsext.Fs {
 	// We want to eliminate disk access at runtime, so we set up a memory mapped cache that's
 	// written every time something is read from the real filesystem. This cache is then used for
 	// successive spawns to read from (they have no access to the real disk).
@@ -20,8 +18,8 @@ func CreateFilesystems(osfs afero.Fs) map[string]afero.Fs {
 		// volumes
 		osfs = fsext.NewTrimFilePathSeparatorFs(osfs)
 	}
-	return map[string]afero.Fs{
-		"file":  fsext.NewCacheOnReadFs(osfs, afero.NewMemMapFs(), 0),
-		"https": afero.NewMemMapFs(),
+	return map[string]fsext.Fs{
+		"file":  fsext.NewCacheOnReadFs(osfs, fsext.NewMemMapFs(), 0),
+		"https": fsext.NewMemMapFs(),
 	}
 }

--- a/loader/github_test.go
+++ b/loader/github_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/testutils"
 )
 
@@ -32,7 +32,7 @@ func TestGithub(t *testing.T) {
 	require.Equal(t, path, resolvedURL.Opaque)
 	t.Run("not cached", func(t *testing.T) {
 		t.Parallel()
-		data, err := Load(logger, map[string]afero.Fs{"https": afero.NewMemMapFs()}, resolvedURL, path)
+		data, err := Load(logger, map[string]fsext.Fs{"https": fsext.NewMemMapFs()}, resolvedURL, path)
 		require.NoError(t, err)
 		assert.Equal(t, data.URL, resolvedURL)
 		assert.Equal(t, path, data.URL.String())
@@ -41,13 +41,13 @@ func TestGithub(t *testing.T) {
 
 	t.Run("cached", func(t *testing.T) {
 		t.Parallel()
-		fs := afero.NewMemMapFs()
+		fs := fsext.NewMemMapFs()
 		testData := []byte("test data")
 
-		err := afero.WriteFile(fs, "/github.com/github/gitignore/Go.gitignore", testData, 0o644)
+		err := fsext.WriteFile(fs, "/github.com/github/gitignore/Go.gitignore", testData, 0o644)
 		require.NoError(t, err)
 
-		data, err := Load(logger, map[string]afero.Fs{"https": fs}, resolvedURL, path)
+		data, err := Load(logger, map[string]fsext.Fs{"https": fs}, resolvedURL, path)
 		require.NoError(t, err)
 		assert.Equal(t, path, data.URL.String())
 		assert.Equal(t, data.Data, testData)

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/lib/testutils/httpmultibin"
 	"go.k6.io/k6/loader"
@@ -138,10 +138,10 @@ func TestLoad(t *testing.T) {
 				moduleURL, err := loader.Resolve(pwdURL, data.path)
 				require.NoError(t, err)
 
-				filesystems := make(map[string]afero.Fs)
-				filesystems["file"] = afero.NewMemMapFs()
+				filesystems := make(map[string]fsext.Fs)
+				filesystems["file"] = fsext.NewMemMapFs()
 				assert.NoError(t, filesystems["file"].MkdirAll("/path/to", 0o755))
-				assert.NoError(t, afero.WriteFile(filesystems["file"], "/path/to/file.txt", []byte("hi"), 0o644))
+				assert.NoError(t, fsext.WriteFile(filesystems["file"], "/path/to/file.txt", []byte("hi"), 0o644))
 				src, err := loader.Load(logger, filesystems, moduleURL, data.path)
 				require.NoError(t, err)
 
@@ -152,10 +152,10 @@ func TestLoad(t *testing.T) {
 
 		t.Run("Nonexistent", func(t *testing.T) {
 			t.Parallel()
-			filesystems := make(map[string]afero.Fs)
-			filesystems["file"] = afero.NewMemMapFs()
+			filesystems := make(map[string]fsext.Fs)
+			filesystems["file"] = fsext.NewMemMapFs()
 			assert.NoError(t, filesystems["file"].MkdirAll("/path/to", 0o755))
-			assert.NoError(t, afero.WriteFile(filesystems["file"], "/path/to/file.txt", []byte("hi"), 0o644))
+			assert.NoError(t, fsext.WriteFile(filesystems["file"], "/path/to/file.txt", []byte("hi"), 0o644))
 
 			root, err := url.Parse("file:///")
 			require.NoError(t, err)
@@ -176,7 +176,7 @@ func TestLoad(t *testing.T) {
 		t.Parallel()
 		t.Run("From local", func(t *testing.T) {
 			t.Parallel()
-			filesystems := map[string]afero.Fs{"https": afero.NewMemMapFs()}
+			filesystems := map[string]fsext.Fs{"https": fsext.NewMemMapFs()}
 			root, err := url.Parse("file:///")
 			require.NoError(t, err)
 
@@ -192,7 +192,7 @@ func TestLoad(t *testing.T) {
 
 		t.Run("Absolute", func(t *testing.T) {
 			t.Parallel()
-			filesystems := map[string]afero.Fs{"https": afero.NewMemMapFs()}
+			filesystems := map[string]fsext.Fs{"https": fsext.NewMemMapFs()}
 			pwdURL, err := url.Parse(sr("HTTPSBIN_URL"))
 			require.NoError(t, err)
 
@@ -208,7 +208,7 @@ func TestLoad(t *testing.T) {
 
 		t.Run("Relative", func(t *testing.T) {
 			t.Parallel()
-			filesystems := map[string]afero.Fs{"https": afero.NewMemMapFs()}
+			filesystems := map[string]fsext.Fs{"https": fsext.NewMemMapFs()}
 			pwdURL, err := url.Parse(sr("HTTPSBIN_URL"))
 			require.NoError(t, err)
 
@@ -232,7 +232,7 @@ func TestLoad(t *testing.T) {
 		moduleSpecifierURL, err := loader.Resolve(root, moduleSpecifier)
 		require.NoError(t, err)
 
-		filesystems := map[string]afero.Fs{"https": afero.NewMemMapFs()}
+		filesystems := map[string]fsext.Fs{"https": fsext.NewMemMapFs()}
 		src, err := loader.Load(logger, filesystems, moduleSpecifierURL, moduleSpecifier)
 
 		require.NoError(t, err)
@@ -259,7 +259,7 @@ func TestLoad(t *testing.T) {
 			{"HOST", "some-path-that-doesnt-exist.js"},
 		}
 
-		filesystems := map[string]afero.Fs{"https": afero.NewMemMapFs()}
+		filesystems := map[string]fsext.Fs{"https": fsext.NewMemMapFs()}
 		for _, data := range testData {
 			moduleSpecifier := data.moduleSpecifier
 			t.Run(data.name, func(t *testing.T) {

--- a/log/file.go
+++ b/log/file.go
@@ -12,7 +12,7 @@ import (
 	"syscall"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
+	"go.k6.io/k6/lib/fsext"
 )
 
 // fileHookBufferSize is a default size for the fileHook's loglines channel.
@@ -20,7 +20,7 @@ const fileHookBufferSize = 100
 
 // fileHook is a hook to handle writing to local files.
 type fileHook struct {
-	fs             afero.Fs
+	fs             fsext.Fs
 	fallbackLogger logrus.FieldLogger
 	loglines       chan []byte
 	path           string
@@ -31,7 +31,7 @@ type fileHook struct {
 
 // FileHookFromConfigLine returns new fileHook hook.
 func FileHookFromConfigLine(
-	fs afero.Fs, getCwd func() (string, error),
+	fs fsext.Fs, getCwd func() (string, error),
 	fallbackLogger logrus.FieldLogger, line string,
 ) (AsyncHook, error) {
 	hook := &fileHook{

--- a/log/file_test.go
+++ b/log/file_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/lib/fsext"
 )
 
 type nopCloser struct {
@@ -95,7 +95,7 @@ func TestFileHookFromConfigLine(t *testing.T) {
 			}
 
 			res, err := FileHookFromConfigLine(
-				afero.NewMemMapFs(), getCwd, logrus.New(), test.line)
+				fsext.NewMemMapFs(), getCwd, logrus.New(), test.line)
 
 			if test.err {
 				require.Error(t, err)

--- a/output/csv/output_test.go
+++ b/output/csv/output_test.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/metrics"
 	"go.k6.io/k6/output"
@@ -317,8 +317,8 @@ func TestSampleToRow(t *testing.T) {
 	}
 }
 
-func readUnCompressedFile(fileName string, fs afero.Fs) string {
-	csvbytes, err := afero.ReadFile(fs, fileName)
+func readUnCompressedFile(fileName string, fs fsext.Fs) string {
+	csvbytes, err := fsext.ReadFile(fs, fileName)
 	if err != nil {
 		return err.Error()
 	}
@@ -326,7 +326,7 @@ func readUnCompressedFile(fileName string, fs afero.Fs) string {
 	return fmt.Sprintf("%s", csvbytes)
 }
 
-func readCompressedFile(fileName string, fs afero.Fs) string {
+func readCompressedFile(fileName string, fs fsext.Fs) string {
 	file, err := fs.Open(fileName)
 	if err != nil {
 		return err.Error()
@@ -355,7 +355,7 @@ func TestRun(t *testing.T) {
 	testData := []struct {
 		samples        []metrics.SampleContainer
 		fileName       string
-		fileReaderFunc func(fileName string, fs afero.Fs) string
+		fileReaderFunc func(fileName string, fs fsext.Fs) string
 		timeFormat     string
 		outputContent  string
 	}{
@@ -475,7 +475,7 @@ func TestRun(t *testing.T) {
 		data := data
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			mem := afero.NewMemMapFs()
+			mem := fsext.NewMemMapFs()
 			env := make(map[string]string)
 			if data.timeFormat != "" {
 				env["K6_CSV_TIME_FORMAT"] = data.timeFormat

--- a/output/json/benchmark_test.go
+++ b/output/json/benchmark_test.go
@@ -5,8 +5,8 @@ import (
 	"path"
 	"testing"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/output"
 )
@@ -17,7 +17,7 @@ func BenchmarkFlushMetrics(b *testing.B) {
 	out, err := New(output.Params{
 		Logger:         testutils.NewLogger(b),
 		StdOut:         stdout,
-		FS:             afero.NewOsFs(),
+		FS:             fsext.NewOsFs(),
 		ConfigArgument: path.Join(dir, "test.gz"),
 	})
 	require.NoError(b, err)

--- a/output/json/json_test.go
+++ b/output/json/json_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/metrics"
 	"go.k6.io/k6/output"
@@ -137,7 +137,7 @@ func TestJsonOutputFileError(t *testing.T) {
 	t.Parallel()
 
 	stdout := new(bytes.Buffer)
-	fs := afero.NewReadOnlyFs(afero.NewMemMapFs())
+	fs := fsext.NewReadOnlyFs(fsext.NewMemMapFs())
 	out, err := New(output.Params{
 		Logger:         testutils.NewLogger(t),
 		StdOut:         stdout,
@@ -152,7 +152,7 @@ func TestJsonOutputFile(t *testing.T) {
 	t.Parallel()
 
 	stdout := new(bytes.Buffer)
-	fs := afero.NewMemMapFs()
+	fs := fsext.NewMemMapFs()
 	out, err := New(output.Params{
 		Logger:         testutils.NewLogger(t),
 		StdOut:         stdout,
@@ -180,7 +180,7 @@ func TestJsonOutputFileGzipped(t *testing.T) {
 	t.Parallel()
 
 	stdout := new(bytes.Buffer)
-	fs := afero.NewMemMapFs()
+	fs := fsext.NewMemMapFs()
 	out, err := New(output.Params{
 		Logger:         testutils.NewLogger(t),
 		StdOut:         stdout,

--- a/output/types.go
+++ b/output/types.go
@@ -9,9 +9,9 @@ import (
 	"net/url"
 
 	"github.com/sirupsen/logrus"
-	"github.com/spf13/afero"
 
 	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/metrics"
 )
 
@@ -25,7 +25,7 @@ type Params struct {
 	Environment    map[string]string
 	StdOut         io.Writer
 	StdErr         io.Writer
-	FS             afero.Fs
+	FS             fsext.Fs
 	ScriptPath     *url.URL
 	ScriptOptions  lib.Options
 	RuntimeOptions lib.RuntimeOptions


### PR DESCRIPTION
This is mostly so that no other part by `fsext` knows anything about afero.

In the future we can replace the actual implementation.

Updates #1079
