### PR TITLE
Quote image tag when tagging :latest-with-browser images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,7 +214,7 @@ jobs:
             echo "Publish to Docker Hub as $DOCKER_IMAGE_ID:latest"
             docker tag "$DOCKER_IMAGE_ID" "$DOCKER_IMAGE_ID:latest"
             docker push "$DOCKER_IMAGE_ID:latest"
-            docker tag "$DOCKER_IMAGE_ID:with-browser" $DOCKER_IMAGE_ID:latest-with-browser"
+            docker tag "$DOCKER_IMAGE_ID:with-browser" "$DOCKER_IMAGE_ID:latest-with-browser"
             docker push "$DOCKER_IMAGE_ID:latest-with-browser"
           fi
       - name: Build loadimpact/k6


### PR DESCRIPTION
## What?

Fixes a syntax error in the build pipeline that publishes built Docker images to Docker Hub.

## Why?

Current build pipeline is broken due to a syntax error. This prevents CI from pushing the `grafana/k6:latest-with-browser` images to Docker hub as well as legacy `loadimpact/k6`

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
