### PR TITLE
chore: add MaxTimeSeriesInBatch to the printable config

### DIFF
--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -346,20 +346,20 @@ func (o *Output) tracingEnabled() bool {
 
 func printableConfig(c cloudapi.Config) map[string]any {
 	m := map[string]any{
-		"host":                       c.Host.String,
-		"name":                       c.Name.String,
-		"timeout":                    c.Timeout.String(),
-		"webAppURL":                  c.WebAppURL.String,
-		"projectID":                  c.ProjectID.Int64,
-		"pushRefID":                  c.PushRefID.String,
-		"stopOnError":                c.StopOnError.Bool,
-		"testRunDetails":             c.TestRunDetails.String,
-		"aggregationPeriod":          c.AggregationPeriod.String(),
-		"aggregationWaitPeriod":      c.AggregationWaitPeriod.String(),
-		"maxMetricSamplesPerPackage": c.MaxMetricSamplesPerPackage.Int64,
-		"metricPushConcurrency":      c.MetricPushConcurrency.Int64,
-		"metricPushInterval":         c.MetricPushInterval.String(),
-		"token":                      "",
+		"host":                  c.Host.String,
+		"name":                  c.Name.String,
+		"timeout":               c.Timeout.String(),
+		"webAppURL":             c.WebAppURL.String,
+		"projectID":             c.ProjectID.Int64,
+		"pushRefID":             c.PushRefID.String,
+		"stopOnError":           c.StopOnError.Bool,
+		"testRunDetails":        c.TestRunDetails.String,
+		"aggregationPeriod":     c.AggregationPeriod.String(),
+		"aggregationWaitPeriod": c.AggregationWaitPeriod.String(),
+		"maxTimeSeriesInBatch":  c.MaxTimeSeriesInBatch.Int64,
+		"metricPushConcurrency": c.MetricPushConcurrency.Int64,
+		"metricPushInterval":    c.MetricPushInterval.String(),
+		"token":                 "",
 	}
 
 	if c.Token.Valid {


### PR DESCRIPTION
## What?

Add MaxTimeSeriesInBatch to the printable config.

## Why?

It's good to print it for debugging/testing purposes.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

* Option was introduced in https://github.com/grafana/k6/pull/3157
* #3117

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
