### PR TITLE
Added Nil Check for Package in File Descriptor

### DIFF
--- a/lib/netext/grpcext/conn_test.go
+++ b/lib/netext/grpcext/conn_test.go
@@ -189,6 +189,28 @@ func TestResolveFileDescriptors(t *testing.T) {
 			services:            []string{},
 			expectedDescriptors: 0,
 		},
+		{
+			name:                "NoPackage",
+			services:            []string{"Service1", "Service2"},
+			expectedDescriptors: 2,
+		},
+		{
+			name:                "NoPackageDeduplicateServices",
+			services:            []string{"Service1", "Service2", "Service1"},
+			expectedDescriptors: 2,
+		},
+		{
+			name:                "MixPackage",
+			pkgs:                []string{"mypkg1"},
+			services:            []string{"Service1", "Service2"},
+			expectedDescriptors: 2,
+		},
+		{
+			name:                "MixPackageDeduplicateServices",
+			pkgs:                []string{"mypkg1"},
+			services:            []string{"Service1", "Service2", "Service1"},
+			expectedDescriptors: 2,
+		},
 	}
 
 	for _, tt := range tests {
@@ -199,10 +221,16 @@ func TestResolveFileDescriptors(t *testing.T) {
 				lsr  = &reflectpb.ListServiceResponse{}
 				mock = &getServiceFileDescriptorMock{}
 			)
+
+			var pkg string
+			if len(tt.pkgs) == 1 {
+				pkg = tt.pkgs[0]
+			}
+
 			for i, service := range tt.services {
 				// if only one package is defined then
 				// the package is the same for every service
-				pkg := tt.pkgs[0]
+
 				if len(tt.pkgs) > 1 {
 					pkg = tt.pkgs[i]
 				}

--- a/lib/netext/grpcext/reflect.go
+++ b/lib/netext/grpcext/reflect.go
@@ -67,10 +67,14 @@ func (rc *reflectionClient) resolveServiceFileDescriptors(
 			if err = proto.Unmarshal(raw, &fdp); err != nil {
 				return nil, fmt.Errorf("can't unmarshal proto on service %q: %w", service, err)
 			}
+
 			fdkey := fileDescriptorLookupKey{
-				Package: *fdp.Package,
-				Name:    *fdp.Name,
+				Name: *fdp.Name,
 			}
+			if fdp.Package != nil {
+				fdkey.Package = *fdp.Package
+			}
+
 			if seen[fdkey] {
 				// When a proto file contains declarations for multiple services
 				// then the same proto file is returned multiple times,


### PR DESCRIPTION
## What?

This code is to guard against a `runtime error: invalid memory address or nil pointer dereference` occuring

## Why?

The package specifier is optional in protobuf spec https://protobuf.dev/programming-guides/proto3/#packages

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes. N/A
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass. N/A
- [x] I have run tests locally (`make tests`) and all tests pass. N/A
- [ ] I have commented on my code, particularly in hard-to-understand areas. N/A
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->
Fixes issue #3222 
<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
