### PR TITLE
[fs] Add a `fs.opensync` function to the `k6/experimental/fs` module

### DIFF
--- a/examples/experimental/fs/opensync.js
+++ b/examples/experimental/fs/opensync.js
@@ -1,0 +1,17 @@
+import { openSync } from "k6/experimental/fs";
+
+export const options = {
+	vus: 100,
+	iterations: 1000,
+};
+
+// As k6 does not support asynchronous code in the init context, yet, we need to
+// use a top-level async function to be able to use the `await` keyword.
+const file = openSync("bonjour.txt")
+
+export default async function () {
+	const fileinfo = await file.stat();
+	if (fileinfo.name != "bonjour.txt") {
+		throw new Error("Unexpected file name");
+	}
+}


### PR DESCRIPTION
## What?

This Pull Request adds an `fs.openSync` function to the `k6/experimental/fs` module, as per #3143.

It allows to open a file as such:

```javascript
const f = fs.openSync('myfile.txt')
```

As opposed to the current workaround necessary to go around the limitation of not being able to use await in the init context:

```javascript
let file
(() => {
  await file = await fs.open('myfile.txt')
)();
```


## Why?

This function acts as a workaround for the lack of support for the `await` keyword in the init context and is meant to go away as soon as we do. It aims at ensuring a good UX that's more intuitive than the existing workaround ☝🏻 

We should document it as such and make it explicit that it won't be supported any further once we address the core issue and that the following syntax is possible:

```javascript
let f = await fs.open('myfile.txt')
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

closes #3143 
<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
