### PR TITLE
Bump the golangci version

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.53.3
+# v1.54.1
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   deadline: 5m


### PR DESCRIPTION
Keep `golangci` up to date https://github.com/golangci/golangci-lint/releases/tag/v1.54.1 and ready for go1.21.