### PR TITLE
release-template: Fix relative links

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -13,7 +13,7 @@ labels: ["release"]
 
 ### At the beginning of the cycle
 
-- [ ] Create a new `release-notes-v0.4x.0` branch and add a new release notes file using the available [template](release notes/template.md) to the [repository's `release notes` folder](/release notes).
+- [ ] Create a new `release-notes-v0.4x.0` branch and add a new release notes file using the available [template](/grafana/k6/tree/master/release%20notes/template.md) to the [repository's `release notes` folder](/grafana/k6/tree/master/release%20notes).
 - [ ] Go through the potential [dependencies updates](Dependencies.md) and create a dedicated PR if any of them is relevant to this release.
 
 ### Release Preparation


### PR DESCRIPTION
It fixes the relative links for the release notes item of the release template.

An example: https://github.com/grafana/k6/issues/3274