### PR TITLE
output/cloudv2: Error handling for flush

### DIFF
--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -183,7 +183,7 @@ func (o *Output) flushMetrics() {
 }
 
 // handleFlushError handles errors generated from the flushing operation.
-// It may interrupts the metric collection or invokes abort of the test.
+// It may interrupt the metric collection or invoke aborting of the test.
 //
 // note: The actual test execution should continue, since for local k6 run tests
 // the end-of-test summary (or any other outputs) will still work,

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -147,6 +147,7 @@ func (o *Output) periodicInvoke(d time.Duration, callback func()) {
 			case <-t.C:
 				callback()
 			case <-o.stop:
+				return
 			case <-o.abort:
 				return
 			}
@@ -220,6 +221,8 @@ func (o *Output) handleFlushError(err error) {
 			errext.AbortedByOutput,
 		)
 
-		o.testStopFunc(serr)
+		if o.testStopFunc != nil {
+			o.testStopFunc(serr)
+		}
 	}
 }

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -143,7 +143,6 @@ func (o *Output) periodicInvoke(d time.Duration, callback func()) {
 			case <-t.C:
 				callback()
 			case <-o.stop:
-				return
 			case <-o.stopSamplesCollection:
 				return
 			}

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -108,7 +108,6 @@ func (o *Output) AddMetricSamples(s []metrics.SampleContainer) {
 	// queue.
 	select {
 	case <-o.stopMetricsCollection:
-		// TODO: unit test this case
 		return
 	default:
 	}

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -261,3 +261,17 @@ func TestOutputPeriodicInvoke(t *testing.T) {
 	<-stop
 	assert.Greater(t, atomic.LoadUint64(&called), uint64(1))
 }
+
+func TestOutputStopWithTestError(t *testing.T) {
+	t.Parallel()
+
+	config := cloudapi.NewConfig()
+	config.Host = null.StringFrom("") // flush not expected
+	config.AggregationPeriod = types.NullDurationFrom(1 * time.Hour)
+
+	o, err := New(testutils.NewLogger(t), config)
+	require.NoError(t, err)
+
+	require.NoError(t, o.Start())
+	require.NoError(t, o.StopWithTestError(errors.New("an error")))
+}

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -257,8 +257,7 @@ func TestOutputPeriodicInvoke(t *testing.T) {
 		}
 	}
 	o := Output{stop: stop}
-	o.wg.Add(1)
-	go o.periodicInvoke(time.Duration(1), cb) // loop
+	o.periodicInvoke(time.Duration(1), cb) // loop
 	<-stop
 	assert.Greater(t, atomic.LoadUint64(&called), uint64(1))
 }

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -200,6 +200,7 @@ func TestOutputHandleFlushError(t *testing.T) {
 // when it is called doesn't stuck
 func TestOutputHandleFlushErrorMultipleTimes(t *testing.T) {
 	t.Parallel()
+
 	var stopFuncCalled int
 	o := Output{
 		logger:                testutils.NewLogger(t),

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -166,7 +166,7 @@ func TestOutputHandleFlushError(t *testing.T) {
 				testStopFunc: func(error) {
 					stopFuncCalled = true
 				},
-				stopMetricsCollection: make(chan struct{}),
+				stopSamplesCollection: make(chan struct{}),
 			}
 			o.config.StopOnError = null.BoolFrom(tc.abort)
 
@@ -178,7 +178,7 @@ func TestOutputHandleFlushError(t *testing.T) {
 
 				<-done
 				select {
-				case <-o.stopMetricsCollection:
+				case <-o.stopSamplesCollection:
 					stopMetricCollection = true
 				default:
 				}
@@ -199,7 +199,7 @@ func TestOutputAddMetricSamples(t *testing.T) {
 
 	stopSamples := make(chan struct{})
 	o := Output{
-		stopMetricsCollection: stopSamples,
+		stopSamplesCollection: stopSamples,
 	}
 	require.Empty(t, o.GetBufferedSamples())
 

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -168,7 +168,7 @@ func TestOutputHandleFlushError(t *testing.T) {
 				testStopFunc: func(error) {
 					stopFuncCalled = true
 				},
-				stopSamplesCollection: make(chan struct{}),
+				abort: make(chan struct{}),
 			}
 			o.config.StopOnError = null.BoolFrom(tc.abort)
 
@@ -180,7 +180,7 @@ func TestOutputHandleFlushError(t *testing.T) {
 
 				<-done
 				select {
-				case <-o.stopSamplesCollection:
+				case <-o.abort:
 					stopMetricCollection = true
 				default:
 				}
@@ -203,8 +203,8 @@ func TestOutputHandleFlushErrorMultipleTimes(t *testing.T) {
 
 	var stopFuncCalled int
 	o := Output{
-		logger:                testutils.NewLogger(t),
-		stopSamplesCollection: make(chan struct{}),
+		logger: testutils.NewLogger(t),
+		abort:  make(chan struct{}),
 		testStopFunc: func(error) {
 			stopFuncCalled++
 		},
@@ -227,7 +227,7 @@ func TestOutputAddMetricSamples(t *testing.T) {
 
 	stopSamples := make(chan struct{})
 	o := Output{
-		stopSamplesCollection: stopSamples,
+		abort: stopSamples,
 	}
 	require.Empty(t, o.GetBufferedSamples())
 

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -193,3 +193,26 @@ func TestOutputHandleFlushError(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputAddMetricSamples(t *testing.T) {
+	t.Parallel()
+
+	stopSamples := make(chan struct{})
+	o := Output{
+		stopMetricsCollection: stopSamples,
+	}
+	require.Empty(t, o.GetBufferedSamples())
+
+	s := metrics.Sample{}
+	o.AddMetricSamples([]metrics.SampleContainer{
+		metrics.Samples([]metrics.Sample{s}),
+	})
+	require.Len(t, o.GetBufferedSamples(), 1)
+
+	// Not accept samples anymore when the chan is closed
+	close(stopSamples)
+	o.AddMetricSamples([]metrics.SampleContainer{
+		metrics.Samples([]metrics.Sample{s}),
+	})
+	require.Empty(t, o.GetBufferedSamples())
+}


### PR DESCRIPTION
It is a small refactor for the error handling on the flush operation.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
