### PR TITLE
Fix example in run command

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -366,7 +366,7 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
   {{.}} run -u 5 -d 10s script.js
 
   # Ramp VUs from 0 to 100 over 10s, stay there for 60s, then 10s down to 0.
-  {{.}} run -u 0 -s 10s:100 -s 60s -s 10s:0
+  {{.}} run -u 0 -s 10s:100 -s 60s:100 -s 10s:0
 
   # Send metrics to an influxdb server
   {{.}} run -o influxdb=http://1.2.3.4:8086/k6`[1:])


### PR DESCRIPTION
The second stage was missing the number of VU, and actually running that command caused complaints.

<!--


  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
