### PR TITLE
feat: command extension type support

### DIFF
--- a/cmd/extensions.go
+++ b/cmd/extensions.go
@@ -1,0 +1,16 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"go.k6.io/k6/cmd/state"
+	"go.k6.io/k6/ext"
+)
+
+// Constructor returns an instance of a command extension module.
+type Constructor func(*state.GlobalState) (*cobra.Command, error)
+
+// RegisterExtension registers the given command extension constructor. This
+// function panics if a module with the same name is already registered.
+func RegisterExtension(name string, c Constructor) {
+	ext.Register(name, ext.CommandExtension, c)
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -7,12 +7,15 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/cmd/tests"
 	"go.k6.io/k6/errext/exitcodes"
+	"go.k6.io/k6/ext"
 	"go.k6.io/k6/lib/testutils"
 )
 
 func TestMain(m *testing.M) {
+	RegisterExtension(testCommandExtensionName, testCommandExtension)
 	tests.Main(m)
 }
 
@@ -61,3 +64,97 @@ func TestPanicHandling(t *testing.T) {
 	assert.True(t, testutils.LogContains(logMsgs, logrus.ErrorLevel, "unexpected k6 panic: oh no"))
 	assert.True(t, testutils.LogContains(logMsgs, logrus.ErrorLevel, "cmd.TestPanicHandling")) // check stacktrace
 }
+
+func TestCommandExtensionHandling(t *testing.T) {
+	t.Parallel()
+
+	ts := tests.NewGlobalTestState(t)
+	ts.CmdArgs = []string{"k6", testCommandExtensionName}
+	ts.ExpectedExitCode = 0
+
+	rootCmd := newRootCommand(ts.GlobalState)
+	rootCmd.execute()
+
+	t.Log(ts.Stderr.String())
+	logMsgs := ts.LoggerHook.Drain()
+	assert.True(t, testutils.LogContains(logMsgs, logrus.InfoLevel, "Hello Extension Command!"))
+}
+
+func Test_getCommandExtensions(t *testing.T) {
+	t.Parallel()
+
+	ts := tests.NewGlobalTestState(t)
+	ts.CmdArgs = []string{"k6", "foo"}
+	ts.ExpectedExitCode = 0
+
+	rootCmd := newRootCommand(ts.GlobalState)
+
+	all := ext.Get(ext.CommandExtension)
+
+	exts := map[string]*ext.Extension{
+		"bar": all[testCommandExtensionName],
+	}
+
+	exts["bar"].Name = "bar"
+
+	ctors, err := getCommandExtensions(rootCmd.cmd, exts)
+
+	assert.NoError(t, err)
+	assert.NotEmpty(t, ctors)
+	assert.Len(t, ctors, 1)
+}
+
+func Test_getCommandExtensions_Error_builtin(t *testing.T) {
+	t.Parallel()
+
+	ts := tests.NewGlobalTestState(t)
+	ts.CmdArgs = []string{"k6", "dummy"}
+	ts.ExpectedExitCode = 0
+
+	rootCmd := newRootCommand(ts.GlobalState)
+
+	ver := getCmdVersion(ts.GlobalState)
+	ver.Use = testCommandExtensionName
+	rootCmd.cmd.AddCommand(ver)
+
+	_, err := getCommandExtensions(rootCmd.cmd, ext.Get(ext.CommandExtension))
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "built-in command with the same name already exists")
+}
+
+func Test_getCommandExtensions_Error_invalid_ctor(t *testing.T) {
+	t.Parallel()
+
+	ts := tests.NewGlobalTestState(t)
+	ts.CmdArgs = []string{"k6", "dummy"}
+	ts.ExpectedExitCode = 0
+
+	rootCmd := newRootCommand(ts.GlobalState)
+
+	exts := map[string]*ext.Extension{
+		"foo": {
+			Name:    "foo",
+			Path:    "",
+			Version: "",
+			Type:    ext.CommandExtension,
+			Module:  TestMain,
+		},
+	}
+
+	_, err := getCommandExtensions(rootCmd.cmd, exts)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected command extension type")
+}
+
+func testCommandExtension(gs *state.GlobalState) (*cobra.Command, error) {
+	return &cobra.Command{
+		Use: testCommandExtensionName,
+		Run: func(cmd *cobra.Command, args []string) {
+			gs.Logger.Info("Hello Extension Command!")
+		},
+	}, nil
+}
+
+const testCommandExtensionName = "command-from-extension"

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -25,6 +25,7 @@ type ExtensionType uint8
 const (
 	JSExtension ExtensionType = iota + 1
 	OutputExtension
+	CommandExtension
 )
 
 func (e ExtensionType) String() string {
@@ -34,6 +35,8 @@ func (e ExtensionType) String() string {
 		s = "js"
 	case OutputExtension:
 		s = "output"
+	case CommandExtension:
+		s = "command"
 	}
 	return s
 }
@@ -100,13 +103,16 @@ func GetAll() []*Extension {
 	mx.RLock()
 	defer mx.RUnlock()
 
-	js, out := extensions[JSExtension], extensions[OutputExtension]
-	result := make([]*Extension, 0, len(js)+len(out))
+	js, out, cmd := extensions[JSExtension], extensions[OutputExtension], extensions[CommandExtension]
+	result := make([]*Extension, 0, len(js)+len(out)+len(cmd))
 
 	for _, e := range js {
 		result = append(result, e)
 	}
 	for _, e := range out {
+		result = append(result, e)
+	}
+	for _, e := range cmd {
 		result = append(result, e)
 	}
 
@@ -157,4 +163,5 @@ func extractModuleInfo(mod interface{}) (path, version string) {
 func init() {
 	extensions[JSExtension] = make(map[string]*Extension)
 	extensions[OutputExtension] = make(map[string]*Extension)
+	extensions[CommandExtension] = make(map[string]*Extension)
 }


### PR DESCRIPTION
## What?

Add command extension type support to k6. 

## Why?

It would be advisable to occasionally expand the k6 command with functionalities not directly related to test execution. These additional functionalities could be included in the k6 binary in the form of an extension.

A Command extension could be introduced along the lines of JavaScript and the Output extension, which would make it possible to extend the k6 command line with new sub-commands.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/issues/3292

Closes #3292

