### PR TITLE
k6 Insights (2/2): Integrate request metadata output to cloud output v1

### DIFF
--- a/cloudapi/insights/client.go
+++ b/cloudapi/insights/client.go
@@ -89,6 +89,7 @@ type Client struct {
 	connMu *sync.RWMutex
 }
 
+// NewDefaultClientConfigForTestRun creates a new default client config for a test run.
 func NewDefaultClientConfigForTestRun(ingesterHost, authToken string, testRunID int64) ClientConfig {
 	return ClientConfig{
 		IngesterHost: ingesterHost,

--- a/cloudapi/insights/client_test.go
+++ b/cloudapi/insights/client_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.k6.io/k6/lib/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -92,8 +91,8 @@ func TestClient_Dial_ReturnsNoErrorWithWorkingDialer(t *testing.T) {
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
-		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
+		Timeout:       1 * time.Second,
+		ConnectConfig: ClientConnectConfig{Timeout: 1 * time.Second, Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig:   ClientRetryConfig{RetryableStatusCodes: `"UNKNOWN","INTERNAL","UNAVAILABLE","DEADLINE_EXCEEDED"`},
 	}
@@ -114,8 +113,8 @@ func TestClient_Dial_ReturnsErrorWhenCalledTwice(t *testing.T) {
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
-		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
+		Timeout:       1 * time.Second,
+		ConnectConfig: ClientConnectConfig{Timeout: 1 * time.Second, Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig:   ClientRetryConfig{RetryableStatusCodes: `"UNKNOWN","INTERNAL","UNAVAILABLE","DEADLINE_EXCEEDED"`},
 	}
@@ -138,6 +137,7 @@ func TestClient_Dial_ReturnsNoErrorWithFailingDialer(t *testing.T) {
 		ConnectConfig: ClientConnectConfig{
 			Block:                  true,
 			FailOnNonTempDialError: true,
+			Timeout:                1 * time.Second,
 			Dialer: func(ctx context.Context, s string) (net.Conn, error) {
 				return nil, &fatalError{}
 			},
@@ -163,7 +163,7 @@ func TestClient_Dial_ReturnsErrorWithoutRetryableStatusCodes(t *testing.T) {
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
+		Timeout:       1 * time.Second,
 		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 	}
@@ -184,7 +184,7 @@ func TestClient_Dial_ReturnsErrorWithInvalidRetryableStatusCodes(t *testing.T) {
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
+		Timeout:       1 * time.Second,
 		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig:   ClientRetryConfig{RetryableStatusCodes: "RANDOM,INTERNAL"},
@@ -206,8 +206,8 @@ func TestClient_IngestRequestMetadatasBatch_ReturnsNoErrorWithWorkingServerAndNo
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
-		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
+		Timeout:       1 * time.Second,
+		ConnectConfig: ClientConnectConfig{Timeout: 1 * time.Second, Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig:   ClientRetryConfig{RetryableStatusCodes: `"UNKNOWN","INTERNAL","UNAVAILABLE","DEADLINE_EXCEEDED"`},
 	}
@@ -231,8 +231,8 @@ func TestClient_IngestRequestMetadatasBatch_ReturnsNoErrorWithWorkingServerAndNo
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
-		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
+		Timeout:       1 * time.Second,
+		ConnectConfig: ClientConnectConfig{Timeout: 1 * time.Second, Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig:   ClientRetryConfig{RetryableStatusCodes: `"UNKNOWN","INTERNAL","UNAVAILABLE","DEADLINE_EXCEEDED"`},
 	}
@@ -272,8 +272,8 @@ func TestClient_IngestRequestMetadatasBatch_ReturnsErrorWithWorkingServerAndCanc
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
-		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
+		Timeout:       1 * time.Second,
+		ConnectConfig: ClientConnectConfig{Timeout: 1 * time.Second, Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig:   ClientRetryConfig{RetryableStatusCodes: `"UNKNOWN","INTERNAL","UNAVAILABLE","DEADLINE_EXCEEDED"`},
 	}
@@ -308,7 +308,7 @@ func TestClient_IngestRequestMetadatasBatch_ReturnsErrorWithUninitializedClient(
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
+		Timeout:       1 * time.Second,
 		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 	}
@@ -341,8 +341,8 @@ func TestClient_IngestRequestMetadatasBatch_ReturnsErrorWithFailingServerAndNonC
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
-		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
+		Timeout:       1 * time.Second,
+		ConnectConfig: ClientConnectConfig{Timeout: 1 * time.Second, Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig:   ClientRetryConfig{RetryableStatusCodes: `"UNKNOWN","INTERNAL","UNAVAILABLE","DEADLINE_EXCEEDED"`},
 	}
@@ -373,8 +373,8 @@ func TestClient_IngestRequestMetadatasBatch_ReturnsNoErrorAfterRetrySeveralTimes
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
-		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
+		Timeout:       1 * time.Second,
+		ConnectConfig: ClientConnectConfig{Timeout: 1 * time.Second, Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig: ClientRetryConfig{
 			MaxAttempts:          20,
@@ -422,8 +422,8 @@ func TestClient_IngestRequestMetadatasBatch_ReturnsErrorAfterExhaustingMaxRetryA
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		Timeout:       types.NullDurationFrom(1 * time.Second),
-		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
+		Timeout:       1 * time.Second,
+		ConnectConfig: ClientConnectConfig{Timeout: 1 * time.Second, Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig: ClientRetryConfig{
 			BackoffConfig: ClientBackoffConfig{
@@ -469,7 +469,7 @@ func TestClient_Close_ReturnsNoErrorWhenClosedOnce(t *testing.T) {
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
+		ConnectConfig: ClientConnectConfig{Timeout: 1 * time.Second, Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig:   ClientRetryConfig{RetryableStatusCodes: `"UNKNOWN","INTERNAL","UNAVAILABLE","DEADLINE_EXCEEDED"`},
 	}
@@ -491,7 +491,7 @@ func TestClient_Close_ReturnsNoErrorWhenClosedTwice(t *testing.T) {
 	lis := newMockListener(t, ser)
 
 	cfg := ClientConfig{
-		ConnectConfig: ClientConnectConfig{Dialer: newMockContextDialer(t, lis)},
+		ConnectConfig: ClientConnectConfig{Timeout: 1 * time.Second, Dialer: newMockContextDialer(t, lis)},
 		TLSConfig:     ClientTLSConfig{Insecure: true},
 		RetryConfig:   ClientRetryConfig{RetryableStatusCodes: `"UNKNOWN","INTERNAL","UNAVAILABLE","DEADLINE_EXCEEDED"`},
 	}

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -300,6 +300,8 @@ func (o *Output) flushRequestMetadatas() {
 	err := o.requestMetadatasFlusher.Flush()
 	if err != nil {
 		o.logger.WithError(err).WithField("t", time.Since(start)).Error("Failed to push trace samples to the cloud")
+
+		return
 	}
 
 	o.logger.WithField("t", time.Since(start)).Debug("Successfully flushed buffered trace samples to the cloud")

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -131,9 +131,7 @@ func (o *Output) Start() error {
 		)
 		insightsClient := insights.NewClient(insightsClientConfig)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := insightsClient.Dial(ctx); err != nil {
+		if err := insightsClient.Dial(context.Background()); err != nil {
 			return err
 		}
 

--- a/output/cloud/v1/output.go
+++ b/output/cloud/v1/output.go
@@ -123,9 +123,7 @@ func (out *Output) Start() error {
 		)
 		insightsClient := insights.NewClient(insightsClientConfig)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := insightsClient.Dial(ctx); err != nil {
+		if err := insightsClient.Dial(context.Background()); err != nil {
 			return err
 		}
 

--- a/output/cloud/v1/output.go
+++ b/output/cloud/v1/output.go
@@ -3,16 +3,21 @@
 package cloud
 
 import (
+	"context"
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
-	easyjson "github.com/mailru/easyjson"
+	"github.com/mailru/easyjson"
 	"github.com/sirupsen/logrus"
 
 	"go.k6.io/k6/cloudapi"
+	"go.k6.io/k6/cloudapi/insights"
 	"go.k6.io/k6/errext"
 	"go.k6.io/k6/errext/exitcodes"
+	"go.k6.io/k6/lib/types"
+	insightsOutput "go.k6.io/k6/output/cloud/insights"
 
 	"go.k6.io/k6/lib/netext"
 	"go.k6.io/k6/lib/netext/httpext"
@@ -33,6 +38,10 @@ type Output struct {
 	bufferMutex      sync.Mutex
 	bufferHTTPTrails []*httpext.Trail
 	bufferSamples    []*Sample
+
+	insightsClient            insightsOutput.Client
+	requestMetadatasCollector insightsOutput.RequestMetadatasCollector
+	requestMetadatasFlusher   insightsOutput.RequestMetadatasFlusher
 
 	// TODO: optimize this
 	//
@@ -101,6 +110,49 @@ func (out *Output) Start() error {
 		}()
 	}
 
+	if insightsOutput.Enabled(out.config) {
+		testRunID, err := strconv.ParseInt(out.referenceID, 10, 64)
+		if err != nil {
+			return err
+		}
+		out.requestMetadatasCollector = insightsOutput.NewCollector(testRunID)
+
+		insightsClientConfig := insights.ClientConfig{
+			IngesterHost: out.config.TracesHost.String,
+			Timeout:      types.NewNullDuration(90*time.Second, false),
+			AuthConfig: insights.ClientAuthConfig{
+				Enabled:                  true,
+				TestRunID:                testRunID,
+				Token:                    out.config.Token.String,
+				RequireTransportSecurity: true,
+			},
+			TLSConfig: insights.ClientTLSConfig{
+				Insecure: false,
+			},
+			RetryConfig: insights.ClientRetryConfig{
+				RetryableStatusCodes: `"UNKNOWN","INTERNAL","UNAVAILABLE","DEADLINE_EXCEEDED"`,
+				MaxAttempts:          3,
+				PerRetryTimeout:      30 * time.Second,
+				BackoffConfig: insights.ClientBackoffConfig{
+					Enabled:        true,
+					JitterFraction: 0.1,
+					WaitBetween:    1 * time.Second,
+				},
+			},
+		}
+		insightsClient := insights.NewClient(insightsClientConfig)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := insightsClient.Dial(ctx); err != nil {
+			return err
+		}
+
+		out.insightsClient = insightsClient
+		out.requestMetadatasFlusher = insightsOutput.NewFlusher(insightsClient, out.requestMetadatasCollector)
+		out.runFlushRequestMetadatas()
+	}
+
 	out.outputDone.Add(1)
 	go func() {
 		defer out.outputDone.Done()
@@ -136,6 +188,11 @@ func (out *Output) StopWithTestError(testErr error) error {
 	close(out.stopOutput)
 	out.outputDone.Wait()
 	out.logger.Debug("Metric emission stopped, calling cloud API...")
+	if insightsOutput.Enabled(out.config) {
+		if err := out.insightsClient.Close(); err != nil {
+			out.logger.WithError(err).Error("Failed to close the insights client")
+		}
+	}
 	return nil
 }
 
@@ -221,6 +278,10 @@ func (out *Output) AddMetricSamples(sampleContainers []metrics.SampleContainer) 
 		out.bufferSamples = append(out.bufferSamples, newSamples...)
 		out.bufferHTTPTrails = append(out.bufferHTTPTrails, newHTTPTrails...)
 		out.bufferMutex.Unlock()
+	}
+
+	if insightsOutput.Enabled(out.config) {
+		out.requestMetadatasCollector.CollectRequestMetadatas(sampleContainers)
 	}
 }
 
@@ -470,6 +531,44 @@ func (out *Output) pushMetrics() {
 		"samples": count,
 		"t":       time.Since(start),
 	}).Debug("Pushing metrics to cloud finished")
+}
+
+func (out *Output) runFlushRequestMetadatas() {
+	t := time.NewTicker(out.config.TracesPushInterval.TimeDuration())
+
+	for i := int64(0); i < out.config.TracesPushConcurrency.Int64; i++ {
+		out.outputDone.Add(1)
+		go func() {
+			defer out.outputDone.Done()
+			defer t.Stop()
+
+			for {
+				select {
+				case <-out.stopSendingMetrics:
+					return
+				default:
+				}
+				select {
+				case <-out.stopOutput:
+					out.flushRequestMetadatas()
+					return
+				case <-t.C:
+					out.flushRequestMetadatas()
+				}
+			}
+		}()
+	}
+}
+
+func (out *Output) flushRequestMetadatas() {
+	start := time.Now()
+
+	err := out.requestMetadatasFlusher.Flush()
+	if err != nil {
+		out.logger.WithError(err).WithField("t", time.Since(start)).Error("Failed to push trace samples to the cloud")
+	}
+
+	out.logger.WithField("t", time.Since(start)).Debug("Successfully flushed buffered trace samples to the cloud")
 }
 
 const expectedGzipRatio = 6 // based on test it is around 6.8, but we don't need to be that accurate

--- a/output/cloud/v1/output.go
+++ b/output/cloud/v1/output.go
@@ -547,6 +547,8 @@ func (out *Output) flushRequestMetadatas() {
 	err := out.requestMetadatasFlusher.Flush()
 	if err != nil {
 		out.logger.WithError(err).WithField("t", time.Since(start)).Error("Failed to push trace samples to the cloud")
+
+		return
 	}
 
 	out.logger.WithField("t", time.Since(start)).Debug("Successfully flushed buffered trace samples to the cloud")


### PR DESCRIPTION
## What?

This PR incorporates the request metadata output into cloud output v1.

## Why?

Due to cloud output v2 being at risk for v0.46.0, we decided to incorporate the new request metadata output into cloud output v1. This change is done to mitigate the risk of failing to deliver the new insights features.

## Related PR(s)/Issue(s)

This PR is part of a PR chain. Previous PR - https://github.com/grafana/k6/pull/3201.

Previous PRs:
- https://github.com/grafana/k6/pull/3100
- https://github.com/grafana/k6/pull/3158
- https://github.com/grafana/k6/pull/3184