### PR TITLE
golangci-lint version update & minor fixes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.51.2
+# v1.53.3
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   deadline: 5m
@@ -59,6 +59,12 @@ linters-settings:
       # Forbid everything in syscall except the uppercase constants
       - '^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?'
       - '^logrus\.Logger$'
+  depguard:
+     rules:
+      main:
+        deny:
+          - pkg: io/ioutil
+            desc: ioutil is deprecated, see https://go.dev/doc/go1.16#ioutil
 
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,12 +59,6 @@ linters-settings:
       # Forbid everything in syscall except the uppercase constants
       - '^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?'
       - '^logrus\.Logger$'
-  depguard:
-     rules:
-      main:
-        deny:
-          - pkg: io/ioutil
-            desc: ioutil is deprecated, see https://go.dev/doc/go1.16#ioutil
 
 linters:
   disable-all: true
@@ -75,7 +69,6 @@ linters:
     - bodyclose
     - contextcheck
     - cyclop
-    - depguard
     - dogsled
     - dupl
     - durationcheck

--- a/cloudapi/insights/proto/gen.go
+++ b/cloudapi/insights/proto/gen.go
@@ -2,7 +2,6 @@
 // by the k6 Insights.
 package proto
 
-//nolint:lll
 //go:generate protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative ./v1/common/common.proto
 //go:generate protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative ./v1/ingester/ingester.proto
 //go:generate protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative ./v1/k6/labels.proto

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -319,7 +319,7 @@ func (b *Bundle) instantiate(vuImpl *moduleVUImpl, vuID uint64) (*goja.Object, e
 	var exportsV goja.Value
 	err = common.RunWithPanicCatching(b.preInitState.Logger, rt, func() error {
 		return vuImpl.eventLoop.Start(func() error {
-			//nolint:shadow,govet // here we shadow err on purpose
+			//nolint:govet // here we shadow err on purpose
 			var err error
 			exportsV, err = modSys.RunSourceData(b.sourceData)
 			return err

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -19,7 +19,7 @@ import (
 )
 
 //go:embed lib/babel.min.js
-var babelSrc string //nolint:gochecknoglobals
+var babelSrc string
 
 var (
 	DefaultOpts = map[string]interface{}{

--- a/js/init_and_modules_test.go
+++ b/js/init_and_modules_test.go
@@ -27,15 +27,15 @@ type CheckModule struct {
 	vuCtxCalled   int
 }
 
-func (cm *CheckModule) InitCtx(ctx context.Context) {
+func (cm *CheckModule) InitCtx(_ context.Context) {
 	cm.initCtxCalled++
 }
 
-func (cm *CheckModule) VuCtx(ctx context.Context) {
+func (cm *CheckModule) VuCtx(_ context.Context) {
 	cm.vuCtxCalled++
 }
 
-var uniqueModuleNumber int64 //nolint // we need this so multiple test can register differently named modules
+var uniqueModuleNumber int64 //nolint:gochecknoglobals // we need this so multiple test can register differently named modules
 
 func TestNewJSRunnerWithCustomModule(t *testing.T) {
 	t.Parallel()

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -190,13 +190,11 @@ func TestResponse(t *testing.T) {
 
 		t.Run("Invalid", func(t *testing.T) {
 			_, err := rt.RunString(sr(`http.request("GET", "HTTPBIN_URL/html").json();`))
-			//nolint:lll
 			assert.Contains(t, err.Error(), "cannot parse json due to an error at line 1, character 2 , error: invalid character '<' looking for beginning of value")
 		})
 
 		t.Run("Invalid", func(t *testing.T) {
 			_, err := rt.RunString(sr(`http.request("GET", "HTTPBIN_URL/invalidjson").json();`))
-			//nolint:lll
 			assert.Contains(t, err.Error(), "cannot parse json due to an error at line 3, character 9 , error: invalid character 'e' in literal true (expecting 'r')")
 		})
 

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -148,8 +148,6 @@ func (mi *K6) Group(name string, val goja.Value) (goja.Value, error) {
 }
 
 // Check will emit check metrics for the provided checks.
-//
-//nolint:cyclop
 func (mi *K6) Check(arg0, checks goja.Value, extras ...goja.Value) (bool, error) {
 	state := mi.vu.State()
 	if state == nil {

--- a/js/summary.go
+++ b/js/summary.go
@@ -16,10 +16,10 @@ import (
 // Copied from https://github.com/k6io/jslib.k6.io/tree/master/lib/k6-summary
 //
 //go:embed summary.js
-var jslibSummaryCode string //nolint:gochecknoglobals
+var jslibSummaryCode string
 
 //go:embed summary-wrapper.js
-var summaryWrapperLambdaCode string //nolint:gochecknoglobals
+var summaryWrapperLambdaCode string
 
 // TODO: figure out something saner... refactor the sinks and how we deal with
 // metrics in general... so much pain and misery... :sob:

--- a/js/tc39/tc39_test.go
+++ b/js/tc39/tc39_test.go
@@ -284,7 +284,7 @@ func parseTC39File(name string) (*tc39Meta, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	defer f.Close() //nolint:errcheck,gosec
+	defer f.Close() //nolint:errcheck
 
 	b, err := io.ReadAll(f)
 	if err != nil {
@@ -586,7 +586,7 @@ func (ctx *tc39TestCtx) compile(base, name string) (*goja.Program, error) {
 		if err != nil {
 			return nil, err
 		}
-		defer f.Close() //nolint:gosec,errcheck
+		defer f.Close() //nolint:errcheck
 
 		b, err := io.ReadAll(f)
 		if err != nil {

--- a/lib/executor/base_config.go
+++ b/lib/executor/base_config.go
@@ -18,7 +18,8 @@ import (
 // TODO?: Discard? Or make this actually user-configurable somehow? hello #883...
 var DefaultGracefulStopValue = 30 * time.Second //nolint:gochecknoglobals
 
-var executorNameWhitelist = regexp.MustCompile(`^[0-9a-zA-Z_-]+$`) //nolint:gochecknoglobals
+var executorNameWhitelist = regexp.MustCompile(`^[0-9a-zA-Z_-]+$`)
+
 const executorNameErr = "the executor name should contain only numbers, latin letters, underscores, and dashes"
 
 // BaseConfig contains the common config fields for all executors

--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -87,7 +87,7 @@ type executorTest struct {
 	options lib.Options
 	state   *lib.ExecutionState
 
-	ctx      context.Context //nolint
+	ctx      context.Context
 	cancel   context.CancelFunc
 	executor lib.Executor
 	logHook  *testutils.SimpleLogrusHook

--- a/lib/executor/constant_arrival_rate.go
+++ b/lib/executor/constant_arrival_rate.go
@@ -191,7 +191,7 @@ func (car *ConstantArrivalRate) Init(ctx context.Context) error {
 // This will allow us to implement https://github.com/k6io/k6/issues/1386
 // and things like all of the TODOs below in one place only.
 //
-//nolint:funlen,cyclop
+//nolint:funlen
 func (car ConstantArrivalRate) Run(parentCtx context.Context, out chan<- metrics.SampleContainer) (err error) {
 	gracefulStop := car.config.GetGracefulStop()
 	duration := car.config.Duration.TimeDuration()

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -107,7 +107,7 @@ func TestConstantArrivalRateRunCorrectRate(t *testing.T) {
 	require.Empty(t, test.logHook.Drain())
 }
 
-//nolint:tparallel,paralleltest // this is flaky if ran with other tests
+//nolint:paralleltest // this is flaky if ran with other tests
 func TestConstantArrivalRateRunCorrectTiming(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skipf("this test is very flaky on the Windows GitHub Action runners...")

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -301,7 +301,7 @@ func noNegativeSqrt(f float64) float64 {
 // This will allow us to implement https://github.com/k6io/k6/issues/1386
 // and things like all of the TODOs below in one place only.
 //
-//nolint:funlen,cyclop
+//nolint:funlen
 func (varr RampingArrivalRate) Run(parentCtx context.Context, out chan<- metrics.SampleContainer) (err error) {
 	segment := varr.executionState.ExecutionTuple.Segment
 	gracefulStop := varr.config.GetGracefulStop()

--- a/lib/netext/httpext/response.go
+++ b/lib/netext/httpext/response.go
@@ -9,7 +9,6 @@ import (
 // ResponseType is used in the request to specify how the response body should be treated
 // The conversion and validation methods are auto-generated with https://github.com/alvaroloes/enumer:
 //
-//nolint:lll
 //go:generate enumer -type=ResponseType -transform=snake -json -text -trimprefix ResponseType -output response_type_gen.go
 type ResponseType uint
 

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -72,7 +72,7 @@ func newTransport(
 // Helper method to finish the tracer trail, assemble the tag values and emits
 // the metric samples for the supplied unfinished request.
 //
-//nolint:nestif,funlen
+//nolint:funlen
 func (t *transport) measureAndEmitMetrics(unfReq *unfinishedRequest) *finishedRequest {
 	trail := unfReq.tracer.Done()
 

--- a/lib/runtime_options.go
+++ b/lib/runtime_options.go
@@ -9,7 +9,6 @@ import (
 
 // CompatibilityMode specifies the JS compatibility mode
 //
-//nolint:lll
 //go:generate enumer -type=CompatibilityMode -transform=snake -trimprefix CompatibilityMode -output compatibility_mode_gen.go
 type CompatibilityMode uint8
 

--- a/metrics/thresholds_parser_test.go
+++ b/metrics/thresholds_parser_test.go
@@ -66,7 +66,7 @@ func TestParseThresholdExpression(t *testing.T) {
 
 func BenchmarkParseThresholdExpression(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		parseThresholdExpression("count>20") // nolint
+		_, _ = parseThresholdExpression("count>20")
 	}
 }
 
@@ -203,7 +203,7 @@ func TestParseThresholdAggregationMethod(t *testing.T) {
 
 func BenchmarkParseThresholdAggregationMethod(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		parseThresholdAggregationMethod("p(99.9)") // nolint
+		_, _, _ = parseThresholdAggregationMethod("p(99.9)")
 	}
 }
 
@@ -336,6 +336,6 @@ func TestScanThresholdExpression(t *testing.T) {
 
 func BenchmarkScanThresholdExpression(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		scanThresholdExpression("foo<=bar") // nolint
+		_, _, _, _ = scanThresholdExpression("foo<=bar")
 	}
 }

--- a/metrics/thresholds_test.go
+++ b/metrics/thresholds_test.go
@@ -176,7 +176,7 @@ func BenchmarkRunNoTaint(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		threshold.runNoTaint(sinks) // nolint
+		_, _ = threshold.runNoTaint(sinks)
 	}
 }
 

--- a/output/statsd/helper_test.go
+++ b/output/statsd/helper_test.go
@@ -21,7 +21,6 @@ type getOutputFn func(
 	pushInterval types.NullDuration,
 ) (*Output, error)
 
-//nolint:funlen
 func baseTest(t *testing.T,
 	getOutput getOutputFn,
 	checkResult func(t *testing.T, samples []metrics.SampleContainer, expectedOutput, output string),


### PR DESCRIPTION
## What?

Update the golangci lint to the latest version and fix some `nolint` (linter is not used) issues.

## Why?

The reason behind this is a minor inconvenience after the changes for the `deepguard` linter that caused inline reporting of the blocked package.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
