### PR TITLE
Add a `RunOnEventLoop` method to `modulestest.Runtime`

### DIFF
--- a/js/modules/k6/experimental/tracing/client_test.go
+++ b/js/modules/k6/experimental/tracing/client_test.go
@@ -253,15 +253,11 @@ func TestCallingInstrumentedRequestEmitsTraceIdMetadata(t *testing.T) {
 	// Assert there is no trace_id key in vu metadata before calling an instrumented
 	// function, and that it's cleaned up after the call.
 	t.Cleanup(testCase.TestRuntime.EventLoop.WaitOnRegistered)
-	err = testCase.TestRuntime.EventLoop.Start(func() error {
-		_, err = rt.RunString(httpBin.Replacer.Replace(`
-        	assert_has_trace_id_metadata(false)
-        	http.request("GET", "HTTPBIN_URL")
-        	assert_has_trace_id_metadata(false)
-        `))
-
-		return err
-	})
+	_, err = testCase.TestRuntime.RunOnEventLoop(httpBin.Replacer.Replace(`
+		assert_has_trace_id_metadata(false)
+		http.request("GET", "HTTPBIN_URL")
+		assert_has_trace_id_metadata(false)
+	`))
 	require.NoError(t, err)
 	close(samples)
 

--- a/js/modules/k6/http/response_callback_test.go
+++ b/js/modules/k6/http/response_callback_test.go
@@ -262,11 +262,7 @@ func TestResponseCallbackInAction(t *testing.T) {
 			t.Helper()
 			ts.instance.defaultClient.responseCallback = defaultExpectedStatuses.match
 
-			err := ts.runtime.EventLoop.Start(func() error {
-				_, err := ts.runtime.VU.Runtime().RunString(sr(code))
-				return err
-			})
-			ts.runtime.EventLoop.WaitOnRegistered()
+			_, err := ts.runtime.RunOnEventLoop(sr(code))
 			assert.NoError(t, err)
 			bufSamples := metrics.GetBufferedSamples(samples)
 


### PR DESCRIPTION
## What?

This Pull Request adds a `RunOnEventLoop` method to the `modulestest.Runtime`, to facilitate testing code that should be dispatched to the event loop, such as code that returns promises.

## Why?

While writing tests for the #3142, I stumbled upon this code from @mstoykov, with a `TODO` attached. I thought that as I was about to copy-paste that snippet anyway, I might as well do as instructed in `TODO` and move the code to the `modulestest.Runtime` class. 

The `TODO` hinted at potential improvements without detailing that I'd be nonetheless happy to include if necessary 🤞🏻 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
