### PR TITLE
Make the linter CI action reusable by other repos

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -1,0 +1,28 @@
+name: golangci-lint-k6
+description: Run golangci-lint with the k6 ruleset
+
+runs:
+  using: composite
+  steps:
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: 1.20.x
+        check-latest: true
+    - name: Get golangci-lint version and download rules
+      shell: bash
+      env: #TODO: remove after https://github.com/actions/runner/issues/2473 is fixed
+        GITHUB_ACTION_REF: ${{ github.action_ref || github.head_ref }}
+      run: |
+        RulesURL="https://raw.githubusercontent.com/grafana/k6/${{ env.GITHUB_ACTION_REF }}/.golangci.yml"
+        echo "Downloading ${RulesURL}..."
+        curl --silent --show-error --fail --no-location "${RulesURL}" --output "${{ github.action_path }}/.golangci.yml"
+
+        echo "GolangCIVersion=$(head -n 1 "${{ github.action_path }}/.golangci.yml" | tr -d '# ')" >> "${GITHUB_OUTPUT}"
+      id: getenv
+    - name: golangci-lint
+      uses: golangci/golangci-lint-action@v3
+      with:
+        version: ${{ steps.getenv.outputs.GolangCIVersion }}
+        only-new-issues: true
+        args: "--config=${{ github.action_path }}/.golangci.yml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,18 +39,5 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.20.x
-          check-latest: true
-      - name: Retrieve golangci-lint version
-        run: |
-          echo "Version=$(head -n 1 "${GITHUB_WORKSPACE}/.golangci.yml" | tr -d '# ')" >> $GITHUB_OUTPUT
-        id: version
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: ${{ steps.version.outputs.Version }}
-          only-new-issues: true
+      - name: Run linters
+        uses: ./.github/actions/lint/


### PR DESCRIPTION
This allows other repositories to reuse the k6 linter checks, somewhat like this:
```yml
name: Lint
on:
  push:
    branches:
      - main
  pull_request:

jobs:
  lint:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v3
      - name: Run k6 golangci-lint CI
        uses: grafana/k6/.github/actions/lint@master
```