### PR TITLE
cloudv2: Renable the feature flag

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -28,12 +28,7 @@ type Config struct {
 	TestRunDetails null.String `json:"testRunDetails" envconfig:"K6_CLOUD_TEST_RUN_DETAILS"`
 	NoCompress     null.Bool   `json:"noCompress" envconfig:"K6_CLOUD_NO_COMPRESS"`
 	StopOnError    null.Bool   `json:"stopOnError" envconfig:"K6_CLOUD_STOP_ON_ERROR"`
-
-	// TODO: Renable the cloud output versioning
-	// https://github.com/grafana/k6/issues/3117
-	//
-	// APIVersion     null.Int    `json:"apiVersion" envconfig:"K6_CLOUD_API_VERSION"`
-	APIVersion null.Int `json:"-"`
+	APIVersion     null.Int    `json:"apiVersion" envconfig:"K6_CLOUD_API_VERSION"`
 
 	// TODO: rename the config field to align to the new logic by time series
 	// when the migration from the version 1 is completed.

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -136,10 +136,6 @@ func TestOutputCreateTestWithConfigOverwrite(t *testing.T) {
 }
 
 func TestOutputStartVersionError(t *testing.T) {
-	t.Skip("We disabled the Versioning to prevent mistakes and not be forced to " +
-		"maintain an experimental API in the future. " +
-		"We will re-enable it after the v0.45.0 release.")
-
 	t.Parallel()
 	o, err := newOutput(output.Params{
 		Logger: testutils.NewLogger(t),


### PR DESCRIPTION
k6 v0.45 is now released so we bring back the cloud v2 feature flag as planned.

<!--
  (ﾉ◕ヮ◕)ﾉ*:・ﾟ✧
  
  Thank you for your interest in contributing to the k6 project!
  
  Before you get started, we'd kindly like to ask you to read our:
    - Contribution guidelines at https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
    - Code of Conduct at https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
    
  Out of respect for your time, please start a discussion regarding any bigger contributions either
  in a GitHub Issue, in the community forums or in the #contributors channel of the k6 slack before you
  get started on the implementation.
  
  If you've already done all of that, you're more than welcome to proceed with your pull request.
  Thank you again for your contribution! 🙏🏼
  
  
-->
