### PR TITLE
cloudv2: Make sure to use the overwritten config

### DIFF
--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -37,6 +37,18 @@ func TestNew(t *testing.T) {
 	assert.Equal(t, int64(99), o.config.APIVersion.Int64)
 }
 
+func TestNewWithConfigOverwritten(t *testing.T) {
+	t.Parallel()
+
+	logger := testutils.NewLogger(t)
+	c := cloudapi.NewClient(logger, "my-token", "the-host", "v/foo", 1*time.Second)
+	conf := cloudapi.Config{Host: null.StringFrom("the-new-host")}
+	o, err := New(logger, conf, c)
+	require.NoError(t, err)
+	require.NotNil(t, o)
+	assert.Equal(t, "the-new-host/v1", o.cloudClient.BaseURL())
+}
+
 func TestOutputSetTestRunID(t *testing.T) {
 	t.Parallel()
 	o := Output{}

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -337,6 +337,14 @@ func (out *Output) startVersionedOutput() error {
 		return errors.New("TestRunID is required")
 	}
 	var err error
+
+	// TODO: move here the creation of a new cloudapi.Client
+	// so in the case the config has been overwritten the client uses the correct
+	// value.
+	//
+	// This logic is handled individually by each single output, it has the downside
+	// that we could break the logic and not catch easly it.
+
 	switch out.config.APIVersion.Int64 {
 	case int64(apiVersion1):
 		out.versionedOutput, err = cloudv1.New(out.logger, out.config, out.client)


### PR DESCRIPTION
It fixes the cloud v2 initialization that was using the passed client that doesn't consider the overwritten configuration. It now uses a new allocated and dedicated client based on the passed configuration that includes the overwritten fields. 