### PR TITLE
cloudv2: Create batches for single bucket flush

### DIFF
--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -44,19 +44,21 @@ func (f *metricsFlusher) flush() error {
 
 	msb := newMetricSetBuilder(f.testRunID, f.aggregationPeriodInSeconds)
 	for i := 0; i < len(buckets); i++ {
-		msb.addTimeBucket(buckets[i])
-		if len(msb.seriesIndex) < f.maxSeriesInBatch {
-			continue
-		}
+		for timeSeries, sink := range buckets[i].Sinks {
+			msb.addTimeSeries(buckets[i].Time, timeSeries, sink)
+			if len(msb.seriesIndex) < f.maxSeriesInBatch {
+				continue
+			}
 
-		// we hit the batch size, let's flush
-		f.logger.WithField("limit", f.maxSeriesInBatch).
-			Debug("Flushing a partial, hit the max number of series allowed in a single batch")
-		err := f.push(msb)
-		if err != nil {
-			return err
+			// we hit the batch size, let's flush
+			f.logger.WithField("limit", f.maxSeriesInBatch).
+				Debug("Flushing a partial, hit the max number of series allowed in a single batch")
+			err := f.push(msb)
+			if err != nil {
+				return err
+			}
+			msb = newMetricSetBuilder(f.testRunID, f.aggregationPeriodInSeconds)
 		}
-		msb = newMetricSetBuilder(f.testRunID, f.aggregationPeriodInSeconds)
 	}
 
 	if len(msb.seriesIndex) < 1 {
@@ -128,36 +130,34 @@ func newMetricSetBuilder(testRunID string, aggrPeriodSec uint32) metricSetBuilde
 	return builder
 }
 
-func (msb *metricSetBuilder) addTimeBucket(bucket timeBucket) {
-	for timeSeries, sink := range bucket.Sinks {
-		pbmetric, ok := msb.metrics[timeSeries.Metric]
-		if !ok {
-			pbmetric = &pbcloud.Metric{
-				Name: timeSeries.Metric.Name,
-				Type: mapMetricTypeProto(timeSeries.Metric.Type),
-			}
-			msb.metrics[timeSeries.Metric] = pbmetric
-			msb.MetricSet.Metrics = append(msb.MetricSet.Metrics, pbmetric)
+func (msb *metricSetBuilder) addTimeSeries(timestamp int64, timeSeries metrics.TimeSeries, sink metricValue) {
+	pbmetric, ok := msb.metrics[timeSeries.Metric]
+	if !ok {
+		pbmetric = &pbcloud.Metric{
+			Name: timeSeries.Metric.Name,
+			Type: mapMetricTypeProto(timeSeries.Metric.Type),
 		}
-
-		var pbTimeSeries *pbcloud.TimeSeries
-		ix, ok := msb.seriesIndex[timeSeries]
-		if !ok {
-			labels, discardedLabels := mapTimeSeriesLabelsProto(timeSeries.Tags)
-			msb.recordDiscardedLabels(discardedLabels)
-
-			pbTimeSeries = &pbcloud.TimeSeries{
-				Labels: labels,
-			}
-			pbmetric.TimeSeries = append(pbmetric.TimeSeries, pbTimeSeries)
-			msb.seriesIndex[timeSeries] = uint(len(pbmetric.TimeSeries) - 1)
-		} else {
-			pbTimeSeries = pbmetric.TimeSeries[ix]
-		}
-
-		addBucketToTimeSeriesProto(
-			pbTimeSeries, timeSeries.Metric.Type, bucket.Time, sink)
+		msb.metrics[timeSeries.Metric] = pbmetric
+		msb.MetricSet.Metrics = append(msb.MetricSet.Metrics, pbmetric)
 	}
+
+	var pbTimeSeries *pbcloud.TimeSeries
+	ix, ok := msb.seriesIndex[timeSeries]
+	if !ok {
+		labels, discardedLabels := mapTimeSeriesLabelsProto(timeSeries.Tags)
+		msb.recordDiscardedLabels(discardedLabels)
+
+		pbTimeSeries = &pbcloud.TimeSeries{
+			Labels: labels,
+		}
+		pbmetric.TimeSeries = append(pbmetric.TimeSeries, pbTimeSeries)
+		msb.seriesIndex[timeSeries] = uint(len(pbmetric.TimeSeries) - 1)
+	} else {
+		pbTimeSeries = pbmetric.TimeSeries[ix]
+	}
+
+	addBucketToTimeSeriesProto(
+		pbTimeSeries, timeSeries.Metric.Type, timestamp, sink)
 }
 
 func (msb *metricSetBuilder) recordDiscardedLabels(labels []string) {

--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -49,7 +49,9 @@ func (f *metricsFlusher) flush() error {
 			continue
 		}
 
-		// we hit the chunk size, let's flush
+		// we hit the batch size, let's flush
+		f.logger.WithField("limit", f.maxSeriesInBatch).
+			Debug("Flushing a partial, hit the max number of series allowed in a single batch")
 		err := f.push(msb)
 		if err != nil {
 			return err
@@ -61,6 +63,7 @@ func (f *metricsFlusher) flush() error {
 		return nil
 	}
 
+	f.logger.WithField("series", len(msb.seriesIndex)).Debug("Flushing the batch")
 	// send the last (or the unique) MetricSet chunk to the remote service
 	return f.push(msb)
 }

--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -68,8 +68,7 @@ func (f *metricsFlusher) flush() error {
 			// we hit the batch size, let's flush
 			batchesCount++
 			seriesCount += len(msb.seriesIndex)
-			err := f.push(msb)
-			if err != nil {
+			if err := f.push(msb); err != nil {
 				return err
 			}
 			msb = newMetricSetBuilder(f.testRunID, f.aggregationPeriodInSeconds)
@@ -158,8 +157,7 @@ func (msb *metricSetBuilder) addTimeSeries(timestamp int64, timeSeries metrics.T
 	}
 
 	var pbTimeSeries *pbcloud.TimeSeries
-	ix, ok := msb.seriesIndex[timeSeries]
-	if !ok {
+	if ix, ok := msb.seriesIndex[timeSeries]; !ok {
 		labels, discardedLabels := mapTimeSeriesLabelsProto(timeSeries.Tags)
 		msb.recordDiscardedLabels(discardedLabels)
 
@@ -171,9 +169,7 @@ func (msb *metricSetBuilder) addTimeSeries(timestamp int64, timeSeries metrics.T
 	} else {
 		pbTimeSeries = pbmetric.TimeSeries[ix]
 	}
-
-	addBucketToTimeSeriesProto(
-		pbTimeSeries, timeSeries.Metric.Type, timestamp, sink)
+	addBucketToTimeSeriesProto(pbTimeSeries, timeSeries.Metric.Type, timestamp, sink)
 }
 
 func (msb *metricSetBuilder) recordDiscardedLabels(labels []string) {

--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -28,7 +28,6 @@ type metricsFlusher struct {
 // If the number of time series collected is bigger than maximum batch size
 // then it splits in chunks.
 func (f *metricsFlusher) flush() error {
-
 	// drain the buffer
 	buckets := f.bq.PopAll()
 	if len(buckets) < 1 {

--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -261,9 +261,8 @@ func TestFlushWithReservedLabels(t *testing.T) {
 	assert.Equal(t, 1, len(collected))
 
 	// check that warnings sown only once per label
-	require.Len(t, loglines, 2)
-	testutils.LogContains(loglines, logrus.WarnLevel, "Tag __name__ has been discarded since it is reserved for Cloud operations.")
-	testutils.LogContains(loglines, logrus.WarnLevel, "Tag test_run_id has been discarded since it is reserved for Cloud operations.")
+	assert.Len(t, testutils.FilterEntries(loglines, logrus.WarnLevel, "Tag __name__ has been discarded since it is reserved for Cloud operations."), 1)
+	assert.Len(t, testutils.FilterEntries(loglines, logrus.WarnLevel, "Tag test_run_id has been discarded since it is reserved for Cloud operations."), 1)
 
 	// check that flusher is not sending labels with reserved names
 	require.Len(t, collected[0].Metrics, 1)


### PR DESCRIPTION
## What?

1. Split also single buckets into batches if they hit the limit of series.
2. Log the stats of the flush operation:

An example of the generated logs

```
DEBU[0000] Starting executor run...                      duration=1m0s executor=constant-vus scenario=default type=constant-vus vus=1
DEBU[0006] Successfully flushed buffered samples to the cloud  output=cloudv2 t="1.253µs"
DEBU[0012] Flush the queued buckets                      batches=1 buckets=2 output=cloudv2 series=15 t=147.787055ms
DEBU[0012] Successfully flushed buffered samples to the cloud  output=cloudv2 t=147.828593ms
DEBU[0018] Flush the queued buckets                      batches=1 buckets=2 output=cloudv2 series=15 t=57.533889ms
DEBU[0018] Successfully flushed buffered samples to the cloud  output=cloudv2 t=57.597169ms
DEBU[0024] Flush the queued buckets                      batches=1 buckets=2 output=cloudv2 series=15 t=58.928121ms
DEBU[0024] Successfully flushed buffered samples to the cloud  output=cloudv2 t=58.978637ms
DEBU[0030] Flush the queued buckets                      batches=1 buckets=2 output=cloudv2 series=15 t=55.783661ms
DEBU[0030] Successfully flushed buffered samples to the cloud  output=cloudv2 t=55.864234ms
```

## Why?

Batch: if the test has a lot of _active time series_ then having the split across buckets doesn't help because there is a high chance they will be all in the same.

Log: Easier for figuring out if we are experiencing issues.
