### PR TITLE
fix: load multi-platform build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,7 +147,7 @@ jobs:
             --bootstrap --use
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
-            -t $DOCKER_IMAGE_ID .
+            -t $DOCKER_IMAGE_ID . --load
       - name: Check
         run: |
             docker run $DOCKER_IMAGE_ID version


### PR DESCRIPTION
This loads the just built docker image with --load and makes it available to push later on.

Fixes output from #3015 