### PR TITLE
Add a `promises` package with a `New` helper function

### DIFF
--- a/js/promises/promises.go
+++ b/js/promises/promises.go
@@ -9,7 +9,7 @@ import (
 // MakeHandledPromise can be used to create promises that will be dispatched to k6's event loop.
 //
 // Calling the function will create a goja promise and return its `resolve` and `reject` callbacks, wrapped
-// in such a way that it will block the k6 JS runtime's event loop from exiting before they are
+// in such a way that it will block the k6 JavaScript runtime's event loop from exiting before they are
 // called, even if the promise isn't resolved by the time the current script ends executing.
 //
 // A typical usage would be:

--- a/js/promises/promises.go
+++ b/js/promises/promises.go
@@ -1,0 +1,46 @@
+// Package promises provides helpers for working with promises in k6.
+package promises
+
+import (
+	"github.com/dop251/goja"
+	"go.k6.io/k6/js/modules"
+)
+
+// MakeHandledPromise can be used to create promises that will be dispatched to k6's event loop.
+//
+// Calling the function will create a goja promise and return its `resolve` and `reject` callbacks, wrapped
+// in such a way that it will block the k6 JS runtime's event loop from exiting before they are
+// called, even if the promise isn't revoled by the time the current script ends executing.
+//
+// A typical usage would be:
+//
+//	   func myAsynchronousFunc(vu modules.VU) *(goja.Promise) {
+//		    promise, resolve, reject := promises.MakeHandledPromise(vu)
+//		    go func() {
+//		        v, err := someAsyncFunc()
+//				   if err != nil {
+//		            reject(err)
+//		            return
+//		        }
+//
+//		        resolve(v)
+//		    }()
+//		    return promise
+//		  }
+func MakeHandledPromise(vu modules.VU) (*goja.Promise, func(interface{}), func(interface{})) {
+	runtime := vu.Runtime()
+	callback := vu.RegisterCallback()
+	promise, resolve, reject := runtime.NewPromise()
+
+	return promise, func(i interface{}) {
+			callback(func() error {
+				resolve(i)
+				return nil
+			})
+		}, func(i interface{}) {
+			callback(func() error {
+				reject(i)
+				return nil
+			})
+		}
+}

--- a/js/promises/promises.go
+++ b/js/promises/promises.go
@@ -27,7 +27,7 @@ import (
 //		    }()
 //		    return promise
 //		  }
-func MakeHandledPromise(vu modules.VU) (promise *goja.Promise, resolve func(result interface{}), reject func(reason interface{})) {
+func New(vu modules.VU) (p *goja.Promise, resolve func(result any), reject func(reason any)) {
 	runtime := vu.Runtime()
 	promise, resolve, reject = runtime.NewPromise()
 	callback := vu.RegisterCallback()

--- a/js/promises/promises.go
+++ b/js/promises/promises.go
@@ -6,7 +6,7 @@ import (
 	"go.k6.io/k6/js/modules"
 )
 
-// MakeHandledPromise can be used to create promises that will be dispatched to k6's event loop.
+// New can be used to create promises that will be dispatched to k6's event loop.
 //
 // Calling the function will create a goja promise and return its `resolve` and `reject` callbacks, wrapped
 // in such a way that it will block the k6 JavaScript runtime's event loop from exiting before they are
@@ -15,7 +15,7 @@ import (
 // A typical usage would be:
 //
 //	   func myAsynchronousFunc(vu modules.VU) *(goja.Promise) {
-//		    promise, resolve, reject := promises.MakeHandledPromise(vu)
+//		    promise, resolve, reject := promises.New(vu)
 //		    go func() {
 //		        v, err := someAsyncFunc()
 //				   if err != nil {
@@ -29,10 +29,10 @@ import (
 //		  }
 func New(vu modules.VU) (p *goja.Promise, resolve func(result any), reject func(reason any)) {
 	runtime := vu.Runtime()
-	promise, resolve, reject = runtime.NewPromise()
+	p, resolve, reject = runtime.NewPromise()
 	callback := vu.RegisterCallback()
 
-	return promise, func(i interface{}) {
+	return p, func(i interface{}) {
 			callback(func() error {
 				resolve(i)
 				return nil

--- a/js/promises/promises.go
+++ b/js/promises/promises.go
@@ -28,8 +28,7 @@ import (
 //		    return promise
 //		  }
 func New(vu modules.VU) (p *goja.Promise, resolve func(result any), reject func(reason any)) {
-	runtime := vu.Runtime()
-	p, resolve, reject = runtime.NewPromise()
+	p, resolve, reject = vu.Runtime().NewPromise()
 	callback := vu.RegisterCallback()
 
 	return p, func(i interface{}) {

--- a/js/promises/promises.go
+++ b/js/promises/promises.go
@@ -10,7 +10,7 @@ import (
 //
 // Calling the function will create a goja promise and return its `resolve` and `reject` callbacks, wrapped
 // in such a way that it will block the k6 JS runtime's event loop from exiting before they are
-// called, even if the promise isn't revoled by the time the current script ends executing.
+// called, even if the promise isn't resolved by the time the current script ends executing.
 //
 // A typical usage would be:
 //
@@ -27,10 +27,10 @@ import (
 //		    }()
 //		    return promise
 //		  }
-func MakeHandledPromise(vu modules.VU) (*goja.Promise, func(interface{}), func(interface{})) {
+func MakeHandledPromise(vu modules.VU) (promise *Promise, resolve func(result interface{}), reject func(reason interface{})) {
 	runtime := vu.Runtime()
-	callback := vu.RegisterCallback()
 	promise, resolve, reject := runtime.NewPromise()
+	callback := vu.RegisterCallback()
 
 	return promise, func(i interface{}) {
 			callback(func() error {

--- a/js/promises/promises.go
+++ b/js/promises/promises.go
@@ -27,9 +27,9 @@ import (
 //		    }()
 //		    return promise
 //		  }
-func MakeHandledPromise(vu modules.VU) (promise *Promise, resolve func(result interface{}), reject func(reason interface{})) {
+func MakeHandledPromise(vu modules.VU) (promise *goja.Promise, resolve func(result interface{}), reject func(reason interface{})) {
 	runtime := vu.Runtime()
-	promise, resolve, reject := runtime.NewPromise()
+	promise, resolve, reject = runtime.NewPromise()
 	callback := vu.RegisterCallback()
 
 	return promise, func(i interface{}) {


### PR DESCRIPTION
## What?

This Pull Request introduces a `promises` package (under `js`) with a single `New` helper function facilitating the creation of a promise and obtaining its `resolve` and `reject` callback from Go code.

## Why?

We noticed in the context of writing extensions and experimental modules that we would consistently rewrite the same function again and again. Thus, this specific PR aims at declaring this function in a reusable place within the k6 project. 

None of this is definitive, and really is a proposal, if you have improvement ideas, shoot 🚀 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.


## Related PR(s)/Issue(s)

ref #3165 
