### PR TITLE
Log errors when executing setup and teardown via REST API

### DIFF
--- a/api/v1/setup_teardown_routes.go
+++ b/api/v1/setup_teardown_routes.go
@@ -71,6 +71,7 @@ func handleRunSetup(cs *ControlSurface, rw http.ResponseWriter, r *http.Request)
 	runner := cs.RunState.Runner
 
 	if err := cs.RunState.Runner.Setup(r.Context(), cs.Samples); err != nil {
+		cs.RunState.Logger.WithError(err).Error("Error executing setup")
 		apiError(rw, "Error executing setup", err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -81,6 +82,7 @@ func handleRunSetup(cs *ControlSurface, rw http.ResponseWriter, r *http.Request)
 // handleRunTeardown executes the runner's Teardown() method
 func handleRunTeardown(cs *ControlSurface, rw http.ResponseWriter, r *http.Request) {
 	if err := cs.RunState.Runner.Teardown(r.Context(), cs.Samples); err != nil {
+		cs.RunState.Logger.WithError(err).Error("Error executing teardown")
 		apiError(rw, "Error executing teardown", err.Error(), http.StatusInternalServerError)
 	}
 }


### PR DESCRIPTION
## What?

This PR adds error logging for setup and teardown functions invoked from REST API.

## Why?

Error logging is added to enhance visibility into errors during setup and teardown, aiding debugging.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #2422

<!-- Thanks for your contribution! 🙏🏼 -->
