### PR TITLE
Disable auto-assign CI job for draft PRs

### DIFF
--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   add-reviews:
-    if: ${{ join(github.event.pull_request.requested_reviewers.*.login, ',') == '' && github.event.pull_request.draft != "True" }}
+    if: ${{ join(github.event.pull_request.requested_reviewers.*.login, ',') == '' && github.event.pull_request.draft == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   add-reviews:
-    if: ${{ join(github.event.pull_request.requested_reviewers.*.login, ',') == '' }}
+    if: ${{ join(github.event.pull_request.requested_reviewers.*.login, ',') == '' && github.event.pull_request.draft != "True" }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v6


### PR DESCRIPTION
I am not sure this will work, I couldn't test it since apparently draft PRs are not enabled for free private repos... :sweat_smile: But I got it from https://gist.github.com/hamelsmu/4d671aae3d51f972f56e40da9c677f69 and it seems reasonable, so :crossed_fingers: 