### PR TITLE
cloudv2/hdr: Fix off-by-one error for spans

### DIFF
--- a/output/cloud/expv2/hdr.go
+++ b/output/cloud/expv2/hdr.go
@@ -128,8 +128,8 @@ func histogramAsProto(h *histogram, time int64) *pbcloud.TrendHdrValue {
 
 		// if the current and the previous indexes are not consecutive
 		// consider as closed the current on-going span and start a new one.
-		if diff := indexes[i] - indexes[i-1]; diff > 1 {
-			spans = append(spans, &pbcloud.BucketSpan{Offset: diff, Length: 1})
+		if zerosBetween := indexes[i] - indexes[i-1] - 1; zerosBetween > 0 {
+			spans = append(spans, &pbcloud.BucketSpan{Offset: zerosBetween, Length: 1})
 			continue
 		}
 

--- a/output/cloud/expv2/hdr_test.go
+++ b/output/cloud/expv2/hdr_test.go
@@ -251,6 +251,42 @@ func TestHistogramAsProto(t *testing.T) {
 		},
 		{
 			name: "normal values",
+			vals: []float64{7, 8, 9, 11, 12, 11.5, 10.5},
+			exp: &pbcloud.TrendHdrValue{
+				Count:                  7,
+				ExtraLowValuesCounter:  nil,
+				ExtraHighValuesCounter: nil,
+				Counters:               []uint32{1, 1, 1, 2, 2},
+				Spans: []*pbcloud.BucketSpan{
+					{Offset: 7, Length: 3},
+					{Offset: 1, Length: 2},
+				},
+				MinValue: 7,
+				MaxValue: 12,
+				Sum:      69,
+			},
+		},
+		{
+			name: "with Zero-point values",
+			vals: []float64{2, 0.01, 3},
+			exp: &pbcloud.TrendHdrValue{
+				Count:                  3,
+				ExtraLowValuesCounter:  nil,
+				ExtraHighValuesCounter: nil,
+				Counters:               []uint32{1, 1, 1},
+				Spans: []*pbcloud.BucketSpan{
+					{
+						Offset: 1,
+						Length: 3,
+					},
+				},
+				MinValue: 0.01,
+				MaxValue: 3,
+				Sum:      5.01,
+			},
+		},
+		{
+			name: "a basic case",
 			vals: []float64{2, 1.1, 3},
 			exp: &pbcloud.TrendHdrValue{
 				Count:                  3,
@@ -288,17 +324,17 @@ func TestHistogramAsProto(t *testing.T) {
 				Counters: []uint32{3, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 2, 1},
 				Spans: []*pbcloud.BucketSpan{
 					{Offset: 19, Length: 1},
-					{Offset: 33, Length: 2},
-					{Offset: 111, Length: 1},
-					{Offset: 75, Length: 1},
-					{Offset: 23, Length: 2}, // 262
-					{Offset: 57, Length: 1},
-					{Offset: 105, Length: 1},
-					{Offset: 40, Length: 1},
 					{Offset: 32, Length: 2},
-					{Offset: 156, Length: 1}, // 654
-					{Offset: 114, Length: 1},
-					{Offset: 411, Length: 1},
+					{Offset: 110, Length: 1},
+					{Offset: 74, Length: 1},
+					{Offset: 22, Length: 2}, // 262
+					{Offset: 56, Length: 1},
+					{Offset: 104, Length: 1},
+					{Offset: 39, Length: 1},
+					{Offset: 31, Length: 2},
+					{Offset: 155, Length: 1}, // 654
+					{Offset: 113, Length: 1},
+					{Offset: 410, Length: 1},
 				},
 				ExtraLowValuesCounter:  nil,
 				ExtraHighValuesCounter: nil,


### PR DESCRIPTION
## What?

Fix the histogram's Spans encoding.
 
i.e., when encoding a sequence like the following: `[1, 1, 1, 0, 2, 2]`

The second span must be:
`(offset=1, length=2)`

And not:
`(offset=2, length=2)`

## Why

`histogram.Spans.Offset` is expected to be the counter of the empty buckets and not the diff between the indexes.

## Related PR(s)/Issue(s)

Follow-up on https://github.com/grafana/k6/pull/3169