### PR TITLE
Support binary passed in GRPC metadata

### DIFF
--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -461,7 +461,11 @@ func (c *Client) parseInvokeParams(paramsVal goja.Value) (*invokeParams, error) 
 				// TODO(rogchap): Should we manage a string slice?
 				strval, ok := kv.(string)
 				if !ok {
-					return result, fmt.Errorf("metadata %q value must be a string", hk)
+					binval, ok := kv.([]byte)
+					if !ok {
+						return result, fmt.Errorf("metadata %q value must be a string or []byte", hk)
+					}
+					strval = string(binval)
 				}
 				result.Metadata[hk] = strval
 			}

--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -461,6 +461,8 @@ func (c *Client) parseInvokeParams(paramsVal goja.Value) (*invokeParams, error) 
 				// TODO(rogchap): Should we manage a string slice?
 				strval, ok := kv.(string)
 				if !ok {
+					// The spec defines that Binary-valued keys end in -bin
+					//  https://grpc.io/docs/what-is-grpc/core-concepts/#metadata
 					if strings.HasSuffix(hk, "-bin") {
 						binval, ok := kv.([]byte)
 						if !ok {

--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -463,7 +463,8 @@ func (c *Client) parseInvokeParams(paramsVal goja.Value) (*invokeParams, error) 
 				//  https://grpc.io/docs/what-is-grpc/core-concepts/#metadata
 				var strval string
 				if strings.HasSuffix(hk, "-bin") {
-					binval, ok := kv.([]byte)
+					var binval []byte
+					binval, ok = kv.([]byte)
 					if !ok {
 						return result, fmt.Errorf("metadata %q value must be binary", hk)
 					}

--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -468,6 +468,7 @@ func (c *Client) parseInvokeParams(paramsVal goja.Value) (*invokeParams, error) 
 					if !ok {
 						return result, fmt.Errorf("metadata %q value must be binary", hk)
 					}
+					// https://github.com/grpc/grpc-go/blob/v1.57.0/Documentation/grpc-metadata.md#storing-binary-data-in-metadata
 					strval = string(binval)
 				} else if strval, ok = kv.(string); !ok {
 					return result, fmt.Errorf("metadata %q value must be a string", hk)

--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -459,19 +459,17 @@ func (c *Client) parseInvokeParams(paramsVal goja.Value) (*invokeParams, error) 
 			}
 			for hk, kv := range rawHeaders {
 				// TODO(rogchap): Should we manage a string slice?
-				strval, ok := kv.(string)
-				if !ok {
-					// The spec defines that Binary-valued keys end in -bin
-					//  https://grpc.io/docs/what-is-grpc/core-concepts/#metadata
-					if strings.HasSuffix(hk, "-bin") {
-						binval, ok := kv.([]byte)
-						if !ok {
-							return result, fmt.Errorf("metadata %q value must be a string or binary", hk)
-						}
-						strval = string(binval)
-					} else {
-						return result, fmt.Errorf("metadata %q value must be a string", hk)
+				// The spec defines that Binary-valued keys end in -bin
+				//  https://grpc.io/docs/what-is-grpc/core-concepts/#metadata
+				var strval string
+				if strings.HasSuffix(hk, "-bin") {
+					binval, ok := kv.([]byte)
+					if !ok {
+						return result, fmt.Errorf("metadata %q value must be binary", hk)
 					}
+					strval = string(binval)
+				} else if strval, ok = kv.(string); !ok {
+					return result, fmt.Errorf("metadata %q value must be a string", hk)
 				}
 				result.Metadata[hk] = strval
 			}

--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -461,11 +461,15 @@ func (c *Client) parseInvokeParams(paramsVal goja.Value) (*invokeParams, error) 
 				// TODO(rogchap): Should we manage a string slice?
 				strval, ok := kv.(string)
 				if !ok {
-					binval, ok := kv.([]byte)
-					if !ok {
-						return result, fmt.Errorf("metadata %q value must be a string or []byte", hk)
+					if strings.HasSuffix(hk, "-bin") {
+						binval, ok := kv.([]byte)
+						if !ok {
+							return result, fmt.Errorf("metadata %q value must be a string or binary", hk)
+						}
+						strval = string(binval)
+					} else {
+						return result, fmt.Errorf("metadata %q value must be a string", hk)
 					}
-					strval = string(binval)
 				}
 				result.Metadata[hk] = strval
 			}


### PR DESCRIPTION
Use Uint8Array type in metadata declaration to avoid any reencoding issues in goja.

## What?

Changes k6's GRPC client to accept Uint8Array types passed as metadata values.

## Why?

Currently k6 does not support adding binary data in the metadata. The suggestion seems to have been to convert it to a string of some sort but there are issues therein:

* Attempting to just cast bytes into a string via String.fromCharCode or String.fromCodePoint seems to have issues on the goja side. Whenever a byte is >= 0x80 (presumably) another byte is inserted before it by the time it makes it to k6 and protobuf.
* We cannot base64 the data on the JS side because protobuf will re-encode any `-bin` metadata fields itself.

As such, it would be best for k6 to properly accept Uint8Arrays in metadata.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Caveats

You cannot store Uint8Array in the returned data object from setup (possibly related to #2579 ) as it's converted to a base64'd string before it's passed to the scenario. I'm not sure why exactly and didn't investigate, I assume that's expected behavior (though it was surprising to me). I'm not inclined to fix it here as it's simple to work around for my use case, but happy to create a ticket if it does happen to be unexpected.

