### PR TITLE
cloudv2: Downscale the batch size

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -175,9 +175,13 @@ func NewConfig() Config {
 		TracesPushConcurrency: null.NewInt(1, false),
 
 		MaxMetricSamplesPerPackage: null.NewInt(100000, false),
-		MaxTimeSeriesInBatch:       null.NewInt(10000, false),
 		Timeout:                    types.NewNullDuration(1*time.Minute, false),
 		APIVersion:                 null.NewInt(1, false),
+
+		// The set value (1000) is selected for performance reasons.
+		// Any change to this value should be first discussed with internal stakeholders.
+		MaxTimeSeriesInBatch: null.NewInt(1000, false),
+
 		// Aggregation is disabled by default, since AggregationPeriod has no default value
 		// but if it's enabled manually or from the cloud service, those are the default values it will use:
 		AggregationCalcInterval:         types.NewNullDuration(3*time.Second, false),


### PR DESCRIPTION
The backend has the limit set to 1k so it doesn't make sense to use a bigger value forcing the system to split a single batch in multiple jobs.

We are already overwriting the default value for most of the cases.  This PR removes the requirement for setting the env var for doing the overwrite simplifing internal operations.