### PR TITLE
Change thresholds-error verb from breach to cross

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -192,14 +192,14 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 			}
 			tErr := errext.WithAbortReasonIfNone(
 				errext.WithExitCodeIfNone(
-					fmt.Errorf("thresholds on metrics '%s' have been breached", strings.Join(breachedThresholds, ", ")),
+					fmt.Errorf("thresholds on metrics '%s' have been crossed", strings.Join(breachedThresholds, ", ")),
 					exitcodes.ThresholdsHaveFailed,
 				), errext.AbortedByThresholdsAfterTestEnd)
 
 			if err == nil {
 				err = tErr
 			} else {
-				logger.WithError(tErr).Debug("Breached thresholds, but test already exited with another error")
+				logger.WithError(tErr).Debug("Crossed thresholds, but test already exited with another error")
 			}
 		}
 		if finalizeThresholds != nil {

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -655,7 +655,7 @@ func TestThresholdsFailed(t *testing.T) {
 	)
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
-	expErr := "thresholds on metrics 'iterations{scenario:sc1}, iterations{scenario:sc2}' have been breached"
+	expErr := "thresholds on metrics 'iterations{scenario:sc1}, iterations{scenario:sc2}' have been crossed"
 	assert.True(t, testutils.LogContains(ts.LoggerHook.Drain(), logrus.ErrorLevel, expErr))
 	stdout := ts.Stdout.String()
 	t.Log(stdout)
@@ -697,7 +697,7 @@ func TestAbortedByThreshold(t *testing.T) {
 	)
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
-	expErr := "thresholds on metrics 'iterations' were breached; at least one has abortOnFail enabled, stopping test prematurely"
+	expErr := "thresholds on metrics 'iterations' were crossed; at least one has abortOnFail enabled, stopping test prematurely"
 	assert.True(t, testutils.LogContains(ts.LoggerHook.Drain(), logrus.ErrorLevel, expErr))
 	stdOut := ts.Stdout.String()
 	t.Log(stdOut)

--- a/metrics/engine/engine.go
+++ b/metrics/engine/engine.go
@@ -189,7 +189,7 @@ func (me *MetricsEngine) StartThresholdCalculations(
 				breached, shouldAbort := me.evaluateThresholds(true, getCurrentTestRunDuration)
 				if shouldAbort {
 					err := fmt.Errorf(
-						"thresholds on metrics '%s' were breached; at least one has abortOnFail enabled, stopping test prematurely",
+						"thresholds on metrics '%s' were crossed; at least one has abortOnFail enabled, stopping test prematurely",
 						strings.Join(breached, ", "),
 					)
 					me.logger.Debug(err.Error())
@@ -257,7 +257,7 @@ func (me *MetricsEngine) evaluateThresholds(
 	}
 	if len(breachedThresholds) > 0 {
 		sort.Strings(breachedThresholds)
-		me.logger.Debugf("Thresholds on %d metrics breached: %v", len(breachedThresholds), breachedThresholds)
+		me.logger.Debugf("Thresholds on %d metrics crossed: %v", len(breachedThresholds), breachedThresholds)
 	}
 	atomic.StoreUint32(&me.breachedThresholdsCount, uint32(len(breachedThresholds)))
 	return breachedThresholds, shouldAbort


### PR DESCRIPTION
The error message "thresholds have been breached" sounded harshly to my ear. Normally I associate "breaches" with illegal acts, data exfiltrations, and military sieges.

I proposed changing the verb to "cross," which is the verb used by the docs. True, I believe I wrote those docs, so I'm biased. But I also checked the [Corpus of Contemporary American English](https://www.english-corpora.org/coca/), and "cross" is by far the most common collocation (word that co-occurs) with "threshold".

![image](https://github.com/grafana/k6/assets/47385188/44740947-abd2-4656-a056-f86812bcfff6)
