### PR TITLE
docker: Do not pin the ca-certs pkg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ RUN apk --no-cache add git=~2
 RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"
 
 FROM alpine:3.17
-RUN apk add --no-cache ca-certificates=~20220614 && \
+# hadolint ignore=DL3018
+RUN apk add --no-cache ca-certificates && \
     adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /go/bin/k6 /usr/bin/k6
 


### PR DESCRIPTION
Hadolint advises to pin a version, but in this specific case isn't very useful because:
- We always want the latest version for the ca-certificates package
- It has a date-based versioning so we couldn't use the common `=~` selector for patch updates. It mostly breaks every time the Alpine repository releases a new version because they don't keep the previous one.

See also: https://github.com/hadolint/hadolint/issues/464#issuecomment-1386948671

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
