### PR TITLE
output/cloudv2: Aggregation

### DIFF
--- a/output/cloud/expv2/collect.go
+++ b/output/cloud/expv2/collect.go
@@ -1,0 +1,168 @@
+package expv2
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	"go.k6.io/k6/metrics"
+)
+
+type timeBucket struct {
+	Time  time.Time
+	Sinks map[metrics.TimeSeries]metrics.Sink
+}
+
+// bucketQ is a queue for buffering the aggregated metrics
+// that have to be flushed. It is expected to be used concurrently.
+type bucketQ struct {
+	m       sync.Mutex
+	buckets []timeBucket
+}
+
+// PopAll returns a slice with all the pushed buckets.
+// It returns a nil slice if the queue is empty.
+func (q *bucketQ) PopAll() []timeBucket {
+	q.m.Lock()
+	defer q.m.Unlock()
+
+	if len(q.buckets) < 1 {
+		return nil
+	}
+
+	// return the enqueued slice and its relative array and allocate a new one
+	// using the same capacity.
+	b := q.buckets
+	q.buckets = make([]timeBucket, 0, len(b))
+	return b
+}
+
+// Push enqueues a new item in the queue.
+func (q *bucketQ) Push(b []timeBucket) {
+	if len(b) < 1 {
+		return
+	}
+	q.m.Lock()
+	q.buckets = append(q.buckets, b...)
+	q.m.Unlock()
+}
+
+type collector struct {
+	bq      bucketQ
+	nowFunc func() time.Time
+
+	aggregationPeriod time.Duration
+	waitPeriod        time.Duration
+
+	// We should no longer have to handle metrics that have times long in the past.
+	// So, instead of a map, we can probably use a simple slice (or even an array!)
+	// as a ring buffer to store the aggregation buckets.
+	// This should save us a some time, since it would make the lookups and
+	// WaitPeriod checks basically O(1).
+	// And even if for some reason there are occasional metrics with past times
+	// that don't fit in the chosen ring buffer size, we could just send them
+	// along to the buffer unaggregated.
+	timeBuckets map[int64]map[metrics.TimeSeries]metrics.Sink
+}
+
+func newCollector(aggrPeriod, waitPeriod time.Duration) (*collector, error) {
+	if aggrPeriod == 0 {
+		return nil, errors.New("aggregation period is not allowed to be zero")
+	}
+	if waitPeriod == 0 {
+		// TODO: we could simplify the expiring logic
+		// just having an internal static logic.
+		// Like skip only not closed buckets bucketEnd > now.
+		return nil, errors.New("aggregation wait period is not allowed to be zero")
+	}
+	return &collector{
+		bq:                bucketQ{},
+		nowFunc:           time.Now,
+		timeBuckets:       make(map[int64]map[metrics.TimeSeries]metrics.Sink),
+		aggregationPeriod: aggrPeriod,
+		waitPeriod:        waitPeriod,
+	}, nil
+}
+
+// CollectSamples drain the buffer and collect all the samples.
+func (c *collector) CollectSamples(containers []metrics.SampleContainer) {
+	// Distribute all newly buffered samples into related buckets
+	for _, sampleContainer := range containers {
+		samples := sampleContainer.GetSamples()
+
+		for i := 0; i < len(samples); i++ {
+			c.collectSample(samples[i])
+		}
+	}
+	c.bq.Push(c.expiredBuckets())
+}
+
+// DropExpiringDelay drops the waiting time for buckets
+// for the expiring checks.
+func (c *collector) DropExpiringDelay() {
+	c.waitPeriod = 0
+}
+
+func (c *collector) collectSample(s metrics.Sample) {
+	bucketID := c.bucketID(s.Time)
+
+	// Get or create a time bucket
+	bucket, ok := c.timeBuckets[bucketID]
+	if !ok {
+		bucket = make(map[metrics.TimeSeries]metrics.Sink)
+		c.timeBuckets[bucketID] = bucket
+	}
+
+	// Get or create the bucket's sinks map per time series
+	sink, ok := bucket[s.TimeSeries]
+	if !ok {
+		sink = newSink(s.Metric.Type)
+		bucket[s.TimeSeries] = sink
+	}
+
+	// TODO: we may consider to just pass
+	// the single value instead of the entire
+	// sample and save some memory
+	sink.Add(s)
+}
+
+func (c *collector) expiredBuckets() []timeBucket {
+	// Still too recent buckets
+	// where we prefer to wait a bit more
+	// then, hopefully, we can aggregate more samples before flushing.
+	bucketCutoffID := c.bucketCutoffID()
+
+	// Here, it avoids pre-allocation
+	// because it expects to be zero for most of the time
+	var expired []timeBucket //nolint:prealloc
+
+	// Mark as expired all aggregation buckets older than bucketCutoffID
+	for bucketID, seriesSinks := range c.timeBuckets {
+		if bucketID > bucketCutoffID {
+			continue
+		}
+
+		expired = append(expired, timeBucket{
+			Time:  c.timeFromBucketID(bucketID),
+			Sinks: seriesSinks,
+		})
+		delete(c.timeBuckets, bucketID)
+	}
+
+	return expired
+}
+
+func (c *collector) bucketID(t time.Time) int64 {
+	return t.UnixNano() / int64(c.aggregationPeriod)
+}
+
+func (c *collector) timeFromBucketID(id int64) time.Time {
+	return time.Unix(0,
+		// it uses the center of the bucket as time
+		(id*int64(c.aggregationPeriod))+int64(c.aggregationPeriod/2),
+	).Truncate(time.Microsecond).UTC()
+}
+
+func (c *collector) bucketCutoffID() int64 {
+	return c.nowFunc().Add(-c.waitPeriod).UnixNano() / int64(c.aggregationPeriod)
+}

--- a/output/cloud/expv2/collect.go
+++ b/output/cloud/expv2/collect.go
@@ -9,6 +9,8 @@ import (
 )
 
 type timeBucket struct {
+	// TODO: for performance reasons, use directly a unix time here
+	// so we can avoid time->unix->time
 	Time  time.Time
 	Sinks map[metrics.TimeSeries]metrics.Sink
 }
@@ -157,10 +159,8 @@ func (c *collector) bucketID(t time.Time) int64 {
 }
 
 func (c *collector) timeFromBucketID(id int64) time.Time {
-	return time.Unix(0,
-		// it uses the center of the bucket as time
-		(id*int64(c.aggregationPeriod))+int64(c.aggregationPeriod/2),
-	).Truncate(time.Microsecond).UTC()
+	return time.Unix(0, id*int64(c.aggregationPeriod)).
+		Truncate(time.Microsecond).UTC()
 }
 
 func (c *collector) bucketCutoffID() int64 {

--- a/output/cloud/expv2/collect_test.go
+++ b/output/cloud/expv2/collect_test.go
@@ -172,7 +172,7 @@ func TestCollectorExpiredBucketsCutoff(t *testing.T) {
 	assert.NotContains(t, c.timeBuckets, 3)
 
 	require.Len(t, expired, 1)
-	expDateTime := time.Unix(10, int64(500*time.Millisecond)).UTC()
+	expDateTime := time.Unix(9, 0).UTC()
 	assert.Equal(t, expDateTime, expired[0].Time)
 }
 
@@ -202,8 +202,8 @@ func TestCollectorTimeFromBucketID(t *testing.T) {
 
 	c := collector{aggregationPeriod: 3 * time.Second}
 
-	// exp = Time(bucketID * 3s + (3s/2)) = Time(49 * 3s + (1.5s))
-	exp := time.Date(1970, time.January, 1, 0, 2, 28, int(500*time.Millisecond), time.UTC)
+	// exp = TimeFromUnix(bucketID * aggregationPeriod) = Time(49 * 3s)
+	exp := time.Date(1970, time.January, 1, 0, 2, 27, 0, time.UTC)
 	assert.Equal(t, exp, c.timeFromBucketID(49))
 }
 

--- a/output/cloud/expv2/collect_test.go
+++ b/output/cloud/expv2/collect_test.go
@@ -1,0 +1,296 @@
+package expv2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/metrics"
+)
+
+func TestCollectorCollectSample(t *testing.T) {
+	t.Parallel()
+
+	r := metrics.NewRegistry()
+	m1, err := r.NewMetric("metric1", metrics.Counter)
+	require.NoError(t, err)
+
+	tags := r.RootTagSet().With("t1", "v1")
+	samples := metrics.Samples(make([]metrics.Sample, 3))
+
+	c := collector{
+		aggregationPeriod: 3 * time.Second,
+		waitPeriod:        1 * time.Second,
+		timeBuckets:       make(map[int64]map[metrics.TimeSeries]metrics.Sink),
+		nowFunc: func() time.Time {
+			return time.Unix(31, 0)
+		},
+	}
+	for i := 0; i < len(samples); i++ {
+		sample := metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: m1,
+				Tags:   tags,
+			},
+			Value: 1.0,
+			Time:  time.Unix(int64((i+1)*10), 0), // 10, 20, 30
+		}
+		c.collectSample(sample)
+	}
+
+	assert.Len(t, c.timeBuckets, 3)
+}
+
+func TestCollectorCollectSampleAggregateNumbers(t *testing.T) {
+	t.Parallel()
+
+	r := metrics.NewRegistry()
+	m1, err := r.NewMetric("metric1", metrics.Counter)
+	require.NoError(t, err)
+
+	tags := r.RootTagSet().With("t1", "v1")
+	samples := metrics.Samples(make([]metrics.Sample, 3))
+
+	c := collector{
+		aggregationPeriod: 3 * time.Second,
+		waitPeriod:        1 * time.Second,
+		timeBuckets:       make(map[int64]map[metrics.TimeSeries]metrics.Sink),
+		nowFunc: func() time.Time {
+			return time.Unix(31, 0)
+		},
+	}
+	ts := metrics.TimeSeries{
+		Metric: m1,
+		Tags:   tags,
+	}
+
+	for i := 0; i < len(samples); i++ {
+		sample := metrics.Sample{
+			TimeSeries: ts,
+			Value:      3.5,
+			// it generates time // 11, 12, 13
+			// then it will apply the following formula
+			// for finding the bucketID
+			// id(x) = floor(unixnano/aggregation)
+			// e.g id(11) = floor(11/3) = floor(3.x) = 3
+			Time: time.Unix(int64((i+1)+10), 0),
+		}
+		c.collectSample(sample)
+	}
+
+	require.Len(t, c.timeBuckets, 2)
+	assert.Contains(t, c.timeBuckets, int64(3))
+	assert.Contains(t, c.timeBuckets, int64(4))
+
+	sink, ok := c.timeBuckets[4][ts].(*metrics.CounterSink)
+	require.True(t, ok)
+	assert.Equal(t, 7.0, sink.Value)
+}
+
+func TestDropExpiringDelay(t *testing.T) {
+	t.Parallel()
+
+	c := collector{waitPeriod: 1 * time.Second}
+	c.DropExpiringDelay()
+	assert.Zero(t, c.waitPeriod)
+}
+
+func TestCollectorExpiredBucketsNoExipired(t *testing.T) {
+	t.Parallel()
+
+	c := collector{
+		aggregationPeriod: 3 * time.Second,
+		waitPeriod:        1 * time.Second,
+		nowFunc: func() time.Time {
+			return time.Unix(10, 0)
+		},
+		timeBuckets: map[int64]map[metrics.TimeSeries]metrics.Sink{
+			6: {},
+		},
+	}
+	require.Nil(t, c.expiredBuckets())
+}
+
+func TestCollectorExpiredBuckets(t *testing.T) {
+	t.Parallel()
+
+	r := metrics.NewRegistry()
+	m1, err := r.NewMetric("metric1", metrics.Counter)
+	require.NoError(t, err)
+
+	ts1 := metrics.TimeSeries{
+		Metric: m1,
+		Tags:   r.RootTagSet().With("t1", "v1"),
+	}
+	ts2 := metrics.TimeSeries{
+		Metric: m1,
+		Tags:   r.RootTagSet().With("t1", "v2"),
+	}
+
+	c := collector{
+		aggregationPeriod: 3 * time.Second,
+		waitPeriod:        1 * time.Second,
+		nowFunc: func() time.Time {
+			return time.Unix(10, 0)
+		},
+		timeBuckets: map[int64]map[metrics.TimeSeries]metrics.Sink{
+			3: {
+				ts1: &metrics.CounterSink{Value: 10},
+				ts2: &metrics.CounterSink{Value: 4},
+			},
+		},
+	}
+	expired := c.expiredBuckets()
+	require.Len(t, expired, 1)
+
+	assert.NotZero(t, expired[0].Time)
+	assert.Equal(t, expired[0].Sinks, map[metrics.TimeSeries]metrics.Sink{
+		ts1: &metrics.CounterSink{Value: 10},
+		ts2: &metrics.CounterSink{Value: 4},
+	})
+}
+
+func TestCollectorExpiredBucketsCutoff(t *testing.T) {
+	t.Parallel()
+
+	c := collector{
+		aggregationPeriod: 3 * time.Second,
+		waitPeriod:        1 * time.Second,
+		nowFunc: func() time.Time {
+			return time.Unix(10, 0)
+		},
+		timeBuckets: map[int64]map[metrics.TimeSeries]metrics.Sink{
+			3: {},
+			6: {},
+			9: {},
+		},
+	}
+	expired := c.expiredBuckets()
+	require.Len(t, expired, 1)
+	assert.Len(t, c.timeBuckets, 2)
+	assert.NotContains(t, c.timeBuckets, 3)
+
+	require.Len(t, expired, 1)
+	expDateTime := time.Unix(10, int64(500*time.Millisecond)).UTC()
+	assert.Equal(t, expDateTime, expired[0].Time)
+}
+
+func TestCollectorBucketID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		unixSeconds int64
+		unixNano    int64
+		exp         int64
+	}{
+		{0, 0, 0},
+		{2, 0, 0},
+		{3, 0, 1},
+		{28, 0, 9},
+		{59, 7, 19},
+	}
+
+	c := collector{aggregationPeriod: 3 * time.Second}
+	for _, tc := range tests {
+		assert.Equal(t, tc.exp, c.bucketID(time.Unix(tc.unixSeconds, 0)))
+	}
+}
+
+func TestCollectorTimeFromBucketID(t *testing.T) {
+	t.Parallel()
+
+	c := collector{aggregationPeriod: 3 * time.Second}
+
+	// exp = Time(bucketID * 3s + (3s/2)) = Time(49 * 3s + (1.5s))
+	exp := time.Date(1970, time.January, 1, 0, 2, 28, int(500*time.Millisecond), time.UTC)
+	assert.Equal(t, exp, c.timeFromBucketID(49))
+}
+
+func TestCollectorBucketCutoffID(t *testing.T) {
+	t.Parallel()
+
+	c := collector{
+		aggregationPeriod: 3 * time.Second,
+		waitPeriod:        1 * time.Second,
+		nowFunc: func() time.Time {
+			// 1st May 2023 - 01:06:06 + 8ns
+			return time.Date(2023, time.May, 1, 1, 6, 6, 8, time.UTC)
+		},
+	}
+	// exp = floor((now-1s)/3s) = floor(1682903165/3)
+	assert.Equal(t, int64(560967721), c.bucketCutoffID())
+}
+
+func TestBucketQPush(t *testing.T) {
+	t.Parallel()
+
+	bq := bucketQ{}
+	bq.Push([]timeBucket{{Time: time.Unix(1, 0)}})
+	require.Len(t, bq.buckets, 1)
+}
+
+func TestBucketQPopAll(t *testing.T) {
+	t.Parallel()
+	bq := bucketQ{
+		buckets: []timeBucket{
+			{Time: time.Unix(1, 0)},
+			{Time: time.Unix(2, 0)},
+		},
+	}
+	buckets := bq.PopAll()
+	require.Len(t, buckets, 2)
+	assert.NotZero(t, buckets[0].Time)
+
+	assert.NotNil(t, bq.buckets)
+	assert.Empty(t, bq.buckets)
+}
+
+func TestBucketQPushPopConcurrency(t *testing.T) {
+	t.Parallel()
+	var (
+		counter = 0
+		bq      = bucketQ{}
+		sink    = metrics.NewSink(metrics.Counter)
+
+		stop = time.After(100 * time.Millisecond)
+		pop  = make(chan struct{}, 10)
+		done = make(chan struct{})
+	)
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				close(pop)
+				return
+			case <-pop:
+				b := bq.PopAll()
+				_ = append(b, timeBucket{})
+			}
+		}
+	}()
+
+	now := time.Now()
+	for {
+		select {
+		case <-stop:
+			close(done)
+			return
+		default:
+			counter++
+			bq.Push([]timeBucket{
+				{
+					Time: now,
+					Sinks: map[metrics.TimeSeries]metrics.Sink{
+						{}: sink,
+					},
+				},
+			})
+
+			if counter%5 == 0 { // a fixed-arbitrary flush rate
+				pop <- struct{}{}
+			}
+		}
+	}
+}

--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -1,0 +1,16 @@
+package expv2
+
+import "context"
+
+type noopFlusher struct {
+	referenceID string
+	bq          *bucketQ
+
+	// client      MetricsClient
+}
+
+func (f *noopFlusher) Flush(ctx context.Context) error {
+	// drain the buffer
+	_ = f.bq.PopAll()
+	return nil
+}

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -3,25 +3,43 @@
 package expv2
 
 import (
+	"context"
+	"net/http"
+	"time"
+
 	"go.k6.io/k6/cloudapi"
+	"go.k6.io/k6/errext"
+	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/output"
 
 	"github.com/sirupsen/logrus"
 )
 
 // Output sends result data to the k6 Cloud service.
 type Output struct {
+	output.SampleBuffer
+
 	logger       logrus.FieldLogger
 	config       cloudapi.Config
 	referenceID  string
 	testStopFunc func(error)
+
+	// TODO: replace with the real impl
+	metricsFlusher  noopFlusher
+	periodicFlusher *output.PeriodicFlusher
+
+	collector             *collector
+	periodicCollector     *output.PeriodicFlusher
+	stopMetricsCollection chan struct{}
 }
 
 // New creates a new cloud output.
 func New(logger logrus.FieldLogger, conf cloudapi.Config) (*Output, error) {
 	return &Output{
-		config: conf,
-		logger: logger.WithFields(logrus.Fields{"output": "cloudv2"}),
+		config:                conf,
+		logger:                logger.WithFields(logrus.Fields{"output": "cloudv2"}),
+		stopMetricsCollection: make(chan struct{}),
 	}, nil
 }
 
@@ -42,7 +60,31 @@ func (o *Output) SetTestRunStopCallback(stopFunc func(error)) {
 func (o *Output) Start() error {
 	o.logger.Debug("Starting...")
 
-	// TODO: add start implementation
+	var err error
+	o.collector, err = newCollector(
+		o.config.AggregationPeriod.TimeDuration(),
+		o.config.AggregationWaitPeriod.TimeDuration())
+	if err != nil {
+		return err
+	}
+	o.metricsFlusher = noopFlusher{
+		referenceID: o.referenceID,
+		bq:          &o.collector.bq,
+	}
+
+	pf, err := output.NewPeriodicFlusher(
+		o.config.MetricPushInterval.TimeDuration(), o.flushMetrics)
+	if err != nil {
+		return err
+	}
+	o.periodicFlusher = pf
+
+	pfc, err := output.NewPeriodicFlusher(
+		o.config.AggregationPeriod.TimeDuration(), o.collectSamples)
+	if err != nil {
+		return err
+	}
+	o.periodicCollector = pfc
 
 	o.logger.Debug("Started!")
 	return nil
@@ -51,8 +93,15 @@ func (o *Output) Start() error {
 // StopWithTestError gracefully stops all metric emission from the output.
 func (o *Output) StopWithTestError(testErr error) error {
 	o.logger.Debug("Stopping...")
+	close(o.stopMetricsCollection)
 
-	// TODO: add stop implementation
+	// Drain the SampleBuffer and force the aggregation for flushing
+	// all the queued samples even if they haven't yet passed the
+	// wait period.
+	o.periodicCollector.Stop()
+	o.collector.DropExpiringDelay()
+	o.collector.CollectSamples(nil)
+	o.periodicFlusher.Stop()
 
 	o.logger.Debug("Stopped!")
 	return nil
@@ -60,5 +109,84 @@ func (o *Output) StopWithTestError(testErr error) error {
 
 // AddMetricSamples receives the samples streaming.
 func (o *Output) AddMetricSamples(s []metrics.SampleContainer) {
-	// TODO: implement
+	// TODO: this and the next operation are two locking operations,
+	// evaluate to do something smarter, maybe having a lock-free
+	// queue.
+	select {
+	case <-o.stopMetricsCollection:
+		return
+	default:
+	}
+
+	// TODO: when we will have a very good optimized
+	// bucketing process we may evaluate to drop this
+	// buffer.
+	//
+	// If the bucketing process is efficient, the single
+	// operation could be a bit longer than just enqueuing
+	// but it could be fast enough to justify to to direct
+	// run it and save some memory across the e2e operation.
+	//
+	// It requires very specific benchmark.
+	o.SampleBuffer.AddMetricSamples(s)
+}
+
+func (o *Output) collectSamples() {
+	samples := o.GetBufferedSamples()
+	if len(samples) < 1 {
+		return
+	}
+	o.collector.CollectSamples(samples)
+
+	// TODO: other operations with the samples containers
+	// e.g. flushing the Metadata as tracing samples
+}
+
+// flushMetrics receives a set of metric samples.
+func (o *Output) flushMetrics() {
+	start := time.Now()
+
+	ctx, cancel := context.WithTimeout(context.Background(), o.config.MetricPushInterval.TimeDuration())
+	defer cancel()
+
+	err := o.metricsFlusher.Flush(ctx)
+	if err != nil {
+		o.logger.WithError(err).Error("Failed to push metrics to the cloud")
+
+		if o.shouldStopSendingMetrics(err) {
+			o.logger.WithError(err).Warn("Interrupt sending metrics to cloud due to an error")
+			serr := errext.WithAbortReasonIfNone(
+				errext.WithExitCodeIfNone(err, exitcodes.ExternalAbort),
+				errext.AbortedByOutput,
+			)
+			if o.config.StopOnError.Bool {
+				o.testStopFunc(serr)
+			}
+			close(o.stopMetricsCollection)
+		}
+		return
+	}
+
+	o.logger.WithField("t", time.Since(start)).Debug("Successfully flushed buffered samples to the cloud")
+}
+
+// shouldStopSendingMetrics returns true if the output should interrupt the metric flush.
+//
+// note: The actual test execution should continues,
+// since for local k6 run tests the end-of-test summary (or any other outputs) will still work,
+// but the cloud output doesn't send any more metrics.
+// Instead, if cloudapi.Config.StopOnError is enabled
+// the cloud output should stop the whole test run too.
+// This logic should be handled by the caller.
+func (o *Output) shouldStopSendingMetrics(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errResp, ok := err.(cloudapi.ErrorResponse); ok && errResp.Response != nil { //nolint:errorlint
+		// The Cloud service returns the error code 4 when it doesn't accept any more metrics.
+		// So, when k6 sees that, the cloud output just stops prematurely.
+		return errResp.Response.StatusCode == http.StatusForbidden && errResp.Code == 4
+	}
+
+	return false
 }

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -111,6 +111,6 @@ func TestOutputCollectSamples(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 5.0, counter.Value)
 
-	expTime := time.Date(2023, time.May, 1, 1, 1, 16, int(500*time.Millisecond), time.UTC)
+	expTime := time.Date(2023, time.May, 1, 1, 1, 15, 0, time.UTC)
 	assert.Equal(t, expTime, buckets[0].Time)
 }

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -3,11 +3,14 @@ package expv2
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/lib/testutils"
+	"go.k6.io/k6/lib/types"
+	"go.k6.io/k6/metrics"
 	"gopkg.in/guregu/null.v3"
 )
 
@@ -46,4 +49,68 @@ func TestOutputSetTestRunStopCallback(t *testing.T) {
 	})
 	o.testStopFunc(errors.New("my new fake error"))
 	assert.True(t, called)
+}
+
+func TestOutputCollectSamples(t *testing.T) {
+	t.Parallel()
+	o, err := New(testutils.NewLogger(t), cloudapi.Config{
+		AggregationPeriod:     types.NewNullDuration(3*time.Second, true),
+		AggregationWaitPeriod: types.NewNullDuration(5*time.Second, true),
+		MetricPushInterval:    types.NewNullDuration(10*time.Second, true),
+	})
+	require.NoError(t, err)
+	require.NoError(t, o.Start())
+
+	// Manually control and trigger the various steps
+	// instead to be time dependent
+	o.periodicFlusher.Stop()
+
+	o.periodicCollector.Stop()
+	require.Empty(t, o.collector.bq.PopAll())
+
+	o.collector.nowFunc = func() time.Time {
+		// the cut off will be set to (22-1)
+		return time.Date(2023, time.May, 1, 1, 1, 20, 0, time.UTC)
+	}
+
+	r := metrics.NewRegistry()
+	m1 := r.MustNewMetric("metric1", metrics.Counter)
+	ts := metrics.TimeSeries{
+		Metric: m1,
+		Tags:   r.RootTagSet().With("key1", "val1"),
+	}
+
+	s1 := metrics.Sample{
+		TimeSeries: ts,
+		Time:       time.Date(2023, time.May, 1, 1, 1, 15, 0, time.UTC),
+		Value:      1.0,
+	}
+
+	s2 := metrics.Sample{
+		TimeSeries: ts,
+		Time:       time.Date(2023, time.May, 1, 1, 1, 18, 0, time.UTC),
+		Value:      2.0,
+	}
+
+	s3 := metrics.Sample{
+		TimeSeries: ts,
+		Time:       time.Date(2023, time.May, 1, 1, 1, 15, 0, time.UTC),
+		Value:      4.0,
+	}
+
+	o.collector.CollectSamples([]metrics.SampleContainer{
+		metrics.Samples{s1},
+		metrics.Samples{s2},
+		metrics.Samples{s3},
+	})
+	buckets := o.collector.bq.PopAll()
+	require.Len(t, buckets, 1)
+	require.Contains(t, buckets[0].Sinks, ts)
+
+	counter, ok := buckets[0].Sinks[ts].(*metrics.CounterSink)
+	require.True(t, ok)
+	assert.Equal(t, 5.0, counter.Value)
+
+	expTime := time.Date(2023, time.May, 1, 1, 1, 16, int(500*time.Millisecond), time.UTC)
+	assert.Equal(t, expTime, buckets[0].Time)
 }

--- a/output/cloud/expv2/sink.go
+++ b/output/cloud/expv2/sink.go
@@ -1,0 +1,22 @@
+package expv2
+
+import (
+	"time"
+
+	"go.k6.io/k6/metrics"
+)
+
+func newSink(mt metrics.MetricType) metrics.Sink {
+	if mt == metrics.Trend {
+		return &histogram{}
+	}
+
+	return metrics.NewSink(mt)
+}
+
+// TODO: implement the HDR histogram
+type histogram struct{}
+
+func (h *histogram) IsEmpty() bool                           { return true }
+func (h *histogram) Add(metrics.Sample)                      {}
+func (h *histogram) Format(time.Duration) map[string]float64 { panic("nyi") }

--- a/output/cloud/expv2/sink_test.go
+++ b/output/cloud/expv2/sink_test.go
@@ -1,0 +1,22 @@
+package expv2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.k6.io/k6/metrics"
+)
+
+func TestNewSink(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		mt  metrics.MetricType
+		exp any
+	}{
+		{metrics.Counter, &metrics.CounterSink{}},
+		{metrics.Trend, &histogram{}},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.exp, newSink(tc.mt))
+	}
+}

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -162,7 +162,11 @@ func TestOutputStartVersionedOutputV2(t *testing.T) {
 		logger:      testutils.NewLogger(t),
 		referenceID: "123",
 		config: cloudapi.Config{
-			APIVersion: null.IntFrom(2),
+			APIVersion:            null.IntFrom(2),
+			AggregationWaitPeriod: types.NullDurationFrom(1 * time.Second),
+			// Here, we are enabling but silencing the related async ops
+			AggregationPeriod:  types.NullDurationFrom(1 * time.Hour),
+			MetricPushInterval: types.NullDurationFrom(1 * time.Hour),
 		},
 	}
 
@@ -180,7 +184,7 @@ func TestOutputStartVersionedOutputV1(t *testing.T) {
 		referenceID: "123",
 		config: cloudapi.Config{
 			APIVersion: null.IntFrom(1),
-			// Here, we are mostly silencing the flushing op
+			// Here, we are enabling but silencing the related async op
 			MetricPushInterval: types.NullDurationFrom(1 * time.Hour),
 		},
 	}


### PR DESCRIPTION
It mainly implements the same logic as for `v1` but it extends the logic to all the generated time series instead to just limit it to HTTP metrics.

It applies basic separation of concerns, so it should be easier to improve independently the various components in the future.

The flusher is not implemented but it should be mostly a wrap around the client implemented in #2963 draining the `bucketQ` buffer. I would like to get a consensus on this PR before implementing it.

The placeholder for the Trend sink will be implemented by https://github.com/grafana/k6/pull/3027
<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
