### PR TITLE
Improve release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -13,19 +13,21 @@ labels: ["release"]
 
 ### At the beginning of the cycle
 
-- [ ] Create a new `release-notes-v04x` branch and add a new release notes file using the available [template](release notes/template.md) to the [repository's `release notes` folder](/release notes).
+- [ ] Create a new `release-notes-v0.4x.0` branch and add a new release notes file using the available [template](release notes/template.md) to the [repository's `release notes` folder](/release notes).
 - [ ] Go through the potential [dependencies updates](Dependencies.md) and create a dedicated PR if any of them is relevant to this release.
 
 ### Release Preparation
 
 #### ~ 1 week before the release date.
 
-- [ ] Ensure all PRs in the k6-docs repository, related to new or modified functionalities introduced by the new version have been merged.
+- [ ] Ensure all PRs in the k6-docs repository, related to new or modified functionalities introduced by the new version have been created.
 - [ ] Ensure all PRs in the k6 repository, part of the current [milestone](https://github.com/grafana/k6/milestones), have been merged.
 - [ ] Open a PR with the release notes for the new version, and ask teams who might have contributed to the release (@k6-browser, @k6-chaos, @devrel teams, etc.) to contribute their notes and review the existing ones.
-- [ ] Share the release notes PR in the `#k6-oss-dev` internal slack channel, mentioning and asking for contributions of all the impacted teams (@k6-browser, @k6-chaos, @k6 devrel, and any other potential stakeholder of the new release).
+- [ ] Share the release notes PR with the k6 open-source teams. Request contributions from all affected teams (browser, chaos, devrel, docs, etc.) and any other stakeholders involved in the new release.
 - [ ] Open a separate PR for bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/9fa50b2d1f259cdccff5cc7bc18a236d31c345ac/lib/consts/consts.go#L11).
-- [ ] Open a PR in the `DefinitelyTyped/DefinitelyTyped` repository, updating k6 type definitions to fit the newly released version.
+- [ ] Create a dedicated branch for the upcoming version in the grafana/k6-DefinitelyTyped fork repository.
+- [ ] Open a PR in the DefinitelyTyped/DefinitelyTyped repository, using the branch created in the grafana/k6-DefinitelyTyped fork, to update the k6 type definitions for the new release.
+
 
 #### ~ 1 day before the release date.
 
@@ -51,7 +53,7 @@ labels: ["release"]
 #### Announcements
 
 - [ ] Publish a link to the new GitHub release in the #k6-changelog channel.
-- [ ] Notify the DevRel team in the #k6-devrel channel, letting them know that the release is published.
+- [ ] Notify the larger team in the #k6 channel, letting them know that the release is published.
 - [ ] Close the release's milestone.
 
 ## Wrapping Release

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -2,6 +2,7 @@
 name: k6 Release
 about: k6 release accommodates activities and a checklist with the k6 open-source release process.
 title: 'k6 release v0.4x.0'
+labels: ["release"]
 ---
 
 **Release Date**:
@@ -12,7 +13,7 @@ title: 'k6 release v0.4x.0'
 
 ### At the beginning of the cycle
 
-- [ ] Create a new `release-notes-v04x` branch and add a new [release notes file](release-template/release%20notes) using the available [template](release-template/release%20notes/template.md) to the [repository's `release notes` folder](https://github.com/grafana/k6/tree/cbd9e9ad184f19fdd84c7041f8084218ce4b738f/release%20notes).
+- [ ] Create a new `release-notes-v04x` branch and add a new release notes file using the available [template](release notes/template.md) to the [repository's `release notes` folder](/release notes).
 - [ ] Go through the potential [dependencies updates](Dependencies.md) and create a dedicated PR if any of them is relevant to this release.
 
 ### Release Preparation

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,10 +1,10 @@
 ---
-name: k6 Release 
-about: k6 release accommodates activities and a checklist that has the k6 open-source release process.
+name: k6 Release
+about: k6 release accommodates activities and a checklist with the k6 open-source release process.
 title: 'k6 release v0.4x.0'
 ---
 
-**Release Date**: 
+**Release Date**:
 
 25th May 2023 <<  TODO: WRITE HERE THE UPDATED RELEASE DATE
 
@@ -12,48 +12,48 @@ title: 'k6 release v0.4x.0'
 
 ### At the beginning of the cycle
 
-- [ ] Create a new branch `release-notes-v04x` and add a new related [release notes file](release-template/release%20notes) using the available [template](release-template/release%20notes/template.md).
-- [ ] Go through the potential [dependencies updates](Dependencies.md) then create a PR if any is relevant. 
+- [ ] Create a new `release-notes-v04x` branch and add a new [release notes file](release-template/release%20notes) using the available [template](release-template/release%20notes/template.md) to the [repository's `release notes` folder](https://github.com/grafana/k6/tree/cbd9e9ad184f19fdd84c7041f8084218ce4b738f/release%20notes).
+- [ ] Go through the potential [dependencies updates](Dependencies.md) and create a dedicated PR if any of them is relevant to this release.
 
 ### Release Preparation
 
-~ 1 week before the release date.
+#### ~ 1 week before the release date.
 
-- [ ] k6-docs PRs for all new or changed functionality have been created.
-- [ ] All PRs to the k6 repository in the current [milestone](https://github.com/grafana/k6/milestones) have been merged.
-- [ ] A pull request with the release notes and request the final reviews (including the @k6-browser, devrels folks).
-- [ ] Open a separate PR for bumping [the version](https://github.com/grafana/k6/blob/9fa50b2d1f259cdccff5cc7bc18a236d31c345ac/lib/consts/consts.go#L11).
-- [ ] The release notes PR shared in the `#k6-oss-dev` internal channel mentioning all the impacted teams (@k6-browser, @k6-chaos, @k6 devrel and any other potential stackholder of the new release).
-- [ ] `DefinitelyTyped/DefinitelyTyped` PR(s) is ready.
+- [ ] Ensure all PRs in the k6-docs repository, related to new or modified functionalities introduced by the new version have been merged.
+- [ ] Ensure all PRs in the k6 repository, part of the current [milestone](https://github.com/grafana/k6/milestones), have been merged.
+- [ ] Open a PR with the release notes for the new version, and ask teams who might have contributed to the release (@k6-browser, @k6-chaos, @devrel teams, etc.) to contribute their notes and review the existing ones.
+- [ ] Share the release notes PR in the `#k6-oss-dev` internal slack channel, mentioning and asking for contributions of all the impacted teams (@k6-browser, @k6-chaos, @k6 devrel, and any other potential stakeholder of the new release).
+- [ ] Open a separate PR for bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/9fa50b2d1f259cdccff5cc7bc18a236d31c345ac/lib/consts/consts.go#L11).
+- [ ] Open a PR in the `DefinitelyTyped/DefinitelyTyped` repository, updating k6 type definitions to fit the newly released version.
 
-~ 1 day before the release date.
+#### ~ 1 day before the release date.
 
-- [ ] PR for archiving the current k6's JavaScript [API version](https://github.com/grafana/k6-docs/wiki/Add-version-for-Javascript-API-documentation).
-- [ ] Check that the [Existing k6-docs PRs](https://github.com/grafana/k6-docs/pulls) related to the new functionality are reviewed and rebased and pointing to the branch with k6's JavaScript API archived.
- 
+- [ ] Open a PR in the k6-docs repository, archiving the current k6's JavaScript API version as per the following [instructions](https://github.com/grafana/k6-docs/wiki/Add-version-for-Javascript-API-documentation).
+- [ ] Ensure the [existing k6-docs PRs](https://github.com/grafana/k6-docs/pulls), related to the new functionalities and changes, are reviewed, up to date with the latest state of the `master` branch, and based upon the branch containing the k6 archived JavaScript API documentation (as created in the previous step).
+
 ### Release Day
 
 #### Documentation
 
-- [ ] The PR with archiving the old version JS API merged first and rebase the rest on top.
-- [ ] PRs with changes related to the release merged.
-- [ ] After merging all k6-docs' PRs ensure that we have no broken links by checking "Check broken links" job in GitHub actions. 
-- [ ] [The new Docs Release vX.Y.Z](https://github.com/grafana/k6-docs/releases/new) published.
-- [ ] Release Notes PR contains the right links to the docs.
+- [ ] Merge the k6-docs repository's Javascript API archiving PR and rebase the rest of the branches meant for the release on top of the new state of the `master` branch.
+- [ ] Merge all the k6-docs repository's branches containing changes related to the release.
+- [ ] Ensure the last resulting k6-docs GitHub action targetting the `main` branch sees its "Check broken links" job pass.
+- [ ] Publish the new [vX.Y.Z version of docs](https://github.com/grafana/k6-docs/releases/new).
+- [ ] Ensure the k6 repository release notes PR contains the correct links to the docs.
 
 #### In k6 repository
 
-- [ ] PR for bumping [the version](https://github.com/grafana/k6/blob/9fa50b2d1f259cdccff5cc7bc18a236d31c345ac/lib/consts/consts.go#L11) merged.
-- [ ] Release notes PR merged.
-- [ ] A new tag from the CLI `vX.Y.Z` created (`git tag v0.4x.0 -m "v0.4x.0"`) & pushed.
+- [ ] Merge the PR bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/9fa50b2d1f259cdccff5cc7bc18a236d31c345ac/lib/consts/consts.go#L11).
+- [ ] Merge the release notes PR.
+- [ ] Create and push a new tag of the form `vX.Y.Z` using git: `git tag v0.4x.0 -m "v0.4x.0"`.
 
 #### Announcements
 
-- [ ] A GitHub's link to the new release published in #k6-changelog.
-- [ ] DevRel team is notified in #k6-devrel that release is published.
-- [ ] The release's milestone closed.
+- [ ] Publish a link to the new GitHub release in the #k6-changelog channel.
+- [ ] Notify the DevRel team in the #k6-devrel channel, letting them know that the release is published.
+- [ ] Close the release's milestone.
 
 ## Wrapping Release
 
-- [ ] `DefinitelyTyped/DefinitelyTyped` PR(s) merged.
-- [ ] Update the k6's `.github/ISSUE_TEMPLATE/release.md` if new repeated steps appear.
+- [ ] Ensure the `DefinitelyTyped/DefinitelyTyped` PR(s) are merged.
+- [ ] Update the k6 repository's `.github/ISSUE_TEMPLATE/release.md` in the event steps from this checklist were incorrect or missing.


### PR DESCRIPTION
## What?

This PR fixes the grammar of the release checklist, and revamps it a bit to address the unclarities I experienced when using it for the `v0.46.0` release.

## Why?

The last item of the checklist is about bringing improvements to the checklist if possible, so I've given it a shot.
I found the language of the checklist could be improved to make it easier to read, and I experienced difficulties at times really understanding what I needed to do. Although I believe some further improvements would still be possible.

PS: I've also toyed with a much more concise and direct style, just like in aviation checklists, maybe that's even better?

```mardown
// ...

## Pre-Release - One Week Out

- [ ] Confirm merge: All k6-docs PRs with new/modified features for this version.
- [ ] Confirm merge: All k6 PRs for this [milestone](https://github.com/grafana/k6/milestones).
- [ ] Open release notes PR. Request contributions from relevant teams (@k6-browser, @k6-chaos, @devrel teams, etc.).
- [ ] Share notes PR in `#k6-oss-dev` Slack. Tag and request contributions from all impacted teams.
- [ ] PR: Bump [k6 Go project version](https://github.com/grafana/k6/blob/9fa50b2d1f259cdccff5cc7bc18a236d31c345ac/lib/consts/consts.go#L11).
- [ ] PR: Update k6 type definitions at `DefinitelyTyped/DefinitelyTyped`.

## Pre-Release - One Day Out

- [ ] PR: Archive k6's JavaScript API in k6-docs as per [instructions](https://github.com/grafana/k6-docs/wiki/Add-version-for-Javascript-API-documentation).
- [ ] Confirm k6-docs PRs for new features/changes are reviewed and updated.

// ...
```