### PR TITLE
output/cloudv2: Use a static remote service url

### DIFF
--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -8,7 +8,7 @@ import (
 )
 
 type pusher interface {
-	push(referenceID string, samples *pbcloud.MetricSet) error
+	push(samples *pbcloud.MetricSet) error
 }
 
 type metricsFlusher struct {
@@ -46,7 +46,7 @@ func (f *metricsFlusher) flush(_ context.Context) error {
 		}
 
 		// we hit the chunk size, let's flush
-		err := f.client.push(f.referenceID, msb.MetricSet)
+		err := f.client.push(msb.MetricSet)
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ func (f *metricsFlusher) flush(_ context.Context) error {
 	}
 
 	// send the last (or the unique) MetricSet chunk to the remote service
-	return f.client.push(f.referenceID, msb.MetricSet)
+	return f.client.push(msb.MetricSet)
 }
 
 type metricSetBuilder struct {

--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -92,7 +92,7 @@ type pusherMock struct {
 	pushCalled int
 }
 
-func (pm *pusherMock) push(_ string, _ *pbcloud.MetricSet) error {
+func (pm *pusherMock) push(_ *pbcloud.MetricSet) error {
 	pm.pushCalled++
 	return nil
 }

--- a/output/cloud/expv2/metrics_client_test.go
+++ b/output/cloud/expv2/metrics_client_test.go
@@ -36,11 +36,11 @@ func TestMetricsClientPush(t *testing.T) {
 	defer ts.Close()
 
 	c := cloudapi.NewClient(nil, "fake-token", ts.URL, "k6cloud/v0.4", 1*time.Second)
-	mc, err := newMetricsClient(c)
+	mc, err := newMetricsClient(c, "test-ref-id")
 	require.NoError(t, err)
 
 	mset := pbcloud.MetricSet{}
-	err = mc.push("test-ref-id", &mset)
+	err = mc.push(&mset)
 	require.NoError(t, err)
 	assert.Equal(t, 1, reqs)
 }
@@ -55,9 +55,9 @@ func TestMetricsClientPushUnexpectedStatus(t *testing.T) {
 	defer ts.Close()
 
 	c := cloudapi.NewClient(nil, "fake-token", ts.URL, "k6cloud/v0.4", 1*time.Second)
-	mc, err := newMetricsClient(c)
+	mc, err := newMetricsClient(c, "test-ref-id")
 	require.NoError(t, err)
 
-	err = mc.push("test-ref-id", nil)
+	err = mc.push(nil)
 	assert.ErrorContains(t, err, "500 Internal Server Error")
 }

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -83,7 +83,7 @@ func (o *Output) Start() error {
 		return fmt.Errorf("failed to initialize the samples collector: %w", err)
 	}
 
-	mc, err := newMetricsClient(o.cloudClient)
+	mc, err := newMetricsClient(o.cloudClient, o.referenceID)
 	if err != nil {
 		return fmt.Errorf("failed to initialize the http metrics flush client: %w", err)
 	}

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -74,6 +74,8 @@ func TestOutputCollectSamples(t *testing.T) {
 		logger, conf.Token.String, conf.Host.String, "v/test", conf.Timeout.TimeDuration())
 	o, err := New(logger, conf, cc)
 	require.NoError(t, err)
+
+	o.SetReferenceID("ref-id-123")
 	require.NoError(t, o.Start())
 	require.Empty(t, o.collector.bq.PopAll())
 
@@ -286,6 +288,7 @@ func TestOutputStopWithTestError(t *testing.T) {
 	o, err := New(logger, config, cc)
 	require.NoError(t, err)
 
+	o.SetReferenceID("ref-id-123")
 	require.NoError(t, o.Start())
 	require.NoError(t, o.StopWithTestError(errors.New("an error")))
 }


### PR DESCRIPTION
It moves the sets of the test run id and the relative URL generation from per request to once per client. 

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
