### PR TITLE
 output/cloudv2: Use unix nano as bucket time

### DIFF
--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -2,7 +2,6 @@ package expv2
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +23,7 @@ func TestMetricSetBuilderAddTimeBucket(t *testing.T) {
 	}
 
 	tb := timeBucket{
-		Time: time.Unix(1, 0),
+		Time: 1,
 		Sinks: map[metrics.TimeSeries]metricValue{
 			timeSeries: &counter{},
 		},

--- a/output/cloud/expv2/hdr.go
+++ b/output/cloud/expv2/hdr.go
@@ -3,10 +3,8 @@ package expv2
 import (
 	"math"
 	"math/bits"
-	"time"
 
 	"go.k6.io/k6/output/cloud/expv2/pbcloud"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -183,9 +181,9 @@ func (h *histogram) appendBuckets(index uint32) {
 }
 
 // histogramAsProto converts the histogram into the equivalent Protobuf version.
-func histogramAsProto(h *histogram, time time.Time) *pbcloud.TrendHdrValue {
+func histogramAsProto(h *histogram, time int64) *pbcloud.TrendHdrValue {
 	hval := &pbcloud.TrendHdrValue{
-		Time:              timestamppb.New(time),
+		Time:              timestampAsProto(time),
 		MinResolution:     1.0,
 		SignificantDigits: 2,
 		LowerCounterIndex: h.FirstNotZeroBucket,

--- a/output/cloud/expv2/hdr_test.go
+++ b/output/cloud/expv2/hdr_test.go
@@ -311,6 +311,6 @@ func TestHistogramAsProto(t *testing.T) {
 		tc.exp.MinResolution = 1.0
 		tc.exp.SignificantDigits = 2
 		tc.exp.Time = &timestamppb.Timestamp{Seconds: 1}
-		assert.Equal(t, tc.exp, histogramAsProto(&h, time.Unix(1, 0)), tc.name)
+		assert.Equal(t, tc.exp, histogramAsProto(&h, time.Unix(1, 0).UnixNano()), tc.name)
 	}
 }

--- a/output/cloud/expv2/mapping_test.go
+++ b/output/cloud/expv2/mapping_test.go
@@ -1,0 +1,21 @@
+package expv2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimestampAsProto(t *testing.T) {
+	t.Parallel()
+
+	date := time.Unix(10, 0).UTC()
+	timestamp := timestampAsProto(date.UnixNano())
+	assert.Equal(t, date, timestamp.AsTime())
+
+	// sub-second precision is not supported
+	date = time.Unix(10, 282).UTC()
+	timestamp = timestampAsProto(date.UnixNano())
+	assert.Equal(t, time.Unix(10, 0).UTC(), timestamp.AsTime())
+}

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -114,7 +114,7 @@ func TestOutputCollectSamples(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 5.0, counter.Sum)
 
-	expTime := time.Date(2023, time.May, 1, 1, 1, 15, 0, time.UTC)
+	expTime := time.Date(2023, time.May, 1, 1, 1, 15, 0, time.UTC).UnixNano()
 	assert.Equal(t, expTime, buckets[0].Time)
 }
 


### PR DESCRIPTION
A request change from other PRs https://github.com/grafana/k6/pull/3071#discussion_r1205215842

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
