### PR TITLE
Fix loki log output exiting before push is finished

### DIFF
--- a/log/loki.go
+++ b/log/loki.go
@@ -150,10 +150,13 @@ func (h *lokiHook) Listen(ctx context.Context) {
 		pushCh     = make(chan chan int64)
 	)
 
+	pushDone := make(chan struct{})
+	defer func() { <-pushDone }()
 	defer ticker.Stop()
 	defer close(pushCh)
 
 	go func() {
+		defer close(pushDone)
 		oldLogs := make([]tmpMsg, 0, h.limit*2)
 		for ch := range pushCh {
 			msgsToPush, msgs = msgs, msgsToPush


### PR DESCRIPTION
After #2833 log outputs were stopped but loki didn't wait until it push was finished to signal it was done.

Which leads to the actual k6 process exiting before loki could flush its messages.
