### PR TITLE
TestOutputFlush always enabled

### DIFF
--- a/output/cloud/expv2/integration/integration_test.go
+++ b/output/cloud/expv2/integration/integration_test.go
@@ -32,8 +32,7 @@ func TestOutputFlush(t *testing.T) {
 	// TODO: it has 3s for aggregation time
 	// then it means it will execute for +3s that it is a waste of time
 	// because it isn't really required.
-	// Reduce the aggregation time (to 1s?) then run always.
-	t.Skip("Skip the integration test, if required enable it manually")
+	// Reduce the aggregation time (to 1s?)
 	t.Parallel()
 
 	results := make(chan *pbcloud.MetricSet)


### PR DESCRIPTION
## What?

It's better to have the tests always enabled since the initially mentioned `3s` not affecting the total time of the k6's tests (we have worse cases).

E.g. see what it looks like on a local machine (with `time`), there is no significant difference between the runs as far as I can tell.

Without integration test:

```
go test -p 2 -race -timeout 800s -count 1 ./...  250.74s user 11.43s system 211% cpu 2:03.82 total
go test -p 2 -race -timeout 800s -count 1 ./...  230.61s user 9.15s system 197% cpu 2:01.62 total
go test -p 2 -race -timeout 800s -count 1 ./...  230.08s user 9.46s system 202% cpu 1:58.57 total
go test -p 2 -race -timeout 800s -count 1 ./...  209.84s user 8.65s system 199% cpu 1:49.31 total
go test -p 2 -race -timeout 800s -count 1 ./...  219.80s user 9.31s system 201% cpu 1:53.72 total
```
With integration test enabled:

```
go test -p 2 -race -timeout 800s -count 1 ./...  231.20s user 9.57s system 204% cpu 1:57.99 total
go test -p 2 -race -timeout 800s -count 1 ./...  237.81s user 10.10s system 204% cpu 2:01.31 total
go test -p 2 -race -timeout 800s -count 1 ./...  222.45s user 9.19s system 196% cpu 1:58.12 total
go test -p 2 -race -timeout 800s -count 1 ./...  213.54s user 9.04s system 199% cpu 1:51.39 total
go test -p 2 -race -timeout 800s -count 1 ./...  215.50s user 8.97s system 191% cpu 1:57.20 total
```

And in any case, `3s` is almost nothing and acceptable as the price for the test,

## Why?

Having this always enabled is better since, that way, anyone will run this.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#3117

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
