### PR TITLE
Enable user headers in the reflect call in client.connect

### DIFF
--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -552,8 +552,8 @@ func (c *Client) parseConnectParams(raw map[string]interface{}) (connectParams, 
 			if !ok {
 				return params, errors.New("metadata must be an object with key-value pairs")
 			}
+			// Same way metadata is handled in invoke parameter parsing
 			for hk, kv := range rawHeaders {
-				// TODO(rogchap): Should we manage a string slice?
 				strval, ok := kv.(string)
 				if !ok {
 					return params, fmt.Errorf("metadata %q value must be a string", hk)

--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -655,6 +655,20 @@ func TestClient(t *testing.T) {
 			},
 		},
 		{
+			name: "ReflectMetadata",
+			setup: func(tb *httpmultibin.HTTPMultiBin) {
+				reflection.Register(tb.ServerGRPC)
+			},
+			initString: codeBlock{
+				code: `var client = new grpc.Client();`,
+			},
+			vuString: codeBlock{
+				code: `
+					client.connect("GRPCBIN_ADDR", {reflect: true, reflectMetadata: { "X-Load-Tester": "k6" } })
+				`,
+			},
+		},
+		{
 			name: "ReflectInvokeNoExist",
 			setup: func(tb *httpmultibin.HTTPMultiBin) {
 				reflection.Register(tb.ServerGRPC)


### PR DESCRIPTION
## What?

Add a parameter  `reflectMetadata` in `client.connect` to add user-provided headers in the reflect call.

## Why?

Some GRPC servers require a header to authenticate any call (including reflection). The invoke command covers this use case, but the reflect command that's bundled in the connect command does not, which leads to authentication errors.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes https://github.com/grafana/k6/issues/3241

<!-- Thanks for your contribution! 🙏🏼 -->
