### PR TITLE
Release v0.44.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apk --no-cache add git=~2
 RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"
 
 FROM alpine:3.17
-RUN apk add --no-cache ca-certificates=~20220614 && \
+# hadolint ignore=DL3018
+RUN apk add --no-cache ca-certificates && \
     adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /go/bin/k6 /usr/bin/k6
 

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.44.0"
+const Version = "0.44.1"
 
 // VersionDetails can be set externally as part of the build process
 var VersionDetails = "" //nolint:gochecknoglobals

--- a/release notes/v0.44.1.md
+++ b/release notes/v0.44.1.md
@@ -1,0 +1,5 @@
+k6 v0.44.1 is a patch release that fixes a couple of packaging issues:
+- [#3055](https://github.com/grafana/k6/issues/3055) due to an oversight, the k6 package signing key in our RPM repository wasn't updated when its expiration date was extended in March.
+- [#3060](https://github.com/grafana/k6/issues/3060) fixed building of Docker image due to a missing pinned `ca-certificates` version.
+
+There are no functional changes in k6 compared to v0.44.0.


### PR DESCRIPTION
We should tag `v0.44.1` on this branch, and not when it's merged to `master`, to avoid releasing everything currently on `master`.