### PR TITLE
output/cloudv2: Trend as Histogram

### DIFF
--- a/output/cloud/expv2/hdr.go
+++ b/output/cloud/expv2/hdr.go
@@ -1,0 +1,270 @@
+package expv2
+
+import (
+	"math"
+	"math/bits"
+	"time"
+
+	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/output/cloud/expv2/pbcloud"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+const (
+	// lowestTrackable represents the minimum value that the histogram tracks.
+	// Essentially, it excludes negative numbers.
+	// Most of metrics tracked by histograms are durations
+	// where we don't expect negative numbers.
+	//
+	// In the future, we may expand and include them,
+	// probably after https://github.com/grafana/k6/issues/763.
+	lowestTrackable = 0
+
+	// highestTrackable represents the maximum
+	// value that the histogram is able to track with high accuracy (0.1% of error).
+	// It should be a high enough
+	// and rationale value for the k6 context; 2^30 = 1_073_741_824
+	highestTrackable = 1 << 30
+)
+
+// histogram represents a distribution
+// of metrics samples' values as histogram.
+//
+// The histogram is the representation of base-2 exponential Histogram with two layers.
+// The first layer has primary buckets in the form of a power of two, and a second layer of buckets
+// for each primary bucket with an equally distributed amount of buckets inside.
+//
+// The histogram has a series of (N * 2^m) buckets, where:
+// N = a power of 2 that defines the number of primary buckets
+// m = a power of 2 that defines the number of the secondary buckets
+// The current version is: f(N = 25, m = 7) = 3200.
+type histogram struct {
+	// Buckets stores the counters for each bin of the histogram.
+	// It does not include the first and the last absolute bucket,
+	// because they contain exception cases
+	// and they requires to be tracked in a dedicated way.
+	//
+	// It is expected to start and end with a non-zero bucket,
+	// in this way we can avoid extra allocation for not significant buckets.
+	// All the zero buckets in between are preserved.
+	Buckets []uint32
+
+	// ExtraLowBucket counts occurrences of observed values smaller
+	// than the minimum trackable value.
+	ExtraLowBucket uint32
+
+	// ExtraLowBucket counts occurrences of observed values bigger
+	// than the maximum trackable value.
+	ExtraHighBucket uint32
+
+	// FirstNotZeroBucket represents the index of the first bucket
+	// with a significant counter in the Buckets slice (a not zero value).
+	// In this way, all the buckets before can be omitted.
+	FirstNotZeroBucket uint32
+
+	// LastNotZeroBucket represents the index of the last bucket
+	// with a significant counter in the Buckets slice (a not zero value).
+	// In this way, all the buckets after can be omitted.
+	LastNotZeroBucket uint32
+
+	// Max is the absolute maximum observed value.
+	Max float64
+
+	// Min is the absolute minimum observed value.
+	Min float64
+
+	// Sum is the sum of all observed values.
+	Sum float64
+
+	// Count is counts the amount of observed values.
+	Count uint32
+}
+
+// newHistogram creates an histogram of the provided values.
+//
+// TODO: after the aggregation layer probably this constructor
+// doesn't make any sense in this way.
+// It aggregates calling addToBucket time-to-time so
+// trimzeros has to be called at the end of the process.
+func newHistogram(values []float64) histogram {
+	h := histogram{}
+	if len(values) < 1 {
+		return h
+	}
+
+	for i := 0; i < len(values); i++ {
+		h.addToBucket(values[i])
+	}
+
+	h.trimzeros()
+	return h
+}
+
+// addToBucket increments the counter of the bucket
+// releated to the provided value.
+// If the value is lower or higher than the trackable limits
+// then it is counted into specific buckets.
+// All the stats are also updated accordingly.
+//
+// TODO: add the test case in units doing
+// addToBucket + trimzeros + addToBucket
+// so calling addToBucket after trimzeros was called.
+// We don't expect to have this case but the current API
+// would support it so we need to make sure it works or refactor.
+func (h *histogram) addToBucket(v float64) {
+	if h.Count == 0 {
+		h.Max, h.Min = v, v
+	} else {
+		if v > h.Max {
+			h.Max = v
+		}
+		if v < h.Min {
+			h.Min = v
+		}
+	}
+
+	h.Count++
+	h.Sum += v
+
+	if v > highestTrackable {
+		h.ExtraHighBucket++
+		return
+	}
+	if v < lowestTrackable {
+		h.ExtraLowBucket++
+		return
+	}
+
+	index := resolveBucketIndex(v)
+	blen := uint32(len(h.Buckets))
+	if blen == 0 {
+		h.FirstNotZeroBucket = index
+		h.LastNotZeroBucket = index
+	} else {
+		if index < h.FirstNotZeroBucket {
+			h.FirstNotZeroBucket = index
+		}
+		if index > h.LastNotZeroBucket {
+			h.LastNotZeroBucket = index
+		}
+	}
+
+	if index >= blen {
+		h.grow(index)
+	}
+	h.Buckets[index]++
+}
+
+// grow expands the buckets slice
+// with zeros up to the required index
+func (h *histogram) grow(index uint32) {
+	i := int(index)
+	if len(h.Buckets)-1 > i {
+		panic("buckets is already bigger than requested index")
+	}
+	if cap(h.Buckets) > i {
+		// See https://go.dev/ref/spec#Slice_expressions
+		// "For slices, the upper index bound is
+		// the slice capacity cap(a) rather than the length"
+		h.Buckets = h.Buckets[:index+1]
+	} else {
+		length := i + 1
+		// let's make two times larger of
+		// the current request
+		newBuckets := make([]uint32, length, (len(h.Buckets)+length)*2)
+		copy(newBuckets, h.Buckets)
+		h.Buckets = newBuckets
+	}
+}
+
+// trimzeros removes all buckets that have a zero value
+// from the begin and from the end until
+// the first not zero bucket.
+func (h *histogram) trimzeros() {
+	if h.Count < 1 || len(h.Buckets) < 1 {
+		return
+	}
+
+	// all the counters are set to zero, we can remove all
+	if h.FirstNotZeroBucket == 0 && h.LastNotZeroBucket == 0 {
+		h.Buckets = []uint32{}
+		return
+	}
+
+	h.Buckets = h.Buckets[h.FirstNotZeroBucket : h.LastNotZeroBucket+1]
+}
+
+// histogramAsProto converts the histogram into the equivalent Protobuf version.
+func histogramAsProto(h *histogram, time time.Time) *pbcloud.TrendHdrValue {
+	hval := &pbcloud.TrendHdrValue{
+		Time:              timestamppb.New(time),
+		MinResolution:     1.0,
+		SignificantDigits: 2,
+		LowerCounterIndex: h.FirstNotZeroBucket,
+		MinValue:          h.Min,
+		MaxValue:          h.Max,
+		Sum:               h.Sum,
+		Count:             h.Count,
+		Counters:          h.Buckets,
+	}
+	if h.ExtraLowBucket > 0 {
+		hval.ExtraLowValuesCounter = &h.ExtraLowBucket
+	}
+	if h.ExtraHighBucket > 0 {
+		hval.ExtraHighValuesCounter = &h.ExtraHighBucket
+	}
+	return hval
+}
+
+// resolveBucketIndex returns the index
+// of the bucket in the histogram for the provided value.
+func resolveBucketIndex(val float64) uint32 {
+	// the lowest trackable value is zero
+	// negative number are not expected
+	if val < 0 {
+		return 0
+	}
+
+	upscaled := uint32(math.Ceil(val))
+
+	// k is a power of 2 closest to 10^precision_points
+	// At the moment the precision_points is a fixed value set to 2.
+	//
+	// i.e 2^7  = 128  ~  100 = 10^2
+	//     2^10 = 1024 ~ 1000 = 10^3
+	// f(x) = 3*x + 1 - empiric formula that works for us
+	// since f(2)=7 and f(3)=10
+	const k = uint32(7)
+
+	// 256 = 1 << (k+1)
+	if upscaled < 256 {
+		return upscaled
+	}
+
+	//
+	// Here we use some math to get simple formula
+	// derivation:
+	// let u = upscaled
+	// let n = msb(u) - most significant digit position
+	// i.e. n = floor(log(u, 2))
+	//   major_bucket_index = n - k + 1
+	//   sub_bucket_index = u>>(n - k) - (1<<k)
+	//   bucket = major_bucket_index << k + sub_bucket_index =
+	//          = (n-k+1)<<k + u>>(n-k) - (1<<k) =
+	//          = (n-k)<<k + u>>(n-k)
+	//
+	nkdiff := uint32(bits.Len32(upscaled>>k) - 1) // msb index
+	return (nkdiff << k) + (upscaled >> nkdiff)
+}
+
+func (h *histogram) IsEmpty() bool {
+	return h.Count == 0
+}
+
+func (h *histogram) Add(s metrics.Sample) {
+	h.addToBucket(s.Value)
+}
+
+func (h *histogram) Format(time.Duration) map[string]float64 {
+	panic("output/cloud/expv2/histogram.Format is not expected to be called")
+}

--- a/output/cloud/expv2/hdr.go
+++ b/output/cloud/expv2/hdr.go
@@ -125,9 +125,9 @@ func (h *histogram) addToBucket(v float64) {
 	case len(h.Buckets) == 0:
 		h.init(index)
 	case index < h.FirstNotZeroBucket:
-		h.growLeft(index)
+		h.prependBuckets(index)
 	case index > h.LastNotZeroBucket:
-		h.growRight(index)
+		h.appendBuckets(index)
 	default:
 		h.Buckets[index-h.FirstNotZeroBucket]++
 	}
@@ -140,7 +140,9 @@ func (h *histogram) init(index uint32) {
 	h.Buckets[0] = 1
 }
 
-func (h *histogram) growLeft(index uint32) {
+// prependBuckets expands the buckets slice with zeros up to the required index,
+// then it increments the required bucket.
+func (h *histogram) prependBuckets(index uint32) {
 	if h.FirstNotZeroBucket <= index {
 		panic("buckets is already contains the requested index")
 	}
@@ -160,10 +162,10 @@ func (h *histogram) growLeft(index uint32) {
 	h.FirstNotZeroBucket = index
 }
 
-// growRight expands the buckets slice
-// with zeros up to the required index.
-// If it array has enough capacity then it reuses it without allocate.
-func (h *histogram) growRight(index uint32) {
+// appendBuckets expands the buckets slice with zeros buckets till the required index,
+// then it increments the required bucket.
+// If the slice has enough capacity then it reuses it without allocate.
+func (h *histogram) appendBuckets(index uint32) {
 	if h.LastNotZeroBucket >= index {
 		panic("buckets is already bigger than requested index")
 	}

--- a/output/cloud/expv2/hdr.go
+++ b/output/cloud/expv2/hdr.go
@@ -127,8 +127,7 @@ func (h *histogram) addToBucket(v float64) {
 	if index < h.FirstNotZeroBucket {
 		h.growLeft(index)
 		h.FirstNotZeroBucket = index
-	}
-	if index > h.LastNotZeroBucket {
+	} else if index > h.LastNotZeroBucket {
 		h.growRight(index)
 		h.LastNotZeroBucket = index
 	}

--- a/output/cloud/expv2/hdr_test.go
+++ b/output/cloud/expv2/hdr_test.go
@@ -1,0 +1,262 @@
+package expv2
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.k6.io/k6/output/cloud/expv2/pbcloud"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestValueBacket(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in  float64
+		exp uint32
+	}{
+		{in: -1029, exp: 0},
+		{in: -12, exp: 0},
+		{in: -0.82673, exp: 0},
+		{in: 10, exp: 10},
+		{in: 12, exp: 12},
+		{in: 12.5, exp: 13},
+		{in: 20, exp: 20},
+		{in: 255, exp: 255},
+		{in: 256, exp: 256},
+		{in: 282.29, exp: 269},
+		{in: 1029, exp: 512},
+		{in: (1 << 30) - 1, exp: 3071},
+		{in: (1 << 30), exp: 3072},
+		{in: math.MaxInt32, exp: 3199},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.exp, resolveBucketIndex(tc.in), tc.in)
+	}
+}
+
+func TestNewHistogramWithSimpleValue(t *testing.T) {
+	t.Parallel()
+	res := newHistogram([]float64{100})
+
+	exp := histogram{
+		Buckets:            []uint32{1},
+		FirstNotZeroBucket: 100,
+		LastNotZeroBucket:  100,
+		ExtraLowBucket:     0,
+		ExtraHighBucket:    0,
+		Max:                100,
+		Min:                100,
+		Sum:                100,
+		Count:              1,
+	}
+	assert.Equal(t, exp, res)
+}
+
+func TestNewHistogramWithUntrackables(t *testing.T) {
+	t.Parallel()
+	res := newHistogram([]float64{5, -3.14, 2 * 1e9, 1})
+
+	exp := histogram{
+		Buckets:            []uint32{1, 0, 0, 0, 1},
+		FirstNotZeroBucket: 1,
+		LastNotZeroBucket:  5,
+		ExtraLowBucket:     1,
+		ExtraHighBucket:    1,
+		Max:                2 * 1e9,
+		Min:                -3.14,
+		Sum:                2*1e9 + 5 + 1 - 3.14,
+		Count:              4,
+	}
+	assert.Equal(t, exp, res)
+}
+
+func TestNewHistogramWithMultipleValues(t *testing.T) {
+	t.Parallel()
+	res := newHistogram([]float64{51.8, 103.6, 103.6, 103.6, 103.6})
+
+	exp := histogram{
+		FirstNotZeroBucket: 52,
+		LastNotZeroBucket:  104,
+		Max:                103.6,
+		Min:                51.8,
+		ExtraLowBucket:     0,
+		ExtraHighBucket:    0,
+		Buckets:            append(append([]uint32{1}, make([]uint32, 51)...), 4),
+		// Buckets = {1, 0 for 51 times, 4}
+		Sum:   466.20000000000005,
+		Count: 5,
+	}
+	assert.Equal(t, exp, res)
+}
+
+func TestNewHistogramWithNegativeNum(t *testing.T) {
+	t.Parallel()
+	res := newHistogram([]float64{-2.42314})
+
+	exp := histogram{
+		FirstNotZeroBucket: 0,
+		Max:                -2.42314,
+		Min:                -2.42314,
+		Buckets:            nil,
+		ExtraLowBucket:     1,
+		ExtraHighBucket:    0,
+		Sum:                -2.42314,
+		Count:              1,
+	}
+	assert.Equal(t, exp, res)
+}
+
+func TestNewHistogramWithMultipleNegativeNums(t *testing.T) {
+	t.Parallel()
+	res := newHistogram([]float64{-0.001, -0.001, -0.001})
+
+	exp := histogram{
+		Buckets:            nil,
+		FirstNotZeroBucket: 0,
+		ExtraLowBucket:     3,
+		ExtraHighBucket:    0,
+		Max:                -0.001,
+		Min:                -0.001,
+		Sum:                -0.003,
+		Count:              3,
+	}
+	assert.Equal(t, exp, res)
+}
+
+func TestNewHistoramWithNoVals(t *testing.T) {
+	t.Parallel()
+	res := newHistogram([]float64{})
+	exp := histogram{
+		Buckets:            nil,
+		FirstNotZeroBucket: 0,
+		ExtraLowBucket:     0,
+		ExtraHighBucket:    0,
+		Max:                0,
+		Min:                0,
+		Sum:                0,
+	}
+	assert.Equal(t, exp, res)
+}
+
+func TestHistogramTrimzeros(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		in  histogram
+		exp []uint32
+	}{
+		{in: histogram{Buckets: []uint32{}}, exp: []uint32{}},
+		{in: histogram{Buckets: []uint32{0}}, exp: []uint32{}},
+		{in: histogram{Buckets: []uint32{0, 0, 0}}, exp: []uint32{}},
+		{
+			in: histogram{
+				Buckets:            []uint32{0, 0, 0, 0, 0, 0, 1, 0},
+				FirstNotZeroBucket: 6,
+				LastNotZeroBucket:  6,
+			},
+			exp: []uint32{1},
+		},
+		{
+			in: histogram{
+				Buckets:            []uint32{0, 0, 0, 1, 9, 0, 0, 1, 0, 0, 0},
+				FirstNotZeroBucket: 3,
+				LastNotZeroBucket:  7,
+			},
+			exp: []uint32{1, 9, 0, 0, 1},
+		},
+	}
+
+	for _, tc := range cases {
+		h := tc.in
+		h.Count = 1
+		h.trimzeros()
+		assert.Equal(t, tc.exp, h.Buckets, tc.in.Buckets)
+	}
+}
+
+func TestHistogramGrow(t *testing.T) {
+	t.Parallel()
+	h := histogram{}
+
+	// the cap is smaller than requested index
+	// so it creates a new slice
+	h.grow(3)
+	assert.Len(t, h.Buckets, 4)
+
+	// it must preserve already existing items
+	h.Buckets[2] = 101
+
+	// it appends to the same slice
+	h.grow(5)
+	assert.Len(t, h.Buckets, 6)
+	assert.Equal(t, uint32(101), h.Buckets[2])
+	assert.Equal(t, uint32(0), h.Buckets[5])
+
+	// it is not possible to request an index smaller than
+	// the last already available index
+	assert.Panics(t, func() { h.grow(4) })
+}
+
+func TestHistogramAsProto(t *testing.T) {
+	t.Parallel()
+
+	uint32ptr := func(v uint32) *uint32 {
+		return &v
+	}
+
+	cases := []struct {
+		name string
+		in   histogram
+		exp  *pbcloud.TrendHdrValue
+	}{
+		{
+			name: "empty histogram",
+			in:   histogram{},
+			exp:  &pbcloud.TrendHdrValue{},
+		},
+		{
+			name: "not trackable values",
+			in:   newHistogram([]float64{-0.23, 1<<30 + 1}),
+			exp: &pbcloud.TrendHdrValue{
+				Count:                  2,
+				ExtraLowValuesCounter:  uint32ptr(1),
+				ExtraHighValuesCounter: uint32ptr(1),
+				Counters:               nil,
+				LowerCounterIndex:      0,
+				MinValue:               -0.23,
+				MaxValue:               1<<30 + 1,
+			},
+		},
+		{
+			name: "normal values",
+			in:   newHistogram([]float64{2, 1.1, 3}),
+			exp: &pbcloud.TrendHdrValue{
+				Count:                  3,
+				ExtraLowValuesCounter:  nil,
+				ExtraHighValuesCounter: nil,
+				Counters:               []uint32{2, 1},
+				LowerCounterIndex:      2,
+				MinValue:               1.1,
+				MaxValue:               3,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc.exp.MinResolution = 1.0
+		tc.exp.SignificantDigits = 2
+		tc.exp.Time = &timestamppb.Timestamp{Seconds: 1}
+		tc.exp.Sum = tc.in.Sum
+		assert.Equal(t, tc.exp, histogramAsProto(&tc.in, time.Unix(1, 0)), tc.name)
+	}
+}
+
+func TestHistogramIsEmpty(t *testing.T) {
+	h := histogram{}
+	assert.True(t, h.IsEmpty())
+	h.addToBucket(3.1)
+	assert.False(t, h.IsEmpty())
+}

--- a/output/cloud/expv2/hdr_test.go
+++ b/output/cloud/expv2/hdr_test.go
@@ -233,20 +233,20 @@ func TestNewHistoramWithNoVals(t *testing.T) {
 	assert.Equal(t, exp, res)
 }
 
-func TestHistogramGrowRight(t *testing.T) {
+func TestHistogramAppendBuckets(t *testing.T) {
 	t.Parallel()
 	h := histogram{}
 
 	// the cap is smaller than requested index
 	// so it creates a new slice
-	h.growRight(3)
+	h.appendBuckets(3)
 	assert.Len(t, h.Buckets, 4)
 
 	// it must preserve already existing items
 	h.Buckets[2] = 101
 
 	// it appends to the same slice
-	h.growRight(5)
+	h.appendBuckets(5)
 	assert.Len(t, h.Buckets, 6)
 	assert.Equal(t, uint32(101), h.Buckets[2])
 	assert.Equal(t, uint32(1), h.Buckets[5])
@@ -254,7 +254,7 @@ func TestHistogramGrowRight(t *testing.T) {
 	// it is not possible to request an index smaller than
 	// the last already available index
 	h.LastNotZeroBucket = 5
-	assert.Panics(t, func() { h.growRight(4) })
+	assert.Panics(t, func() { h.appendBuckets(4) })
 }
 
 func TestHistogramAsProto(t *testing.T) {

--- a/output/cloud/expv2/hdr_test.go
+++ b/output/cloud/expv2/hdr_test.go
@@ -188,7 +188,7 @@ func TestNewHistogramWithNegativeNum(t *testing.T) {
 		FirstNotZeroBucket: 0,
 		Max:                -2.42314,
 		Min:                -2.42314,
-		Buckets:            []uint32{},
+		Buckets:            nil,
 		ExtraLowBucket:     1,
 		ExtraHighBucket:    0,
 		Sum:                -2.42314,
@@ -205,7 +205,7 @@ func TestNewHistogramWithMultipleNegativeNums(t *testing.T) {
 	}
 
 	exp := histogram{
-		Buckets:            []uint32{},
+		Buckets:            nil,
 		FirstNotZeroBucket: 0,
 		ExtraLowBucket:     3,
 		ExtraHighBucket:    0,
@@ -222,7 +222,7 @@ func TestNewHistoramWithNoVals(t *testing.T) {
 
 	res := newHistogram()
 	exp := histogram{
-		Buckets:            []uint32{},
+		Buckets:            nil,
 		FirstNotZeroBucket: 0,
 		ExtraLowBucket:     0,
 		ExtraHighBucket:    0,

--- a/output/cloud/expv2/hdr_test.go
+++ b/output/cloud/expv2/hdr_test.go
@@ -172,7 +172,7 @@ func TestNewHistogramWithNegativeNum(t *testing.T) {
 		FirstNotZeroBucket: 0,
 		Max:                -2.42314,
 		Min:                -2.42314,
-		Buckets:            nil,
+		Buckets:            []uint32{},
 		ExtraLowBucket:     1,
 		ExtraHighBucket:    0,
 		Sum:                -2.42314,
@@ -189,7 +189,7 @@ func TestNewHistogramWithMultipleNegativeNums(t *testing.T) {
 	}
 
 	exp := histogram{
-		Buckets:            nil,
+		Buckets:            []uint32{},
 		FirstNotZeroBucket: 0,
 		ExtraLowBucket:     3,
 		ExtraHighBucket:    0,
@@ -206,7 +206,7 @@ func TestNewHistoramWithNoVals(t *testing.T) {
 
 	res := newHistogram()
 	exp := histogram{
-		Buckets:            nil,
+		Buckets:            []uint32{},
 		FirstNotZeroBucket: 0,
 		ExtraLowBucket:     0,
 		ExtraHighBucket:    0,

--- a/output/cloud/expv2/hdr_test.go
+++ b/output/cloud/expv2/hdr_test.go
@@ -41,12 +41,28 @@ func TestValueBacket(t *testing.T) {
 func TestNewHistogramWithSimpleValue(t *testing.T) {
 	t.Parallel()
 
-	// Add a lower bucket index within slice capacity
+	// Zero as value
 	res := newHistogram()
+	res.addToBucket(0)
+	exp := histogram{
+		Buckets:            []uint32{1},
+		FirstNotZeroBucket: 0,
+		LastNotZeroBucket:  0,
+		ExtraLowBucket:     0,
+		ExtraHighBucket:    0,
+		Max:                0,
+		Min:                0,
+		Sum:                0,
+		Count:              1,
+	}
+	require.Equal(t, exp, res)
+
+	// Add a lower bucket index within slice capacity
+	res = newHistogram()
 	res.addToBucket(8)
 	res.addToBucket(5)
 
-	exp := histogram{
+	exp = histogram{
 		Buckets:            []uint32{1, 0, 0, 1},
 		FirstNotZeroBucket: 5,
 		LastNotZeroBucket:  8,
@@ -233,7 +249,7 @@ func TestHistogramGrowRight(t *testing.T) {
 	h.growRight(5)
 	assert.Len(t, h.Buckets, 6)
 	assert.Equal(t, uint32(101), h.Buckets[2])
-	assert.Equal(t, uint32(0), h.Buckets[5])
+	assert.Equal(t, uint32(1), h.Buckets[5])
 
 	// it is not possible to request an index smaller than
 	// the last already available index

--- a/output/cloud/expv2/hdr_test.go
+++ b/output/cloud/expv2/hdr_test.go
@@ -41,6 +41,7 @@ func TestValueBacket(t *testing.T) {
 func TestNewHistogramWithSimpleValue(t *testing.T) {
 	t.Parallel()
 
+	// Add a lower bucket index within slice capacity
 	res := newHistogram()
 	res.addToBucket(8)
 	res.addToBucket(5)
@@ -56,9 +57,9 @@ func TestNewHistogramWithSimpleValue(t *testing.T) {
 		Sum:                13,
 		Count:              2,
 	}
-
 	require.Equal(t, exp, res)
 
+	// Add a higher bucket index within slice capacity
 	res = newHistogram()
 	res.addToBucket(100)
 	res.addToBucket(101)
@@ -74,7 +75,9 @@ func TestNewHistogramWithSimpleValue(t *testing.T) {
 		Sum:                201,
 		Count:              2,
 	}
+	require.Equal(t, exp, res)
 
+	// Same case but reversed test check
 	res = newHistogram()
 	res.addToBucket(101)
 	res.addToBucket(100)
@@ -92,6 +95,7 @@ func TestNewHistogramWithSimpleValue(t *testing.T) {
 	}
 	assert.Equal(t, exp, res)
 
+	// One more complex case with lower index and more than two indexes
 	res = newHistogram()
 	res.addToBucket(8)
 	res.addToBucket(9)

--- a/output/cloud/expv2/integration/integration_test.go
+++ b/output/cloud/expv2/integration/integration_test.go
@@ -148,7 +148,7 @@ func testSamples() metrics.Samples {
 				Tags:   r.RootTagSet().With("my_label_4", "my_label_value_4"),
 			},
 			Time:  time.Date(2023, time.May, 1, 4, 0, 0, 0, time.UTC),
-			Value: 186,
+			Value: 6,
 		},
 	}
 	return samples

--- a/output/cloud/expv2/integration/testdata/metricset.json
+++ b/output/cloud/expv2/integration/testdata/metricset.json
@@ -119,7 +119,17 @@
           "trendHdrSamples": {
             "values": [
               {
-                "time": "2023-05-01T04:00:00Z"
+                "time": "2023-05-01T04:00:00Z",
+                "count": 1,
+                "counters": [
+                  1
+                ],
+                "lowerCounterIndex": 6,
+                "maxValue": 6,
+                "minResolution": 1,
+                "minValue": 6,
+                "significantDigits": 2,
+                "sum": 6
               }
             ]
           }

--- a/output/cloud/expv2/mapping.go
+++ b/output/cloud/expv2/mapping.go
@@ -87,6 +87,8 @@ func addBucketToTimeSeriesProto(
 			TotalCount:   uint32(r.Total),
 		})
 	case metrics.Trend:
+		h := sink.(*histogram) //nolint: forcetypeassert
+		h.trimzeros()
 		samples := timeSeries.GetTrendHdrSamples()
 		samples.Values = append(samples.Values, &pbcloud.TrendHdrValue{
 			Time: timestamppb.New(time),

--- a/output/cloud/expv2/mapping.go
+++ b/output/cloud/expv2/mapping.go
@@ -92,7 +92,6 @@ func addBucketToTimeSeriesProto(
 		samples.Values = append(samples.Values, histogramAsProto(h, time))
 	default:
 		panic(fmt.Sprintf("MetricType %q is not supported", mt))
-
 	}
 }
 

--- a/output/cloud/expv2/mapping.go
+++ b/output/cloud/expv2/mapping.go
@@ -88,14 +88,11 @@ func addBucketToTimeSeriesProto(
 		})
 	case metrics.Trend:
 		h := sink.(*histogram) //nolint: forcetypeassert
-		h.trimzeros()
 		samples := timeSeries.GetTrendHdrSamples()
-		samples.Values = append(samples.Values, &pbcloud.TrendHdrValue{
-			Time: timestamppb.New(time),
-			// TODO: implement the histogram
-		})
+		samples.Values = append(samples.Values, histogramAsProto(h, time))
 	default:
 		panic(fmt.Sprintf("MetricType %q is not supported", mt))
+
 	}
 }
 

--- a/output/cloud/expv2/sink.go
+++ b/output/cloud/expv2/sink.go
@@ -1,8 +1,6 @@
 package expv2
 
 import (
-	"time"
-
 	"go.k6.io/k6/metrics"
 )
 
@@ -13,10 +11,3 @@ func newSink(mt metrics.MetricType) metrics.Sink {
 
 	return metrics.NewSink(mt)
 }
-
-// TODO: implement the HDR histogram
-type histogram struct{}
-
-func (h *histogram) IsEmpty() bool                           { return true }
-func (h *histogram) Add(metrics.Sample)                      {}
-func (h *histogram) Format(time.Duration) map[string]float64 { panic("nyi") }


### PR DESCRIPTION
Custom Histogram representation of the Trend metric type. It is the porting of the Histogram generation on the client side.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
-->
