### PR TITLE
cloudv2: Higher resolution for Histograms

### DIFF
--- a/output/cloud/expv2/hdr.go
+++ b/output/cloud/expv2/hdr.go
@@ -28,7 +28,8 @@ const (
 // of metrics samples' values as histogram.
 //
 // The histogram is the representation of base-2 exponential Histogram with two layers.
-// The first layer has primary buckets in the form of a power of two, and a second layer of buckets for each primary bucket with an equally distributed amount of buckets inside.
+// The first layer has primary buckets in the form of a power of two, and a second layer of buckets
+// for each primary bucket with an equally distributed amount of buckets inside.
 //
 // The histogram has a series of (N * 2^m) buckets, where:
 // N = a power of 2 that defines the number of primary buckets

--- a/output/cloud/expv2/hdr.go
+++ b/output/cloud/expv2/hdr.go
@@ -28,8 +28,7 @@ const (
 // of metrics samples' values as histogram.
 //
 // The histogram is the representation of base-2 exponential Histogram with two layers.
-// The first layer has primary buckets in the form of a power of two, and a second layer of buckets
-// for each primary bucket with an equally distributed amount of buckets inside.
+// The first layer has primary buckets in the form of a power of two, and a second layer of buckets for each primary bucket with an equally distributed amount of buckets inside.
 //
 // The histogram has a series of (N * 2^m) buckets, where:
 // N = a power of 2 that defines the number of primary buckets
@@ -91,12 +90,12 @@ func (h *histogram) addToBucket(v float64) {
 
 	v /= h.MinimumResolution
 
-	if v > math.MaxInt64 {
-		h.ExtraHighBucket++
-		return
-	}
 	if v < lowestTrackable {
 		h.ExtraLowBucket++
+		return
+	}
+	if v > math.MaxInt64 {
+		h.ExtraHighBucket++
 		return
 	}
 

--- a/output/cloud/expv2/hdr_test.go
+++ b/output/cloud/expv2/hdr_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/output/cloud/expv2/pbcloud"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -33,12 +34,24 @@ func TestResolveBucketIndex(t *testing.T) {
 		{in: 282.29, exp: 269},
 		{in: 1029, exp: 512},
 		{in: 39751, exp: 1179},
+		{in: 100000, exp: 1347},
+		{in: 182272, exp: 1458},
+		{in: 183000, exp: 1458},
+		{in: 184000, exp: 1459},
+		{in: 200000, exp: 1475},
+
+		{in: 1 << 20, exp: 1792},
 		{in: (1 << 30) - 1, exp: 3071},
-		{in: (1 << 30), exp: 3072},
-		{in: math.MaxInt32, exp: 3199},
+		{in: 1 << 30, exp: 3072},
+		{in: 1 << 40, exp: 4352},
+		{in: 1 << 62, exp: 7168},
+
+		{in: math.MaxInt32, exp: 3199},  // 2B
+		{in: math.MaxUint32, exp: 3327}, // 4B
+		{in: math.MaxInt64, exp: 7296},  // Huge number // 9.22...e+18
 	}
 	for _, tc := range tests {
-		assert.Equal(t, tc.exp, resolveBucketIndex(tc.in), tc.in)
+		assert.Equal(t, int(tc.exp), int(resolveBucketIndex(tc.in)), tc.in)
 	}
 }
 
@@ -116,9 +129,11 @@ func TestHistogramAddWithSimpleValues(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			h := newHistogram()
+			h.MinimumResolution = 1.0
 			for _, v := range tc.vals {
 				h.Add(v)
 			}
+			tc.exp.MinimumResolution = 1.0
 			assert.Equal(t, &tc.exp, h)
 		})
 	}
@@ -128,18 +143,20 @@ func TestHistogramAddWithUntrackables(t *testing.T) {
 	t.Parallel()
 
 	h := newHistogram()
-	for _, v := range []float64{5, -3.14, 2 * 1e9, 1} {
+	h.MinimumResolution = 1.0
+	for _, v := range []float64{5, -3.14, 1<<62 + 1, 1} {
 		h.Add(v)
 	}
 
 	exp := &histogram{
-		Buckets:         map[uint32]uint32{1: 1, 5: 1},
-		ExtraLowBucket:  1,
-		ExtraHighBucket: 1,
-		Max:             2 * 1e9,
-		Min:             -3.14,
-		Sum:             2*1e9 + 5 + 1 - 3.14,
-		Count:           4,
+		Buckets:           map[uint32]uint32{1: 1, 5: 1},
+		ExtraLowBucket:    1,
+		ExtraHighBucket:   1,
+		Max:               1 << 62,
+		Min:               -3.14,
+		Sum:               1<<62 + 1 + 5 + 1 - 3.14,
+		Count:             4,
+		MinimumResolution: 1.0,
 	}
 	assert.Equal(t, exp, h)
 }
@@ -148,6 +165,7 @@ func TestHistogramAddWithMultipleOccurances(t *testing.T) {
 	t.Parallel()
 
 	h := newHistogram()
+	h.MinimumResolution = 1.0
 	for _, v := range []float64{51.8, 103.6, 103.6, 103.6, 103.6} {
 		h.Add(v)
 	}
@@ -161,6 +179,7 @@ func TestHistogramAddWithMultipleOccurances(t *testing.T) {
 		Sum:             466.20000000000005,
 		Count:           5,
 	}
+	exp.MinimumResolution = 1.0
 	assert.Equal(t, exp, h)
 }
 
@@ -168,16 +187,18 @@ func TestHistogramAddWithNegativeNum(t *testing.T) {
 	t.Parallel()
 
 	h := newHistogram()
+	h.MinimumResolution = 1.0
 	h.Add(-2.42314)
 
 	exp := &histogram{
-		Max:             -2.42314,
-		Min:             -2.42314,
-		Buckets:         map[uint32]uint32{},
-		ExtraLowBucket:  1,
-		ExtraHighBucket: 0,
-		Sum:             -2.42314,
-		Count:           1,
+		Max:               -2.42314,
+		Min:               -2.42314,
+		Buckets:           map[uint32]uint32{},
+		ExtraLowBucket:    1,
+		ExtraHighBucket:   0,
+		Sum:               -2.42314,
+		Count:             1,
+		MinimumResolution: 1.0,
 	}
 	assert.Equal(t, exp, h)
 }
@@ -185,33 +206,57 @@ func TestHistogramAddWithNegativeNum(t *testing.T) {
 func TestHistogramAddWithMultipleNegativeNums(t *testing.T) {
 	t.Parallel()
 	h := newHistogram()
+	h.MinimumResolution = 1.0
 	for _, v := range []float64{-0.001, -0.001, -0.001} {
 		h.Add(v)
 	}
 
 	exp := &histogram{
-		Buckets:         map[uint32]uint32{},
-		ExtraLowBucket:  3,
-		ExtraHighBucket: 0,
-		Max:             -0.001,
-		Min:             -0.001,
-		Sum:             -0.003,
-		Count:           3,
+		Buckets:           map[uint32]uint32{},
+		ExtraLowBucket:    3,
+		ExtraHighBucket:   0,
+		Max:               -0.001,
+		Min:               -0.001,
+		Sum:               -0.003,
+		Count:             3,
+		MinimumResolution: 1.0,
+	}
+	h.MinimumResolution = 1.0
+	assert.Equal(t, exp, h)
+}
+
+func TestHistogramAddWithZeroToOneValues(t *testing.T) {
+	t.Parallel()
+	h := newHistogram()
+	for _, v := range []float64{0.000052, 0.002115, 0.012013, 0.05017, 0.250, 0.54, 0.541, 0.803} {
+		h.Add(v)
+	}
+
+	exp := &histogram{
+		Buckets:           map[uint32]uint32{1: 1, 3: 1, 13: 1, 51: 1, 250: 1, 391: 2, 456: 1},
+		ExtraLowBucket:    0,
+		ExtraHighBucket:   0,
+		Max:               .803,
+		Min:               .000052,
+		Sum:               2.19835,
+		Count:             8,
+		MinimumResolution: .001,
 	}
 	assert.Equal(t, exp, h)
 }
 
-func TestNewHistoramWithNoVals(t *testing.T) {
+func TestNewHistoram(t *testing.T) {
 	t.Parallel()
 
 	h := newHistogram()
 	exp := &histogram{
-		Buckets:         map[uint32]uint32{},
-		ExtraLowBucket:  0,
-		ExtraHighBucket: 0,
-		Max:             -math.MaxFloat64,
-		Min:             math.MaxFloat64,
-		Sum:             0,
+		Buckets:           map[uint32]uint32{},
+		ExtraLowBucket:    0,
+		ExtraHighBucket:   0,
+		Max:               -math.MaxFloat64,
+		Min:               math.MaxFloat64,
+		Sum:               0,
+		MinimumResolution: 0.001,
 	}
 	assert.Equal(t, exp, h)
 }
@@ -224,20 +269,21 @@ func TestHistogramAsProto(t *testing.T) {
 	}
 
 	cases := []struct {
-		name string
-		vals []float64
-		exp  *pbcloud.TrendHdrValue
+		name          string
+		vals          []float64
+		minResolution float64
+		exp           *pbcloud.TrendHdrValue
 	}{
 		{
-			name: "empty histogram",
+			name: "EmptyHistogram",
 			exp: &pbcloud.TrendHdrValue{
 				MaxValue: -math.MaxFloat64,
 				MinValue: math.MaxFloat64,
 			},
 		},
 		{
-			name: "not trackable values",
-			vals: []float64{-0.23, 1<<30 + 1},
+			name: "UntrackableValues",
+			vals: []float64{-0.23, 1<<62 + 1},
 			exp: &pbcloud.TrendHdrValue{
 				ExtraLowValuesCounter:  uint32ptr(1),
 				ExtraHighValuesCounter: uint32ptr(1),
@@ -245,12 +291,12 @@ func TestHistogramAsProto(t *testing.T) {
 				Spans:                  nil,
 				Count:                  2,
 				MinValue:               -0.23,
-				MaxValue:               1<<30 + 1,
-				Sum:                    (1 << 30) + 1 - 0.23,
+				MaxValue:               1<<62 + 1,
+				Sum:                    (1 << 62) + 1 - 0.23,
 			},
 		},
 		{
-			name: "normal values",
+			name: "SimpleValues",
 			vals: []float64{7, 8, 9, 11, 12, 11.5, 10.5},
 			exp: &pbcloud.TrendHdrValue{
 				Count:                  7,
@@ -267,7 +313,7 @@ func TestHistogramAsProto(t *testing.T) {
 			},
 		},
 		{
-			name: "with Zero-point values",
+			name: "WithZeroPointValues",
 			vals: []float64{2, 0.01, 3},
 			exp: &pbcloud.TrendHdrValue{
 				Count:                  3,
@@ -286,7 +332,7 @@ func TestHistogramAsProto(t *testing.T) {
 			},
 		},
 		{
-			name: "a basic case",
+			name: "VeryBasic",
 			vals: []float64{2, 1.1, 3},
 			exp: &pbcloud.TrendHdrValue{
 				Count:                  3,
@@ -305,7 +351,7 @@ func TestHistogramAsProto(t *testing.T) {
 			},
 		},
 		{
-			name: "longer sequence",
+			name: "LongerSequence",
 			vals: []float64{
 				2275, 52.25, 268.85, 383.47, 18.49,
 				163.85, 4105, 835.27, 52, 18.28, 238.44, 39751, 18.86,
@@ -343,18 +389,79 @@ func TestHistogramAsProto(t *testing.T) {
 				Sum:                    56153.280000000006,
 			},
 		},
+		{
+			name: "Unrealistic",
+			vals: []float64{math.MaxUint32},
+			exp: &pbcloud.TrendHdrValue{
+				Count:                  1,
+				ExtraLowValuesCounter:  nil,
+				ExtraHighValuesCounter: nil,
+				Counters:               []uint32{1},
+				Spans: []*pbcloud.BucketSpan{
+					{
+						Offset: 3327,
+						Length: 1,
+					},
+				},
+				MinValue: math.MaxUint32,
+				MaxValue: math.MaxUint32,
+				Sum:      math.MaxUint32,
+			},
+		},
+		{
+			name:          "DefaultMinimumResolution",
+			vals:          []float64{200, 100, 200.1},
+			minResolution: .001,
+			exp: &pbcloud.TrendHdrValue{
+				Count:                  3,
+				ExtraLowValuesCounter:  nil,
+				ExtraHighValuesCounter: nil,
+				MinResolution:          float64ptr(defaultMinimumResolution),
+				Counters:               []uint32{1, 2},
+				Spans: []*pbcloud.BucketSpan{
+					{
+						Offset: 1347,
+						Length: 1,
+					},
+					{
+						Offset: 127,
+						Length: 1,
+					},
+				},
+				MinValue: 100,
+				MaxValue: 200.1,
+				Sum:      500.1,
+			},
+		},
 	}
 
-	for i, tc := range cases {
+	for _, tc := range cases {
 		tc := tc
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
+
 			h := newHistogram()
+			// TODO: refactor
+			// An hack for preserving as the default for the tests the old value 1.0
+			if tc.minResolution == 0 {
+				tc.minResolution = 1.0
+				tc.exp.MinResolution = float64ptr(1.0)
+			}
+			h.MinimumResolution = tc.minResolution
+
 			for _, v := range tc.vals {
 				h.Add(v)
 			}
 			tc.exp.Time = &timestamppb.Timestamp{Seconds: 1}
-			assert.Equal(t, tc.exp, histogramAsProto(h, time.Unix(1, 0).UnixNano()), tc.name)
+			hproto := histogramAsProto(h, time.Unix(1, 0).UnixNano())
+			require.Equal(t, tc.exp.Count, hproto.Count)
+			require.Equal(t, tc.exp.Counters, hproto.Counters)
+			require.Equal(t, len(tc.exp.Spans), len(hproto.Spans))
+			assert.Equal(t, tc.exp, hproto, tc.name)
 		})
 	}
+}
+
+func float64ptr(n float64) *float64 {
+	return &n
 }

--- a/output/cloud/expv2/integration/testdata/metricset.json
+++ b/output/cloud/expv2/integration/testdata/metricset.json
@@ -94,13 +94,14 @@
                 ],
                 "spans": [
                   {
-                    "offset": 6,
+                    "offset": 827,
                     "length": 1
                   }
                 ],
                 "maxValue": 6,
                 "minValue": 6,
-                "sum": 6
+                "sum": 6,
+                "minResolution": 0.001
               }
             ]
           }


### PR DESCRIPTION
## What?

It expands the resolution for Histograms, setting `0.001` as the minimum resolution.

## Why?

It allows us to support decimal numbers up to 3 digits, increasing the detail of the values that we can store.