### PR TITLE
refactor: moving issue-assigning logic to make it re-usable

### DIFF
--- a/.github/actions/issue-assigner/action.yml
+++ b/.github/actions/issue-assigner/action.yml
@@ -1,0 +1,34 @@
+name: assign-k6-maintainer
+description: Assign a k6 maintainer to an issue
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          const assignees = ['mstoykov', 'codebien', 'olegbespalov', 'oleiade'];
+          const assigneeCount = 1;
+
+          // Do not automatically assign users if someone was already assigned or it was opened by a maintainer
+          if (context.payload.issue.assignees.length > 0 || assignees.includes(context.payload.issue.user.login)) {
+            return;
+          }
+          const crypto = require("node:crypto");
+
+          const getNRandom = (n, array) => {
+            let result = new Array();
+            for (;n > 0 && array.length > 0; n--) {
+              const chosen = array[crypto.randomInt(array.length)];
+              result.push(chosen);
+              array = array.filter(el => el != chosen);
+            }
+            return result;
+          }
+
+          github.rest.issues.addAssignees({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.issue.number,
+            assignees: getNRandom(assigneeCount, assignees),
+          });

--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -10,31 +10,5 @@ jobs:
   assign-user:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
-        with:
-          script: |
-            const assignees = ['mstoykov', 'codebien', 'olegbespalov', 'oleiade'];
-            const assigneeCount = 1;
-
-            // Do not automatically assign users if someone was already assigned or it was opened by a maintainer
-            if (context.payload.issue.assignees.length > 0 || assignees.includes(context.payload.issue.user.login)) {
-              return;
-            }
-            const crypto = require("node:crypto");
-
-            const getNRandom = (n, array) => {
-              let result = new Array();
-              for (;n > 0 && array.length > 0; n--) {
-                const chosen = array[crypto.randomInt(array.length)];
-                result.push(chosen);
-                array = array.filter(el => el != chosen);
-              }
-              return result;
-            }
-
-            github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              assignees: getNRandom(assigneeCount, assignees),
-            });
+      - name: Assign k6's maintainer to issue
+        uses: ./.github/actions/issue-assigner/


### PR DESCRIPTION
## What?

Moving issue assigner logic to make it re-usable in another package.

## Why?

Hopefully, that way, we could have a single source of the truth for the issue assigned code, re-use this in our other repositories, while waiting for the better implementation of the codeowners.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->
