### PR TITLE
cloud: Use static reference ID in tests

### DIFF
--- a/output/cloud/bench_test.go
+++ b/output/cloud/bench_test.go
@@ -262,6 +262,7 @@ func generateSamples(registry *metrics.Registry, count int) []*Sample {
 }
 
 func generateHTTPExtTrail(now time.Time, i time.Duration, tags *metrics.TagSet) *httpext.Trail {
+	//nolint:durationcheck
 	return &httpext.Trail{
 		Blocked:        i % 200 * 100 * time.Millisecond,
 		Connecting:     i % 200 * 200 * time.Millisecond,

--- a/output/cloud/data_test.go
+++ b/output/cloud/data_test.go
@@ -194,6 +194,7 @@ func TestSampleMarshaling(t *testing.T) {
 }
 
 func TestMetricAggregation(t *testing.T) {
+	t.Parallel()
 	m := AggregatedMetric{}
 	m.Add(1 * time.Second)
 	m.Add(1 * time.Second)
@@ -220,7 +221,7 @@ func TestMetricAggregation(t *testing.T) {
 func getDurations(r *rand.Rand, count int, min, multiplier float64) durations {
 	data := make(durations, count)
 	for j := 0; j < count; j++ {
-		data[j] = time.Duration(min + r.Float64()*multiplier) //nolint:gosec
+		data[j] = time.Duration(min + r.Float64()*multiplier)
 	}
 	return data
 }
@@ -263,9 +264,8 @@ func BenchmarkDurationBounds(b *testing.B) {
 	}
 }
 
+//nolint:paralleltest
 func TestQuickSelectAndBounds(t *testing.T) {
-	t.Parallel()
-
 	seed := time.Now().UnixNano()
 	r := rand.New(rand.NewSource(seed)) //nolint:gosec
 	t.Logf("Random source seeded with %d\n", seed)

--- a/output/cloud/metrics_client.go
+++ b/output/cloud/metrics_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -64,7 +65,11 @@ func (mc *MetricsClient) PushMetric(referenceID string, s []*Sample) error {
 	var additionalFields logrus.Fields
 
 	if !mc.noCompress {
-		buf := mc.pushBufferPool.Get().(*bytes.Buffer)
+		buf, ok := mc.pushBufferPool.Get().(*bytes.Buffer)
+		if !ok {
+			return errors.New("failed to convert a buffer pool item " +
+				"into the expected type bytes Buffer for gzip compression operation")
+		}
 		buf.Reset()
 		defer mc.pushBufferPool.Put(buf)
 		unzippedSize := len(b)

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -1,3 +1,4 @@
+// Package cloud implements an Output that flushes to the k6 Cloud platform.
 package cloud
 
 import (
@@ -579,7 +580,7 @@ func (out *Output) shouldStopSendingMetrics(err error) bool {
 		return false
 	}
 
-	if errResp, ok := err.(cloudapi.ErrorResponse); ok && errResp.Response != nil {
+	if errResp, ok := err.(cloudapi.ErrorResponse); ok && errResp.Response != nil { //nolint:errorlint
 		return errResp.Response.StatusCode == http.StatusForbidden && errResp.Code == 4
 	}
 

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -31,6 +31,7 @@ const TestName = "k6 test"
 
 // Output sends result data to the k6 Cloud service.
 type Output struct {
+	logger      logrus.FieldLogger
 	config      cloudapi.Config
 	referenceID string
 
@@ -42,9 +43,6 @@ type Output struct {
 	bufferMutex      sync.Mutex
 	bufferHTTPTrails []*httpext.Trail
 	bufferSamples    []*Sample
-
-	logger logrus.FieldLogger
-	opts   lib.Options
 
 	// TODO: optimize this
 	//
@@ -126,7 +124,6 @@ func newOutput(params output.Params) (*Output, error) {
 		client:        NewMetricsClient(apiClient, logger, conf.Host.String, conf.NoCompress.Bool),
 		executionPlan: params.ExecutionPlan,
 		duration:      int64(duration / time.Second),
-		opts:          params.ScriptOptions,
 		aggrBuckets:   map[int64]aggregationBucket{},
 		logger:        logger,
 


### PR DESCRIPTION
The master's version mocks the test creation for all the tests doing them dependent on the resolution logic. The current PR removes this requirement and centralizes this assertion in a single test. Instead, all the other tests use a static-injected reference ID.

It should simplify the migration to something like the following architecture that I would do in https://github.com/grafana/k6/pull/3041:

output/cloud/output.go: has the logic for the test creation and cleaning up (common logic)
- output/cloud/v1/output.go has the **old** logic for metric collect/aggregate/flush
- output/cloud/expv2/output.go has the **new** logic for metric collect/aggregate/flush

Applying the current PR would be easier to eventually divide the unit tests of the test creation from the unit tests for metrics collection/aggregation/flushing logic across different components in the next PRs.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
