### PR TITLE
Support for per-vu TLS configuration (grpc.Client.connect only) and custom (self-signed) RootCAs

### DIFF
--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -223,7 +223,7 @@ func TestAbortTest(t *testing.T) { //nolint:tparallel
 func TestOptionsTestFull(t *testing.T) {
 	t.Parallel()
 
-	expected := `{"paused":true,"scenarios":{"const-vus":{"executor":"constant-vus","options":{"browser":{"someOption":true}},"startTime":"10s","gracefulStop":"30s","env":{"FOO":"bar"},"exec":"default","tags":{"tagkey":"tagvalue"},"vus":50,"duration":"10m0s"}},"executionSegment":"0:1/4","executionSegmentSequence":"0,1/4,1/2,1","noSetup":true,"setupTimeout":"1m0s","noTeardown":true,"teardownTimeout":"5m0s","rps":100,"dns":{"ttl":"1m","select":"roundRobin","policy":"any"},"maxRedirects":3,"userAgent":"k6-user-agent","batch":15,"batchPerHost":5,"httpDebug":"full","insecureSkipTLSVerify":true,"tlsCipherSuites":["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"],"tlsVersion":{"min":"tls1.2","max":"tls1.3"},"tlsAuth":[{"domains":["example.com"],"cert":"mycert.pem","key":"mycert-key.pem","password":"mypwd"}],"throw":true,"thresholds":{"http_req_duration":[{"threshold":"rate>0.01","abortOnFail":true,"delayAbortEval":"10s"}]},"blacklistIPs":["192.0.2.0/24"],"blockHostnames":["test.k6.io","*.example.com"],"hosts":{"test.k6.io":"1.2.3.4:8443"},"noConnectionReuse":true,"noVUConnectionReuse":true,"minIterationDuration":"10s","ext":{"ext-one":{"rawkey":"rawvalue"}},"summaryTrendStats":["avg","min","max"],"summaryTimeUnit":"ms","systemTags":["iter","vu"],"tags":null,"metricSamplesBufferSize":8,"noCookiesReset":true,"discardResponseBodies":true,"consoleOutput":"loadtest.log","tags":{"runtag-key":"runtag-value"},"localIPs":"192.168.20.12-192.168.20.15,192.168.10.0/27"}`
+	expected := `{"paused":true,"scenarios":{"const-vus":{"executor":"constant-vus","options":{"browser":{"someOption":true}},"startTime":"10s","gracefulStop":"30s","env":{"FOO":"bar"},"exec":"default","tags":{"tagkey":"tagvalue"},"vus":50,"duration":"10m0s"}},"executionSegment":"0:1/4","executionSegmentSequence":"0,1/4,1/2,1","noSetup":true,"setupTimeout":"1m0s","noTeardown":true,"teardownTimeout":"5m0s","rps":100,"dns":{"ttl":"1m","select":"roundRobin","policy":"any"},"maxRedirects":3,"userAgent":"k6-user-agent","batch":15,"batchPerHost":5,"httpDebug":"full","insecureSkipTLSVerify":true,"tlsCipherSuites":["TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"],"tlsVersion":{"min":"tls1.2","max":"tls1.3"},"tlsAuth":[{"cacerts":[],"domains":["example.com"],"cert":"mycert.pem","key":"mycert-key.pem","password":"mypwd"}],"throw":true,"thresholds":{"http_req_duration":[{"threshold":"rate>0.01","abortOnFail":true,"delayAbortEval":"10s"}]},"blacklistIPs":["192.0.2.0/24"],"blockHostnames":["test.k6.io","*.example.com"],"hosts":{"test.k6.io":"1.2.3.4:8443"},"noConnectionReuse":true,"noVUConnectionReuse":true,"minIterationDuration":"10s","ext":{"ext-one":{"rawkey":"rawvalue"}},"summaryTrendStats":["avg","min","max"],"summaryTimeUnit":"ms","systemTags":["iter","vu"],"tags":null,"metricSamplesBufferSize":8,"noCookiesReset":true,"discardResponseBodies":true,"consoleOutput":"loadtest.log","tags":{"runtag-key":"runtag-value"},"localIPs":"192.168.20.12-192.168.20.15,192.168.10.0/27"}`
 
 	var (
 		rt    = goja.New()
@@ -294,6 +294,7 @@ func TestOptionsTestFull(t *testing.T) {
 				TLSAuth: []*lib.TLSAuth{
 					{
 						TLSAuthFields: lib.TLSAuthFields{
+							CACerts:  []string{},
 							Cert:     "mycert.pem",
 							Key:      "mycert-key.pem",
 							Password: null.StringFrom("mypwd"),

--- a/js/runner.go
+++ b/js/runner.go
@@ -3,6 +3,7 @@ package js
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -148,8 +149,13 @@ func (r *Runner) newVU(
 	tlsAuth := r.Bundle.Options.TLSAuth
 	certs := make([]tls.Certificate, len(tlsAuth))
 	nameToCert := make(map[string]*tls.Certificate)
+	var rootCAs *x509.CertPool
 	for i, auth := range tlsAuth {
 		cert, errC := auth.Certificate()
+		if errC != nil {
+			return nil, errC
+		}
+		errC = auth.RootCAs(rootCAs)
 		if errC != nil {
 			return nil, errC
 		}
@@ -175,6 +181,7 @@ func (r *Runner) newVU(
 	}
 
 	tlsConfig := &tls.Config{
+		RootCAs:            rootCAs,
 		InsecureSkipVerify: r.Bundle.Options.InsecureSkipTLSVerify.Bool, //nolint:gosec
 		CipherSuites:       cipherSuites,
 		MinVersion:         uint16(tlsVersions.Min),


### PR DESCRIPTION
## What? and Why?

You can now use self-signed ca-certificates when authenticating with TLS. Using the `cacerts` property of an options `tlsAuth` object, you can now indicate the CA certificate(s) that k6 will use to verify the server certificates your tests will access. CA certificates must be in `pem` format and multiple CA certificates can be included.

```javascript
export const options = {
    tlsAuth: [
        {
            cacerts: [open("cacerts.pem")],
            cert: open("cert.pem"),
            key: open("cert-key.pem"),
            password: "cert-passphrase",
            domains: ["grpcbin.test.k6.io"], // Deprecated
        },
    ],
};
```

You can also now use per-vu TLS configuration on `grpc.Client` `connect` params. Previously, `grpc.Client` `connect` made use of a shared (immutable) `tls.Config` cloned into every VU. Now, the `connect` `params` argument can contain a `tlsconfig` key that maps to the `TLSAuth` struct. This will create a per-vu TLS configuration for the `grpc.Client` allowing you to connect to multiple mTLS endpoints in a single VU. Note: the global tls.Config will remain unmodified.

```javascript
const params = {
    plaintext: false,
    tlsconfig: {
        cacerts: ["cacerts.pem"],
        cert: "cert.pem",
        key: "key.pem",
        password: "cert-passphrase",
        domains: ["grpcbin.test.notk6.io"], // Deprecated
    }
};
const hostPort = "grpcbin.test.notk6.io:9001";
const client = new grpc.Client();

client.connect(hostPort, params);
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] ~I have added tests for my changes.~
- [x] I have *updated* tests to consider my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
This PR does not close an issue but it does reference at least one conversation about per-vu mTLS: https://community.k6.io/t/grpc-mtls-per-vu-iteration/1868

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
