### PR TITLE
fix for registering nested message types

### DIFF
--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -995,7 +995,7 @@ func TestClientLoadProto(t *testing.T) {
 		samples := make(chan metrics.SampleContainer, 1000)
 		testRuntime := modulestest.NewRuntime(t)
 
-		cwd, err := os.Getwd()
+		cwd, err := os.Getwd() //nolint:forbidigo
 		require.NoError(t, err)
 		fs := fsext.NewOsFs()
 		if isWindows {

--- a/lib/testutils/httpmultibin/grpc_testing/nested_types.proto
+++ b/lib/testutils/httpmultibin/grpc_testing/nested_types.proto
@@ -1,0 +1,36 @@
+// The purpose of this proto file is to demonstrate that we can have
+// nested types and that we should be able to load them correctly.
+
+syntax = "proto3";
+
+package grpc.testing;
+
+// Example to demonstrate that it is possible to define
+// and use message types within other message types
+message Outer {      // Level 0
+  message MiddleAA { // Level 1
+    message Inner {  // Level 2
+      int64 ival = 1;
+      bool booly = 2;
+    }
+    Inner inner = 1;
+  }
+
+  message MiddleBB { // Level 1
+    message Inner {  // Level 2
+      int32 ival = 1;
+      bool booly = 2;
+    }
+    Inner inner = 1;
+  }
+
+  MiddleAA middleAA = 1;
+  MiddleBB middleBB = 2;
+}
+
+// Example to demonstrate that it is possible to reuse
+// a message type outside its parent message type
+message MeldOuter {
+  Outer.MiddleAA.Inner innerAA = 1;
+  Outer.MiddleBB.Inner innerBB = 2;
+}


### PR DESCRIPTION
## What?

`client.load()` (grpc module) was not registering protobuf nested messages in `protoregistry.GlobalTypes`.

## Why?

It was necessary to go through the message structures starting from the root, but as it was before the PR, it only registered the root message.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes #3160 issue.

backport from [xk6-grpc PR](https://github.com/grafana/xk6-grpc/pull/23)


<!-- Thanks for your contribution! 🙏🏼 -->
