### PR TITLE
Deprecate loadimpact docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,7 @@ jobs:
           fi
       - name: Build loadimpact/k6
         run: docker build -t $LI_DOCKER_IMAGE_ID .
-      - name: Publish loadimpact/k6 image to Docker Hub
+      - name: Publish loadimpact/k6:master image to Docker Hub
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           echo "Publish to Docker Hub as $LI_DOCKER_IMAGE_ID:master"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build
-        run: docker build -t $DOCKER_IMAGE_ID .
+        run: docker build --target release -t $DOCKER_IMAGE_ID .
       - name: Check
         run: |
             docker run $DOCKER_IMAGE_ID version
@@ -187,27 +187,41 @@ jobs:
       - name: Publish k6:master image to Docker Hub
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
-          echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:master and $LI_DOCKER_IMAGE_ID:master"
+          echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:master"
           docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:master"
-          docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:master"
           docker push "$DOCKER_IMAGE_ID:master"
-          docker push "$LI_DOCKER_IMAGE_ID:master"
       - name: Publish tagged version image to Docker Hub
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
-          # We need to push the same image in both the loadimpact and the grafana docker hub orgs
           VERSION="${VERSION#v}"
-          echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:$VERSION and $LI_DOCKER_IMAGE_ID:$VERSION"
+          echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:$VERSION"
           docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:$VERSION"
-          docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:$VERSION"
           docker push "$DOCKER_IMAGE_ID:$VERSION"
+          # We also want to tag the latest stable version as latest
+          if [[ ! "$VERSION" =~ (RC|rc) ]]; then
+            echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:latest"
+            docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:latest"
+            docker push "$DOCKER_IMAGE_ID:latest"
+          fi
+      - name: Build loadimpact/k6
+        run: docker build -t $LI_DOCKER_IMAGE_ID .
+      - name: Publish loadimpact/k6 image to Docker Hub
+        if: ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          echo "Publish to Docker Hub as $LI_DOCKER_IMAGE_ID:master"
+          docker tag "$LI_DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:master"
+          docker push "$LI_DOCKER_IMAGE_ID:master"
+      - name: Publish loadimpact/k6 tagged version image to Docker Hub
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        run: |
+          VERSION="${VERSION#v}"
+          echo "Publish to Docker Hub as $LI_DOCKER_IMAGE_ID:$VERSION"
+          docker tag "$LI_DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:$VERSION"
           docker push "$LI_DOCKER_IMAGE_ID:$VERSION"
           # We also want to tag the latest stable version as latest
           if [[ ! "$VERSION" =~ (RC|rc) ]]; then
-            echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:latest and $LI_DOCKER_IMAGE_ID:latest"
-            docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:latest"
-            docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:latest"
-            docker push "$DOCKER_IMAGE_ID:latest"
+            echo "Publish to Docker Hub as $LI_DOCKER_IMAGE_ID:latest"
+            docker tag "$LI_DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:latest"
             docker push "$LI_DOCKER_IMAGE_ID:latest"
           fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ COPY . .
 RUN apk --no-cache add git=~2
 RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"
 
-FROM alpine:3.17
+# Runtime stage
+FROM alpine:3.17 as release
+
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates && \
     adduser -D -u 12345 -g 12345 k6
@@ -13,3 +15,10 @@ COPY --from=builder /go/bin/k6 /usr/bin/k6
 USER 12345
 WORKDIR /home/k6
 ENTRYPOINT ["k6"]
+
+# Legacy loadimpact/k6 image
+FROM release
+
+COPY entrypoint-legacy.sh /usr/bin/
+
+ENTRYPOINT ["/usr/bin/entrypoint-legacy.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,9 @@ RUN apk add --no-cache ca-certificates && \
     adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /go/bin/k6 /usr/bin/k6
 
-USER 12345
+USER k6
 WORKDIR /home/k6
+
 ENTRYPOINT ["k6"]
 
 # Legacy loadimpact/k6 image

--- a/entrypoint-legacy.sh
+++ b/entrypoint-legacy.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+cat >&2 <<-EOF
++------------------------------------------------------------------------------+
+| WARNING: The loadimpact/k6 Docker image has been replaced by grafana/k6.     |
+|          THIS IMAGE IS DEPRECATED and its support will be discontinued after |
+|          Dec 31, 2023. Please update your scripts to use grafana/k6 to       |
+|          continue using the latest version of k6.                            |
++------------------------------------------------------------------------------+
+
+EOF
+
+/usr/bin/k6 "$@"


### PR DESCRIPTION
With this PR we begin the deprecation process for `loadimpact/k6` Docker image. `k6` is a part of Grafana now, and we aim to continue releasing future versions under [Grafana organization](https://hub.docker.com/r/grafana/) on DockerHub.

Once merged, all future versions of `loadimpact/k6` Docker image will be displaying a warning banner that suggests migrating to `grafana/k6` before running the tool.

This PR splits the release workflow step that builds and publishes the image to Docker Hub in two stages. The first one builds `grafana/k6` image and publishes it, the second stage creates a new image that displays deprecation warning before running `k6`. This image is than published as `loadimpact/k6`.