### PR TITLE
Google/protobuf/wrappers.proto support is not implemented in K6

### DIFF
--- a/lib/netext/grpcext/conn.go
+++ b/lib/netext/grpcext/conn.go
@@ -162,8 +162,11 @@ func (c *Conn) Invoke(
 		// {"x":6,"y":4,"z":0}
 		raw, _ := marshaler.Marshal(resp)
 		msg := make(map[string]interface{})
-		_ = json.Unmarshal(raw, &msg)
+		er := json.Unmarshal(raw, &msg)
 		response.Message = msg
+		if er != nil {
+			response.Message = string(raw)
+		}
 	}
 	return &response, nil
 }


### PR DESCRIPTION
## What?
The GRPC response.message is empty

## Why?

The response from the GRPC service, which uses google/protobuf/wrappers, is not processed correctly

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<https://github.com/grafana/k6/issues/3232>

<!-- Does it close an issue? -->
Yes, this closes the problem

<https://github.com/grafana/k6/issues/3232>

