### PR TITLE
Fixed empty response with protobuf_wrappers

### DIFF
--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -59,7 +59,7 @@ import (
 	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 )
 
-//nolint: lll
+// nolint: lll
 var (
 	errInvokeRPCInInitContext = common.NewInitContextError("invoking RPC methods in the init context is not supported")
 	errConnectInInitContext   = common.NewInitContextError("connecting to a gRPC server in the init context is not supported")
@@ -557,8 +557,11 @@ func (c *Client) Invoke(
 		// {"x":6,"y":4,"z":0}
 		raw, _ := marshaler.Marshal(resp)
 		msg := make(map[string]interface{})
-		_ = json.Unmarshal(raw, &msg)
+		er := json.Unmarshal(raw, &msg)
 		response.Message = msg
+		if er != nil {
+			response.Message = string(raw)
+		}
 	}
 	return &response, nil
 }


### PR DESCRIPTION
## What?

I received an empty message, although I should have received a primitive value in the response. It was due to the fact that the service returned not a json object, but a primitive

## Why?

[<!-- A short (or detailed) explanation of why these changes are made and needed. -->
](https://github.com/grafana/k6/issues/3232)

## Checklist

- [x] Added error handling and message return to support google/protobuf/wrappers.proto, as an example, it was not possible to test under load services like:
rpc Foo(Request) returns (google.protobuf.boolValue) {
}.

## Related PR(s)/Issue(s)

[<!-- A short (or detailed) explanation of why these changes are made and needed. -->
](https://github.com/grafana/k6/issues/3232)

<!-- Does it close an issue? -->
 Yes
