### PR TITLE
Add interfacebloat linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,6 +96,7 @@ linters:
     - govet
     - importas
     - ineffassign
+    - interfacebloat
     - lll
     - makezero
     - misspell

--- a/lib/executors.go
+++ b/lib/executors.go
@@ -55,6 +55,8 @@ type ExecutionStep struct {
 // TODO: make []ExecutionStep or []ExecutorConfig their own type?
 
 // ExecutorConfig is an interface that should be implemented by all executor config types
+//
+//nolint:interfacebloat // We don't have plan to split it.
 type ExecutorConfig interface {
 	Validate() []error
 

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -46,6 +46,11 @@ type VUActivationParams struct {
 //
 // TODO: Rename this to something more obvious? This name made sense a very long
 // time ago.
+//
+// interfacebloat: We may evaluate in the future to move out some methods;
+// but considering how central it is, it would require a huge effort.
+//
+//nolint:interfacebloat
 type Runner interface {
 	// Creates an Archive of the runner. There should be a corresponding NewFromArchive() function
 	// that will restore the runner from the archive.


### PR DESCRIPTION
## What?

Added `interfacebloat` linter as it is the unique linter currently disabled that we may want to enable.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes https://github.com/grafana/k6/issues/2715

<!-- Thanks for your contribution! 🙏🏼 -->
