### PR TITLE
Bump k6 version to v0.46

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.45.0"
+const Version = "0.46.0"
 
 // VersionDetails can be set externally as part of the build process
 var VersionDetails = "" //nolint:gochecknoglobals


### PR DESCRIPTION
## What?

This PR bumps the k6 binary version to version `v0.46`, as per the [release checklist](https://github.com/grafana/k6/issues/3138).


## Related PR(s)/Issue(s)

#3138 
#3246 