### PR TITLE
Deprecate prepending https:// in tries to load modules

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -199,8 +199,8 @@ func Load(
 			}
 		case moduleSpecifier.Scheme == "":
 			logger.Warningf(`The moduleSpecifier "%s" has no scheme but we will try to resolve it as remote module. `+
-				`This will be deprecated in the future and all remote modules will `+
-				`need to explicitly use "https" as scheme.`, originalModuleSpecifier)
+				`This is deprecated and will be removed in v0.48.0 - all remote modules will `+
+				`need to explicitly be prepended with "https://".`, originalModuleSpecifier)
 			*finalModuleSpecifierURL = *moduleSpecifier
 			finalModuleSpecifierURL.Scheme = scheme
 		default:


### PR DESCRIPTION
## What?

Change the message to make it explicit prepending `https://` to module specifiers is deprecated. 

## Why?

It was there only as that was how remote modules were only loadable before it was changed that full URLs are supported. 

As there have been 4 years and it seems like nobody is using this anymore, removing it removes some guessing and warning messages that mostly confuse users.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Part of #3287


