### PR TITLE
Revert "Add multi-arch docker image build support"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,14 +140,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build
-        run: |
-          docker buildx create \
-            --name multibuilder \
-            --platform linux/amd64,linux/arm64 \
-            --bootstrap --use
-          docker buildx build \
-            --platform linux/amd64,linux/arm64 \
-            -t $DOCKER_IMAGE_ID .
+        run: docker build -t $DOCKER_IMAGE_ID .
       - name: Check
         run: |
             docker run $DOCKER_IMAGE_ID version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,14 @@
-# syntax=docker/dockerfile:1
-# Build
-FROM --platform=$BUILDPLATFORM golang:1.20-alpine3.17 AS builder
-
-ARG TARGETOS TARGETARCH
-
-ENV GOOS=$TARGETOS \
-  GOARCH=$TARGETARCH \
-  CGO_ENABLED=0
-
+FROM golang:1.20-alpine3.17 as builder
 WORKDIR $GOPATH/src/go.k6.io/k6
 COPY . .
 RUN apk --no-cache add git=~2
-RUN go build -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)" -o /usr/bin/k6 .
+RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"
 
-# Runtime stage
 FROM alpine:3.17
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates && \
     adduser -D -u 12345 -g 12345 k6
-COPY --from=builder /usr/bin/k6 /usr/bin/k6
+COPY --from=builder /go/bin/k6 /usr/bin/k6
 
 USER 12345
 WORKDIR /home/k6


### PR DESCRIPTION
This reverts commit 9fa50b2d1f259cdccff5cc7bc18a236d31c345ac.

[Pushing of ARM images is not working](https://github.com/grafana/k6/pull/3015#issuecomment-1525428295), and there are [issues with pushing master images](https://github.com/grafana/k6/pull/3127).

Rather than deal with risky fixes with `buildx` days before the v0.45.0 release, we've decided to roll back this change and migrate to `buildx` later, once we've understood and tested the build process better.