### PR TITLE
Address eventloop's double registerCallback call when using promises.New

### DIFF
--- a/js/promises/promises.go
+++ b/js/promises/promises.go
@@ -28,18 +28,22 @@ import (
 //		    return promise
 //		  }
 func New(vu modules.VU) (p *goja.Promise, resolve func(result any), reject func(reason any)) {
-	p, resolve, reject = vu.Runtime().NewPromise()
+	p, resolveFunc, rejectFunc := vu.Runtime().NewPromise()
 	callback := vu.RegisterCallback()
 
-	return p, func(i interface{}) {
-			callback(func() error {
-				resolve(i)
-				return nil
-			})
-		}, func(i interface{}) {
-			callback(func() error {
-				reject(i)
-				return nil
-			})
-		}
+	resolve = func(result any) {
+		callback(func() error {
+			resolveFunc(result)
+			return nil
+		})
+	}
+
+	reject = func(reason any) {
+		callback(func() error {
+			rejectFunc(reason)
+			return nil
+		})
+	}
+
+	return p, resolve, reject
 }

--- a/js/promises/promises_test.go
+++ b/js/promises/promises_test.go
@@ -1,0 +1,69 @@
+package promises
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/modulestest"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should resolve", func(t *testing.T) {
+		t.Parallel()
+
+		runtime := modulestest.NewRuntime(t)
+		promise, resolve, _ := New(runtime.VU)
+
+		go func() {
+			resolve("resolved")
+		}()
+
+		err := runtime.EventLoop.Start(func() error {
+			err := runtime.VU.Runtime().Set("promise", promise)
+			require.NoError(t, err)
+
+			_, err = runtime.VU.Runtime().RunString(`
+				promise
+					.then(
+						res => { if (res !== "resolved") { throw "unexpected promise resolution with result: " + res } },
+						err => { throw "unexpected error: " + err },
+					)
+			`)
+
+			return err
+		})
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("should reject", func(t *testing.T) {
+		t.Parallel()
+
+		runtime := modulestest.NewRuntime(t)
+		promise, _, reject := New(runtime.VU)
+
+		go func() {
+			reject("rejected")
+		}()
+
+		err := runtime.EventLoop.Start(func() error {
+			err := runtime.VU.Runtime().Set("promise", promise)
+			require.NoError(t, err)
+
+			_, err = runtime.VU.Runtime().RunString(`
+				promise
+					.then(
+						res => { throw "unexpected promise resolution with result: " + res },
+						err => { if (err !== "rejected") { throw "unexpected error: " + err } },
+					)
+			`)
+
+			return err
+		})
+
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## What?

This Pull Request addresses the misuse of named arguments introduced by #3176, and fixes the resulting `registerCallback called twice` issue that followed from it.

It also adds two minimal tests covering ensuring the `resolve` and `reject` callbacks are effective. I wasn't entirely sure how to properly test that function; this is the simplest thing I came up with. I'm all ears 👂🏻 for alternatives and suggestions to improve it 🙇🏻 

## Why?

As I started using the `promises.New` function in another stream of work, I noticed that as soon as I used the `promises.New` function, I would end up having `registerCallback called twice` panic all over. I tracked down the issue, and it turned out that it was because we needed to use Go named return arguments properly.

## Checklist

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

ref #3176
ref https://github.com/grafana/k6/pull/3176#pullrequestreview-1521556345
<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
