### PR TITLE
output/cloudv2: Retry and flushers pool

### DIFF
--- a/cloudapi/client.go
+++ b/cloudapi/client.go
@@ -135,6 +135,7 @@ func (c *Client) do(req *http.Request, v interface{}, attempt int) (retry bool, 
 
 	defer func() {
 		if resp != nil {
+			_, _ = io.Copy(io.Discard, resp.Body)
 			if cerr := resp.Body.Close(); cerr != nil && err == nil {
 				err = cerr
 			}

--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -8,7 +8,7 @@ import (
 )
 
 type pusher interface {
-	push(ctx context.Context, referenceID string, samples *pbcloud.MetricSet) error
+	push(referenceID string, samples *pbcloud.MetricSet) error
 }
 
 type metricsFlusher struct {
@@ -19,10 +19,10 @@ type metricsFlusher struct {
 	maxSeriesInSingleBatch     int
 }
 
-// Flush flushes the queued buckets sending them to the remote Cloud service.
-// If the number of time series collected is bigger than maximum batch size than
-// it splits in chunks.
-func (f *metricsFlusher) Flush(ctx context.Context) error {
+// flush flushes the queued buckets sending them to the remote Cloud service.
+// If the number of time series collected is bigger than maximum batch size
+// then it splits in chunks.
+func (f *metricsFlusher) flush(_ context.Context) error {
 	// drain the buffer
 	buckets := f.bq.PopAll()
 	if len(buckets) < 1 {
@@ -46,7 +46,7 @@ func (f *metricsFlusher) Flush(ctx context.Context) error {
 		}
 
 		// we hit the chunk size, let's flush
-		err := f.client.push(ctx, f.referenceID, msb.MetricSet)
+		err := f.client.push(f.referenceID, msb.MetricSet)
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ func (f *metricsFlusher) Flush(ctx context.Context) error {
 	}
 
 	// send the last (or the unique) MetricSet chunk to the remote service
-	return f.client.push(ctx, f.referenceID, msb.MetricSet)
+	return f.client.push(f.referenceID, msb.MetricSet)
 }
 
 type metricSetBuilder struct {

--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -82,7 +82,7 @@ func TestMetricsFlusherFlushChunk(t *testing.T) {
 		}
 		require.Len(t, bq.buckets, tc.series)
 
-		err := mf.Flush(context.TODO())
+		err := mf.flush(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, tc.expFlushCalls, pm.pushCalled)
 	}
@@ -92,7 +92,7 @@ type pusherMock struct {
 	pushCalled int
 }
 
-func (pm *pusherMock) push(_ context.Context, _ string, _ *pbcloud.MetricSet) error {
+func (pm *pusherMock) push(_ string, _ *pbcloud.MetricSet) error {
 	pm.pushCalled++
 	return nil
 }

--- a/output/cloud/expv2/integration/integration_test.go
+++ b/output/cloud/expv2/integration/integration_test.go
@@ -41,14 +41,18 @@ func TestOutputFlush(t *testing.T) {
 	defer ts.Close()
 
 	// init conifg
-	c := cloudapi.NewConfig()
-	c.Host = null.StringFrom(ts.URL)
-	c.Token = null.StringFrom("my-secret-token")
-	c.AggregationPeriod = types.NullDurationFrom(3 * time.Second)
-	c.AggregationWaitPeriod = types.NullDurationFrom(1 * time.Second)
+	conf := cloudapi.NewConfig()
+	conf.Host = null.StringFrom(ts.URL)
+	conf.Token = null.StringFrom("my-secret-token")
+	conf.AggregationPeriod = types.NullDurationFrom(3 * time.Second)
+	conf.AggregationWaitPeriod = types.NullDurationFrom(1 * time.Second)
+
+	logger := testutils.NewLogger(t)
+	cc := cloudapi.NewClient(logger, conf.Token.String, conf.Host.String,
+		"expv2/integration", conf.Timeout.TimeDuration())
 
 	// init and start the output
-	o, err := expv2.New(testutils.NewLogger(t), c)
+	o, err := expv2.New(logger, conf, cc)
 	require.NoError(t, err)
 	o.SetReferenceID("my-test-run-id-123")
 	require.NoError(t, o.Start())

--- a/output/cloud/expv2/metrics_client.go
+++ b/output/cloud/expv2/metrics_client.go
@@ -5,64 +5,45 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
-	"sync"
-	"time"
+	"strings"
 
 	"github.com/klauspost/compress/snappy"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/proto"
 
 	"go.k6.io/k6/cloudapi"
-	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/output/cloud/expv2/pbcloud"
 )
-
-type httpDoer interface {
-	Do(*http.Request) (*http.Response, error)
-}
 
 // metricsClient is a Protobuf over HTTP client for sending
 // the collected metrics from the Cloud output
 // to the remote service.
 type metricsClient struct {
-	httpClient httpDoer
-	logger     logrus.FieldLogger
-	token      string
-	userAgent  string
-
-	pushBufferPool sync.Pool
-	baseURL        string
+	httpClient *cloudapi.Client
+	baseURL    string
 }
 
 // newMetricsClient creates and initializes a new MetricsClient.
-func newMetricsClient(logger logrus.FieldLogger, host string, token string) (*metricsClient, error) {
-	if host == "" {
-		return nil, errors.New("host is required")
-	}
-	if token == "" {
-		return nil, errors.New("token is required")
+func newMetricsClient(c *cloudapi.Client) (*metricsClient, error) {
+	// Unfortunately, the cloudapi.Client works across different versions
+	// of the API, but it has the v1 harcoded so we need to trim the wrong path
+	// to be able to replace it with the correct one.
+	u := c.BaseURL()
+	if !strings.HasSuffix(u, "/v1") {
+		return nil, errors.New("a /v1 suffix is expected in the Cloud service's BaseURL path")
 	}
 	return &metricsClient{
-		httpClient: &http.Client{Timeout: 5 * time.Second},
-		logger:     logger,
-		baseURL:    host + "/v2/metrics/",
-		token:      token,
-		userAgent:  "k6cloud/v" + consts.Version,
-		pushBufferPool: sync.Pool{
-			New: func() interface{} {
-				return &bytes.Buffer{}
-			},
-		},
+		httpClient: c,
+		baseURL:    strings.TrimSuffix(u, "/v1") + "/v2/metrics/",
 	}, nil
 }
 
-// Push pushes the provided metrics the given test run.
-func (mc *metricsClient) push(ctx context.Context, referenceID string, samples *pbcloud.MetricSet) error {
+// Push the provided metrics for the given test run ID.
+func (mc *metricsClient) push(referenceID string, samples *pbcloud.MetricSet) error {
 	if referenceID == "" {
 		return errors.New("TestRunID of the test is required")
 	}
-	start := time.Now()
 
 	b, err := newRequestBody(samples)
 	if err != nil {
@@ -73,30 +54,25 @@ func (mc *metricsClient) push(ctx context.Context, referenceID string, samples *
 	// we don't expect to share this client across different refID
 	// with a bit of effort we can find a way to just allocate once
 	url := mc.baseURL + referenceID
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(b))
+	req, err := http.NewRequestWithContext(
+		context.Background(), http.MethodPost, url, io.NopCloser(bytes.NewReader(b)))
 	if err != nil {
 		return err
 	}
 
-	req.Header.Set("User-Agent", mc.userAgent)
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(b)), nil
+	}
+
 	req.Header.Set("Content-Type", "application/x-protobuf")
 	req.Header.Set("Content-Encoding", "snappy")
 	req.Header.Set("K6-Metrics-Protocol-Version", "2.0")
-	req.Header.Set("Authorization", "Token "+mc.token)
 
-	resp, err := mc.httpClient.Do(req)
+	err = mc.httpClient.Do(req, nil)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		_ = resp.Body.Close()
-	}()
 
-	if err := cloudapi.CheckResponse(resp); err != nil {
-		return err
-	}
-	mc.logger.WithField("t", time.Since(start)).WithField("size", len(b)).
-		Debug("Pushed the collected metrics to the Cloud service")
 	return nil
 }
 

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -336,7 +336,7 @@ func (out *Output) startVersionedOutput() error {
 	case int64(apiVersion1):
 		out.versionedOutput, err = cloudv1.New(out.logger, out.config, out.client)
 	case int64(apiVersion2):
-		out.versionedOutput, err = cloudv2.New(out.logger, out.config)
+		out.versionedOutput, err = cloudv2.New(out.logger, out.config, out.client)
 	default:
 		err = fmt.Errorf("v%d is an unexpected version", out.config.APIVersion.Int64)
 	}

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -108,12 +108,12 @@ func newOutput(params output.Params) (*Output, error) {
 		return nil, errors.New("tests with unspecified duration are not allowed when outputting data to k6 cloud")
 	}
 
-	if !(conf.MetricPushConcurrency.Int64 > 0) {
+	if conf.MetricPushConcurrency.Int64 < 1 {
 		return nil, fmt.Errorf("metrics push concurrency must be a positive number but is %d",
 			conf.MetricPushConcurrency.Int64)
 	}
 
-	if !(conf.MaxMetricSamplesPerPackage.Int64 > 0) {
+	if conf.MaxMetricSamplesPerPackage.Int64 < 1 {
 		return nil, fmt.Errorf("metric samples per package must be a positive number but is %d",
 			conf.MaxMetricSamplesPerPackage.Int64)
 	}

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -176,6 +176,9 @@ func TestOutputStartVersionedOutputV2(t *testing.T) {
 		},
 	}
 
+	o.client = cloudapi.NewClient(
+		nil, o.config.Token.String, o.config.Host.String, "v/tests", o.config.Timeout.TimeDuration())
+
 	err := o.startVersionedOutput()
 	require.NoError(t, err)
 


### PR DESCRIPTION
It adds two features:

- HTTP requests retry
- Pool of flushers so that if a flush operation is slow, the output can continue and not get stuck.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
