### PR TITLE
Add browser migration guide link to the release notes

### DIFF
--- a/release notes/v0.46.0.md
+++ b/release notes/v0.46.0.md
@@ -11,7 +11,7 @@ k6 `v0.46` is here 🎉! This release includes:
 
 ### Browser
 
-In this release, the xk6-browser extension version is bumped up to `v1.0.2`, as it includes multiple breaking changes concerning options, browser lifecycle, and metrics.
+In this release, the xk6-browser extension version is bumped up to `v1.0.2`, as it includes multiple breaking changes concerning options, browser lifecycle, and metrics. See the [migration guide](https://k6.io/docs/using-k6-browser/migrating-to-k6-v0-46/) for making your test scripts compatible with the new version.
 
 **Options** `devtools`, `env` and `proxy` are deprecated ([browser#868](https://github.com/grafana/xk6-browser/pull/868), [browser#870](https://github.com/grafana/xk6-browser/pull/870), [browser#872](https://github.com/grafana/xk6-browser/pull/872)). Additionally, browser `launch`/`connect` options are no longer defined in the corresponding JS API methods, instead the test execution related options are now defined inside the browser scenario options (see [#3036](https://github.com/grafana/k6/pull/3036)), and the other more "environmental options", such as `headless`, `debug`, `executablePath`, are set as ENV vars. Also, the `slowMo` option is no longer supported, although it might be supported again in the future through a different API ([browser#876](https://github.com/grafana/xk6-browser/pull/876)).
 


### PR DESCRIPTION
Adds a link to the migration guide to make the switch easier to the new browser version.