### PR TITLE
Refactor browser module test to run a fake cmd

### DIFF
--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -2200,7 +2200,7 @@ func TestBrowserPermissions(t *testing.T) {
 				},
 			}`,
 			expectedExitCode: 108,
-			expectedError:    "error building browser on IterStart: launching browser: exec: \"k6-browser-fake-cmd\": executable file not found in $PATH",
+			expectedError:    "error building browser on IterStart: launching browser: exec: \"k6-browser-fake-cmd\": executable file not found",
 		},
 	}
 


### PR DESCRIPTION
## What?

Instead of relying on a chrome instance being present on the dev/ci machine to verify that the correct browser options do indeed start a browser process and run the browser tests, we will instead rely on the browser module trying to start a fake command and ensure that the error message verifies that it attempted to start the fake command.

We also think that this is a useful feature to help avoid unnecessary issues for users who do not work with chrome on their dev machines or aren't working with the browser module.

## Why?

We're not able to run the browser module test on the arm test runner since it does not have chrome installed.

## Checklist

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

Related to the ARM runnier error here: https://github.com/grafana/k6/actions/runs/5806262818/job/15739071012
