### PR TITLE
output/cloudv2: Return empty string instead of "unknown" in rmCollector

### DIFF
--- a/output/cloud/expv2/collect.go
+++ b/output/cloud/expv2/collect.go
@@ -251,7 +251,7 @@ func (c *rmCollector) getStringTagFromTrail(trail *httpext.Trail, key string) st
 		return tag
 	}
 
-	return "unknown"
+	return ""
 }
 
 func (c *rmCollector) getIntTagFromTrail(trail *httpext.Trail, key string) int64 {

--- a/output/cloud/expv2/collect_test.go
+++ b/output/cloud/expv2/collect_test.go
@@ -408,8 +408,8 @@ func Test_requestMetadatasCollector_CollectRequestMetadatas_FiltersAndStoresHTTP
 		TraceID:        "test-trace-id-3",
 		Start:          time.Unix(19, 0),
 		End:            time.Unix(20, 0),
-		TestRunLabels:  insights.TestRunLabels{ID: 1337, Scenario: "unknown", Group: "unknown"},
-		ProtocolLabels: insights.ProtocolHTTPLabels{URL: "unknown", Method: "unknown", StatusCode: 0},
+		TestRunLabels:  insights.TestRunLabels{ID: 1337, Scenario: "", Group: ""},
+		ProtocolLabels: insights.ProtocolHTTPLabels{URL: "", Method: "", StatusCode: 0},
 	})
 }
 


### PR DESCRIPTION
This change is done to be on par with how the core backend handles unset tags.