### PR TITLE
Add new auth headers required for tailing k6 Cloud logs

### DIFF
--- a/cloudapi/logs.go
+++ b/cloudapi/logs.go
@@ -100,6 +100,8 @@ func (c *Config) logtailConn(ctx context.Context, referenceID string, since time
 
 	headers := make(http.Header)
 	headers.Add("Sec-WebSocket-Protocol", "token="+c.Token.String)
+	headers.Add("Authorization", "token "+c.Token.String)
+	headers.Add("X-K6TestRun-Id", referenceID)
 
 	var conn *websocket.Conn
 	err = retry(sleeperFunc(time.Sleep), 3, 5*time.Second, 2*time.Minute, func() (err error) {


### PR DESCRIPTION
## What?

Adds two new HTTP headers required to tail logs from k6 Cloud in the near future.

## Why?

See issue https://github.com/grafana/k6/issues/3216 and backlinked issue from the Grafana private repository.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/issues/3216

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
