### PR TITLE
k6/execution: Add metadata JS API

### DIFF
--- a/js/common/tags.go
+++ b/js/common/tags.go
@@ -56,7 +56,7 @@ func ApplyCustomUserTag(tagsAndMeta *metrics.TagsAndMeta, key string, val goja.V
 }
 
 // ApplyCustomUserMetadata modifies the given metrics.TagsAndMeta object with the
-// given custom metadata and theirs value.
+// given custom metadata and their value.
 func ApplyCustomUserMetadata(tagsAndMeta *metrics.TagsAndMeta, key string, val goja.Value) error {
 	kind := reflect.Invalid
 	if typ := val.ExportType(); typ != nil {
@@ -76,7 +76,7 @@ func ApplyCustomUserMetadata(tagsAndMeta *metrics.TagsAndMeta, key string, val g
 	default:
 		return fmt.Errorf(
 			"invalid value for metric metadata '%s': "+
-				"only String, Boolean and Number types are accepted as a metric metadata values",
+				"only String, Boolean and Number types are accepted as a metric metadata value",
 			key,
 		)
 	}

--- a/js/common/tags.go
+++ b/js/common/tags.go
@@ -20,7 +20,7 @@ func ApplyCustomUserTags(rt *goja.Runtime, tagsAndMeta *metrics.TagsAndMeta, key
 	keyValuesObj := keyValues.ToObject(rt)
 
 	for _, key := range keyValuesObj.Keys() {
-		if err := ApplyCustomUserTag(rt, tagsAndMeta, key, keyValuesObj.Get(key)); err != nil {
+		if err := ApplyCustomUserTag(tagsAndMeta, key, keyValuesObj.Get(key)); err != nil {
 			return err
 		}
 	}
@@ -29,8 +29,8 @@ func ApplyCustomUserTags(rt *goja.Runtime, tagsAndMeta *metrics.TagsAndMeta, key
 }
 
 // ApplyCustomUserTag modifies the given metrics.TagsAndMeta object with the
-// given custom tag or metadata and theirs value.
-func ApplyCustomUserTag(rt *goja.Runtime, tagsAndMeta *metrics.TagsAndMeta, key string, val goja.Value) error {
+// given custom tag and theirs value.
+func ApplyCustomUserTag(tagsAndMeta *metrics.TagsAndMeta, key string, val goja.Value) error {
 	kind := reflect.Invalid
 	if typ := val.ExportType(); typ != nil {
 		kind = typ.Kind()
@@ -50,6 +50,33 @@ func ApplyCustomUserTag(rt *goja.Runtime, tagsAndMeta *metrics.TagsAndMeta, key 
 		return fmt.Errorf(
 			"invalid value for metric tag '%s': "+
 				"only String, Boolean and Number types are accepted as a metric tag values",
+			key,
+		)
+	}
+}
+
+// ApplyCustomUserMetadata modifies the given metrics.TagsAndMeta object with the
+// given custom metadata and theirs value.
+func ApplyCustomUserMetadata(tagsAndMeta *metrics.TagsAndMeta, key string, val goja.Value) error {
+	kind := reflect.Invalid
+	if typ := val.ExportType(); typ != nil {
+		kind = typ.Kind()
+	}
+
+	switch kind {
+	case
+		reflect.String,
+		reflect.Bool,
+		reflect.Int64,
+		reflect.Float64:
+
+		tagsAndMeta.SetMetadata(key, val.String())
+		return nil
+
+	default:
+		return fmt.Errorf(
+			"invalid value for metric metadata '%s': "+
+				"only String, Boolean and Number types are accepted as a metric metadata values",
 			key,
 		)
 	}

--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -216,11 +216,34 @@ func (mi *ModuleInstance) newVUInfo() (*goja.Object, error) {
 	if err != nil {
 		return o, err
 	}
-
-	err = o.Set("tags", rt.NewDynamicObject(&tagsDynamicObject{
+	tagsDynamicObject := rt.NewDynamicObject(&tagsDynamicObject{
 		runtime: rt,
 		state:   vuState,
-	}))
+	})
+	err = o.Set("tags", tagsDynamicObject)
+
+	if err != nil {
+		return o, err
+	}
+	metrics, err := newInfoObj(rt, map[string]func() interface{}{
+		"tags": func() interface{} { return tagsDynamicObject },
+		"metadata": func() interface{} {
+			return rt.NewDynamicObject(&metadataDynamicObject{
+				runtime: rt,
+				state:   vuState,
+			})
+		},
+	})
+	if err != nil {
+		return o, err
+	}
+
+	err = o.Set("metrics", metrics)
+
+	if err != nil {
+		return o, err
+	}
+
 	return o, err
 }
 
@@ -311,9 +334,6 @@ func (o *tagsDynamicObject) Get(key string) goja.Value {
 	if tag, ok := tcv.Tags.Get(key); ok {
 		return o.runtime.ToValue(tag)
 	}
-	if metadatum, ok := tcv.Metadata[key]; ok {
-		return o.runtime.ToValue(metadatum)
-	}
 	return nil
 }
 
@@ -323,7 +343,7 @@ func (o *tagsDynamicObject) Get(key string) goja.Value {
 func (o *tagsDynamicObject) Set(key string, val goja.Value) bool {
 	var err error
 	o.state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
-		err = common.ApplyCustomUserTag(o.runtime, tagsAndMeta, key, val)
+		err = common.ApplyCustomUserTag(tagsAndMeta, key, val)
 		if err != nil {
 			panic(o.runtime.NewTypeError(err.Error()))
 		}
@@ -335,9 +355,6 @@ func (o *tagsDynamicObject) Set(key string, val goja.Value) bool {
 func (o *tagsDynamicObject) Has(key string) bool {
 	ctv := o.state.Tags.GetCurrentValues()
 	if _, ok := ctv.Tags.Get(key); ok {
-		return true
-	}
-	if _, ok := ctv.Metadata[key]; ok {
 		return true
 	}
 	return false
@@ -362,6 +379,61 @@ func (o *tagsDynamicObject) Keys() []string {
 	for k := range tagsMap {
 		keys = append(keys, k)
 	}
+	return keys
+}
+
+type metadataDynamicObject struct {
+	runtime *goja.Runtime
+	state   *lib.State
+}
+
+// Get a property value for the key. May return nil if the property does not exist.
+func (o *metadataDynamicObject) Get(key string) goja.Value {
+	tcv := o.state.Tags.GetCurrentValues()
+	if metadatum, ok := tcv.Metadata[key]; ok {
+		return o.runtime.ToValue(metadatum)
+	}
+	return nil
+}
+
+// Set a property value for the key. It returns true if succeed. String, Boolean
+// and Number types are implicitly converted to the goja's relative string
+// representation. An exception is raised in case a denied type is provided.
+func (o *metadataDynamicObject) Set(key string, val goja.Value) bool {
+	var err error
+	o.state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
+		err = common.ApplyCustomUserMetadata(tagsAndMeta, key, val)
+		if err != nil {
+			panic(o.runtime.NewTypeError(err.Error()))
+		}
+	})
+	return true
+}
+
+// Has returns true if the property exists.
+func (o *metadataDynamicObject) Has(key string) bool {
+	ctv := o.state.Tags.GetCurrentValues()
+	if _, ok := ctv.Metadata[key]; ok {
+		return true
+	}
+	return false
+}
+
+// Delete deletes the property for the key. It returns true on success (note,
+// that includes missing property).
+func (o *metadataDynamicObject) Delete(key string) bool {
+	o.state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
+		tagsAndMeta.DeleteMetadata(key)
+	})
+	return true
+}
+
+// Keys returns a slice with all existing property keys. The order is not
+// deterministic.
+func (o *metadataDynamicObject) Keys() []string {
+	ctv := o.state.Tags.GetCurrentValues()
+
+	keys := make([]string, 0, len(ctv.Metadata))
 	for k := range ctv.Metadata {
 		keys = append(keys, k)
 	}

--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -220,8 +220,10 @@ func (mi *ModuleInstance) newVUInfo() (*goja.Object, error) {
 		runtime: rt,
 		state:   vuState,
 	})
-	err = o.Set("tags", tagsDynamicObject)
 
+	// This is kept for backwards compatibility reasons, but should be deprecated,
+	// since tags are also accessible via vu.metrics.tags.
+	err = o.Set("tags", tagsDynamicObject)
 	if err != nil {
 		return o, err
 	}
@@ -396,7 +398,7 @@ func (o *metadataDynamicObject) Get(key string) goja.Value {
 	return nil
 }
 
-// Set a property value for the key. It returns true if succeed. String, Boolean
+// Set a property value for the key. It returns true if successful. String, Boolean
 // and Number types are implicitly converted to the goja's relative string
 // representation. An exception is raised in case a denied type is provided.
 func (o *metadataDynamicObject) Set(key string, val goja.Value) bool {

--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -343,10 +343,8 @@ func (o *tagsDynamicObject) Get(key string) goja.Value {
 // and Number types are implicitly converted to the goja's relative string
 // representation. An exception is raised in case a denied type is provided.
 func (o *tagsDynamicObject) Set(key string, val goja.Value) bool {
-	var err error
 	o.state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
-		err = common.ApplyCustomUserTag(tagsAndMeta, key, val)
-		if err != nil {
+		if err := common.ApplyCustomUserTag(tagsAndMeta, key, val); err != nil {
 			panic(o.runtime.NewTypeError(err.Error()))
 		}
 	})
@@ -402,10 +400,8 @@ func (o *metadataDynamicObject) Get(key string) goja.Value {
 // and Number types are implicitly converted to the goja's relative string
 // representation. An exception is raised in case a denied type is provided.
 func (o *metadataDynamicObject) Set(key string, val goja.Value) bool {
-	var err error
 	o.state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
-		err = common.ApplyCustomUserMetadata(tagsAndMeta, key, val)
-		if err != nil {
+		if err := common.ApplyCustomUserMetadata(tagsAndMeta, key, val); err != nil {
 			panic(o.runtime.NewTypeError(err.Error()))
 		}
 	})

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -95,7 +95,7 @@ func TestVUTagsMetadatasJSONEncoding(t *testing.T) {
 	}
 }
 
-func TestVUTagMetadatasSetSuccessAccetedTypes(t *testing.T) {
+func TestVUTagMetadatasSetSuccessAcceptedTypes(t *testing.T) {
 	t.Parallel()
 
 	// bool and numbers are implicitly converted into string

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -41,7 +41,7 @@ func setupTagsExecEnv(t *testing.T) *modulestest.Runtime {
 	return testRuntime
 }
 
-func TestVUTagMetadatasGet(t *testing.T) {
+func TestVUTagsMetadatasGet(t *testing.T) {
 	t.Parallel()
 
 	for prop, propType := range tagsAndMetricsPropertyNames {
@@ -67,7 +67,7 @@ func TestVUTagMetadatasGet(t *testing.T) {
 	}
 }
 
-func TestVUTagMetadasJSONEncoding(t *testing.T) {
+func TestVUTagsMetadatasJSONEncoding(t *testing.T) {
 	t.Parallel()
 
 	for prop, propType := range tagsAndMetricsPropertyNames {
@@ -131,7 +131,7 @@ func TestVUTagMetadatasSetSuccessAccetedTypes(t *testing.T) {
 	}
 }
 
-func TestVUTagMetadatasSuccessOverwriteSystemTag(t *testing.T) {
+func TestVUTagsMetadatasSuccessOverwriteSystemTag(t *testing.T) {
 	t.Parallel()
 
 	tenv := setupTagsExecEnv(t)


### PR DESCRIPTION
A bare minimum API to set and get metadata set for the whole VU.

It is added on top of the vu property and on top of a new `metrics` one so. If `k6/execution` is imported as `exec` -
`exec.vu.metrics.metadata["foo"]` will get you the currently set metadata for `foo` the same way `exec.vu.tags["bar"]` will get you the value of the tag `bar`.

Setting metadata is the same.

It also adds `exec.vu.metrics.tags` which is the same as `exec.vu.tags` for consistency. While leaving the old one for backwards compatibility.

This also includes dropping the ability to list metadata keys and values from `exec.vu.tags`. This was likely left in by mistake.

This is a breaking change due to the fact that before that `iter` and `vu` could've been accessed this way but this will now need to be done through the new `exec.vu.metrics.metadata`.

Closes #2766

