### PR TITLE
output/cloudv2: Flush chunks

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	// APIVersion     null.Int    `json:"apiVersion" envconfig:"K6_CLOUD_API_VERSION"`
 	APIVersion null.Int `json:"-"`
 
+	// TODO: rename the config field to align to the new logic by time series
+	// when the migration from the version 1 is completed.
 	MaxMetricSamplesPerPackage null.Int `json:"maxMetricSamplesPerPackage" envconfig:"K6_CLOUD_MAX_METRIC_SAMPLES_PER_PACKAGE"`
 
 	// The time interval between periodic API calls for sending samples to the cloud ingest service.

--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -1,11 +1,14 @@
 package expv2
 
 import (
+	"context"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/output/cloud/expv2/pbcloud"
 )
 
 // TODO: additional case
@@ -29,7 +32,7 @@ func TestMetricSetBuilderAddTimeBucket(t *testing.T) {
 		},
 	}
 	msb := newMetricSetBuilder("testrunid-123", 1)
-	msb.addTimeBucket(&tb)
+	msb.addTimeBucket(tb)
 
 	assert.Contains(t, msb.metrics, m1)
 	require.Contains(t, msb.seriesIndex, timeSeries)
@@ -37,4 +40,59 @@ func TestMetricSetBuilderAddTimeBucket(t *testing.T) {
 
 	require.Len(t, msb.MetricSet.Metrics, 1)
 	assert.Len(t, msb.MetricSet.Metrics[0].TimeSeries, 1)
+}
+
+func TestMetricsFlusherFlushChunk(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		series        int
+		expFlushCalls int
+	}{
+		{series: 5, expFlushCalls: 2},
+		{series: 2, expFlushCalls: 1},
+	}
+
+	r := metrics.NewRegistry()
+	m1 := r.MustNewMetric("metric1", metrics.Counter)
+
+	for _, tc := range testCases {
+		bq := &bucketQ{}
+		pm := &pusherMock{}
+		mf := metricsFlusher{
+			bq:                     bq,
+			client:                 pm,
+			maxSeriesInSingleBatch: 3,
+		}
+
+		bq.buckets = make([]timeBucket, 0, tc.series)
+		for i := 0; i < tc.series; i++ {
+			ts := metrics.TimeSeries{
+				Metric: m1,
+				Tags:   r.RootTagSet().With("key1", "val"+strconv.Itoa(i)),
+			}
+			bq.Push([]timeBucket{
+				{
+					Time: int64(i) + 1,
+					Sinks: map[metrics.TimeSeries]metricValue{
+						ts: &counter{Sum: float64(1)},
+					},
+				},
+			})
+		}
+		require.Len(t, bq.buckets, tc.series)
+
+		err := mf.Flush(context.TODO())
+		require.NoError(t, err)
+		assert.Equal(t, tc.expFlushCalls, pm.pushCalled)
+	}
+}
+
+type pusherMock struct {
+	pushCalled int
+}
+
+func (pm *pusherMock) push(_ context.Context, _ string, _ *pbcloud.MetricSet) error {
+	pm.pushCalled++
+	return nil
 }

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -86,6 +86,9 @@ func (o *Output) Start() error {
 		bq:                         &o.collector.bq,
 		client:                     mc,
 		aggregationPeriodInSeconds: uint32(o.config.AggregationPeriod.TimeDuration().Seconds()),
+		// TODO: rename the config field to align to the new logic by time series
+		// when the migration from the version 1 is completed.
+		maxSeriesInSingleBatch: int(o.config.MaxMetricSamplesPerPackage.Int64),
 	}
 
 	o.periodicInvoke(o.config.MetricPushInterval.TimeDuration(), o.flushMetrics)


### PR DESCRIPTION
If the number of time series is higher than the maximum batch size than split them in chunks.

Part of https://github.com/grafana/k6/issues/3117

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
