### PR TITLE
Allow specifying custom headers for Loki log output

### DIFF
--- a/log/loki.go
+++ b/log/loki.go
@@ -342,7 +342,7 @@ func (h *lokiHook) push(b bytes.Buffer) error {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	for _, header := range(h.headers) {
+	for _, header := range h.headers {
 		req.Header.Set(header[0], header[1])
 	}
 

--- a/log/loki.go
+++ b/log/loki.go
@@ -343,7 +343,7 @@ func (h *lokiHook) push(b bytes.Buffer) error {
 	req.Header.Set("Content-Type", "application/json")
 
 	for _, header := range h.headers {
-		req.Header.Set(header[0], header[1])
+		req.Header.Add(header[0], header[1])
 	}
 
 	res, err := h.client.Do(req)

--- a/log/loki.go
+++ b/log/loki.go
@@ -19,6 +19,7 @@ import (
 type lokiHook struct {
 	fallbackLogger logrus.FieldLogger
 	addr           string
+	headers        [][2]string
 	labels         [][2]string
 	ch             chan *logrus.Entry
 	limit          int
@@ -123,6 +124,11 @@ func (h *lokiHook) parseArgs(line string) error {
 			if strings.HasPrefix(key, "label.") {
 				labelKey := strings.TrimPrefix(key, "label.")
 				h.labels = append(h.labels, [2]string{labelKey, value})
+
+				continue
+			} else if strings.HasPrefix(key, "header.") {
+				headerKey := strings.TrimPrefix(key, "header.")
+				h.headers = append(h.headers, [2]string{headerKey, value})
 
 				continue
 			}
@@ -335,6 +341,10 @@ func (h *lokiHook) push(b bytes.Buffer) error {
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+
+	for _, header := range(h.headers) {
+		req.Header.Set(header[0], header[1])
+	}
 
 	res, err := h.client.Do(req)
 

--- a/log/loki_test.go
+++ b/log/loki_test.go
@@ -36,9 +36,10 @@ func TestSyslogFromConfigLine(t *testing.T) {
 			},
 		},
 		{
-			line: "loki=somewhere:1233,label.something=else,label.foo=bar,limit=32,level=info,allowedLabels=[something],pushPeriod=5m32s,msgMaxSize=1231",
+			line: "loki=somewhere:1233,label.something=else,label.foo=bar,limit=32,level=info,allowedLabels=[something],pushPeriod=5m32s,msgMaxSize=1231,header.x-test=123,header.authorization=token foobar",
 			res: lokiHook{
 				addr:          "somewhere:1233",
+				headers:       [][2]string{{"x-test", "123"}, {"authorization", "token foobar"}},
 				limit:         32,
 				pushPeriod:    time.Minute*5 + time.Second*32,
 				levels:        logrus.AllLevels[:5],


### PR DESCRIPTION
## What?

Allows users to specify custom headers for the `loki` log output option. For example:
```
--log-output=loki=http://example.org,header.X-My-Header=123,header.Authorization=mytoken
```

In this case, requests done to `example.org` will contain the HTTP headers `X-My-Header: 123` and `Authorization: mytoken`.

## Why?

See issue https://github.com/grafana/k6/issues/3216 and backlinked issue from the Grafana private repository.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/issues/3216
https://github.com/grafana/k6/pull/3224 (this PR implements the other half of #3216)

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
