### PR TITLE
Implement the `fs.File.seek` operation

### DIFF
--- a/examples/experimental/fs/fs.js
+++ b/examples/experimental/fs/fs.js
@@ -1,8 +1,8 @@
-import { open } from "k6/experimental/fs";
+import { open, SeekMode } from "k6/experimental/fs";
 
 export const options = {
-	vus: 100,
-	iterations: 1000,
+	vus: 1,
+	iterations: 1,
 };
 
 // As k6 does not support asynchronous code in the init context, yet, we need to
@@ -30,4 +30,7 @@ export default async function () {
 	if (bytesRead != fileinfo.size) {
 		throw new Error("Unexpected number of bytes read");
 	}
+
+	const offset = await file.seek(0, SeekMode.Start);
+	console.log(`Seeked to offset ${offset}`);
 }

--- a/js/modules/k6/experimental/fs/file.go
+++ b/js/modules/k6/experimental/fs/file.go
@@ -13,7 +13,7 @@ type file struct {
 	data []byte
 
 	// offset holds the current offset in the file
-	offset int
+	offset int64
 }
 
 // Stat returns a FileInfo describing the named file.
@@ -36,18 +36,84 @@ type FileInfo struct {
 
 func (f *file) Read(into []byte) (int, error) {
 	start := f.offset
-	if start == len(f.data) {
+	if start == f.size() {
 		return 0, newFsError(EOFError, "EOF")
 	}
 
-	end := f.offset + len(into)
-	if end > len(f.data) {
-		end = len(f.data)
+	end := f.offset + int64(len(into))
+	if end > f.size() {
+		end = f.size()
 	}
 
 	n := copy(into, f.data[start:end])
 
-	f.offset += n
+	f.offset += int64(n)
 
 	return n, nil
+}
+
+// Seek sets the offset for the next operation on the file, under the mode given by `whence`.
+//
+// `offset` indicates the number of bytes to move the offset. Based on
+// the `whence` parameter, the offset is set relative to the start,
+// current offset or end of the file.
+//
+// When using SeekModeStart, the offset must be positive.
+// Negative offsets are allowed when using `SeekModeCurrent` or `SeekModeEnd`.
+func (f *file) Seek(offset int64, whence SeekMode) (int64, error) {
+	newOffset := f.offset
+
+	switch whence {
+	case SeekModeStart:
+		if offset < 0 {
+			return 0, newFsError(TypeError, "offset cannot be negative when using SeekModeStart")
+		}
+
+		newOffset = offset
+	case SeekModeCurrent:
+		newOffset += offset
+	case SeekModeEnd:
+		if offset > 0 {
+			return 0, newFsError(TypeError, "offset cannot be positive when using SeekModeEnd")
+		}
+
+		newOffset = f.size() + offset
+	default:
+		return 0, newFsError(TypeError, "invalid seek mode")
+	}
+
+	if newOffset < 0 {
+		return 0, newFsError(TypeError, "seeking before start of file")
+	}
+
+	if newOffset > f.size() {
+		return 0, newFsError(TypeError, "seeking beyond end of file")
+	}
+
+	// Note that the implementation assumes one `file` instance per file/vu.
+	// If that assumption was invalidated, we would need to atomically update
+	// the offset instead.
+	f.offset = newOffset
+	return newOffset, nil
+}
+
+// SeekMode is used to specify the seek mode when seeking in a file.
+type SeekMode = int
+
+const (
+	// SeekModeStart sets the offset relative to the start of the file.
+	SeekModeStart SeekMode = iota + 1
+
+	// SeekModeCurrent seeks relative to the current offset.
+	SeekModeCurrent
+
+	// SeekModeEnd seeks relative to the end of the file.
+	//
+	// When using this mode the seek operation will move backwards from
+	// the end of the file.
+	SeekModeEnd
+)
+
+func (f *file) size() int64 {
+	return int64(len(f.data))
 }

--- a/js/modules/k6/experimental/fs/module.go
+++ b/js/modules/k6/experimental/fs/module.go
@@ -52,6 +52,11 @@ func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{
 		Named: map[string]any{
 			"open": mi.Open,
+			"SeekMode": map[string]SeekMode{
+				"Start":   SeekModeStart,
+				"Current": SeekModeCurrent,
+				"End":     SeekModeEnd,
+			},
 		},
 	}
 }
@@ -204,6 +209,55 @@ func (f *File) Read(into goja.Value) *goja.Promise {
 		}
 
 		resolve(n)
+	}()
+
+	return promise
+}
+
+// Seek seeks to the given `offset` in the file, under the given `whence` mode.
+//
+// The returned promise resolves to the new `offset` (position) within the file, which
+// is expressed in bytes from the selected start, current, or end position depending
+// the provided `whence`.
+func (f *File) Seek(offset goja.Value, whence goja.Value) *goja.Promise {
+	promise, resolve, reject := promises.New(f.vu)
+
+	if common.IsNullish(offset) {
+		reject(newFsError(TypeError, "seek() failed; reason: offset cannot be null or undefined"))
+		return promise
+	}
+
+	offsetInt := offset.ToInteger()
+	if offsetInt < 0 {
+		reject(newFsError(TypeError, "seek() failed; reason: offset cannot be negative"))
+		return promise
+	}
+
+	if common.IsNullish(whence) {
+		reject(newFsError(TypeError, "seek() failed; reason: whence cannot be null or undefined"))
+		return promise
+	}
+
+	// var seekMode SeekMode
+	// if err := f.vu.Runtime().ExportTo(whence, &seekMode); err != nil {
+	// 	reject(newFsError(TypeError, "seek() failed; reason: whence must be a SeekMode"))
+	// 	return promise
+	// }
+
+	seekMode := SeekMode(whence.ToInteger())
+	if seekMode != SeekModeStart && seekMode != SeekModeCurrent && seekMode != SeekModeEnd {
+		reject(newFsError(TypeError, "seek() failed; reason: whence must be a SeekMode"))
+		return promise
+	}
+
+	go func() {
+		newOffset, err := f.file.Seek(offsetInt, seekMode)
+		if err != nil {
+			reject(err)
+			return
+		}
+
+		resolve(newOffset)
 	}()
 
 	return promise

--- a/js/modules/k6/experimental/fs/module_test.go
+++ b/js/modules/k6/experimental/fs/module_test.go
@@ -290,6 +290,62 @@ func TestFile(t *testing.T) {
 
 		assert.NoError(t, err)
 	})
+
+	t.Run("seek with invalid arguments should fail", func(t *testing.T) {
+		t.Parallel()
+
+		runtime, err := newConfiguredRuntime(t)
+		require.NoError(t, err)
+
+		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		fs := newTestFs(t, func(fs afero.Fs) error {
+			return afero.WriteFile(fs, testFilePath, []byte("hello"), 0o644)
+		})
+		runtime.VU.InitEnvField.FileSystems["file"] = fs
+
+		_, err = runtime.RunOnEventLoop(fmt.Sprintf(`
+			fs.open(%q).then(file => {
+
+				// null offset should fail with TypeError.
+				file.seek(null).then(
+					res => { throw "file.seek(null) promise unexpectedly resolved with result: " + res },
+					err => { if (err.name !== 'TypeError') { throw "file.seek(null) rejected with unexpected error: " + err } },
+				)
+
+				// undefined offset should fail with TypeError.
+				file.seek(undefined).then(
+					res => { throw "file.seek(undefined) promise unexpectedly promise resolved with result: " + res },
+					err => { if (err.name !== 'TypeError') { throw "file.seek(undefined) rejected with unexpected error: " + err} },
+				)
+
+				// Invalid type offset should fail with TypeError.
+				file.seek('abc').then(
+					res => { throw "file.seek('abc') promise unexpectedly resolved with result: " + res },
+					err => { if (err.name !== 'TypeError') { throw "file.seek('1') rejected with unexpected error: " + err } },
+				)
+
+				// Negative offset should fail with TypeError.
+				file.seek(-1).then(
+					res => { throw "file.seek(-1) promise unexpectedly resolved with result: " + res },
+					err => { if (err.name !== 'TypeError') { throw "file.seek(-1) rejected with unexpected error: " + err} },
+				)
+
+				// Invalid type whence should fail with TypeError.
+				file.seek(1, 'abc').then(
+					res => { throw "file.seek(1, 'abc') promise unexpectedly resolved with result: " + res },
+					err => { if (err.name !== 'TypeError') { throw "file.seek(1, '1') rejected with unexpected error: " + err } },
+				)
+
+				// Invalid whence should fail with TypeError.
+				file.seek(1, -1).then(
+					res => { throw "file.seek(1, -1) promise unexpectedly resolved with result: " + res },
+					err => { if (err.name !== 'TypeError') { throw "file.seek(1, -1) rejected with unexpected error: " + err} },
+				)
+			})
+		`, testFilePath))
+
+		assert.NoError(t, err)
+	})
 }
 
 func TestOpenImpl(t *testing.T) {


### PR DESCRIPTION
## What?

This Pull Request adds a `seek` method to the `k6/experimental/fs` module's `File` object, as per #3148.

⚠️ This PR is based on the [`experimental/fs-read`](#3219) branch.

It allows to seek to a specified `offset` within a file, under the given `whence`.

The offset is expressed in bytes. Whence allows you to seek from the start of the file (the `offset` needs to be strictly negative), the current position within the file (`offset` can be either positive or negative), or from the end of the file (`offset` needs to be strictly negative).

The method resolves to either the new offset in bytes after the seek operation.

```javascript
import { open, SeekMode } from 'k6/experimental/fs'

const f = fs.openSync('myfile.txt')

export default function () {
    const buf = new Uint8Array(100);
    const numberOfBytesRead = await file.read(buf); // 11 bytes
    
    const newOffset = await file.seek(0, SeekMode.Start)
}
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

ref #3219
closes #3148 
<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
