### PR TITLE
Fix tracing module sampling option should default to 1.0 when not set

### DIFF
--- a/js/modules/k6/experimental/tracing/options.go
+++ b/js/modules/k6/experimental/tracing/options.go
@@ -38,7 +38,7 @@ func newOptions(rt *goja.Runtime, from goja.Value) (options, error) {
 	}
 
 	fromSamplingValue := from.ToObject(rt).Get("sampling")
-	if fromSamplingValue == nil || common.IsNullish(fromSamplingValue) {
+	if common.IsNullish(fromSamplingValue) {
 		opts.Sampling = defaultSamplingRate
 	}
 


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->
This Pull Request ensures that if the `sampling` option of the tracing module's client is not provided by the user, the Client defaults to sample 100% of the request.

```javascript
		import http from "k6/http";
		import tracing from "k6/experimental/tracing";

		// We do not set the sampling option, thus the default
		// behavior should be to always sample.
		const instrumentedHTTP = new tracing.Client({
			propagator: "w3c",
		})
```

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->
As noted by @Blinkuu, the current behavior of the tracing module client is to use a 0% sampling when the option is not set. It leads to effectively no HTTP request being sampled. Whereas the desired behavior would be to have all requests sampled unless instructed otherwise.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

