### PR TITLE
chore: fix typo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 - [ ] I have performed a self-review of my code.
 - [ ] I have added tests for my changes.
 - [ ] I have run linter locally (`make ci-like-lint`) and all checks pass.
-- [ ] I have run tests locally (`make test`) and all tests pass.
+- [ ] I have run tests locally (`make tests`) and all tests pass.
 - [ ] I have commented on my code, particularly in hard-to-understand areas.
 <!-- - [ ] Any other relevant item -->
 


### PR DESCRIPTION
## What?

Fixing the type in the Makefile target of the pull request template.

## Why?

The current version doesn't work.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/3131

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
