### PR TITLE
metrics: Sink contructor from metric type

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -77,20 +77,7 @@ func (r *Registry) newMetric(name string, mt MetricType, vt ...ValueType) *Metri
 		valueType = vt[0]
 	}
 
-	var sink Sink
-	switch mt {
-	case Counter:
-		sink = &CounterSink{}
-	case Gauge:
-		sink = &GaugeSink{}
-	case Trend:
-		sink = &TrendSink{}
-	case Rate:
-		sink = &RateSink{}
-	default:
-		return nil
-	}
-
+	sink := NewSink(mt)
 	return &Metric{
 		registry: r,
 		Name:     name,

--- a/metrics/sink.go
+++ b/metrics/sink.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"sort"
 	"time"
@@ -19,6 +20,28 @@ type Sink interface {
 	Add(s Sample)                              // Add a sample to the sink.
 	Format(t time.Duration) map[string]float64 // Data for thresholds.
 	IsEmpty() bool                             // Check if the Sink is empty.
+}
+
+// NewSink creates the related Sink for
+// the provided MetricType.
+func NewSink(mt MetricType) Sink {
+	var sink Sink
+	switch mt {
+	case Counter:
+		sink = &CounterSink{}
+	case Gauge:
+		sink = &GaugeSink{}
+	case Trend:
+		sink = &TrendSink{}
+	case Rate:
+		sink = &RateSink{}
+	default:
+		// Should not be possible to create
+		// an invalid metric type except for specific
+		// and controlled tests
+		panic(fmt.Sprintf("MetricType %q is not supported", mt))
+	}
+	return sink
 }
 
 type CounterSink struct {

--- a/metrics/sink_test.go
+++ b/metrics/sink_test.go
@@ -9,6 +9,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNewSink(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		sink interface{}
+		mt   MetricType
+	}{
+		{mt: Counter, sink: &CounterSink{}},
+		{mt: Gauge, sink: &GaugeSink{}},
+		{mt: Rate, sink: &RateSink{}},
+		{mt: Trend, sink: &TrendSink{}},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.sink, NewSink(tc.mt))
+	}
+}
+
+func TestNewSinkInvalidMetricType(t *testing.T) {
+	t.Parallel()
+	assert.Panics(t, func() { NewSink(MetricType(6)) })
+}
+
 func TestCounterSink(t *testing.T) {
 	samples10 := []float64{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 100.0}
 	now := time.Now()


### PR DESCRIPTION
I did this multiple times across different outputs, maybe we can have a central function.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
