### PR TITLE
Build and publish browser-enabled Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -204,7 +204,7 @@ jobs:
             docker push "$DOCKER_IMAGE_ID:latest"
           fi
       - name: Build loadimpact/k6
-        run: docker build -t $LI_DOCKER_IMAGE_ID .
+        run: docker build -t $LI_DOCKER_IMAGE_ID --target legacy .
       - name: Publish loadimpact/k6:master image to Docker Hub
         if: ${{ github.ref == 'refs/heads/master' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,8 @@ jobs:
             docker run $DOCKER_IMAGE_ID pause --help
             docker run $DOCKER_IMAGE_ID resume --help
 
+      - name: Build browser-enabled image
+        run: docker build -t $DOCKER_IMAGE_ID:with-browser --target with-browser .
       - name: Log into ghcr.io
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
         run: |
@@ -165,6 +167,8 @@ jobs:
           echo "Publish as ghcr.io/$GHCR_IMAGE_ID:$VERSION"
           docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$GHCR_IMAGE_ID:master"
           docker push "ghcr.io/$GHCR_IMAGE_ID:master"
+          docker tag "$DOCKER_IMAGE_ID:with-browser" "ghcr.io/$GHCR_IMAGE_ID:master-with-browser"
+          docker push "ghcr.io/$GHCR_IMAGE_ID:master-with-browser"
       - name: Publish tagged version image to ghcr.io
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
@@ -172,11 +176,15 @@ jobs:
           echo "Publish as ghcr.io/$GHCR_IMAGE_ID:$VERSION"
           docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$GHCR_IMAGE_ID:$VERSION"
           docker push "ghcr.io/$GHCR_IMAGE_ID:$VERSION"
+          docker tag "$DOCKER_IMAGE_ID:with-browser" "ghcr.io/$GHCR_IMAGE_ID:$VERSION-with-browser"
+          docker push "ghcr.io/$GHCR_IMAGE_ID:$VERSION-with-browser"
           # We also want to tag the latest stable version as latest
           if [[ ! "$VERSION" =~ (RC|rc) ]]; then
             echo "Publish as ghcr.io/$GHCR_IMAGE_ID:latest"
             docker tag "$DOCKER_IMAGE_ID" "ghcr.io/$GHCR_IMAGE_ID:latest"
             docker push "ghcr.io/$GHCR_IMAGE_ID:latest"
+            docker tag "$DOCKER_IMAGE_ID:with-browser" "ghcr.io/$GHCR_IMAGE_ID:latest-with-browser"
+            docker push "ghcr.io/$GHCR_IMAGE_ID:latest-with-browser"
           fi
 
       - name: Log into Docker Hub
@@ -190,6 +198,8 @@ jobs:
           echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:master"
           docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:master"
           docker push "$DOCKER_IMAGE_ID:master"
+          docker tag "$DOCKER_IMAGE_ID:with-browser" "$DOCKER_IMAGE_ID:master-with-browser"
+          docker push "$DOCKER_IMAGE_ID:master-with-browser"
       - name: Publish tagged version image to Docker Hub
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
@@ -197,11 +207,15 @@ jobs:
           echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:$VERSION"
           docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:$VERSION"
           docker push "$DOCKER_IMAGE_ID:$VERSION"
+          docker tag "$DOCKER_IMAGE_ID:with-browser" "$DOCKER_IMAGE_ID:$VERSION-with-browser"
+          docker push "$DOCKER_IMAGE_ID:$VERSION-with-browser"
           # We also want to tag the latest stable version as latest
           if [[ ! "$VERSION" =~ (RC|rc) ]]; then
             echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:latest"
             docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:latest"
             docker push "$DOCKER_IMAGE_ID:latest"
+            docker tag "$DOCKER_IMAGE_ID:with-browser" $DOCKER_IMAGE_ID:latest-with-browser"
+            docker push "$DOCKER_IMAGE_ID:latest-with-browser"
           fi
       - name: Build loadimpact/k6
         run: docker build -t $LI_DOCKER_IMAGE_ID --target legacy .

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,21 @@ FROM release as legacy
 COPY entrypoint-legacy.sh /usr/bin/
 
 ENTRYPOINT ["/usr/bin/entrypoint-legacy.sh"]
+
+# Browser-enabled bundle
+FROM release as with-browser
+
+USER root
+
+COPY --from=release /usr/bin/k6 /usr/bin/k6
+RUN apk --no-cache add chromium-swiftshader
+
+USER k6
+
+ENV CHROME_BIN=/usr/bin/chromium-browser
+ENV CHROME_PATH=/usr/lib/chromium/
+
+ENV K6_BROWSER_ENABLED=true
+ENV K6_BROWSER_HEADLESS=true
+
+ENTRYPOINT ["k6"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ WORKDIR /home/k6
 ENTRYPOINT ["k6"]
 
 # Legacy loadimpact/k6 image
-FROM release
+FROM release as legacy
 
 COPY entrypoint-legacy.sh /usr/bin/
 


### PR DESCRIPTION
## What?

This PR adds a stage to the Dockerfile that adds `chromium` to the Docker image and enables k6 Browser API. The new stage is used to build and publish images with `-with-browser` label suffix.

The resulting image is fairly large (~220MB compressed compared to ~16MB without `chromium` installed), hence a separate label for those who want to opt-in to use Browser API.

## Why?

Currently there is no easy way to use Browser API when running k6 as a Docker container. This makes it difficult to run browser-based tests in CI, since users need to first launch browser process in a separate container, provide the CDP URL to the k6 container and conditionally use `browser.connect()` instead of `browser.launch()` in their test scripts.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have tested the build pipeline changes in [andrewslotin/k6](https://github.com/andrewslotin/k6) fork (see the [Docker Hub image](https://hub.docker.com/r/andrewslotin/k6/tags))

## Related PR(s)/Issue(s)

Closes #2914
