### PR TITLE
output/cloudv2: Unlimited size for body payload

### DIFF
--- a/output/cloud/expv2/metrics_client.go
+++ b/output/cloud/expv2/metrics_client.go
@@ -76,16 +76,10 @@ func (mc *metricsClient) push(referenceID string, samples *pbcloud.MetricSet) er
 	return nil
 }
 
-const payloadSizeLimit = 100 * 1024 // 100 KiB
-
 func newRequestBody(data *pbcloud.MetricSet) ([]byte, error) {
 	b, err := proto.Marshal(data)
 	if err != nil {
 		return nil, fmt.Errorf("encoding metrics as Protobuf write request failed: %w", err)
-	}
-	if len(b) > payloadSizeLimit {
-		return nil, fmt.Errorf("the Protobuf message is too large to be handled from the Cloud processor; "+
-			"size: %d, limit: 100 KB", len(b))
 	}
 	// TODO: use the framing format
 	// https://github.com/google/snappy/blob/main/framing_format.txt


### PR DESCRIPTION
We have decided to drop the check for the body's payload. The remote service will take care of splitting the chunk more if it turns out they are too big to be handled.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
