### PR TITLE
Retrieve the host from cloudapi Client

### DIFF
--- a/cloudapi/client.go
+++ b/cloudapi/client.go
@@ -49,6 +49,11 @@ func NewClient(logger logrus.FieldLogger, token, host, version string, timeout t
 	return c
 }
 
+// BaseURL returns configured host.
+func (c *Client) BaseURL() string {
+	return c.baseURL
+}
+
 // NewRequest creates new HTTP request.
 //
 // This is the same as http.NewRequest, except that data if not nil


### PR DESCRIPTION
A tiny PR to extend cloudapi interface.

Why? To make it possible to use `cloudapi.Client` in external contexts (e.g. k6-operator).
