### PR TITLE
Release notes v0.46.0

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.45.0"
+const Version = "0.46.0"
 
 // VersionDetails can be set externally as part of the build process
 var VersionDetails = "" //nolint:gochecknoglobals

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.46.0"
+const Version = "0.45.0"
 
 // VersionDetails can be set externally as part of the build process
 var VersionDetails = "" //nolint:gochecknoglobals

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -149,14 +149,14 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
 - [#3176](https://github.com/grafana/k6/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
 - [#3181](https://github.com/grafana/k6/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
-- [#xk6-grpc#19](https://github.com/grafana/xk6-grpc/pull/19) Writing to the closed GRPC stream no longer produce the EOF (end of file) error. Additionally, if no errors' handler were set up. The error is logged to the console.
+- [#xk6-grpc#19](https://github.com/grafana/xk6-grpc/pull/19) Writing to the closed gRPC stream no longer produces the EOF (end of file) error. Additionally, if no error handlers were set up, the error is logged to the console.
 - [browser#881](https://github.com/grafana/xk6-browser/pull/881) Adds a new `browser_http_req_failed` metric.
 - [browser#901](https://github.com/grafana/xk6-browser/pull/901) Adds support for shadow DOM piercing in `locator`. Thanks to @tmc for its implementation.
 - [browser#953](https://github.com/grafana/xk6-browser/pull/953) Improves Web Vitals reporting for better accuracy and consistency.
 
 ## Bug fixes
 
-- [#3178](https://github.com/grafana/k6/pull/3178), [xk6-grpc#23](https://github.com/grafana/xk6-grpc/pull/23) Fixes the registration of nested protobuf messages in the gRPC module. Thanks @thiagodpf for reporting and actually fixing the bug!
+- [#3178](https://github.com/grafana/k6/pull/3178), [xk6-grpc#23](https://github.com/grafana/xk6-grpc/pull/23) Fixes the registration of nested protobuf messages in the gRPC module. Thanks @thiagodpf for reporting and fixing the bug!
 - [#3194](https://github.com/grafana/k6/pull/3194) Fixes loki log output exiting before push is finished.
 - [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to `1.0` when not set by the user.
 - [#3163](https://github.com/grafana/k6/pull/3163) Fixes our [gRPC example](https://github.com/grafana/k6/blob/8fa0e6b9a8b63f430df34047e4393b281ff9ee30/examples/grpc.js).
@@ -170,7 +170,7 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 
 ## Maintenance and internal improvements
 
-- [#3170](https://github.com/grafana/pull/3170) Upgraded the version of gRPC k6 demo service dependency for addressing a security vulnerability ([CVE-2023-32731]).
+- [#3170](https://github.com/grafana/k6/pull/3170) Upgraded the version of gRPC k6 demo service dependency to address a security vulnerability ([CVE-2023-32731]).
 - [#3211](https://github.com/grafana/k6/pull/3211) Updates the experimental gRPC module version used by k6.
 - [#3210](https://github.com/grafana/k6/pull/3210) Updates the xk6-output-prometheus-remote version used by k6.
 - [#3136](https://github.com/grafana/k6/pull/3136) Updates k6 Go dependencies.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -7,6 +7,7 @@ k6 `v0.46` is here 🎉! This release includes:
 - Cloud output v2
 - And many UX improvements, bug fixes, and internal improvements
 
+## Breaking Changes
 
 ### Browser
 
@@ -50,6 +51,10 @@ export default async function () {
   }
 }
 ```
+
+### Deprecations
+
+- [#3121](https://github.com/grafana/k6/issues/3121) deprecates the `loadimpact/k6` docker image. We intend to keep supporting it for at most a year from now, but we recommend switching to the `grafana/k6` image as soon as possible.
 
 
 ## New features
@@ -162,6 +167,7 @@ The full list of related PRs: [#3104](https://github.com/grafana/k6/pull/3104), 
 
 ## Maintenance and internal improvements
 
+- [#3112](https://github.com/grafana/k6/pull/3112) Adds an event system for core JS modules.
 - [#3170](https://github.com/grafana/k6/pull/3170) Upgraded the version of gRPC k6 demo service dependency to address a security vulnerability ([CVE-2023-32731]).
 - [#3211](https://github.com/grafana/k6/pull/3211) Updates the experimental gRPC module version used by k6.
 - [#3210](https://github.com/grafana/k6/pull/3210) Updates the xk6-output-prometheus-remote version used by k6.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -159,7 +159,7 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 
 - [#3178](https://github.com/grafana/k6/pull/3178), [xk6-grpc#23](https://github.com/grafana/xk6-grpc/pull/23) Fixes the registration of nested protobuf messages in the gRPC module. Thanks @thiagodpf for reporting and actually fixing the bug!
 - [#3194](https://github.com/grafana/k6/pull/3194) Fixes loki log output exiting before push is finished.
-- [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to 1.0 when not set by the user.
+- [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to `1.0` when not set by the user.
 - [#3163](https://github.com/grafana/k6/pull/3163) Fixes our gRPC example.
 - [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
 - [browser#866](https://github.com/grafana/xk6-browser/pull/866) Disables the timeout on browser process execution.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -29,6 +29,13 @@ Will now send the header `X-My-Header` with value `123` and `Authorization` with
 
 Thanks to @federicotdn for doign the changes
 
+### Cloud Traces [#3100](https://github.com/grafana/k6/pull/3100), [#3202](https://github.com/grafana/k6/pull/3202)
+
+This release supports the new integration between k6 and Tempo in the cloud. Grafana Cloud k6 and Grafana Cloud Traces customers will be able to start their traces in k6 using the existing `k6/experimental/tracing` module to enrich their test run analysis page with metrics and aggregations from tracing data.
+
+The new cloud traces will work "out of the box" for `k6 cloud` runs. In case of `k6 run` execution, the `K6_CLOUD_TRACES_ENABLED` environment variable has to be set to `true`.
+
+
 ### `<big_feature_1>` `#pr`
 
 _what, why, and what this means for the user_

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -11,16 +11,16 @@ k6 `v0.46` is here 🎉! This release includes:
 
 ### Browser
 
-In this release, xk6-browser extension version is bumped up to `v1.0.2`, as it includes multiple breaking changes in relation with options, browser lifecycle and metrics.
+In this release, the xk6-browser extension version is bumped up to `v1.0.2`, as it includes multiple breaking changes concerning options, browser lifecycle, and metrics.
 
-**Options** `devtools`, `env` and `proxy` are deprecated ([browser#868](https://github.com/grafana/xk6-browser/pull/868), [browser#870](https://github.com/grafana/xk6-browser/pull/870), [browser#872](https://github.com/grafana/xk6-browser/pull/872)). Additionally, browser `launch`/`connect` options are no longer defined in the corresponding JS API methods, instead the test execution related options are now defined inside the browser scenario options (see [#3036](https://github.com/grafana/k6/pull/3036)), and the other more "environmental options", such as `headless`, `debug`, `executablePath`, are set as ENV vars. Also `slowMo` option is no longer supported, although it might be supported again in the future through a different API ([browser#876](https://github.com/grafana/xk6-browser/pull/876)).
+**Options** `devtools`, `env` and `proxy` are deprecated ([browser#868](https://github.com/grafana/xk6-browser/pull/868), [browser#870](https://github.com/grafana/xk6-browser/pull/870), [browser#872](https://github.com/grafana/xk6-browser/pull/872)). Additionally, browser `launch`/`connect` options are no longer defined in the corresponding JS API methods, instead the test execution related options are now defined inside the browser scenario options (see [#3036](https://github.com/grafana/k6/pull/3036)), and the other more "environmental options", such as `headless`, `debug`, `executablePath`, are set as ENV vars. Also, the `slowMo` option is no longer supported, although it might be supported again in the future through a different API ([browser#876](https://github.com/grafana/xk6-browser/pull/876)).
 
-**Metrics** also went through a few changes. The Web Vitals metrics are renamed to use `browser_` prefix and short namings (e.g.: `webvital_first_input_delay` -> `browser_web_vital_fid`) ([browser#885](https://github.com/grafana/xk6-browser/pull/885), [browser#903](https://github.com/grafana/xk6-browser/pull/903)), and the rating metric is removed, as it is now set as a label in the corresponding Web Vitals metrics ([browser#915](https://github.com/grafana/xk6-browser/pull/915))
+**Metrics** also went through a few changes. The Web Vitals metrics are renamed to use the `browser_` prefix and short namings (e.g.: `webvital_first_input_delay` -> `browser_web_vital_fid`) ([browser#885](https://github.com/grafana/xk6-browser/pull/885), [browser#903](https://github.com/grafana/xk6-browser/pull/903)), and the rating metric is removed, as it is now set as a label in the corresponding Web Vitals metrics ([browser#915](https://github.com/grafana/xk6-browser/pull/915)).
 The browser HTTP metrics have also been modified, as these are now split from the HTTP module ones, so there are new `browser_` prefixed HTTP metrics, specifically for request duration and failed requests ([browser#916](https://github.com/grafana/xk6-browser/pull/916)).
 
-Another big change introduced in this version affects the way the **browser lifecycle** is handled. Now the users no longer have to explicitly initialize/close the browser instance through the JS API. Instead a browser instance will be automatically initialized/closed at the beginning/end of each iteration if the browser type is set in scenario options (see [#3036](https://github.com/grafana/k6/pull/3036)). This also implies that the `chromium` entity from `k6/experimental/browser` import path is no longer valid, instead the `browser` entity provides access to the browser methods such as `browser.newPage()` ([browser#910](https://github.com/grafana/xk6-browser/pull/910), [browser#944](https://github.com/grafana/xk6-browser/pull/944)). This change implies that the `browser.on()` method is no longer applicable, and therefore it has been removed ([browser#919](https://github.com/grafana/xk6-browser/pull/919)).
+Another big change introduced in this version affects the way the **browser lifecycle** is handled. Users no longer have to explicitly initialize/close the browser instance through the JS API. Instead, a browser instance will be automatically initialized/closed at the beginning/end of each iteration if the browser type is set in scenario options (see [#3036](https://github.com/grafana/k6/pull/3036)). This also means that the `chromium` entity from `k6/experimental/browser` import path is no longer valid. Instead, the `browser` entity provides access to the browser methods such as `browser.newPage()` ([browser#910](https://github.com/grafana/xk6-browser/pull/910), [browser#944](https://github.com/grafana/xk6-browser/pull/944)). This change means that the `browser.on()` method is no longer applicable, and therefore it has been removed ([browser#919](https://github.com/grafana/xk6-browser/pull/919)).
 
-Following with **import changes**, the browser module version is no longer an exported field ([browser#923](https://github.com/grafana/xk6-browser/pull/923)).
+Additionally, related to **import changes**, the browser module version is no longer an exported field ([browser#923](https://github.com/grafana/xk6-browser/pull/923)).
 
 Last but not least, this release also includes constraints on **browser contexts** usage as now only one `browserContext` is allowed per iteration, which means that the user can create a new `browserContext`, close it, and then create it again; but can not have more than one "live" `browserContext`. Instead, [scenarios](https://k6.io/docs/using-k6/scenarios/) should be used to separate independent actions in a test ([browser#929](https://github.com/grafana/xk6-browser/pull/929), [browser#945](https://github.com/grafana/xk6-browser/pull/945)).
 
@@ -52,29 +52,28 @@ export default async function () {
 }
 ```
 
-### (_optional h3_) `<big_breaking_change>` `#pr`
 
 ## New features
 
 ### Loki log output sending additional headers [#3227](https://github.com/grafana/k6/pull/3227)
 
-k6 has been able to send logs to loki for nearly 3 years since [v0.28.0](https://github.com/grafana/k6/releases/tag/v0.28.0) but didn't support any way to authenticate.
+k6 has been able to send logs to [Loki](https://github.com/grafana/loki) for nearly 3 years since [v0.28.0](https://github.com/grafana/k6/releases/tag/v0.28.0) but didn't support any way to authenticate.
 
-Now it can be configured to send additional headers on every request.
+Now, it can be configured to send additional headers on every request.
 
-This is being configured with the new `header` config option similar to `label`:
+This can be done by using the new `header` config option, similar to `label`:
 
 ```
 k6 --log-output=loki=http://example.org,header.X-My-Header=123,header.Authorization=mytoken ...
 ```
 
-Will now send the header `X-My-Header` with value `123` and `Authorization` with `mytoken`.
+The example above will now send the header `X-My-Header` with the value `123` and the `Authorization` header with the value `mytoken`.
 
-Thanks to @federicotdn for doing the changes.
+Thanks to @federicotdn for adding this feature.
 
 ### Cloud Traces [#3100](https://github.com/grafana/k6/pull/3100), [#3202](https://github.com/grafana/k6/pull/3202)
 
-This release supports the new integration between k6 and Tempo in the cloud. Grafana Cloud k6 and Grafana Cloud Traces customers will be able to start their traces in k6 using the existing `k6/experimental/tracing` module to enrich their test run analysis page with metrics and aggregations from tracing data.
+This release supports the new integration between k6 and Tempo in the cloud. [Grafana Cloud k6](https://grafana.com/products/cloud/k6) and Grafana Cloud Tempo customers will be able to start their traces in k6 using the existing `k6/experimental/tracing` module to enrich their test run analysis page with metrics and aggregations from tracing data.
 
 The new cloud traces will work "out of the box" for `k6 cloud` runs. In case of `k6 run` execution, the `K6_CLOUD_TRACES_ENABLED` environment variable has to be set to `true`.
 
@@ -127,15 +126,16 @@ Thanks @chrismoran-mica for the contribution 🙇‍♂️.
 
 ### Cloud Output v2 [#3117](https://github.com/grafana/k6/issues/3117)
 
-After years of great service, we decided to refresh the k6 Cloud output introducing a more efficient end-to-end solution for ingesting the generated tests' metrics. The main change regards the protocol used for flushing metrics that is now a binary based payload over HTTP.
+After years of great service, we decided to refresh the k6 Cloud output introducing a more efficient end-to-end solution for ingesting the generated tests' metrics. The main change regards the protocol used for flushing metrics that is now a binary-based payload over HTTP.
 
-The new output reduces the load generators' used resources for tests that produce many metrics. There is no significant difference in the user experience; it's expected to be the same.
+The new output reduces the resources a load generator uses for tests that produce many metrics. There is no significant difference in the user experience; it's expected to be the same.
 
-The one thing worth highlighting is that the new output is strict about tags and drops tags if they are reserved:
-- `test_run_id` as it is reserved for internal k6 Cloud operations
-- any tag with a key that starts with two underscores (`__`), that is marked by Prometheus convention as reserved
+The one thing worth highlighting is that the new output is strict about tags, and it'll drops tags if they are reserved. For example:
 
-At the moment this is not yet the default Cloud output for the test runs executed from local machines (`k6 run -o cloud`), but it is expected to be transparently enabled in the upcoming weeks.
+- A custom tag named `test_run_id`, since that is reserved for internal k6 Cloud operations
+- Any tag with a key that starts with two underscores (`__`), that is marked by Prometheus convention as reserved
+
+This is not yet the default Cloud output for the test runs executed from local machines (`k6 run -o cloud`), but it is expected to be transparently enabled in the upcoming weeks.
 
 The full list of related PRs: [#3104](https://github.com/grafana/k6/pull/3104), [#3108](https://github.com/grafana/k6/pull/3108), [#3120](https://github.com/grafana/k6/pull/3120), [#3125](https://github.com/grafana/k6/pull/3125), [#3162](https://github.com/grafana/k6/pull/3162), [#3169](https://github.com/grafana/k6/pull/3169), [#3182](https://github.com/grafana/k6/pull/3182), [#3186](https://github.com/grafana/k6/pull/3186), [#3187](https://github.com/grafana/k6/pull/3187), [#3193](https://github.com/grafana/k6/pull/3193), [#3195](https://github.com/grafana/k6/pull/3195), [#3206](https://github.com/grafana/k6/pull/3206), [#3226](https://github.com/grafana/k6/pull/3226), [#3157](https://github.com/grafana/k6/pull/3157), [#3172](https://github.com/grafana/k6/pull/3172).
 
@@ -183,6 +183,3 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
  - [browser#918](https://github.com/grafana/xk6-browser/pull/918) Replaces the usage of `os.LookupEnv` for k6 `LookupEnv` and abstracts environment variables lookup.
  - [browser#984](https://github.com/grafana/xk6-browser/pull/984) Ensures CDP requests message ID are unique at the connection scope.
 
-## _Optional_ Roadmap
-
-_Discussion of future plans_

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -70,7 +70,7 @@ k6 --log-output=loki=http://example.org,header.X-My-Header=123,header.Authorizat
 
 Will now send the header `X-My-Header` with value `123` and `Authorization` with `mytoken`.
 
-Thanks to @federicotdn for doign the changes
+Thanks to @federicotdn for doing the changes.
 
 ### Cloud Traces [#3100](https://github.com/grafana/k6/pull/3100), [#3202](https://github.com/grafana/k6/pull/3202)
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -54,7 +54,7 @@ export default async function () {
 
 ### Deprecations
 
-- [#3121](https://github.com/grafana/k6/issues/3121) deprecates the `loadimpact/k6` docker image. We intend to keep supporting it for at most a year from now, but we recommend switching to the `grafana/k6` image as soon as possible.
+- [#3121](https://github.com/grafana/k6/issues/3121) deprecates the `loadimpact/k6` docker image. We recommend switching to the `grafana/k6` image as soon as possible.
 
 
 ## New features

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -144,7 +144,7 @@ The full list of related PRs: [#3104](https://github.com/grafana/k6/pull/3104), 
 
 - [#3176](https://github.com/grafana/k6/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
 - [#3181](https://github.com/grafana/k6/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
-- [#xk6-grpc#19](https://github.com/grafana/xk6-grpc/pull/19) Fixes EOF (end of file) error that was produced when writing to a closed gRPC stream. Additionally, if no error handlers are set up, the error is logged to the console.
+- [xk6-grpc#19](https://github.com/grafana/xk6-grpc/pull/19) Fixes EOF (end of file) error that was produced when writing to a closed gRPC stream. Additionally, if no error handlers are set up, the error is logged to the console.
 - [browser#881](https://github.com/grafana/xk6-browser/pull/881) Adds a new `browser_http_req_failed` metric.
 - [browser#901](https://github.com/grafana/xk6-browser/pull/901) Adds support for shadow DOM piercing in `locator`. Thanks to @tmc for its implementation.
 - [browser#953](https://github.com/grafana/xk6-browser/pull/953) Improves Web Vitals reporting for better accuracy and consistency.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -82,9 +82,19 @@ if (__ITER === 0) {
 
 Thanks @chrismoran-mica for contribution 🙇‍♂️.
 
-### `<big_feature_1>` `#pr`
+### Cloud Output v2 [#3117](https://github.com/grafana/k6/issues/3117)
 
-_what, why, and what this means for the user_
+After years of great service, we decided to refresh the k6 Cloud output introducing a more efficient end-to-end solution for ingesting the generated tests' metrics. The main change regards the protocol used for flushing metrics that is now a binary based payload over HTTP.
+
+The new output reduces the load generators' used resources for tests that produce many metrics. There is no significant difference in the user experience; it's expected to be the same. 
+
+The one thing worth highlighting is that the new output is strict about tags and drops tags if they are reserved:
+- `test_run_id` as it is reserved for internal k6 Cloud operations
+- any tag with a key that starts with two underscores (`__`), that is marked by Prometheus convention as reserved
+
+At the moment this is not yet the default Cloud output for the test runs executed from local machines (`k6 run -o cloud`), but it is expected to be transparently enabled in the upcoming weeks.
+
+The full list of related PRs: [#3104](https://github.com/grafana/k6/pull/3104), [#3108](https://github.com/grafana/k6/pull/3108), [#3120](https://github.com/grafana/k6/pull/3120), [#3125](https://github.com/grafana/k6/pull/3125), [#3162](https://github.com/grafana/k6/pull/3162), [#3169](https://github.com/grafana/k6/pull/3169), [#3182](https://github.com/grafana/k6/pull/3182), [#3186](https://github.com/grafana/k6/pull/3186), [#3187](https://github.com/grafana/k6/pull/3187), [#3193](https://github.com/grafana/k6/pull/3193), [#3195](https://github.com/grafana/k6/pull/3195), [#3206](https://github.com/grafana/k6/pull/3206), [#3226](https://github.com/grafana/k6/pull/3226), [#3157](https://github.com/grafana/k6/pull/3157), [#3172](https://github.com/grafana/k6/pull/3172).
 
 ### `<big_feature_n>` `#pr`
 
@@ -95,7 +105,6 @@ _what, why, and what this means for the user_
 _Format as `<number> <present_verb> <object>. <credit>`_:
 - _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
 
-- [#3157](https://github.com/grafana/k6/pull/3157) and [#3172](https://github.com/grafana/k6/pull/3172) Add a `MaxTimeSeriesInBatch` configuration option.
 - [#3176](https://github.com/grafana/k6/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
 - [#3181](https://github.com/grafana/k6/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
 
@@ -115,24 +124,6 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3136](https://github.com/grafana/k6/pull/3136) Updates k6 Go dependencies.
 - [#3131](https://github.com/grafana/k6/pull/3131) Updates our Pull Request template to be more structured and include a checklist for contributors.
 - [#3177](https://github.com/grafana/k6/pull/3177) Updates the version of golangci-lint we use to the latest version.
-
-### Cloud output v2
-
-// TODO @codebien
-
-* [3104](https://github.com/grafana/k6/pull/3104) Retry and flushers pool
-* [3108](https://github.com/grafana/k6/pull/3108) Flush chunks
-* [3120](https://github.com/grafana/k6/pull/3120) Unlimited size for body payload
-* [3125](https://github.com/grafana/k6/pull/3125) Use a static remote service url
-* [3162](https://github.com/grafana/k6/pull/3162) Warn about labels that have reserved names
-* [3169](https://github.com/grafana/k6/pull/3169) Compact histogram
-- [#3182](https://github.com/grafana/k6/pull/3182) Fix off-by-one error for spans
-- [#3186](https://github.com/grafana/k6/pull/3186) Be less noisy when handling errors
-- [#3187](https://github.com/grafana/k6/pull/3187) Create batches for single bucket flush
-- [#3193](https://github.com/grafana/k6/pull/3193) Downscale the batch size
-- [#3195](https://github.com/grafana/k6/pull/3195) Make sure to use the overwritten config
-- [#3206](https://github.com/grafana/k6/pull/3206) Implement concurrent pushes accross batches
-- [#3226](https://github.com/grafana/k6/pull/3226) don't go over maxSeriesInBatch
 
 ## _Optional_ Roadmap
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -27,13 +27,13 @@ k6 --log-output=loki=http://example.org,header.X-My-Header=123,header.Authorizat
 
 Will now send the header `X-My-Header` with value `123` and `Authorization` with `mytoken`.
 
-Thanks to @federicotdn for doing the changes.
+Thanks to @federicotdn for doign the changes
 
 ### Cloud Traces [#3100](https://github.com/grafana/k6/pull/3100), [#3202](https://github.com/grafana/k6/pull/3202)
 
 This release supports the new integration between k6 and Tempo in the cloud. Grafana Cloud k6 and Grafana Cloud Traces customers will be able to start their traces in k6 using the existing `k6/experimental/tracing` module to enrich their test run analysis page with metrics and aggregations from tracing data.
 
-The new cloud traces will work _out of the box_ for runs started from the Grafana Cloud k6 app or from the `k6 cloud script.js` command. In case of `k6 run -o cloud script.js` runs, the `K6_CLOUD_TRACES_ENABLED` environment variable has to be set to `true`.
+The new cloud traces will work "out of the box" for `k6 cloud` runs. In case of `k6 run` execution, the `K6_CLOUD_TRACES_ENABLED` environment variable has to be set to `true`.
 
 ### Ability to configure TLS per gRPC connection [#3159](https://github.com/grafana/k6/pull/3159), [xk6-grpc#25](https://github.com/grafana/xk6-grpc/pull/25)
 
@@ -95,17 +95,20 @@ _what, why, and what this means for the user_
 _Format as `<number> <present_verb> <object>. <credit>`_:
 - _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
 
-- TODO: [#3157](https://github.com/grafana/pull/3157) and [#3172](https://github.com/grafana/pull/3172) Add a `MaxTimeSeriesInBatch` configuration option.
-- [#3176](https://github.com/grafana/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
-- [#3181](https://github.com/grafana/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
+- [#3157](https://github.com/grafana/k6/pull/3157) and [#3172](https://github.com/grafana/k6/pull/3172) Add a `MaxTimeSeriesInBatch` configuration option.
+- [#3176](https://github.com/grafana/k6/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
+- [#3181](https://github.com/grafana/k6/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
 
 ## Bug fixes
 
-- [#3163](https://github.com/grafana/pull/3163) Addresses a bug in our gRPC example.
-- [#3178](https://github.com/grafana/pull/3178) Fixes the registration of nested protobuf messages in the gRPC module.
-- [#3170](https://github.com/grafana/pull/3170) Upgrades the version of gRPC k6 depends on to address a security vulnerability ([CVE-2023-32731]).
+- [#3178](https://github.com/grafana/k6/pull/3178), [xk6-grpc#23](https://github.com/grafana/xk6-grpc/pull/23) Fixes the registration of nested protobuf messages in the gRPC module. Thanks @thiagodpf for reporting and actually fixing the bug!
+- [#3194](https://github.com/grafana/k6/pull/3194) Fixes loki log output exiting before push is finished.
+- [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to 1.0 when not set by the user.
 
 ## Maintenance and internal improvements
+
+- [#3163](https://github.com/grafana/pull/3163) Addresses a bug in our gRPC example.
+- [#3170](https://github.com/grafana/pull/3170) Upgraded the version of gRPC k6 demo service dependency for addressing a security vulnerability ([CVE-2023-32731]).
 
 ### Cloud output v2
 
@@ -129,9 +132,7 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 
 - [#3211](https://github.com/grafana/k6/pull/3211) Updates the experimental gRPC module version used by k6.
 - [#3210](https://github.com/grafana/k6/pull/3210) Updates the xk6-output-prometheus-remote version used by k6.
-- [#3194](https://github.com/grafana/k6/pull/3194) Fixes loki log output exiting before push is finished.
 - [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
-- [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to 1.0 when not set by the user.
 - [#3136](https://github.com/grafana/k6/pull/3136) Updates k6 Go dependencies.
 - [#3131](https://github.com/grafana/k6/pull/3131) Updates our Pull Request template to be more structured and include a checklist for contributors.
 - [#3177](https://github.com/grafana/k6/pull/3177) Updates the version of golangci-lint we use to the latest version.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -74,7 +74,7 @@ Thanks to @federicotdn for adding this feature.
 
 This release supports the new integration between k6 and Tempo in the cloud. [Grafana Cloud k6](https://grafana.com/products/cloud/k6) and Grafana Cloud Tempo customers will be able to start their traces in k6 using the existing `k6/experimental/tracing` module to enrich their test run analysis page with metrics and aggregations from tracing data.
 
-The new cloud traces will work "out of the box" for `k6 cloud` runs. In case of `k6 run` execution, the `K6_CLOUD_TRACES_ENABLED` environment variable has to be set to `true`.
+The new Cloud traces will work "out of the box" for `k6 cloud` runs. In case of `k6 run` execution, the `K6_CLOUD_TRACES_ENABLED` environment variable has to be set to `true`.
 
 ### Ability to configure TLS per gRPC connection [#3159](https://github.com/grafana/k6/pull/3159), [xk6-grpc#25](https://github.com/grafana/xk6-grpc/pull/25)
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -160,7 +160,7 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3178](https://github.com/grafana/k6/pull/3178), [xk6-grpc#23](https://github.com/grafana/xk6-grpc/pull/23) Fixes the registration of nested protobuf messages in the gRPC module. Thanks @thiagodpf for reporting and actually fixing the bug!
 - [#3194](https://github.com/grafana/k6/pull/3194) Fixes loki log output exiting before push is finished.
 - [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to `1.0` when not set by the user.
-- [#3163](https://github.com/grafana/k6/pull/3163) Fixes our gRPC example.
+- [#3163](https://github.com/grafana/k6/pull/3163) Fixes our [gRPC example](https://github.com/grafana/k6/blob/8fa0e6b9a8b63f430df34047e4393b281ff9ee30/examples/grpc.js).
 - [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
 - [browser#866](https://github.com/grafana/xk6-browser/pull/866) Disables the timeout on browser process execution.
 - [browser#942](https://github.com/grafana/xk6-browser/pull/942) Fixes deadlock in `frameNavigated`.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -123,7 +123,7 @@ if (__ITER === 0) {
 ```
 </details>
 
-Thanks @chrismoran-mica for contribution 🙇‍♂️.
+Thanks @chrismoran-mica for the contribution 🙇‍♂️.
 
 ### Cloud Output v2 [#3117](https://github.com/grafana/k6/issues/3117)
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -107,6 +107,7 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 
 - [#3176](https://github.com/grafana/k6/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
 - [#3181](https://github.com/grafana/k6/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
+- [#xk6-grpc#19](https://github.com/grafana/xk6-grpc/pull/19) Writing to the closed GRPC stream no longer produce the EOF (end of file) error. Additionally, if no errors' handler were set up. The error is logged to the console.
 
 ## Bug fixes
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -139,17 +139,12 @@ This is not yet the default Cloud output for the test runs executed from local m
 
 The full list of related PRs: [#3104](https://github.com/grafana/k6/pull/3104), [#3108](https://github.com/grafana/k6/pull/3108), [#3120](https://github.com/grafana/k6/pull/3120), [#3125](https://github.com/grafana/k6/pull/3125), [#3162](https://github.com/grafana/k6/pull/3162), [#3169](https://github.com/grafana/k6/pull/3169), [#3182](https://github.com/grafana/k6/pull/3182), [#3186](https://github.com/grafana/k6/pull/3186), [#3187](https://github.com/grafana/k6/pull/3187), [#3193](https://github.com/grafana/k6/pull/3193), [#3195](https://github.com/grafana/k6/pull/3195), [#3206](https://github.com/grafana/k6/pull/3206), [#3226](https://github.com/grafana/k6/pull/3226), [#3157](https://github.com/grafana/k6/pull/3157), [#3172](https://github.com/grafana/k6/pull/3172).
 
-### `<big_feature_n>` `#pr`
 
-_what, why, and what this means for the user_
+## UX improvements and enhancements
 
-### UX improvements and enhancements
-
-_Format as `<number> <present_verb> <object>. <credit>`_:
-- _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
 - [#3176](https://github.com/grafana/k6/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
 - [#3181](https://github.com/grafana/k6/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
-- [#xk6-grpc#19](https://github.com/grafana/xk6-grpc/pull/19) Writing to the closed gRPC stream no longer produces the EOF (end of file) error. Additionally, if no error handlers were set up, the error is logged to the console.
+- [#xk6-grpc#19](https://github.com/grafana/xk6-grpc/pull/19) Fixes EOF (end of file) error that was produced when writing to a closed gRPC stream. Additionally, if no error handlers are set up, the error is logged to the console.
 - [browser#881](https://github.com/grafana/xk6-browser/pull/881) Adds a new `browser_http_req_failed` metric.
 - [browser#901](https://github.com/grafana/xk6-browser/pull/901) Adds support for shadow DOM piercing in `locator`. Thanks to @tmc for its implementation.
 - [browser#953](https://github.com/grafana/xk6-browser/pull/953) Improves Web Vitals reporting for better accuracy and consistency.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -104,7 +104,7 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3178](https://github.com/grafana/k6/pull/3178), [xk6-grpc#23](https://github.com/grafana/xk6-grpc/pull/23) Fixes the registration of nested protobuf messages in the gRPC module. Thanks @thiagodpf for reporting and actually fixing the bug!
 - [#3194](https://github.com/grafana/k6/pull/3194) Fixes loki log output exiting before push is finished.
 - [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to 1.0 when not set by the user.
-- [#3163](https://github.com/grafana/pull/3163) Addresses a bug in our gRPC example.
+- [#3163](https://github.com/grafana/k6/pull/3163) Fixes our gRPC example.
 - [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
 
 ## Maintenance and internal improvements

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -61,7 +61,7 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3206](https://github.com/grafana/k6/pull/3206) Implement concurrent pushes accross batches
 - [#3226](https://github.com/grafana/k6/pull/3226) don't go over maxSeriesInBatch
 
-### Miscelaneous
+### Miscellaneous
 
 - [#3211](https://github.com/grafana/k6/pull/3211) Updates the experimental gRPC module version used by k6.
 - [#3210](https://github.com/grafana/k6/pull/3210) Updates the xk6-output-prometheus-remote version used by k6.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -104,11 +104,17 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3178](https://github.com/grafana/k6/pull/3178), [xk6-grpc#23](https://github.com/grafana/xk6-grpc/pull/23) Fixes the registration of nested protobuf messages in the gRPC module. Thanks @thiagodpf for reporting and actually fixing the bug!
 - [#3194](https://github.com/grafana/k6/pull/3194) Fixes loki log output exiting before push is finished.
 - [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to 1.0 when not set by the user.
+- [#3163](https://github.com/grafana/pull/3163) Addresses a bug in our gRPC example.
+- [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
 
 ## Maintenance and internal improvements
 
-- [#3163](https://github.com/grafana/pull/3163) Addresses a bug in our gRPC example.
 - [#3170](https://github.com/grafana/pull/3170) Upgraded the version of gRPC k6 demo service dependency for addressing a security vulnerability ([CVE-2023-32731]).
+- [#3211](https://github.com/grafana/k6/pull/3211) Updates the experimental gRPC module version used by k6.
+- [#3210](https://github.com/grafana/k6/pull/3210) Updates the xk6-output-prometheus-remote version used by k6.
+- [#3136](https://github.com/grafana/k6/pull/3136) Updates k6 Go dependencies.
+- [#3131](https://github.com/grafana/k6/pull/3131) Updates our Pull Request template to be more structured and include a checklist for contributors.
+- [#3177](https://github.com/grafana/k6/pull/3177) Updates the version of golangci-lint we use to the latest version.
 
 ### Cloud output v2
 
@@ -127,15 +133,6 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3195](https://github.com/grafana/k6/pull/3195) Make sure to use the overwritten config
 - [#3206](https://github.com/grafana/k6/pull/3206) Implement concurrent pushes accross batches
 - [#3226](https://github.com/grafana/k6/pull/3226) don't go over maxSeriesInBatch
-
-### Miscellaneous
-
-- [#3211](https://github.com/grafana/k6/pull/3211) Updates the experimental gRPC module version used by k6.
-- [#3210](https://github.com/grafana/k6/pull/3210) Updates the xk6-output-prometheus-remote version used by k6.
-- [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
-- [#3136](https://github.com/grafana/k6/pull/3136) Updates k6 Go dependencies.
-- [#3131](https://github.com/grafana/k6/pull/3131) Updates our Pull Request template to be more structured and include a checklist for contributors.
-- [#3177](https://github.com/grafana/k6/pull/3177) Updates the version of golangci-lint we use to the latest version.
 
 ## _Optional_ Roadmap
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -27,7 +27,7 @@ k6 --log-output=loki=http://example.org,header.X-My-Header=123,header.Authorizat
 
 Will now send the header `X-My-Header` with value `123` and `Authorization` with `mytoken`.
 
-Thanks to @federicotdn for doign the changes
+Thanks to @federicotdn for doing the changes.
 
 ### Cloud Traces [#3100](https://github.com/grafana/k6/pull/3100), [#3202](https://github.com/grafana/k6/pull/3202)
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -33,7 +33,7 @@ Thanks to @federicotdn for doing the changes.
 
 This release supports the new integration between k6 and Tempo in the cloud. Grafana Cloud k6 and Grafana Cloud Traces customers will be able to start their traces in k6 using the existing `k6/experimental/tracing` module to enrich their test run analysis page with metrics and aggregations from tracing data.
 
-The new cloud traces will work "out of the box" for `k6 cloud` runs. In case of `k6 run` execution, the `K6_CLOUD_TRACES_ENABLED` environment variable has to be set to `true`.
+The new cloud traces will work _out of the box_ for runs started from the Grafana Cloud k6 app or from the `k6 cloud script.js` command. In case of `k6 run -o cloud script.js` runs, the `K6_CLOUD_TRACES_ENABLED` environment variable has to be set to `true`.
 
 ### `<big_feature_1>` `#pr`
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -1,8 +1,11 @@
 k6 `v0.46` is here 🎉! This release includes:
 
-- (_optional_) `<highlight of breaking changes>`
-- `<Summary of new features>` (_one or multiple bullets_)
-
+- xk6-browser extension version bump to `v1.0.2`, which includes breaking changes.
+- Send custom headers to Loki log output
+- Cloud Traces, the new integration between k6 and [Tempo](https://github.com/grafana/tempo)
+- Ability to configure TLS per gRPC connection
+- Cloud output v2
+- And many UX improvements, bug fixes, and internal improvements
 
 ## Breaking changes
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -84,7 +84,6 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3211](https://github.com/grafana/k6/pull/3211) Updates the experimental gRPC module version used by k6.
 - [#3210](https://github.com/grafana/k6/pull/3210) Updates the xk6-output-prometheus-remote version used by k6.
 - [#3194](https://github.com/grafana/k6/pull/3194) Fixes loki log output exiting before push is finished.
-- [#3227](https://github.com/grafana/k6/pull/3227) Allows specifying custom headers for Loki log output.
 - [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
 - [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to 1.0 when not set by the user.
 - [#3136](https://github.com/grafana/k6/pull/3136) Updates k6 Go dependencies.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -35,6 +35,53 @@ This release supports the new integration between k6 and Tempo in the cloud. Gra
 
 The new cloud traces will work _out of the box_ for runs started from the Grafana Cloud k6 app or from the `k6 cloud script.js` command. In case of `k6 run -o cloud script.js` runs, the `K6_CLOUD_TRACES_ENABLED` environment variable has to be set to `true`.
 
+### Ability to configure TLS per gRPC connection [#3159](https://github.com/grafana/k6/pull/3159), [xk6-grpc#25](https://github.com/grafana/xk6-grpc/pull/25)
+
+The `k6/net/grpc` and `k6/experimental/grpc` modules now support configuring TLS per-connection via [ConnectParams](https://k6.io/docs/javascript-api/k6-net-grpc/client/client-connect/#connectparams). This is useful when connecting to multiple gRPC servers with different TLS configurations within the same VU.
+
+<details>
+<summary> Expand to see an example of the new functionality.</summary>
+
+```javascript
+// init phase (1)
+const params = {
+  "grpcbin.test.notk6.io:9001": {
+    plaintext: false,
+    tls: {
+      cacerts: [open("cacerts0.pem")],
+      cert: open("cert0.pem"),
+      key: open("key0.pem"),
+    }, // password omitted to demonstrate 'optional password'
+  },
+  "grpcbin.test.fakek6.io:9001": {
+    plaintext: false,
+    tls: {
+      cacerts: open("cacerts1.pem"),
+      cert: open("cert1.pem"),
+      key: open("key1.pem"),
+      password: "cert1-passphrase",
+    }, // cacerts as a 'string' to demonstrate string|string[] typing of cacerts
+  },
+};
+const clients = {
+  "grpcbin.test.notk6.io:9001": new grpc.Client(),
+  "grpcbin.test.fakek6.io:9001": new grpc.Client(),
+};
+...
+
+// k6 - VU code phase (3)
+if (__ITER === 0) {
+  clients["grpcbin.test.notk6.io:9001"]
+    .connect("grpcbin.test.notk6.io:9001", params["grpcbin.test.notk6.io:9001"]);
+  clients["grpcbin.test.notk6.io:9001"]
+    .connect("grpcbin.test.fakek6.io:9001", params["grpcbin.test.fakek6.io:9001"]);
+}
+...
+```
+</details>
+
+Thanks @chrismoran-mica for contribution 🙇‍♂️.
+
 ### `<big_feature_1>` `#pr`
 
 _what, why, and what this means for the user_
@@ -49,7 +96,6 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
 
 - TODO: [#3157](https://github.com/grafana/pull/3157) and [#3172](https://github.com/grafana/pull/3172) Add a `MaxTimeSeriesInBatch` configuration option.
-- [#3159](https://github.com/grafana/pull/3159) Adds per-vu TLS configuration to `grpc.Client` connect method's parameters. Thanks @chrismoran-mica 🙇‍♂️.
 - [#3176](https://github.com/grafana/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
 - [#3181](https://github.com/grafana/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -147,7 +147,6 @@ _what, why, and what this means for the user_
 
 _Format as `<number> <present_verb> <object>. <credit>`_:
 - _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
-
 - [#3176](https://github.com/grafana/k6/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
 - [#3181](https://github.com/grafana/k6/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
 - [#xk6-grpc#19](https://github.com/grafana/xk6-grpc/pull/19) Writing to the closed GRPC stream no longer produce the EOF (end of file) error. Additionally, if no errors' handler were set up. The error is logged to the console.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -35,7 +35,6 @@ This release supports the new integration between k6 and Tempo in the cloud. Gra
 
 The new cloud traces will work "out of the box" for `k6 cloud` runs. In case of `k6 run` execution, the `K6_CLOUD_TRACES_ENABLED` environment variable has to be set to `true`.
 
-
 ### `<big_feature_1>` `#pr`
 
 _what, why, and what this means for the user_

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -9,6 +9,49 @@ k6 `v0.46` is here 🎉! This release includes:
 - `#pr`, `<small_break_1>`
 - `#pr`, `<small_break_2>`
 
+### Browser
+
+In this release, xk6-browser extension version is bumped up to `v1.0.2`, as it includes multiple breaking changes in relation with options, browser lifecycle and metrics.
+
+**Options** `devtools`, `env` and `proxy` are deprecated ([browser#868](https://github.com/grafana/xk6-browser/pull/868), [browser#870](https://github.com/grafana/xk6-browser/pull/870), [browser#872](https://github.com/grafana/xk6-browser/pull/872)). Additionally, browser `launch`/`connect` options are no longer defined in the corresponding JS API methods, instead the test execution related options are now defined inside the browser scenario options (see [#3036](https://github.com/grafana/k6/pull/3036)), and the other more "environmental options", such as `headless`, `debug`, `executablePath`, are set as ENV vars. Also `slowMo` option is no longer supported, although it might be supported again in the future through a different API ([browser#876](https://github.com/grafana/xk6-browser/pull/876)).
+
+**Metrics** also went through a few changes. The Web Vitals metrics are renamed to use `browser_` prefix and short namings (e.g.: `webvital_first_input_delay` -> `browser_web_vital_fid`) ([browser#885](https://github.com/grafana/xk6-browser/pull/885), [browser#903](https://github.com/grafana/xk6-browser/pull/903)), and the rating metric is removed, as it is now set as a label in the corresponding Web Vitals metrics ([browser#915](https://github.com/grafana/xk6-browser/pull/915))
+The browser HTTP metrics have also been modified, as these are now split from the HTTP module ones, so there are new `browser_` prefixed HTTP metrics, specifically for request duration and failed requests ([browser#916](https://github.com/grafana/xk6-browser/pull/916)).
+
+Another big change introduced in this version affects the way the **browser lifecycle** is handled. Now the users no longer have to explicitly initialize/close the browser instance through the JS API. Instead a browser instance will be automatically initialized/closed at the beginning/end of each iteration if the browser type is set in scenario options (see [#3036](https://github.com/grafana/k6/pull/3036)). This also implies that the `chromium` entity from `k6/experimental/browser` import path is no longer valid, instead the `browser` entity provides access to the browser methods such as `browser.newPage()` ([browser#910](https://github.com/grafana/xk6-browser/pull/910), [browser#944](https://github.com/grafana/xk6-browser/pull/944)). This change implies that the `browser.on()` method is no longer applicable, and therefore it has been removed ([browser#919](https://github.com/grafana/xk6-browser/pull/919)).
+
+Following with **import changes**, the browser module version is no longer an exported field ([browser#923](https://github.com/grafana/xk6-browser/pull/923)).
+
+Last but not least, this release also includes constraints on **browser contexts** usage as now only one `browserContext` is allowed per iteration, which means that the user can create a new `browserContext`, close it, and then create it again; but can not have more than one "live" `browserContext`. Instead, [scenarios](https://k6.io/docs/using-k6/scenarios/) should be used to separate independent actions in a test ([browser#929](https://github.com/grafana/xk6-browser/pull/929), [browser#945](https://github.com/grafana/xk6-browser/pull/945)).
+
+With all these changes, a simple browser test now looks like:
+```js
+import { browser } from 'k6/experimental/browser';
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium', // chromium is the only supported browser type so as long as
+                            // the option is set, Chromium/Google Chrome will be used
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = browser.newPage();
+  try {
+    await page.goto('https://grafana.com')
+  } finally {
+    page.close();
+  }
+}
+```
+
 ### (_optional h3_) `<big_breaking_change>` `#pr`
 
 ## New features
@@ -108,6 +151,9 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3176](https://github.com/grafana/k6/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
 - [#3181](https://github.com/grafana/k6/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
 - [#xk6-grpc#19](https://github.com/grafana/xk6-grpc/pull/19) Writing to the closed GRPC stream no longer produce the EOF (end of file) error. Additionally, if no errors' handler were set up. The error is logged to the console.
+- [browser#881](https://github.com/grafana/xk6-browser/pull/881) Adds a new `browser_http_req_failed` metric.
+- [browser#901](https://github.com/grafana/xk6-browser/pull/901) Adds support for shadow DOM piercing in `locator`. Thanks to @tmc for its implementation.
+- [browser#953](https://github.com/grafana/xk6-browser/pull/953) Improves Web Vitals reporting for better accuracy and consistency.
 
 ## Bug fixes
 
@@ -116,6 +162,12 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to 1.0 when not set by the user.
 - [#3163](https://github.com/grafana/k6/pull/3163) Fixes our gRPC example.
 - [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
+- [browser#866](https://github.com/grafana/xk6-browser/pull/866) Disables the timeout on browser process execution.
+- [browser#942](https://github.com/grafana/xk6-browser/pull/942) Fixes deadlock in `frameNavigated`.
+- [browser#943](https://github.com/grafana/xk6-browser/pull/943) Fixes a race condition in navigation and lifecycle events.
+- [browser#979](https://github.com/grafana/xk6-browser/pull/979) Fixes a deadlock on `pagehide` event evaluation when `page.close()` is called.
+- [browser#980](https://github.com/grafana/xk6-browser/pull/980) Fixes Loki log output for console log serializer.
+- [browser#991](https://github.com/grafana/xk6-browser/pull/991) Fixes data directory not being cleared during `browser.close()` panic.
 
 ## Maintenance and internal improvements
 
@@ -125,6 +177,12 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3136](https://github.com/grafana/k6/pull/3136) Updates k6 Go dependencies.
 - [#3131](https://github.com/grafana/k6/pull/3131) Updates our Pull Request template to be more structured and include a checklist for contributors.
 - [#3177](https://github.com/grafana/k6/pull/3177) Updates the version of golangci-lint we use to the latest version.
+- [browser#849](https://github.com/grafana/xk6-browser/pull/849), [browser#972](https://github.com/grafana/xk6-browser/pull/972), [browser#977](https://github.com/grafana/xk6-browser/pull/977), [browser#978](https://github.com/grafana/xk6-browser/pull/978), [browser#983](https://github.com/grafana/xk6-browser/pull/983) Log fixes and improvements.
+- [browser#889](https://github.com/grafana/xk6-browser/pull/889), [browser#889](https://github.com/grafana/xk6-browser/pull/899), [browser#902](https://github.com/grafana/xk6-browser/pull/902), [browser#935](https://github.com/grafana/xk6-browser/pull/935), [browser#936](https://github.com/grafana/xk6-browser/pull/936) Internal refactors.
+- [browser#904](https://github.com/grafana/xk6-browser/pull/904), [browser#959](https://github.com/grafana/xk6-browser/pull/959) Test fixes.
+ - [browser#906](https://github.com/grafana/xk6-browser/pull/906) Parses the scenarios JSON definition from the `K6_INSTANCE_SCENARIOS` environment variable.
+ - [browser#918](https://github.com/grafana/xk6-browser/pull/918) Replaces the usage of `os.LookupEnv` for k6 `LookupEnv` and abstracts environment variables lookup.
+ - [browser#984](https://github.com/grafana/xk6-browser/pull/984) Ensures CDP requests message ID are unique at the connection scope.
 
 ## _Optional_ Roadmap
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -7,10 +7,6 @@ k6 `v0.46` is here 🎉! This release includes:
 - Cloud output v2
 - And many UX improvements, bug fixes, and internal improvements
 
-## Breaking changes
-
-- `#pr`, `<small_break_1>`
-- `#pr`, `<small_break_2>`
 
 ### Browser
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -38,8 +38,7 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 
 ## Maintenance and internal improvements
 
-_Format as `<number> <present_verb> <object>. <credit>`_:
-- _`#2770` Refactors parts of the JS module._
+- [#3136](https://github.com/grafana/k6/pull/3136) Go dependencies updates.
 
 ## _Optional_ Roadmap
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -1,4 +1,4 @@
-k6 `v0.46.0` is here 🎉! This release includes:
+k6 `v0.46` is here 🎉! This release includes:
 
 - (_optional_) `<highlight of breaking changes>`
 - `<Summary of new features>` (_one or multiple bullets_)

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -13,7 +13,9 @@ k6 `v0.46` is here 🎉! This release includes:
 
 ## New features
 
-_optional intro here_
+### [#3030](https://github.com/grafana/k6/pull/3030)
+
+// TODO
 
 ### `<big_feature_1>` `#pr`
 
@@ -26,19 +28,50 @@ _what, why, and what this means for the user_
 ### UX improvements and enhancements
 
 _Format as `<number> <present_verb> <object>. <credit>`_:
-
 - _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
-- `#pr` `<description>`
-- `#pr` `<description>`
+
+- TODO: [#3157](https://github.com/grafana/pull/3157) and [#3172](https://github.com/grafana/pull/3172) Add a `MaxTimeSeriesInBatch` configuration option.
+- [#3159](https://github.com/grafana/pull/3159) Adds per-vu TLS configuration to `grpc.Client` connect method's parameters. Thanks @chrismoran-mica 🙇‍♂️.
+- [#3176](https://github.com/grafana/pull/3176) Adds a `js/promises` package, which enables extension developers to easily create promises that will be dispatched to the eventloop using the `New` function.
+- [#3181](https://github.com/grafana/pull/3181) Adds a `RunOnEventLoop` method to the `modulestest.Runtime` type, which allows extensions developers to run code on the event loop from their tests.
 
 ## Bug fixes
 
-_Format as `<number> <present_verb> <object>. <credit>`_:
-- _`#111` fixes race condition in runtime_
+- [#3163](https://github.com/grafana/pull/3163) Addresses a bug in our gRPC example.
+- [#3178](https://github.com/grafana/pull/3178) Fixes the registration of nested protobuf messages in the gRPC module.
+- [#3170](https://github.com/grafana/pull/3170) Upgrades the version of gRPC k6 depends on to address a security vulnerability ([CVE-2023-32731]).
 
 ## Maintenance and internal improvements
 
-- [#3136](https://github.com/grafana/k6/pull/3136) Go dependencies updates.
+### Cloud output v2
+
+// TODO @codebien
+
+* [3104](https://github.com/grafana/k6/pull/3104) Retry and flushers pool
+* [3108](https://github.com/grafana/k6/pull/3108) Flush chunks
+* [3120](https://github.com/grafana/k6/pull/3120) Unlimited size for body payload
+* [3125](https://github.com/grafana/k6/pull/3125) Use a static remote service url
+* [3162](https://github.com/grafana/k6/pull/3162) Warn about labels that have reserved names
+* [3169](https://github.com/grafana/k6/pull/3169) Compact histogram
+- [#3182](https://github.com/grafana/k6/pull/3182) Fix off-by-one error for spans
+- [#3186](https://github.com/grafana/k6/pull/3186) Be less noisy when handling errors
+- [#3187](https://github.com/grafana/k6/pull/3187) Create batches for single bucket flush
+- [#3193](https://github.com/grafana/k6/pull/3193) Downscale the batch size
+- [#3195](https://github.com/grafana/k6/pull/3195) Make sure to use the overwritten config
+- [#3206](https://github.com/grafana/k6/pull/3206) Implement concurrent pushes accross batches
+- [#3226](https://github.com/grafana/k6/pull/3226) don't go over maxSeriesInBatch
+
+### Miscelaneous
+
+- [#3211](https://github.com/grafana/k6/pull/3211) Updates the experimental gRPC module version used by k6.
+- [#3210](https://github.com/grafana/k6/pull/3210) Updates the xk6-output-prometheus-remote version used by k6.
+- [#3194](https://github.com/grafana/k6/pull/3194) Fixes loki log output exiting before push is finished.
+- [#3227](https://github.com/grafana/k6/pull/3227) Allows specifying custom headers for Loki log output.
+- [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
+- [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to 1.0 when not set by the user.
+- [#3136](https://github.com/grafana/k6/pull/3136) Updates k6 Go dependencies.
+- [#3131](https://github.com/grafana/k6/pull/3131) Updates our Pull Request template to be more structured and include a checklist for contributors.
+- [#3177](https://github.com/grafana/k6/pull/3177) Updates the version of golangci-lint we use to the latest version.
 
 ## _Optional_ Roadmap
 

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -129,7 +129,7 @@ Thanks @chrismoran-mica for the contribution 🙇‍♂️.
 
 After years of great service, we decided to refresh the k6 Cloud output introducing a more efficient end-to-end solution for ingesting the generated tests' metrics. The main change regards the protocol used for flushing metrics that is now a binary based payload over HTTP.
 
-The new output reduces the load generators' used resources for tests that produce many metrics. There is no significant difference in the user experience; it's expected to be the same. 
+The new output reduces the load generators' used resources for tests that produce many metrics. There is no significant difference in the user experience; it's expected to be the same.
 
 The one thing worth highlighting is that the new output is strict about tags and drops tags if they are reserved:
 - `test_run_id` as it is reserved for internal k6 Cloud operations
@@ -159,8 +159,6 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3178](https://github.com/grafana/k6/pull/3178), [xk6-grpc#23](https://github.com/grafana/xk6-grpc/pull/23) Fixes the registration of nested protobuf messages in the gRPC module. Thanks @thiagodpf for reporting and fixing the bug!
 - [#3194](https://github.com/grafana/k6/pull/3194) Fixes loki log output exiting before push is finished.
 - [#3231](https://github.com/grafana/k6/pull/3231) Fixes the tracing module sampling option to default to `1.0` when not set by the user.
-- [#3163](https://github.com/grafana/k6/pull/3163) Fixes our [gRPC example](https://github.com/grafana/k6/blob/8fa0e6b9a8b63f430df34047e4393b281ff9ee30/examples/grpc.js).
-- [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
 - [browser#866](https://github.com/grafana/xk6-browser/pull/866) Disables the timeout on browser process execution.
 - [browser#942](https://github.com/grafana/xk6-browser/pull/942) Fixes deadlock in `frameNavigated`.
 - [browser#943](https://github.com/grafana/xk6-browser/pull/943) Fixes a race condition in navigation and lifecycle events.
@@ -176,6 +174,8 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 - [#3136](https://github.com/grafana/k6/pull/3136) Updates k6 Go dependencies.
 - [#3131](https://github.com/grafana/k6/pull/3131) Updates our Pull Request template to be more structured and include a checklist for contributors.
 - [#3177](https://github.com/grafana/k6/pull/3177) Updates the version of golangci-lint we use to the latest version.
+- [#3163](https://github.com/grafana/k6/pull/3163) Fixes our [gRPC example](https://github.com/grafana/k6/blob/8fa0e6b9a8b63f430df34047e4393b281ff9ee30/examples/grpc.js).
+- [#3196](https://github.com/grafana/k6/pull/3196) Logs packages lint fixes, and test for loki flushing at end.
 - [browser#849](https://github.com/grafana/xk6-browser/pull/849), [browser#972](https://github.com/grafana/xk6-browser/pull/972), [browser#977](https://github.com/grafana/xk6-browser/pull/977), [browser#978](https://github.com/grafana/xk6-browser/pull/978), [browser#983](https://github.com/grafana/xk6-browser/pull/983) Log fixes and improvements.
 - [browser#889](https://github.com/grafana/xk6-browser/pull/889), [browser#889](https://github.com/grafana/xk6-browser/pull/899), [browser#902](https://github.com/grafana/xk6-browser/pull/902), [browser#935](https://github.com/grafana/xk6-browser/pull/935), [browser#936](https://github.com/grafana/xk6-browser/pull/936) Internal refactors.
 - [browser#904](https://github.com/grafana/xk6-browser/pull/904), [browser#959](https://github.com/grafana/xk6-browser/pull/959) Test fixes.

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -1,0 +1,46 @@
+k6 `v0.46.0` is here 🎉! This release includes:
+
+- (_optional_) `<highlight of breaking changes>`
+- `<Summary of new features>` (_one or multiple bullets_)
+
+
+## Breaking changes
+
+- `#pr`, `<small_break_1>`
+- `#pr`, `<small_break_2>`
+
+### (_optional h3_) `<big_breaking_change>` `#pr`
+
+## New features
+
+_optional intro here_
+
+### `<big_feature_1>` `#pr`
+
+_what, why, and what this means for the user_
+
+### `<big_feature_n>` `#pr`
+
+_what, why, and what this means for the user_
+
+### UX improvements and enhancements
+
+_Format as `<number> <present_verb> <object>. <credit>`_:
+
+- _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
+- `#pr` `<description>`
+- `#pr` `<description>`
+
+## Bug fixes
+
+_Format as `<number> <present_verb> <object>. <credit>`_:
+- _`#111` fixes race condition in runtime_
+
+## Maintenance and internal improvements
+
+_Format as `<number> <present_verb> <object>. <credit>`_:
+- _`#2770` Refactors parts of the JS module._
+
+## _Optional_ Roadmap
+
+_Discussion of future plans_

--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -13,9 +13,21 @@ k6 `v0.46` is here 🎉! This release includes:
 
 ## New features
 
-### [#3030](https://github.com/grafana/k6/pull/3030)
+### Loki log output sending additional headers [#3227](https://github.com/grafana/k6/pull/3227)
 
-// TODO
+k6 has been able to send logs to loki for nearly 3 years since [v0.28.0](https://github.com/grafana/k6/releases/tag/v0.28.0) but didn't support any way to authenticate.
+
+Now it can be configured to send additional headers on every request.
+
+This is being configured with the new `header` config option similar to `label`:
+
+```
+k6 --log-output=loki=http://example.org,header.X-My-Header=123,header.Authorization=mytoken ...
+```
+
+Will now send the header `X-My-Header` with value `123` and `Authorization` with `mytoken`.
+
+Thanks to @federicotdn for doign the changes
 
 ### `<big_feature_1>` `#pr`
 


### PR DESCRIPTION
## What?

This Pull Request bumps k6's version and updates release notes for the upcoming version `0.46`.

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/issues/3138
https://github.com/grafana/k6/milestone/36
https://github.com/DefinitelyTyped/DefinitelyTyped/pull/66271