### PR TITLE
Add documentation to k6 exit codes definitions

### DIFF
--- a/errext/exitcodes/codes.go
+++ b/errext/exitcodes/codes.go
@@ -29,7 +29,7 @@ const (
 	GenericTimeout ExitCode = 102 // TODO: remove?
 
 	// ScriptStoppedFromRESTAPI indicates the execution has been
-	// stopped by a call to the REST API.
+	// stopped by a call to the k6's REST API.
 	ScriptStoppedFromRESTAPI ExitCode = 103
 
 	// InvalidConfig indicates an invalid configuration.

--- a/errext/exitcodes/codes.go
+++ b/errext/exitcodes/codes.go
@@ -40,7 +40,7 @@ const (
 	// than a failure.
 	ExternalAbort ExitCode = 105
 
-	// CannotStartRESTAPI indicates the REST API server could not be started.
+	// CannotStartRESTAPI indicates the k6's REST API server could not be started.
 	CannotStartRESTAPI ExitCode = 106
 
 	// ScriptException indicates an exception was thrown during the

--- a/errext/exitcodes/codes.go
+++ b/errext/exitcodes/codes.go
@@ -8,17 +8,49 @@ type ExitCode uint8
 
 // list of exit codes used by k6
 const (
-	CloudTestRunFailed       ExitCode = 97 // This used to be 99 before k6 v0.33.0
+	// CloudTestRunFailed indicates that the cloud test run failed.
+	// Its value used to be 99 before k6 v0.33.0.
+	CloudTestRunFailed ExitCode = 97 // This used to be 99 before k6 v0.33.0
+
+	// CloudFailedToGetProgress indicates that k6 was unable to synchronize the
+	// test progress with the cloud.
 	CloudFailedToGetProgress ExitCode = 98
-	ThresholdsHaveFailed     ExitCode = 99
-	SetupTimeout             ExitCode = 100
-	TeardownTimeout          ExitCode = 101
-	GenericTimeout           ExitCode = 102 // TODO: remove?
+
+	// ThresholdsHaveFailed indicates that one or more thresholds have failed.
+	ThresholdsHaveFailed ExitCode = 99
+
+	// SetupTimeout indicates the execution of the test setup function timed out.
+	SetupTimeout ExitCode = 100
+
+	// TeardownTimeout indicates the execution of the test teardown function timed out.
+	TeardownTimeout ExitCode = 101
+
+	// GenericTimeout indicates a timeout with an unspecified reason.
+	GenericTimeout ExitCode = 102 // TODO: remove?
+
+	// ScriptStoppedFromRESTAPI indicates the execution has been
+	// stopped by a call to the REST API.
 	ScriptStoppedFromRESTAPI ExitCode = 103
-	InvalidConfig            ExitCode = 104
-	ExternalAbort            ExitCode = 105
-	CannotStartRESTAPI       ExitCode = 106
-	ScriptException          ExitCode = 107
-	ScriptAborted            ExitCode = 108
-	GoPanic                  ExitCode = 109
+
+	// InvalidConfig indicates an invalid configuration.
+	InvalidConfig ExitCode = 104
+
+	// ExternalAbort indicates the test was aborted by an external signal
+	// (e.g. SIGINT, SIGTERM, etc.) and should be considered aborted rather
+	// than a failure.
+	ExternalAbort ExitCode = 105
+
+	// CannotStartRESTAPI indicates the REST API server could not be started.
+	CannotStartRESTAPI ExitCode = 106
+
+	// ScriptException indicates an exception was thrown during the
+	// test script's execution.
+	ScriptException ExitCode = 107
+
+	// ScriptAborted indicates the script was aborted by a call to the
+	// k6 execution module's `test.abort()` function.
+	ScriptAborted ExitCode = 108
+
+	// GoPanic indicates the script was aborted by a panic in the Go runtime.
+	GoPanic ExitCode = 109
 )


### PR DESCRIPTION
## What?

This Pull Request adds Godoc documentation comment to k6 exit codes.

I've added my context, but if reviewers have more about specific exit codes they wish to add, that would be the perfect opportunity.

## Why?

Having recently been in the situation of interpreting the status code (on-call) for debugging purposes, I found that in some instances, the reason and context for each status code could have been more straightforward. Hence, I added documentation to each of them, albeit probably not complete and not having as much context as possible.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
