### PR TITLE
feat: catch, discard & warn about the labels that have reserved names

### DIFF
--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -74,7 +74,7 @@ func (f *metricsFlusher) push(msb metricSetBuilder) error {
 		}
 
 		f.discardedLabels[key] = struct{}{}
-		f.logger.Warnf("Label %s was discarded since it can't be used with the cloud output", key)
+		f.logger.Warnf("Tag %s has been discarded since it is reserved for Cloud operations.", key)
 	}
 
 	return f.client.push(msb.MetricSet)
@@ -107,7 +107,7 @@ type metricSetBuilder struct {
 	seriesIndex map[metrics.TimeSeries]uint
 
 	// discardedLabels tracks the labels that have been discarded
-	// because they are not supported by the remote service.
+	// since they are reserved for internal usage by the Cloud service.
 	discardedLabels map[string]struct{}
 }
 
@@ -157,12 +157,16 @@ func (msb *metricSetBuilder) addTimeBucket(bucket timeBucket) {
 	}
 }
 
-func (msb *metricSetBuilder) recordDiscardedLabels(labels map[string]struct{}) {
+func (msb *metricSetBuilder) recordDiscardedLabels(labels []string) {
+	if len(labels) == 0 {
+		return
+	}
+
 	if msb.discardedLabels == nil {
 		msb.discardedLabels = make(map[string]struct{})
 	}
 
-	for key := range labels {
+	for _, key := range labels {
 		if _, ok := msb.discardedLabels[key]; ok {
 			continue
 		}

--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -118,7 +118,7 @@ func newMetricSetBuilder(testRunID string, aggrPeriodSec uint32) metricSetBuilde
 		// is a better trade-off
 		metrics:         make(map[*metrics.Metric]*pbcloud.Metric),
 		seriesIndex:     make(map[metrics.TimeSeries]uint),
-		discardedLabels: make(map[string]struct{}),
+		discardedLabels: nil,
 	}
 	builder.MetricSet.TestRunId = testRunID
 	builder.MetricSet.AggregationPeriod = aggrPeriodSec
@@ -158,6 +158,10 @@ func (msb *metricSetBuilder) addTimeBucket(bucket timeBucket) {
 }
 
 func (msb *metricSetBuilder) recordDiscardedLabels(labels map[string]struct{}) {
+	if msb.discardedLabels == nil {
+		msb.discardedLabels = make(map[string]struct{})
+	}
+
 	for key := range labels {
 		if _, ok := msb.discardedLabels[key]; ok {
 			continue

--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -135,10 +135,10 @@ func TestMetricsFlusherFlushChunk(t *testing.T) {
 		bq := &bucketQ{}
 		pm := &pusherMock{}
 		mf := metricsFlusher{
-			bq:                     bq,
-			client:                 pm,
-			logger:                 logger,
-			discardedLabels:        make(map[string]struct{}),
+			bq:               bq,
+			client:           pm,
+			logger:           logger,
+			discardedLabels:  make(map[string]struct{}),
 			maxSeriesInBatch: 3,
 		}
 
@@ -180,11 +180,11 @@ func TestFlushWithReservedLabels(t *testing.T) {
 	}
 
 	mf := metricsFlusher{
-		bq:                     bq,
-		client:                 pm,
-		maxSeriesInSingleBatch: 2,
-		logger:                 logger,
-		discardedLabels:        make(map[string]struct{}),
+		bq:               bq,
+		client:           pm,
+		maxSeriesInBatch: 2,
+		logger:           logger,
+		discardedLabels:  make(map[string]struct{}),
 	}
 
 	r := metrics.NewRegistry()
@@ -224,8 +224,8 @@ func TestFlushWithReservedLabels(t *testing.T) {
 
 	// check that warnings sown only once per label
 	require.Len(t, loglines, 2)
-	testutils.LogContains(loglines, logrus.WarnLevel, "Label __name__ was discarded since it can't be used with the cloud output")
-	testutils.LogContains(loglines, logrus.WarnLevel, "Label test_run_id was discarded since it can't be used with the cloud output")
+	testutils.LogContains(loglines, logrus.WarnLevel, "Tag __name__ has been discarded since it is reserved for Cloud operations.")
+	testutils.LogContains(loglines, logrus.WarnLevel, "Tag test_run_id has been discarded since it is reserved for Cloud operations.")
 
 	// check that flusher is not sending labels with reserved names
 	require.Len(t, collected[0].Metrics, 1)

--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -7,10 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/cloudapi/insights"
+	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/metrics"
 	"go.k6.io/k6/output/cloud/expv2/pbcloud"
 )
@@ -127,13 +129,16 @@ func TestMetricsFlusherFlushChunk(t *testing.T) {
 
 	r := metrics.NewRegistry()
 	m1 := r.MustNewMetric("metric1", metrics.Counter)
-
 	for _, tc := range testCases {
+		logger, _ := testutils.NewLoggerWithHook(t)
+
 		bq := &bucketQ{}
 		pm := &pusherMock{}
 		mf := metricsFlusher{
-			bq:               bq,
-			client:           pm,
+			bq:                     bq,
+			client:                 pm,
+			logger:                 logger,
+			discardedLabels:        make(map[string]struct{}),
 			maxSeriesInBatch: 3,
 		}
 
@@ -160,11 +165,91 @@ func TestMetricsFlusherFlushChunk(t *testing.T) {
 	}
 }
 
+func TestFlushWithReservedLabels(t *testing.T) {
+	t.Parallel()
+
+	logger, hook := testutils.NewLoggerWithHook(t)
+
+	collected := make([]*pbcloud.MetricSet, 0)
+
+	bq := &bucketQ{}
+	pm := &pusherMock{
+		hook: func(ms *pbcloud.MetricSet) {
+			collected = append(collected, ms)
+		},
+	}
+
+	mf := metricsFlusher{
+		bq:                     bq,
+		client:                 pm,
+		maxSeriesInSingleBatch: 2,
+		logger:                 logger,
+		discardedLabels:        make(map[string]struct{}),
+	}
+
+	r := metrics.NewRegistry()
+	m1 := r.MustNewMetric("metric1", metrics.Counter)
+
+	ts1 := metrics.TimeSeries{
+		Metric: m1,
+		Tags:   r.RootTagSet().With("key1", "val1").With("__name__", "val2").With("test_run_id", "testrunid-123"),
+	}
+	bq.Push([]timeBucket{
+		{
+			Time: 1,
+			Sinks: map[metrics.TimeSeries]metricValue{
+				ts1: &counter{Sum: float64(1)},
+			},
+		},
+	})
+
+	ts2 := metrics.TimeSeries{
+		Metric: m1,
+		Tags:   r.RootTagSet().With("key1", "val2").With("__name__", "val2"),
+	}
+	bq.Push([]timeBucket{
+		{
+			Time: 2,
+			Sinks: map[metrics.TimeSeries]metricValue{
+				ts2: &counter{Sum: float64(1)},
+			},
+		},
+	})
+
+	err := mf.flush(context.Background())
+	require.NoError(t, err)
+
+	loglines := hook.Drain()
+	assert.Equal(t, 1, len(collected))
+
+	// check that warnings sown only once per label
+	require.Len(t, loglines, 2)
+	testutils.LogContains(loglines, logrus.WarnLevel, "Label __name__ was discarded since it can't be used with the cloud output")
+	testutils.LogContains(loglines, logrus.WarnLevel, "Label test_run_id was discarded since it can't be used with the cloud output")
+
+	// check that flusher is not sending labels with reserved names
+	require.Len(t, collected[0].Metrics, 1)
+
+	ts := collected[0].Metrics[0].TimeSeries
+	require.Len(t, ts[0].Labels, 1)
+	assert.Equal(t, "key1", ts[0].Labels[0].Name)
+	assert.Equal(t, "val1", ts[0].Labels[0].Value)
+
+	require.Len(t, ts[1].Labels, 1)
+	assert.Equal(t, "key1", ts[1].Labels[0].Name)
+	assert.Equal(t, "val2", ts[1].Labels[0].Value)
+}
+
 type pusherMock struct {
+	hook       func(*pbcloud.MetricSet)
 	pushCalled int
 }
 
-func (pm *pusherMock) push(_ *pbcloud.MetricSet) error {
+func (pm *pusherMock) push(ms *pbcloud.MetricSet) error {
+	if pm.hook != nil {
+		pm.hook(ms)
+	}
+
 	pm.pushCalled++
 	return nil
 }

--- a/output/cloud/expv2/mapping.go
+++ b/output/cloud/expv2/mapping.go
@@ -11,9 +11,9 @@ import (
 )
 
 // TODO: unit test
-func mapTimeSeriesLabelsProto(tags *metrics.TagSet) ([]*pbcloud.Label, map[string]struct{}) {
+func mapTimeSeriesLabelsProto(tags *metrics.TagSet) ([]*pbcloud.Label, []string) {
 	labels := make([]*pbcloud.Label, 0, ((*atlas.Node)(tags)).Len())
-	var discardedLabels map[string]struct{}
+	var discardedLabels []string
 
 	// TODO: move this as a shared func
 	// https://github.com/grafana/k6/issues/2764
@@ -31,10 +31,10 @@ func mapTimeSeriesLabelsProto(tags *metrics.TagSet) ([]*pbcloud.Label, map[strin
 		}
 
 		if discardedLabels == nil {
-			discardedLabels = make(map[string]struct{})
+			discardedLabels = make([]string, 0, 1)
 		}
 
-		discardedLabels[key] = struct{}{}
+		discardedLabels = append(discardedLabels, key)
 	}
 	return labels, discardedLabels
 }

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -106,6 +106,8 @@ func (o *Output) Start() error {
 		referenceID:                o.referenceID,
 		bq:                         &o.collector.bq,
 		client:                     mc,
+		logger:                     o.logger,
+		discardedLabels:            make(map[string]struct{}),
 		aggregationPeriodInSeconds: uint32(o.config.AggregationPeriod.TimeDuration().Seconds()),
 		maxSeriesInBatch:           int(o.config.MaxTimeSeriesInBatch.Int64),
 	}


### PR DESCRIPTION
## What?

Cloud Output V2 drops labels that are reserved, for now, we're sticking with the `test_run_id` and Prometheus system metrics (everything that prefixed with `__`) 

## Why?

These tags are reserved for internal use and can't be set with the client.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #3155

<!-- Thanks for your contribution! 🙏🏼 -->
