### PR TITLE
Implement  concurrent pushes across batches

### DIFF
--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -126,7 +126,7 @@ outer:
 
 	for ; workers != 0; workers-- {
 		err := <-errs
-		if err != nil && finalErr != nil {
+		if err != nil && finalErr == nil {
 			finalErr = err
 		}
 	}

--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -1,7 +1,6 @@
 package expv2
 
 import (
-	"math"
 	"sync"
 	"time"
 
@@ -86,13 +85,20 @@ func (f *metricsFlusher) flush() error {
 }
 
 func (f *metricsFlusher) flushBatches(batches []*pbcloud.MetricSet) error {
+	// TODO remove after go 1.21 becomes the minimum supported version - it has `min` in it
+	min := func(a, b int) int {
+		if a < b {
+			return a
+		}
+		return b
+	}
 	var (
 		wg   = sync.WaitGroup{}
 		errs = make(chan error)
 		done = make(chan struct{})
 		stop = make(chan struct{})
 
-		workers   = int(math.Min(float64(len(batches)), float64(f.batchPushConcurrency)))
+		workers   = min(len(batches), f.batchPushConcurrency)
 		chunkSize = len(batches) / workers
 	)
 

--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -112,7 +112,11 @@ func (f *metricsFlusher) flushBatches(batches []metricSetBuilder) error {
 				default:
 				}
 				if err := f.push(chunk[i]); err != nil {
-					errs <- err
+					select {
+					case errs <- err:
+					case <-stop:
+						return
+					}
 				}
 			}
 		}(batches[offset:end])

--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -1,6 +1,7 @@
 package expv2
 
 import (
+	"errors"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -39,6 +40,7 @@ func TestMetricSetBuilderAddTimeBucket(t *testing.T) {
 	require.Len(t, msb.MetricSet.Metrics, 1)
 	assert.Len(t, msb.MetricSet.Metrics[0].TimeSeries, 1)
 }
+
 func TestMetricsFlusherFlushInBatchWithinBucket(t *testing.T) {
 	t.Parallel()
 
@@ -89,11 +91,11 @@ func TestMetricsFlusherFlushInBatchAcrossBuckets(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		series        int
-		expFlushCalls int
+		series       int
+		expPushCalls int
 	}{
-		{series: 5, expFlushCalls: 2},
-		{series: 2, expFlushCalls: 1},
+		{series: 5, expPushCalls: 2},
+		{series: 2, expPushCalls: 1},
 	}
 
 	r := metrics.NewRegistry()
@@ -131,7 +133,7 @@ func TestMetricsFlusherFlushInBatchAcrossBuckets(t *testing.T) {
 
 		err := mf.flush()
 		require.NoError(t, err)
-		assert.Equal(t, tc.expFlushCalls, pm.timesCalled())
+		assert.Equal(t, tc.expPushCalls, pm.timesCalled())
 	}
 }
 
@@ -214,7 +216,11 @@ func TestFlushWithReservedLabels(t *testing.T) {
 }
 
 type pusherMock struct {
-	hook       func(*pbcloud.MetricSet)
+	// hook is called when the push method is called.
+	hook func(*pbcloud.MetricSet)
+	// errFn if this defined, it is called at the end of push
+	// and result error is returned.
+	errFn      func() error
 	pushCalled int64
 }
 
@@ -228,5 +234,61 @@ func (pm *pusherMock) push(ms *pbcloud.MetricSet) error {
 	}
 
 	atomic.AddInt64(&pm.pushCalled, 1)
+
+	if pm.errFn != nil {
+		return pm.errFn()
+	}
+
 	return nil
+}
+
+func TestMetricsFlusherErrorCase(t *testing.T) {
+	t.Parallel()
+
+	r := metrics.NewRegistry()
+	m1 := r.MustNewMetric("metric1", metrics.Counter)
+
+	logger, _ := testutils.NewLoggerWithHook(t)
+
+	bq := &bucketQ{}
+	pm := &pusherMock{
+		errFn: func() error {
+			return errors.New("some error")
+		},
+	}
+	mf := metricsFlusher{
+		bq:                   bq,
+		client:               pm,
+		logger:               logger,
+		discardedLabels:      make(map[string]struct{}),
+		maxSeriesInBatch:     3,
+		batchPushConcurrency: 2,
+	}
+
+	series := 7
+
+	bq.buckets = make([]timeBucket, 0, series)
+	for i := 0; i < series; i++ {
+		ts := metrics.TimeSeries{
+			Metric: m1,
+			Tags:   r.RootTagSet().With("key1", "val"+strconv.Itoa(i)),
+		}
+		bq.Push([]timeBucket{
+			{
+				Time: int64(i) + 1,
+				Sinks: map[metrics.TimeSeries]metricValue{
+					ts: &counter{Sum: float64(1)},
+				},
+			},
+		})
+	}
+	require.Len(t, bq.buckets, series)
+
+	err := mf.flush()
+	require.Error(t, err)
+	// since the push happens concurrently the number of the calls could vary,
+	// but at least one call should happen and it should be less than the
+	// batchPushConcurrency
+	assert.LessOrEqual(t, pm.timesCalled(), mf.batchPushConcurrency)
+	assert.GreaterOrEqual(t, pm.timesCalled(), 1)
 }

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -117,7 +117,7 @@ func (o *Output) Start() error {
 		batchPushConcurrency: int(o.config.MetricPushConcurrency.Int64),
 	}
 
-	o.runFlushWorkers()
+	o.runPeriodicFlush()
 	o.periodicInvoke(o.config.AggregationPeriod.TimeDuration(), o.collectSamples)
 
 	if insightsOutput.Enabled(o.config) {
@@ -180,7 +180,7 @@ func (o *Output) StopWithTestError(_ error) error {
 	return nil
 }
 
-func (o *Output) runFlushWorkers() {
+func (o *Output) runPeriodicFlush() {
 	t := time.NewTicker(o.config.MetricPushInterval.TimeDuration())
 
 	o.wg.Add(1)

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -178,9 +178,13 @@ func (o *Output) StopWithTestError(_ error) error {
 }
 
 func (o *Output) runFlushWorkers() {
+	// workers := o.config.MetricPushConcurrency.Int64
+	// Details: https://github.com/grafana/k6/issues/3192
+	workers := 1
+
 	t := time.NewTicker(o.config.MetricPushInterval.TimeDuration())
 
-	for i := int64(0); i < o.config.MetricPushConcurrency.Int64; i++ {
+	for i := 0; i < workers; i++ {
 		o.wg.Add(1)
 		go func() {
 			defer func() {

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -326,7 +326,7 @@ func TestOutputFlushTicks(t *testing.T) {
 	o := Output{logger: testutils.NewLogger(t)}
 	o.config.MetricPushInterval = types.NullDurationFrom(100 * time.Millisecond) // loop
 	o.flushing = flusherFunc(flusherMock)
-	o.runFlushWorkers()
+	o.runPeriodicFlush()
 
 	select {
 	case <-time.After(5 * time.Second):
@@ -352,7 +352,7 @@ func TestOutputFlushWorkersStop(t *testing.T) {
 	}
 
 	o.flushing = flusherFunc(flusherMock)
-	o.runFlushWorkers()
+	o.runPeriodicFlush()
 
 	// it asserts that all flushers exit
 	done := make(chan struct{})
@@ -383,7 +383,7 @@ func TestOutputFlushWorkersAbort(t *testing.T) {
 	}
 
 	o.flushing = flusherFunc(flusherMock)
-	o.runFlushWorkers()
+	o.runPeriodicFlush()
 
 	// it asserts that all flushers exit
 	done := make(chan struct{})

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -305,7 +305,7 @@ func TestOutputStopWithTestError(t *testing.T) {
 	require.NoError(t, o.StopWithTestError(errors.New("an error")))
 }
 
-func TestOutputFlushMetricsConcurrently(t *testing.T) {
+func TestOutputFlushTicks(t *testing.T) {
 	t.Parallel()
 
 	done := make(chan struct{})
@@ -321,12 +321,10 @@ func TestOutputFlushMetricsConcurrently(t *testing.T) {
 			close(done)
 			return
 		}
-		<-done
 	}
 
 	o := Output{logger: testutils.NewLogger(t)}
-	o.config.MetricPushConcurrency = null.IntFrom(2)
-	o.config.MetricPushInterval = types.NullDurationFrom(1) // loop
+	o.config.MetricPushInterval = types.NullDurationFrom(100 * time.Millisecond) // loop
 	o.flushing = flusherFunc(flusherMock)
 	o.runFlushWorkers()
 


### PR DESCRIPTION
## What?

This change moves the concurrency from flushes to batches. That fixes issue #3192 and generally improves processing.

## Why?

Even if the single network request to ingester is fast enough, executing them sequentially increases the time.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #3192 

<!-- Thanks for your contribution! 🙏🏼 -->
