### PR TITLE
output/cloudv2: Flush the aggregated metrics

### DIFF
--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -1,0 +1,41 @@
+package expv2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/metrics"
+)
+
+// TODO: additional case
+// case: add when the metric already exist
+// case: add when the metric and the timeseries already exist
+
+func TestMetricSetBuilderAddTimeBucket(t *testing.T) {
+	t.Parallel()
+
+	r := metrics.NewRegistry()
+	m1 := r.MustNewMetric("metric1", metrics.Counter)
+	timeSeries := metrics.TimeSeries{
+		Metric: m1,
+		Tags:   r.RootTagSet().With("key1", "val1"),
+	}
+
+	tb := timeBucket{
+		Time: time.Unix(1, 0),
+		Sinks: map[metrics.TimeSeries]metrics.Sink{
+			timeSeries: &metrics.CounterSink{},
+		},
+	}
+	msb := newMetricSetBuilder("testrunid-123", 1)
+	msb.addTimeBucket(&tb)
+
+	assert.Contains(t, msb.metrics, m1)
+	require.Contains(t, msb.seriesIndex, timeSeries)
+	assert.Equal(t, uint(0), msb.seriesIndex[timeSeries]) // TODO: assert with another number
+
+	require.Len(t, msb.MetricSet.Metrics, 1)
+	assert.Len(t, msb.MetricSet.Metrics[0].TimeSeries, 1)
+}

--- a/output/cloud/expv2/integration/integration_test.go
+++ b/output/cloud/expv2/integration/integration_test.go
@@ -1,0 +1,155 @@
+package integration
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/klauspost/compress/snappy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/cloudapi"
+	"go.k6.io/k6/lib/testutils"
+	"go.k6.io/k6/lib/types"
+	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/output/cloud/expv2"
+	"go.k6.io/k6/output/cloud/expv2/pbcloud"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"gopkg.in/guregu/null.v3"
+)
+
+// This test runs an integration tests for the Output cloud.
+// It only calls public API of the Output and
+// it implements a concrete http endpoint where to get
+// the protobuf flush requests.
+
+func TestOutputFlush(t *testing.T) {
+	// TODO: it has 3s for aggregation time
+	// then it means it will execute for +3s that it is a waste of time
+	// because it isn't really required.
+	// Reduce the aggregation time (to 1s?) then run always.
+	t.Skip("Skip the integration test, if required enable it manually")
+	t.Parallel()
+
+	results := make(chan *pbcloud.MetricSet)
+	ts := httptest.NewServer(metricsHandler(results))
+	defer ts.Close()
+
+	// init conifg
+	c := cloudapi.NewConfig()
+	c.Host = null.StringFrom(ts.URL)
+	c.Token = null.StringFrom("my-secret-token")
+	c.AggregationPeriod = types.NullDurationFrom(3 * time.Second)
+	c.AggregationWaitPeriod = types.NullDurationFrom(1 * time.Second)
+
+	// init and start the output
+	o, err := expv2.New(testutils.NewLogger(t), c)
+	require.NoError(t, err)
+	o.SetReferenceID("my-test-run-id-123")
+	require.NoError(t, o.Start())
+
+	// collect and flush samples
+	o.AddMetricSamples([]metrics.SampleContainer{
+		testSamples(),
+	})
+
+	// wait for results
+	mset := <-results
+	close(results)
+	assert.NoError(t, o.StopWithTestError(nil))
+
+	// read and convert the json version
+	// of the expected protobuf sent request
+	var exp pbcloud.MetricSet
+	expjs, err := os.ReadFile("./testdata/metricset.json") //nolint:forbidigo // ReadFile here is used in a test
+	require.NoError(t, err)
+	err = protojson.Unmarshal(expjs, &exp)
+	require.NoError(t, err)
+
+	msetjs, err := protojson.Marshal(mset)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(expjs), string(msetjs))
+}
+
+func metricsHandler(results chan<- *pbcloud.MetricSet) http.HandlerFunc {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		if token != "Token my-secret-token" {
+			http.Error(rw, fmt.Sprintf("token is required; got %q", token), http.StatusUnauthorized)
+			return
+		}
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		mset, err := metricSetFromRequest(b)
+		if err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		results <- mset
+	}
+}
+
+func metricSetFromRequest(b []byte) (*pbcloud.MetricSet, error) {
+	b, err := snappy.Decode(nil, b)
+	if err != nil {
+		return nil, err
+	}
+	var mset pbcloud.MetricSet
+	err = proto.Unmarshal(b, &mset)
+	if err != nil {
+		return nil, err
+	}
+	return &mset, nil
+}
+
+func testSamples() metrics.Samples {
+	r := metrics.NewRegistry()
+	m1 := r.MustNewMetric("metric_counter_1", metrics.Counter)
+	m2 := r.MustNewMetric("metric_gauge_2", metrics.Gauge)
+	m3 := r.MustNewMetric("metric_rate_3", metrics.Rate)
+	m4 := r.MustNewMetric("metric_trend_4", metrics.Trend)
+
+	samples := []metrics.Sample{
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: m1,
+				Tags:   r.RootTagSet().With("my_label_1", "my_label_value_1"),
+			},
+			Time:  time.Date(2023, time.May, 1, 1, 0, 0, 0, time.UTC),
+			Value: 42.2,
+		},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: m2,
+				Tags:   r.RootTagSet().With("my_label_2", "my_label_value_2"),
+			},
+			Time:  time.Date(2023, time.May, 1, 2, 0, 0, 0, time.UTC),
+			Value: 3.14,
+		},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: m3,
+				Tags:   r.RootTagSet().With("my_label_3", "my_label_value_3"),
+			},
+			Time:  time.Date(2023, time.May, 1, 3, 0, 0, 0, time.UTC),
+			Value: 2.718,
+		},
+		{
+			TimeSeries: metrics.TimeSeries{
+				Metric: m4,
+				Tags:   r.RootTagSet().With("my_label_4", "my_label_value_4"),
+			},
+			Time:  time.Date(2023, time.May, 1, 4, 0, 0, 0, time.UTC),
+			Value: 186,
+		},
+	}
+	return samples
+}

--- a/output/cloud/expv2/integration/testdata/metricset.json
+++ b/output/cloud/expv2/integration/testdata/metricset.json
@@ -1,0 +1,130 @@
+{
+  "metrics": [
+    {
+      "name": "metric_counter_1",
+      "type": "METRIC_TYPE_COUNTER",
+      "timeSeries": [
+        {
+          "labels": [
+            {
+              "name": "__name__",
+              "value": "metric_counter_1"
+            },
+            {
+              "name": "test_run_id",
+              "value": "my-test-run-id-123"
+            },
+            {
+              "name": "my_label_1",
+              "value": "my_label_value_1"
+            }
+          ],
+          "aggregationPeriod": 3,
+          "counterSamples": {
+            "values": [
+              {
+                "time": "2023-05-01T01:00:00Z",
+                "value": 42.2
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "metric_gauge_2",
+      "type": "METRIC_TYPE_GAUGE",
+      "timeSeries": [
+        {
+          "labels": [
+            {
+              "name": "__name__",
+              "value": "metric_gauge_2"
+            },
+            {
+              "name": "test_run_id",
+              "value": "my-test-run-id-123"
+            },
+            {
+              "name": "my_label_2",
+              "value": "my_label_value_2"
+            }
+          ],
+          "aggregationPeriod": 3,
+          "gaugeSamples": {
+            "values": [
+              {
+                "time": "2023-05-01T02:00:00Z",
+                "last": 3.14,
+                "min": 3.14,
+                "max": 3.14
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "metric_rate_3",
+      "type": "METRIC_TYPE_RATE",
+      "timeSeries": [
+        {
+          "labels": [
+            {
+              "name": "__name__",
+              "value": "metric_rate_3"
+            },
+            {
+              "name": "test_run_id",
+              "value": "my-test-run-id-123"
+            },
+            {
+              "name": "my_label_3",
+              "value": "my_label_value_3"
+            }
+          ],
+          "aggregationPeriod": 3,
+          "rateSamples": {
+            "values": [
+              {
+                "time": "2023-05-01T03:00:00Z",
+                "nonzeroCount": 1,
+                "totalCount": 1
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "name": "metric_trend_4",
+      "type": "METRIC_TYPE_TREND",
+      "timeSeries": [
+        {
+          "labels": [
+            {
+              "name": "__name__",
+              "value": "metric_trend_4"
+            },
+            {
+              "name": "test_run_id",
+              "value": "my-test-run-id-123"
+            },
+            {
+              "name": "my_label_4",
+              "value": "my_label_value_4"
+            }
+          ],
+          "aggregationPeriod": 3,
+          "trendHdrSamples": {
+            "values": [
+              {
+                "time": "2023-05-01T04:00:00Z"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/output/cloud/expv2/mapping.go
+++ b/output/cloud/expv2/mapping.go
@@ -1,0 +1,120 @@
+package expv2
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mstoykov/atlas"
+	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/output/cloud/expv2/pbcloud"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// TODO: unit test
+func mapTimeSeriesLabelsProto(timeSeries metrics.TimeSeries, testRunID string) []*pbcloud.Label {
+	labels := make([]*pbcloud.Label, 0, ((*atlas.Node)(timeSeries.Tags)).Len()+2)
+	labels = append(labels,
+		&pbcloud.Label{Name: "__name__", Value: timeSeries.Metric.Name},
+		&pbcloud.Label{Name: "test_run_id", Value: testRunID})
+
+	// TODO: move it as a shared func
+	// https://github.com/grafana/k6/issues/2764
+	n := (*atlas.Node)(timeSeries.Tags)
+	if n.Len() < 1 {
+		return labels
+	}
+	for !n.IsRoot() {
+		prev, key, value := n.Data()
+		labels = append(labels, &pbcloud.Label{Name: key, Value: value})
+		n = prev
+	}
+	return labels
+}
+
+// TODO: unit test
+func mapMetricTypeProto(mt metrics.MetricType) pbcloud.MetricType {
+	var mtype pbcloud.MetricType
+	switch mt {
+	case metrics.Counter:
+		mtype = pbcloud.MetricType_METRIC_TYPE_COUNTER
+	case metrics.Gauge:
+		mtype = pbcloud.MetricType_METRIC_TYPE_GAUGE
+	case metrics.Rate:
+		mtype = pbcloud.MetricType_METRIC_TYPE_RATE
+	case metrics.Trend:
+		mtype = pbcloud.MetricType_METRIC_TYPE_TREND
+	}
+	return mtype
+}
+
+// TODO: unit test
+func addBucketToTimeSeriesProto(
+	timeSeries *pbcloud.TimeSeries,
+	mt metrics.MetricType,
+	time time.Time,
+	sink metrics.Sink,
+) {
+	if timeSeries.Samples == nil {
+		initTimeSeriesSamples(timeSeries, mt)
+	}
+
+	switch mt {
+	case metrics.Counter:
+		c := sink.(*metrics.CounterSink).Value //nolint: forcetypeassert
+		samples := timeSeries.GetCounterSamples()
+		samples.Values = append(samples.Values, &pbcloud.CounterValue{
+			Time:  timestamppb.New(time),
+			Value: c,
+		})
+	case metrics.Gauge:
+		g := sink.(*metrics.GaugeSink) //nolint: forcetypeassert
+		samples := timeSeries.GetGaugeSamples()
+		samples.Values = append(samples.Values, &pbcloud.GaugeValue{
+			Time: timestamppb.New(time),
+			Last: g.Value,
+			Min:  g.Max,
+			Max:  g.Min,
+			// TODO: implement the custom gauge for track them
+			Avg:   0,
+			Count: 0,
+		})
+	case metrics.Rate:
+		r := sink.(*metrics.RateSink) //nolint: forcetypeassert
+		samples := timeSeries.GetRateSamples()
+		samples.Values = append(samples.Values, &pbcloud.RateValue{
+			Time:         timestamppb.New(time),
+			NonzeroCount: uint32(r.Trues),
+			TotalCount:   uint32(r.Total),
+		})
+	case metrics.Trend:
+		samples := timeSeries.GetTrendHdrSamples()
+		samples.Values = append(samples.Values, &pbcloud.TrendHdrValue{
+			Time: timestamppb.New(time),
+			// TODO: implement the histogram
+		})
+	default:
+		panic(fmt.Sprintf("MetricType %q is not supported", mt))
+	}
+}
+
+// TODO: unit test
+func initTimeSeriesSamples(timeSeries *pbcloud.TimeSeries, mt metrics.MetricType) {
+	switch mt {
+	case metrics.Counter:
+		timeSeries.Samples = &pbcloud.TimeSeries_CounterSamples{
+			CounterSamples: &pbcloud.CounterSamples{},
+		}
+	case metrics.Gauge:
+		timeSeries.Samples = &pbcloud.TimeSeries_GaugeSamples{
+			GaugeSamples: &pbcloud.GaugeSamples{},
+		}
+	case metrics.Rate:
+		timeSeries.Samples = &pbcloud.TimeSeries_RateSamples{
+			RateSamples: &pbcloud.RateSamples{},
+		}
+	case metrics.Trend:
+		timeSeries.Samples = &pbcloud.TimeSeries_TrendHdrSamples{
+			TrendHdrSamples: &pbcloud.TrendHdrSamples{},
+		}
+	}
+}

--- a/output/cloud/expv2/metrics_client.go
+++ b/output/cloud/expv2/metrics_client.go
@@ -58,7 +58,7 @@ func newMetricsClient(logger logrus.FieldLogger, host string, token string) (*me
 }
 
 // Push pushes the provided metrics the given test run.
-func (mc *metricsClient) Push(ctx context.Context, referenceID string, samples *pbcloud.MetricSet) error {
+func (mc *metricsClient) push(ctx context.Context, referenceID string, samples *pbcloud.MetricSet) error {
 	if referenceID == "" {
 		return errors.New("TestRunID of the test is required")
 	}

--- a/output/cloud/expv2/metrics_client_test.go
+++ b/output/cloud/expv2/metrics_client_test.go
@@ -52,7 +52,7 @@ func TestMetricsClientPush(t *testing.T) {
 	mc.httpClient = ts.Client()
 
 	mset := pbcloud.MetricSet{}
-	err = mc.Push(context.TODO(), "test-ref-id", &mset)
+	err = mc.push(context.TODO(), "test-ref-id", &mset)
 	<-done
 	require.NoError(t, err)
 	assert.Equal(t, 1, reqs)
@@ -71,7 +71,7 @@ func TestMetricsClientPushUnexpectedStatus(t *testing.T) {
 	require.NoError(t, err)
 	mc.httpClient = ts.Client()
 
-	err = mc.Push(context.TODO(), "test-ref-id", nil)
+	err = mc.push(context.TODO(), "test-ref-id", nil)
 	assert.ErrorContains(t, err, "500 Internal Server Error")
 }
 
@@ -91,7 +91,7 @@ func TestMetricsClientPushError(t *testing.T) {
 		},
 	}
 
-	err := mc.Push(context.TODO(), "test-ref-id", nil)
+	err := mc.push(context.TODO(), "test-ref-id", nil)
 	assert.ErrorContains(t, err, "fake generated error")
 }
 
@@ -119,6 +119,6 @@ func TestMetricsClientPushStructuredError(t *testing.T) {
 		},
 	}
 
-	err := mc.Push(context.TODO(), "test-ref-id", nil)
+	err := mc.push(context.TODO(), "test-ref-id", nil)
 	assert.Equal(t, exp, err)
 }

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -57,6 +57,8 @@ func TestOutputSetTestRunStopCallback(t *testing.T) {
 func TestOutputCollectSamples(t *testing.T) {
 	t.Parallel()
 	o, err := New(testutils.NewLogger(t), cloudapi.Config{
+		Host:                  null.StringFrom("flush-is-disabled"),
+		Token:                 null.StringFrom("a-fake-token"),
 		AggregationWaitPeriod: types.NewNullDuration(5*time.Second, true),
 		// Manually control and trigger the various steps
 		// instead to be time dependent
@@ -266,7 +268,8 @@ func TestOutputStopWithTestError(t *testing.T) {
 	t.Parallel()
 
 	config := cloudapi.NewConfig()
-	config.Host = null.StringFrom("") // flush not expected
+	config.Host = null.StringFrom("host-is-required-but-flush-isnot-expected")
+	config.Token = null.StringFrom("token-is-required")
 	config.AggregationPeriod = types.NullDurationFrom(1 * time.Hour)
 
 	o, err := New(testutils.NewLogger(t), config)

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -163,8 +163,10 @@ func TestOutputStartVersionedOutputV2(t *testing.T) {
 		referenceID: "123",
 		config: cloudapi.Config{
 			APIVersion:            null.IntFrom(2),
+			Host:                  null.StringFrom("fake-cloud-url"),
+			Token:                 null.StringFrom("fake-token"),
 			AggregationWaitPeriod: types.NullDurationFrom(1 * time.Second),
-			// Here, we are enabling but silencing the related async ops
+			// Here, we are enabling it but silencing the related async ops
 			AggregationPeriod:  types.NullDurationFrom(1 * time.Hour),
 			MetricPushInterval: types.NullDurationFrom(1 * time.Hour),
 		},


### PR DESCRIPTION
It implements the drain of the queue of the aggregated metrics and the conversion to Protobuf.
 
<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
