### PR TITLE
fix: use default buildx builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,11 +141,7 @@ jobs:
           fetch-depth: 0
       - name: Build
         run: |
-          docker buildx create \
-            --name multibuilder \
-            --platform linux/amd64,linux/arm64 \
-            --bootstrap --use
-          docker buildx build \
+          docker buildx --builder default build \
             --platform linux/amd64,linux/arm64 \
             -t $DOCKER_IMAGE_ID .
       - name: Check


### PR DESCRIPTION
This is a fix for the PR #3015. Using an external builder will create issues for docker loading images locally and then won't be able to push the multi-platform images correctly.