### PR TITLE
k6/metrics: Warn on metric names not compatible with Prometheus

### DIFF
--- a/lib/testutils/logrus_hook.go
+++ b/lib/testutils/logrus_hook.go
@@ -87,3 +87,15 @@ func LogContains(logEntries []logrus.Entry, expLevel logrus.Level, expContents s
 	}
 	return false
 }
+
+// FilterEntries is a helper function that checks the provided list of log entries
+// for a messages matching the provided level and contents and returns an array with only them.
+func FilterEntries(logEntries []logrus.Entry, expLevel logrus.Level, expContents string) []logrus.Entry {
+	filtered := make([]logrus.Entry, 0)
+	for _, entry := range logEntries {
+		if entry.Level == expLevel && strings.Contains(entry.Message, expContents) {
+			filtered = append(filtered, entry)
+		}
+	}
+	return filtered
+}


### PR DESCRIPTION
This adds a warning for custom metrics that are not Prometheus compatible.

The warning is in the k6/metrics as the alternative was threading a logger in the registry specifically for this and then removing it.

The major downside of this is that extension can still register incompatible metric names without any warnings.

Updates #3065
