### PR TITLE
Fix tracing module's Jaeger sampling flag

### DIFF
--- a/js/modules/k6/experimental/tracing/propagator.go
+++ b/js/modules/k6/experimental/tracing/propagator.go
@@ -69,11 +69,11 @@ const (
 	// "0 value is valid and means “root span” (when not ignored)"
 	JaegerRootSpanID = "0"
 
-	// JaegerSampledTraceFlag is the trace-flag value for an unsampled trace.
-	JaegerSampledTraceFlag = "0"
+	// JaegerUnsampledTraceFlag is the trace-flag value for an unsampled trace.
+	JaegerUnsampledTraceFlag = "0"
 
-	// JaegerUnsampledTraceFlag is the trace-flag value for a sampled trace.
-	JaegerUnsampledTraceFlag = "1"
+	// JaegerSampledTraceFlag is the trace-flag value for a sampled trace.
+	JaegerSampledTraceFlag = "1"
 )
 
 // JaegerPropagator is a Propagator for the Jaeger trace context header

--- a/js/modules/k6/experimental/tracing/propagator_test.go
+++ b/js/modules/k6/experimental/tracing/propagator_test.go
@@ -1,0 +1,112 @@
+package tracing
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPropagate(t *testing.T) {
+	t.Parallel()
+
+	traceID := "abc123"
+
+	t.Run("W3C Propagator", func(t *testing.T) {
+		t.Parallel()
+
+		sampler := mockSampler{decision: true}
+		propagator := NewW3CPropagator(sampler)
+
+		gotHeader, gotErr := propagator.Propagate(traceID)
+
+		assert.NoError(t, gotErr)
+		assert.Contains(t, gotHeader, W3CHeaderName)
+
+		//nolint:staticcheck // as traceparent is not a canonical header
+		headerContent := gotHeader[W3CHeaderName][0]
+		assert.True(t, strings.HasPrefix(headerContent, W3CVersion+"-"+traceID+"-"))
+	})
+
+	t.Run("W3C propagator with sampled trace", func(t *testing.T) {
+		t.Parallel()
+
+		sampler := mockSampler{decision: true}
+		propagator := NewW3CPropagator(sampler)
+
+		gotHeader, gotErr := propagator.Propagate(traceID)
+		require.NoError(t, gotErr)
+		require.Contains(t, gotHeader, W3CHeaderName)
+
+		//nolint:staticcheck // as traceparent is not a canonical header
+		assert.True(t, strings.HasSuffix(gotHeader[W3CHeaderName][0], "-01"))
+	})
+
+	t.Run("W3C propagator with unsampled trace", func(t *testing.T) {
+		t.Parallel()
+
+		sampler := mockSampler{decision: false}
+		propagator := NewW3CPropagator(sampler)
+
+		gotHeader, gotErr := propagator.Propagate(traceID)
+		require.NoError(t, gotErr)
+		require.Contains(t, gotHeader, W3CHeaderName)
+
+		//nolint:staticcheck // as traceparent is not a canonical header
+		assert.True(t, strings.HasSuffix(gotHeader[W3CHeaderName][0], "-00"))
+	})
+
+	t.Run("Jaeger Propagator", func(t *testing.T) {
+		t.Parallel()
+
+		sampler := mockSampler{decision: true}
+		propagator := NewJaegerPropagator(sampler)
+
+		gotHeader, gotErr := propagator.Propagate(traceID)
+
+		assert.NoError(t, gotErr)
+		assert.Contains(t, gotHeader, JaegerHeaderName)
+
+		//nolint:staticcheck // as traceparent is not a canonical header
+		headerContent := gotHeader[JaegerHeaderName][0]
+		assert.True(t, strings.HasPrefix(headerContent, traceID+":"))
+		assert.True(t, strings.HasSuffix(headerContent, ":0:1"))
+	})
+
+	t.Run("Jaeger propagator with sampled trace", func(t *testing.T) {
+		t.Parallel()
+
+		sampler := mockSampler{decision: true}
+		propagator := NewJaegerPropagator(sampler)
+
+		gotHeader, gotErr := propagator.Propagate(traceID)
+		require.NoError(t, gotErr)
+		require.Contains(t, gotHeader, JaegerHeaderName)
+
+		//nolint:staticcheck // as traceparent is not a canonical header
+		assert.True(t, strings.HasSuffix(gotHeader[JaegerHeaderName][0], ":1"))
+	})
+
+	t.Run("Jaeger propagator with unsampled trace", func(t *testing.T) {
+		t.Parallel()
+
+		sampler := mockSampler{decision: false}
+		propagator := NewJaegerPropagator(sampler)
+
+		gotHeader, gotErr := propagator.Propagate(traceID)
+		require.NoError(t, gotErr)
+		require.Contains(t, gotHeader, JaegerHeaderName)
+
+		//nolint:staticcheck // as traceparent is not a canonical header
+		assert.True(t, strings.HasSuffix(gotHeader[JaegerHeaderName][0], ":0"))
+	})
+}
+
+type mockSampler struct {
+	decision bool
+}
+
+func (m mockSampler) ShouldSample() bool {
+	return m.decision
+}


### PR DESCRIPTION
## What?

This Pull Request contains a fix for the sample flags values being incorrect when using the tracing module's Jaeger propagator.

## Why?

As reported by @Blinkuu, the sampling option of the tracing module did not set the trace header flags correctly. That led to traces not being sampled, regardless of the options set on the `instrumentHTTP` called.

This was caused by the constant values defining the sampled/unsampled flags being inverted. This Pull Request sets their values back to their specified values. It also adds tests ensuring that we observe the correct flags from the propagators `Propagate` methods under various conditions.  

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#3212 
<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
