### PR TITLE
output/cloudv2: Fix insights client initialization

### DIFF
--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -124,12 +124,12 @@ func (o *Output) Start() error {
 		o.requestMetadatasCollector = newRequestMetadatasCollector(testRunID)
 
 		insightsClientConfig := insights.ClientConfig{
-			IngesterHost: o.config.TracesHost.ValueOrZero(),
+			IngesterHost: o.config.TracesHost.String,
 			Timeout:      types.NewNullDuration(90*time.Second, false),
 			AuthConfig: insights.ClientAuthConfig{
 				Enabled:                  true,
 				TestRunID:                testRunID,
-				Token:                    o.config.Token.ValueOrZero(),
+				Token:                    o.config.Token.String,
 				RequireTransportSecurity: true,
 			},
 			TLSConfig: insights.ClientTLSConfig{


### PR DESCRIPTION
Fixes a bug where `K6_CLOUD_TRACES_HOST` didn't work with default values.