### PR TITLE
Use docker buildx to publish images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,6 +150,7 @@ jobs:
             -t $DOCKER_IMAGE_ID .
       - name: Check
         run: |
+            docker buildx build --load -t $DOCKER_IMAGE_ID .
             docker run $DOCKER_IMAGE_ID version
             docker run $DOCKER_IMAGE_ID --help
             docker run $DOCKER_IMAGE_ID help
@@ -170,20 +171,23 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           echo "Publish as ghcr.io/$GHCR_IMAGE_ID:$VERSION"
-          docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$GHCR_IMAGE_ID:master"
-          docker push "ghcr.io/$GHCR_IMAGE_ID:master"
+          docker buildx build --push \
+            --platform linux/amd64,linux/arm64 \
+            -t ghcr.io/$GHCR_IMAGE_ID:master .
       - name: Publish tagged version image to ghcr.io
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           VERSION="${VERSION#v}"
           echo "Publish as ghcr.io/$GHCR_IMAGE_ID:$VERSION"
-          docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$GHCR_IMAGE_ID:$VERSION"
-          docker push "ghcr.io/$GHCR_IMAGE_ID:$VERSION"
+          docker buildx build --push \
+            --platform linux/amd64,linux/arm64 \
+            -t ghcr.io/$GHCR_IMAGE_ID:$VERSION .
           # We also want to tag the latest stable version as latest
           if [[ ! "$VERSION" =~ (RC|rc) ]]; then
             echo "Publish as ghcr.io/$GHCR_IMAGE_ID:latest"
-            docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$GHCR_IMAGE_ID:latest"
-            docker push "ghcr.io/$GHCR_IMAGE_ID:latest"
+            docker buildx build --push \
+              --platform linux/amd64,linux/arm64 \
+              -t ghcr.io/$GHCR_IMAGE_ID:latest .
           fi
 
       - name: Log into Docker Hub
@@ -195,27 +199,33 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |
           echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:master and $LI_DOCKER_IMAGE_ID:master"
-          docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:master"
-          docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:master"
-          docker push "$DOCKER_IMAGE_ID:master"
-          docker push "$LI_DOCKER_IMAGE_ID:master"
+          docker buildx build --push \
+            --platform linux/amd64,linux/arm64 \
+            -t ghcr.io/$DOCKER_IMAGE_ID:master .
+          docker buildx build --push \
+            --platform linux/amd64,linux/arm64 \
+            -t ghcr.io/$LI_DOCKER_IMAGE_ID:master .
       - name: Publish tagged version image to Docker Hub
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           # We need to push the same image in both the loadimpact and the grafana docker hub orgs
           VERSION="${VERSION#v}"
           echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:$VERSION and $LI_DOCKER_IMAGE_ID:$VERSION"
-          docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:$VERSION"
-          docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:$VERSION"
-          docker push "$DOCKER_IMAGE_ID:$VERSION"
-          docker push "$LI_DOCKER_IMAGE_ID:$VERSION"
+          docker buildx build --push \
+            --platform linux/amd64,linux/arm64 \
+            -t ghcr.io/$DOCKER_IMAGE_ID:$VERSION .
+          docker buildx build --push \
+            --platform linux/amd64,linux/arm64 \
+            -t ghcr.io/$LI_DOCKER_IMAGE_ID:$VERSION .
           # We also want to tag the latest stable version as latest
           if [[ ! "$VERSION" =~ (RC|rc) ]]; then
             echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:latest and $LI_DOCKER_IMAGE_ID:latest"
-            docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:latest"
-            docker tag "$DOCKER_IMAGE_ID" "$LI_DOCKER_IMAGE_ID:latest"
-            docker push "$DOCKER_IMAGE_ID:latest"
-            docker push "$LI_DOCKER_IMAGE_ID:latest"
+            docker buildx build --push \
+              --platform linux/amd64,linux/arm64 \
+              -t ghcr.io/$DOCKER_IMAGE_ID:latest .
+            docker buildx build --push \
+              --platform linux/amd64,linux/arm64 \
+              -t ghcr.io/$LI_DOCKER_IMAGE_ID:latest .
           fi
 
   package-windows:


### PR DESCRIPTION
This PR addresses an issue with the current build process not pushing the latest built image caused by https://github.com/grafana/k6/pull/3015. For example `grafana/k6:master` image built a few days ago is the same as `grafana/k6:0.44.1` that has been pushed a month ago.

<img width="360" alt="Screenshot 2023-06-16 at 11 19 39" src="https://github.com/grafana/k6/assets/203793/20c0c0c9-3b16-44e5-a834-aca38f6e18e2">

The reason for this is that `docker buildx` uses a different context to build images, which means that all subsequent docker run and docker push commands work with an image that is different from what has been built at the “Build” step. 

The reason why this went unnoticed is the “Check” step, that “fixes” default context state by pulling the latest grafana/k6 image from DockerHub and this is the image used by all subsequent stages.

Once this applied, `build-docker` job will start using `docker buildx --push` to publish the image from `multibuilder` context instead of `default`. Since we don't change any files in-between, this command always uses the cached image created during the "Build" step. To run smoke test at the "Check" stage, we're going to load it into the `default` context by executing `docker buildx --load` before running the image.