### PR TITLE
Introduce `execution.Controller` with a `local` no-op implementation

### DIFF
--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/execution"
+	"go.k6.io/k6/execution/local"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/lib/testutils/minirunner"
@@ -41,7 +42,7 @@ func getTestRunState(tb testing.TB, options lib.Options, runner lib.Runner) *lib
 }
 
 func getControlSurface(tb testing.TB, testState *lib.TestRunState) *ControlSurface {
-	execScheduler, err := execution.NewScheduler(testState)
+	execScheduler, err := execution.NewScheduler(testState, local.NewController())
 	require.NoError(tb, err)
 
 	me, err := engine.NewMetricsEngine(testState.Registry, testState.Logger)

--- a/api/v1/setup_teardown_routes_test.go
+++ b/api/v1/setup_teardown_routes_test.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/execution"
+	"go.k6.io/k6/execution/local"
 	"go.k6.io/k6/js"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/types"
@@ -138,7 +139,7 @@ func TestSetupData(t *testing.T) {
 				TeardownTimeout: types.NullDurationFrom(5 * time.Second),
 			}, runner)
 
-			execScheduler, err := execution.NewScheduler(testState)
+			execScheduler, err := execution.NewScheduler(testState, local.NewController())
 			require.NoError(t, err)
 			metricsEngine, err := engine.NewMetricsEngine(testState.Registry, testState.Logger)
 			require.NoError(t, err)

--- a/api/v1/status_routes_test.go
+++ b/api/v1/status_routes_test.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/execution"
+	"go.k6.io/k6/execution/local"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/testutils/minirunner"
 	"go.k6.io/k6/metrics"
@@ -115,7 +116,7 @@ func TestPatchStatus(t *testing.T) {
 			require.NoError(t, err)
 
 			testState := getTestRunState(t, lib.Options{Scenarios: scenarios}, &minirunner.MiniRunner{})
-			execScheduler, err := execution.NewScheduler(testState)
+			execScheduler, err := execution.NewScheduler(testState, local.NewController())
 			require.NoError(t, err)
 
 			metricsEngine, err := engine.NewMetricsEngine(testState.Registry, testState.Logger)

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -16,7 +16,7 @@ type cmdArchive struct {
 }
 
 func (c *cmdArchive) run(cmd *cobra.Command, args []string) error {
-	test, err := loadAndConfigureTest(c.gs, cmd, args, getPartialConfig)
+	test, err := loadAndConfigureLocalTest(c.gs, cmd, args, getPartialConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -84,7 +84,7 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	)
 	printBar(c.gs, progressBar)
 
-	test, err := loadAndConfigureTest(c.gs, cmd, args, getPartialConfig)
+	test, err := loadAndConfigureLocalTest(c.gs, cmd, args, getPartialConfig)
 	if err != nil {
 		return err
 	}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -21,7 +21,7 @@ func getCmdInspect(gs *state.GlobalState) *cobra.Command {
 		Long:  `Inspect a script or archive.`,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			test, err := loadTest(gs, cmd, args)
+			test, err := loadLocalTest(gs, cmd, args)
 			if err != nil {
 				return err
 			}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -25,6 +25,7 @@ import (
 	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/event"
 	"go.k6.io/k6/execution"
+	"go.k6.io/k6/execution/local"
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
@@ -132,7 +133,7 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 
 	// Create a local execution scheduler wrapping the runner.
 	logger.Debug("Initializing the execution scheduler...")
-	execScheduler, err := execution.NewScheduler(testRunState)
+	execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 	if err != nil {
 		return err
 	}

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -41,7 +41,7 @@ type loadedTest struct {
 	keyLogger      io.Closer
 }
 
-func loadTest(gs *state.GlobalState, cmd *cobra.Command, args []string) (*loadedTest, error) {
+func loadLocalTest(gs *state.GlobalState, cmd *cobra.Command, args []string) (*loadedTest, error) {
 	if len(args) < 1 {
 		return nil, fmt.Errorf("k6 needs at least one argument to load the test")
 	}
@@ -236,11 +236,11 @@ type loadedAndConfiguredTest struct {
 	derivedConfig      Config
 }
 
-func loadAndConfigureTest(
+func loadAndConfigureLocalTest(
 	gs *state.GlobalState, cmd *cobra.Command, args []string,
 	cliConfigGetter func(flags *pflag.FlagSet) (Config, error),
 ) (*loadedAndConfiguredTest, error) {
-	test, err := loadTest(gs, cmd, args)
+	test, err := loadLocalTest(gs, cmd, args)
 	if err != nil {
 		return nil, err
 	}

--- a/execution/controller.go
+++ b/execution/controller.go
@@ -1,0 +1,53 @@
+package execution
+
+// Controller implementations are used to control the k6 execution of a test or
+// test suite, either locally or in a distributed environment.
+type Controller interface {
+	// GetOrCreateData requests the data chunk with the given ID, if it already
+	// exists. If it doesn't (i.e. this was the first time this function was
+	// called with that ID), the given callback is called and its result and
+	// error are saved for the ID and returned for all other calls with it.
+	//
+	// This is an atomic and single-flight function, so any calls to it while the callback is
+	// being executed the the same ID will wait for the first call to to finish
+	// and receive its result.
+	//
+	// TODO: split apart into `Once()`, `SetData(), `GetData()` and implement
+	// the GetOrCreateData() behavior in a helper like the ones below?
+	GetOrCreateData(ID string, callback func() ([]byte, error)) ([]byte, error)
+
+	// Signal is used to notify that the current instance has reached the given
+	// event ID, or that it has had an error.
+	Signal(eventID string, err error) error
+
+	// Subscribe creates a listener for the specified event ID and returns a
+	// callback that can wait until all other instances have reached it.
+	Subscribe(eventID string) (wait func() error)
+}
+
+// SignalAndWait implements a rendezvous point / barrier, a way for all
+// instances to reach the same execution point and wait for each other, before
+// they all ~simultaneously continue with the execution.
+//
+// It subscribes for the given event ID, signals that the current instance has
+// reached it without an error, and then waits until all other instances have
+// reached it or until there is an error in one of them.
+func SignalAndWait(c Controller, eventID string) error {
+	wait := c.Subscribe(eventID)
+
+	if err := c.Signal(eventID, nil); err != nil {
+		return err
+	}
+	return wait()
+}
+
+// SignalErrorOrWait is a helper method that either immediately signals the
+// given error and returns it, or it signals nominal completion and waits for
+// all other instances to do the same (or signal an error themselves).
+func SignalErrorOrWait(c Controller, eventID string, err error) error {
+	if err != nil {
+		_ = c.Signal(eventID, err)
+		return err // return the same error we got
+	}
+	return SignalAndWait(c, eventID)
+}

--- a/execution/local/controller.go
+++ b/execution/local/controller.go
@@ -1,0 +1,45 @@
+// Package local implements the execution.Controller interface for local
+// (single-machine) k6 execution.
+package local
+
+// Controller "controls" local tests. It doesn't actually do anything, it just
+// implements the execution.Controller interface with no-op operations. The
+// methods don't do anything because local tests have only a single instance.
+//
+// However, for test suites (https://github.com/grafana/k6/issues/1342) in the
+// future, we will probably need to actually implement some of these methods and
+// introduce simple synchronization primitives even for a single machine...
+type Controller struct{}
+
+// NewController creates a new local execution Controller.
+func NewController() *Controller {
+	return &Controller{}
+}
+
+// GetOrCreateData immediately calls the given callback and returns its results.
+func (c *Controller) GetOrCreateData(_ string, callback func() ([]byte, error)) ([]byte, error) {
+	return callback()
+}
+
+// Subscribe is a no-op, it doesn't actually wait for anything, because there is
+// nothing to wait on - we only have one instance in local tests.
+//
+// TODO: actually use waitgroups, since this may actually matter for test
+// suites, even for local test runs. That's because multiple tests might be
+// executed even by a single instance, and if we have complicated flows (e.g.
+// "test C is executed only after test A and test B finish"), the easiest way
+// would be for different tests in the suite to reuse this Controller API *both*
+// local and distributed runs.
+func (c *Controller) Subscribe(_ string) func() error {
+	return func() error {
+		return nil
+	}
+}
+
+// Signal is a no-op, it doesn't actually do anything for local test runs.
+//
+// TODO: similar to Wait() above, this might actually be required for
+// complex/branching test suites, even during local non-distributed execution.
+func (c *Controller) Signal(_ string, _ error) error {
+	return nil
+}

--- a/execution/scheduler_ext_test.go
+++ b/execution/scheduler_ext_test.go
@@ -19,6 +19,7 @@ import (
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/execution"
+	"go.k6.io/k6/execution/local"
 	"go.k6.io/k6/js"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/executor"
@@ -73,7 +74,7 @@ func newTestScheduler(
 		testRunState.Logger = logger
 	}
 
-	execScheduler, err = execution.NewScheduler(testRunState)
+	execScheduler, err = execution.NewScheduler(testRunState, local.NewController())
 	require.NoError(t, err)
 
 	samples = make(chan metrics.SampleContainer, newOpts.MetricSamplesBufferSize.Int64)
@@ -141,7 +142,7 @@ func TestSchedulerRunNonDefault(t *testing.T) {
 
 			testRunState := getTestRunState(t, piState, runner.GetOptions(), runner)
 
-			execScheduler, err := execution.NewScheduler(testRunState)
+			execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 			require.NoError(t, err)
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -258,7 +259,7 @@ func TestSchedulerRunEnv(t *testing.T) {
 			require.NoError(t, err)
 
 			testRunState := getTestRunState(t, piState, runner.GetOptions(), runner)
-			execScheduler, err := execution.NewScheduler(testRunState)
+			execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 			require.NoError(t, err)
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -332,7 +333,7 @@ func TestSchedulerSystemTags(t *testing.T) {
 	})))
 
 	testRunState := getTestRunState(t, piState, runner.GetOptions(), runner)
-	execScheduler, err := execution.NewScheduler(testRunState)
+	execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -468,7 +469,7 @@ func TestSchedulerRunCustomTags(t *testing.T) {
 			require.NoError(t, err)
 
 			testRunState := getTestRunState(t, piState, runner.GetOptions(), runner)
-			execScheduler, err := execution.NewScheduler(testRunState)
+			execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 			require.NoError(t, err)
 
 			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
@@ -637,7 +638,7 @@ func TestSchedulerRunCustomConfigNoCrossover(t *testing.T) {
 	require.NoError(t, err)
 
 	testRunState := getTestRunState(t, piState, runner.GetOptions(), runner)
-	execScheduler, err := execution.NewScheduler(testRunState)
+	execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -978,7 +979,7 @@ func TestSchedulerEndIterations(t *testing.T) {
 	defer cancel()
 
 	testRunState := getTestRunState(t, getTestPreInitState(t), runner.GetOptions(), runner)
-	execScheduler, err := execution.NewScheduler(testRunState)
+	execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 	require.NoError(t, err)
 
 	samples := make(chan metrics.SampleContainer, 300)
@@ -1190,7 +1191,7 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	testRunState := getTestRunState(t, piState, options, runner)
-	execScheduler, err := execution.NewScheduler(testRunState)
+	execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1362,7 +1363,7 @@ func TestNewSchedulerHasWork(t *testing.T) {
 	require.NoError(t, err)
 
 	testRunState := getTestRunState(t, piState, runner.GetOptions(), runner)
-	execScheduler, err := execution.NewScheduler(testRunState)
+	execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 	require.NoError(t, err)
 
 	assert.Len(t, execScheduler.GetExecutors(), 2)

--- a/execution/scheduler_int_test.go
+++ b/execution/scheduler_int_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/execution/local"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/lib/testutils/minirunner"
@@ -43,7 +44,7 @@ func TestSetPaused(t *testing.T) {
 	t.Run("second pause is an error", func(t *testing.T) {
 		t.Parallel()
 		testRunState := getBogusTestRunState(t)
-		sched, err := NewScheduler(testRunState)
+		sched, err := NewScheduler(testRunState, local.NewController())
 		require.NoError(t, err)
 		sched.executors = []lib.Executor{pausableExecutor{err: nil}}
 
@@ -56,7 +57,7 @@ func TestSetPaused(t *testing.T) {
 	t.Run("unpause at the start is an error", func(t *testing.T) {
 		t.Parallel()
 		testRunState := getBogusTestRunState(t)
-		sched, err := NewScheduler(testRunState)
+		sched, err := NewScheduler(testRunState, local.NewController())
 		require.NoError(t, err)
 		sched.executors = []lib.Executor{pausableExecutor{err: nil}}
 		err = sched.SetPaused(false)
@@ -67,7 +68,7 @@ func TestSetPaused(t *testing.T) {
 	t.Run("second unpause is an error", func(t *testing.T) {
 		t.Parallel()
 		testRunState := getBogusTestRunState(t)
-		sched, err := NewScheduler(testRunState)
+		sched, err := NewScheduler(testRunState, local.NewController())
 		require.NoError(t, err)
 		sched.executors = []lib.Executor{pausableExecutor{err: nil}}
 		require.NoError(t, sched.SetPaused(true))
@@ -80,7 +81,7 @@ func TestSetPaused(t *testing.T) {
 	t.Run("an error on pausing is propagated", func(t *testing.T) {
 		t.Parallel()
 		testRunState := getBogusTestRunState(t)
-		sched, err := NewScheduler(testRunState)
+		sched, err := NewScheduler(testRunState, local.NewController())
 		require.NoError(t, err)
 		expectedErr := errors.New("testing pausable executor error")
 		sched.executors = []lib.Executor{pausableExecutor{err: expectedErr}}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -34,6 +34,7 @@ import (
 
 	"go.k6.io/k6/errext"
 	"go.k6.io/k6/execution"
+	"go.k6.io/k6/execution/local"
 	"go.k6.io/k6/js/modules/k6"
 	k6http "go.k6.io/k6/js/modules/k6/http"
 	k6metrics "go.k6.io/k6/js/modules/k6/metrics"
@@ -383,7 +384,7 @@ func TestDataIsolation(t *testing.T) {
 		RunTags:          runner.preInitState.Registry.RootTagSet().WithTagsFromMap(options.RunTags),
 	}
 
-	execScheduler, err := execution.NewScheduler(testRunState)
+	execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 	require.NoError(t, err)
 
 	globalCtx, globalCancel := context.WithCancel(context.Background())
@@ -2697,7 +2698,7 @@ func TestExecutionInfo(t *testing.T) {
 				Runner:           r,
 			}
 
-			execScheduler, err := execution.NewScheduler(testRunState)
+			execScheduler, err := execution.NewScheduler(testRunState, local.NewController())
 			require.NoError(t, err)
 
 			ctx = lib.WithExecutionState(ctx, execScheduler.GetState())


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

This is another sliver of the [newly refactored](https://github.com/grafana/k6/pull/2816#issuecomment-1635466149) https://github.com/grafana/k6/pull/2816, a follow-up to https://github.com/grafana/k6/pull/3191.

It adds the concept of an `execution.Controller`, a very lightweight API by which multiple k6 instances could synchronize the concurrent execution of different [segments](https://k6.io/docs/using-k6/k6-options/reference/#execution-segment) of the same test run. However, it doesn't actually add any distributed execution by itself, just a `local` implementation of it that doesn't do anything (because a single instance doesn't need to synchronize with itself... [yet](https://github.com/grafana/k6/issues/1342) :sweat_smile:)

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

This is a backwards-compatible prerequisite for distributed execution.

As you can see, no tests have been changed beyond adding the extra parameter to `execution.NewScheduler()`. So this doesn't change any existing k6 behavior. However, it makes merging the distributed execution much easier because it reduces the likelihood of conflicts. For example, I recently had to resolve conflicts between https://github.com/grafana/k6/pull/2816 and https://github.com/grafana/k6/pull/3112. Even ignoring  the code conflicts, logical conflicts are also easier to foresee when this is merged into the codebase, and it makes distributed execution a smaller and easier to review PR.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] ~I have added tests for my changes.~ (not needed)
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- https://github.com/grafana/k6/issues/140
- https://github.com/grafana/k6/issues/3218
- https://github.com/grafana/k6/pull/2816
- https://github.com/grafana/k6/pull/3217
- https://github.com/grafana/k6/issues/1342