### PR TITLE
[fs] Add `file.read` and `file.seek` methods to the `fs` module (2/3)

### DIFF
--- a/examples/experimental/fs/fs.js
+++ b/examples/experimental/fs/fs.js
@@ -1,20 +1,52 @@
-import { open } from "k6/experimental/fs";
+import { open, SeekMode } from "k6/experimental/fs";
 
 export const options = {
 	vus: 100,
 	iterations: 1000,
 };
 
-// As k6 does not support asynchronous code in the init context, yet, we need to
-// use a top-level async function to be able to use the `await` keyword.
+// k6 doesn't support async in the init context. We use a top-level async function for `await`.
+//
+// Each Virtual User gets its own `file` copy.
+// So, operations like `seek` or `read` won't impact other VUs.
 let file;
 (async function () {
 	file = await open("bonjour.txt");
 })();
 
 export default async function () {
+	// About information about the file
 	const fileinfo = await file.stat();
 	if (fileinfo.name != "bonjour.txt") {
 		throw new Error("Unexpected file name");
 	}
+
+	const buffer = new Uint8Array(4);
+
+	let totalBytesRead = 0;
+	while (true) {
+		// Read into the buffer
+		const bytesRead = await file.read(buffer);
+		if (bytesRead == null) {
+			// EOF
+			break;
+		}
+
+		// Do something useful with the content of the buffer
+
+		totalBytesRead += bytesRead;
+
+		// If bytesRead is less than the buffer size, we've read the whole file
+		if (bytesRead < buffer.byteLength) {
+			break;
+		}
+	}
+
+	// Check that we read the expected number of bytes
+	if (totalBytesRead != fileinfo.size) {
+		throw new Error("Unexpected number of bytes read");
+	}
+
+	// Seek back to the beginning of the file
+	await file.seek(0, SeekMode.Start);
 }

--- a/js/modules/k6/experimental/fs/errors.go
+++ b/js/modules/k6/experimental/fs/errors.go
@@ -34,6 +34,9 @@ const (
 
 	// TypeError is emitted when an incorrect type has been used.
 	TypeError
+
+	// EOFError is emitted when the end of a file has been reached.
+	EOFError
 )
 
 // fsError represents a custom error object emitted by the fs module.

--- a/js/modules/k6/experimental/fs/errors_gen.go
+++ b/js/modules/k6/experimental/fs/errors_gen.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _errorKindName = "NotFoundErrorInvalidResourceErrorForbiddenErrorTypeError"
+const _errorKindName = "NotFoundErrorInvalidResourceErrorForbiddenErrorTypeErrorEOFError"
 
-var _errorKindIndex = [...]uint8{0, 13, 33, 47, 56}
+var _errorKindIndex = [...]uint8{0, 13, 33, 47, 56, 64}
 
-const _errorKindLowerName = "notfounderrorinvalidresourceerrorforbiddenerrortypeerror"
+const _errorKindLowerName = "notfounderrorinvalidresourceerrorforbiddenerrortypeerroreoferror"
 
 func (i errorKind) String() string {
 	i -= 1
@@ -29,9 +29,10 @@ func _errorKindNoOp() {
 	_ = x[InvalidResourceError-(2)]
 	_ = x[ForbiddenError-(3)]
 	_ = x[TypeError-(4)]
+	_ = x[EOFError-(5)]
 }
 
-var _errorKindValues = []errorKind{NotFoundError, InvalidResourceError, ForbiddenError, TypeError}
+var _errorKindValues = []errorKind{NotFoundError, InvalidResourceError, ForbiddenError, TypeError, EOFError}
 
 var _errorKindNameToValueMap = map[string]errorKind{
 	_errorKindName[0:13]:       NotFoundError,
@@ -42,6 +43,8 @@ var _errorKindNameToValueMap = map[string]errorKind{
 	_errorKindLowerName[33:47]: ForbiddenError,
 	_errorKindName[47:56]:      TypeError,
 	_errorKindLowerName[47:56]: TypeError,
+	_errorKindName[56:64]:      EOFError,
+	_errorKindLowerName[56:64]: EOFError,
 }
 
 var _errorKindNames = []string{
@@ -49,6 +52,7 @@ var _errorKindNames = []string{
 	_errorKindName[13:33],
 	_errorKindName[33:47],
 	_errorKindName[47:56],
+	_errorKindName[56:64],
 }
 
 // errorKindString retrieves an enum value from the enum constants string name.

--- a/js/modules/k6/experimental/fs/file.go
+++ b/js/modules/k6/experimental/fs/file.go
@@ -62,3 +62,66 @@ func (f *file) Read(into []byte) (n int, err error) {
 
 // Ensure that `file` implements the io.Reader interface.
 var _ io.Reader = (*file)(nil)
+
+// Seek sets the offset for the next operation on the file, under the mode given by `whence`.
+//
+// `offset` indicates the number of bytes to move the offset. Based on
+// the `whence` parameter, the offset is set relative to the start,
+// current offset or end of the file.
+//
+// When using SeekModeStart, the offset must be positive.
+// Negative offsets are allowed when using `SeekModeCurrent` or `SeekModeEnd`.
+func (f *file) Seek(offset int, whence SeekMode) (int, error) {
+	newOffset := f.offset
+
+	switch whence {
+	case SeekModeStart:
+		if offset < 0 {
+			return 0, newFsError(TypeError, "offset cannot be negative when using SeekModeStart")
+		}
+
+		newOffset = offset
+	case SeekModeCurrent:
+		newOffset += offset
+	case SeekModeEnd:
+		if offset > 0 {
+			return 0, newFsError(TypeError, "offset cannot be positive when using SeekModeEnd")
+		}
+
+		newOffset = len(f.data) + offset
+	default:
+		return 0, newFsError(TypeError, "invalid seek mode")
+	}
+
+	if newOffset < 0 {
+		return 0, newFsError(TypeError, "seeking before start of file")
+	}
+
+	if newOffset > len(f.data) {
+		return 0, newFsError(TypeError, "seeking beyond end of file")
+	}
+
+	// Note that the implementation assumes one `file` instance per file/vu.
+	// If that assumption was invalidated, we would need to atomically update
+	// the offset instead.
+	f.offset = newOffset
+
+	return newOffset, nil
+}
+
+// SeekMode is used to specify the seek mode when seeking in a file.
+type SeekMode = int
+
+const (
+	// SeekModeStart sets the offset relative to the start of the file.
+	SeekModeStart SeekMode = iota + 1
+
+	// SeekModeCurrent seeks relative to the current offset.
+	SeekModeCurrent
+
+	// SeekModeEnd seeks relative to the end of the file.
+	//
+	// When using this mode the seek operation will move backwards from
+	// the end of the file.
+	SeekModeEnd
+)

--- a/js/modules/k6/experimental/fs/file.go
+++ b/js/modules/k6/experimental/fs/file.go
@@ -3,6 +3,9 @@ package fs
 import (
 	"io"
 	"path/filepath"
+	"sync/atomic"
+
+	"go.k6.io/k6/lib"
 )
 
 // file is an abstraction for interacting with files.
@@ -13,7 +16,11 @@ type file struct {
 	data []byte
 
 	// offset holds the current offset in the file
-	offset int
+	//
+	// TODO: using an atomic here does not guarantee ordering of reads and seeks, and leaves
+	// the behavior not strictly defined. This is something we might want to address in the future, and
+	// is tracked as part of #3433.
+	offset atomic.Int64
 }
 
 // Stat returns a FileInfo describing the named file.
@@ -38,24 +45,27 @@ type FileInfo struct {
 //
 // If the end of the file has been reached, it returns EOFError.
 func (f *file) Read(into []byte) (n int, err error) {
-	start := f.offset
-	if start == len(f.data) {
+	currentOffset := f.offset.Load()
+	fileSize := f.size()
+
+	// Check if we have reached the end of the file
+	if currentOffset == fileSize {
 		return 0, newFsError(EOFError, "EOF")
 	}
 
-	end := f.offset + len(into)
-	if end > len(f.data) {
-		end = len(f.data)
-		// We align with the [io.Reader.Read] method's behavior
-		// and return EOFError when we reach the end of the
-		// file, regardless of how much data we were able to
-		// read.
+	// Calculate the effective new offset
+	targetOffset := currentOffset + int64(len(into))
+	newOffset := lib.Min(targetOffset, fileSize)
+
+	// Read the data into the provided slice, and update
+	// the offset accordingly
+	n = copy(into, f.data[currentOffset:newOffset])
+	f.offset.Store(newOffset)
+
+	// If we've reached or surpassed the end, set the error to EOF
+	if targetOffset > fileSize {
 		err = newFsError(EOFError, "EOF")
 	}
-
-	n = copy(into, f.data[start:end])
-
-	f.offset += n
 
 	return n, err
 }
@@ -71,9 +81,10 @@ var _ io.Reader = (*file)(nil)
 //
 // When using SeekModeStart, the offset must be positive.
 // Negative offsets are allowed when using `SeekModeCurrent` or `SeekModeEnd`.
-func (f *file) Seek(offset int, whence SeekMode) (int, error) {
-	newOffset := f.offset
+func (f *file) Seek(offset int64, whence SeekMode) (int64, error) {
+	startingOffset := f.offset.Load()
 
+	newOffset := startingOffset
 	switch whence {
 	case SeekModeStart:
 		if offset < 0 {
@@ -88,7 +99,7 @@ func (f *file) Seek(offset int, whence SeekMode) (int, error) {
 			return 0, newFsError(TypeError, "offset cannot be positive when using SeekModeEnd")
 		}
 
-		newOffset = len(f.data) + offset
+		newOffset = f.size() + offset
 	default:
 		return 0, newFsError(TypeError, "invalid seek mode")
 	}
@@ -97,17 +108,17 @@ func (f *file) Seek(offset int, whence SeekMode) (int, error) {
 		return 0, newFsError(TypeError, "seeking before start of file")
 	}
 
-	if newOffset > len(f.data) {
+	if newOffset > f.size() {
 		return 0, newFsError(TypeError, "seeking beyond end of file")
 	}
 
-	// Note that the implementation assumes one `file` instance per file/vu.
-	// If that assumption was invalidated, we would need to atomically update
-	// the offset instead.
-	f.offset = newOffset
+	// Update the file instance's offset to the new selected position
+	f.offset.Store(newOffset)
 
 	return newOffset, nil
 }
+
+var _ io.Seeker = (*file)(nil)
 
 // SeekMode is used to specify the seek mode when seeking in a file.
 type SeekMode = int
@@ -125,3 +136,7 @@ const (
 	// the end of the file.
 	SeekModeEnd
 )
+
+func (f *file) size() int64 {
+	return int64(len(f.data))
+}

--- a/js/modules/k6/experimental/fs/file.go
+++ b/js/modules/k6/experimental/fs/file.go
@@ -125,16 +125,16 @@ type SeekMode = int
 
 const (
 	// SeekModeStart sets the offset relative to the start of the file.
-	SeekModeStart SeekMode = iota + 1
+	SeekModeStart SeekMode = 0
 
 	// SeekModeCurrent seeks relative to the current offset.
-	SeekModeCurrent
+	SeekModeCurrent = 1
 
 	// SeekModeEnd seeks relative to the end of the file.
 	//
 	// When using this mode the seek operation will move backwards from
 	// the end of the file.
-	SeekModeEnd
+	SeekModeEnd = 2
 )
 
 func (f *file) size() int64 {

--- a/js/modules/k6/experimental/fs/file.go
+++ b/js/modules/k6/experimental/fs/file.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"io"
 	"path/filepath"
 )
 
@@ -10,6 +11,9 @@ type file struct {
 
 	// data holds a pointer to the file's data
 	data []byte
+
+	// offset holds the current offset in the file
+	offset int
 }
 
 // Stat returns a FileInfo describing the named file.
@@ -26,3 +30,35 @@ type FileInfo struct {
 	// Size holds the size of the file in bytes.
 	Size int `json:"size"`
 }
+
+// Read reads up to len(into) bytes into the provided byte slice.
+//
+// It returns the number of bytes read (0 <= n <= len(into)) and any error
+// encountered.
+//
+// If the end of the file has been reached, it returns EOFError.
+func (f *file) Read(into []byte) (n int, err error) {
+	start := f.offset
+	if start == len(f.data) {
+		return 0, newFsError(EOFError, "EOF")
+	}
+
+	end := f.offset + len(into)
+	if end > len(f.data) {
+		end = len(f.data)
+		// We align with the [io.Reader.Read] method's behavior
+		// and return EOFError when we reach the end of the
+		// file, regardless of how much data we were able to
+		// read.
+		err = newFsError(EOFError, "EOF")
+	}
+
+	n = copy(into, f.data[start:end])
+
+	f.offset += n
+
+	return n, err
+}
+
+// Ensure that `file` implements the io.Reader interface.
+var _ io.Reader = (*file)(nil)

--- a/js/modules/k6/experimental/fs/file_test.go
+++ b/js/modules/k6/experimental/fs/file_test.go
@@ -18,7 +18,7 @@ func TestFileImpl(t *testing.T) {
 			name     string
 			into     []byte
 			fileData []byte
-			offset   int
+			offset   int64
 			wantInto []byte
 			wantN    int
 			wantErr  errorKind
@@ -105,10 +105,10 @@ func TestFileImpl(t *testing.T) {
 				t.Parallel()
 
 				f := &file{
-					path:   "",
-					data:   tc.fileData,
-					offset: tc.offset,
+					path: "",
+					data: tc.fileData,
 				}
+				f.offset.Store(tc.offset)
 
 				gotN, err := f.Read(tc.into)
 
@@ -138,16 +138,16 @@ func TestFileImpl(t *testing.T) {
 		t.Parallel()
 
 		type args struct {
-			offset int
+			offset int64
 			whence SeekMode
 		}
 
 		// The test file is 100 bytes long
 		tests := []struct {
 			name       string
-			fileOffset int
+			fileOffset int64
 			args       args
-			wantOffset int
+			wantOffset int64
 			wantError  bool
 		}{
 			{
@@ -242,7 +242,8 @@ func TestFileImpl(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				f := &file{data: make([]byte, 100), offset: tt.fileOffset}
+				f := &file{data: make([]byte, 100)}
+				f.offset.Store(tt.fileOffset)
 
 				got, err := f.Seek(tt.args.offset, tt.args.whence)
 				if tt.wantError {

--- a/js/modules/k6/experimental/fs/file_test.go
+++ b/js/modules/k6/experimental/fs/file_test.go
@@ -1,0 +1,103 @@
+package fs
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFileImpl(t *testing.T) {
+	t.Parallel()
+
+	t.Run("read", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			name     string
+			into     []byte
+			fileData []byte
+			offset   int
+			wantN    int
+			wantErr  errorKind
+		}{
+			{
+				name:     "empty file data should fail",
+				into:     make([]byte, 10),
+				fileData: []byte{},
+				offset:   0,
+				wantN:    0,
+				wantErr:  EOFError,
+			},
+			{
+				name:     "non-empty file data, and empty into should succeed",
+				into:     []byte{},
+				fileData: []byte("hello"),
+				offset:   0,
+				wantN:    0,
+				wantErr:  0, // No error expected
+			},
+			{
+				name:     "non-empty file data, and non-empty into should succeed",
+				into:     make([]byte, 5),
+				fileData: []byte("hello"),
+				offset:   0,
+				wantN:    5,
+				wantErr:  0, // No error expected
+			},
+			{
+				name:     "non-empty file data, non-empty into, at an offset should succeed",
+				into:     make([]byte, 3),
+				fileData: []byte("hello"),
+				offset:   1,
+				wantN:    3,
+				wantErr:  0, // No error expected
+			},
+			{
+				name:     "non-empty file data, non-empty into reading till the end should succeed",
+				into:     make([]byte, 5),
+				fileData: []byte("hello"),
+				offset:   2,
+				wantN:    3,
+				wantErr:  EOFError, // No error expected
+			},
+			{
+				name:     "non-empty file data, non-empty into with offset at the end should fail",
+				into:     make([]byte, 5),
+				fileData: []byte("hello"),
+				offset:   5,
+				wantN:    0,
+				wantErr:  EOFError,
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+
+				f := &file{
+					path:   "",
+					data:   tc.fileData,
+					offset: tc.offset,
+				}
+
+				gotN, err := f.Read(tc.into)
+
+				// Cast the error to your custom error type to access its kind
+				var gotErr errorKind
+				if err != nil {
+					var fsErr *fsError
+					ok := errors.As(err, &fsErr)
+					if !ok {
+						t.Fatalf("unexpected error type: got %T, want %T", err, &fsError{})
+					}
+					gotErr = fsErr.kind
+				}
+
+				if gotN != tc.wantN || gotErr != tc.wantErr {
+					t.Errorf("Read() = %d, %v, want %d, %v", gotN, gotErr, tc.wantN, tc.wantErr)
+				}
+			})
+		}
+	})
+}

--- a/js/modules/k6/experimental/fs/file_test.go
+++ b/js/modules/k6/experimental/fs/file_test.go
@@ -3,6 +3,8 @@ package fs
 import (
 	"errors"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFileImpl(t *testing.T) {
@@ -96,6 +98,53 @@ func TestFileImpl(t *testing.T) {
 
 				if gotN != tc.wantN || gotErr != tc.wantErr {
 					t.Errorf("Read() = %d, %v, want %d, %v", gotN, gotErr, tc.wantN, tc.wantErr)
+				}
+			})
+		}
+	})
+
+	t.Run("seek", func(t *testing.T) {
+		t.Parallel()
+
+		type args struct {
+			offset int
+			whence SeekMode
+		}
+
+		tests := []struct {
+			name       string
+			fileOffset int
+			args       args
+			want       int
+			wantError  bool
+		}{
+			{"StartSeekWithinBounds", 0, args{50, SeekModeStart}, 50, false},
+			{"StartSeekTooFar", 0, args{150, SeekModeStart}, 0, true},
+			{"StartSeekNegative", 0, args{-50, SeekModeStart}, 0, true},
+			{"CurrentSeekWithinBounds", 0, args{10, SeekModeCurrent}, 10, false},
+			{"CurrentSeekNegativeWithinBounds", 20, args{-20, SeekModeCurrent}, 0, false},
+			{"CurrentSeekNegativeTooFar", 20, args{-40, SeekModeCurrent}, 0, true},
+			{"CurrentSeekTooFar", 0, args{150, SeekModeCurrent}, 0, true},
+			{"EndSeekPositiveOffset", 0, args{20, SeekModeEnd}, 80, true}, // Cannot seek beyond the end of the file
+			{"EndSeekWithinBounds", 0, args{-20, SeekModeEnd}, 80, false},
+			{"EndSeekTooFar", 0, args{120, SeekModeEnd}, 0, true},
+			{"InvalidWhence", 0, args{10, SeekMode(42)}, 0, true},
+		}
+
+		for _, tt := range tests {
+			tt := tt
+
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				f := &file{data: make([]byte, 100), offset: tt.fileOffset}
+
+				got, err := f.Seek(tt.args.offset, tt.args.whence)
+				if tt.wantError {
+					assert.Error(t, err, tt.name)
+				} else {
+					assert.NoError(t, err, tt.name)
+					assert.Equal(t, tt.want, got, tt.name)
 				}
 			})
 		}

--- a/js/modules/k6/experimental/fs/module.go
+++ b/js/modules/k6/experimental/fs/module.go
@@ -173,3 +173,71 @@ func (f *File) Stat() *goja.Promise {
 
 	return promise
 }
+
+// Read the file's content, and writes it into the provided Uint8Array.
+//
+// Resolves to either the number of bytes read during the operation
+// or EOF (null) if there was nothing more to read.
+//
+// It is possible for a read to successfully return with 0 bytes.
+// This does not indicate EOF.
+func (f *File) Read(into goja.Value) *goja.Promise {
+	promise, resolve, reject := promises.New(f.vu)
+
+	if common.IsNullish(into) {
+		reject(newFsError(TypeError, "read() failed; reason: into cannot be null or undefined"))
+		return promise
+	}
+
+	// We expect the into argument to be a `Uint8Array` instance
+	intoObj := into.ToObject(f.vu.Runtime())
+	uint8ArrayConstructor := f.vu.Runtime().Get("Uint8Array")
+	if isUint8Array := intoObj.Get("constructor").SameAs(uint8ArrayConstructor); !isUint8Array {
+		reject(newFsError(TypeError, "read() failed; reason: into argument must be a Uint8Array"))
+		return promise
+	}
+
+	// Obtain the underlying ArrayBuffer from the Uint8Array
+	ab, ok := intoObj.Get("buffer").Export().(goja.ArrayBuffer)
+	if !ok {
+		reject(newFsError(TypeError, "read() failed; reason: into argument cannot be interpreted as ArrayBuffer"))
+		return promise
+	}
+
+	// Obtain the underlying byte slice from the ArrayBuffer.
+	// Note that this is not a copy, and will be modified by the Read operation
+	// in place.
+	buffer := ab.Bytes()
+
+	go func() {
+		n, err := f.file.Read(buffer)
+		if err == nil {
+			resolve(n)
+			return
+		}
+
+		// The [file.Read] method will return an EOFError as soon as it reached
+		// the end of the file.
+		//
+		// However, following deno's behavior, we express
+		// EOF to users by returning null, when and only when there aren't any
+		// more bytes to read.
+		//
+		// Thus, although the [file.Read] method will return an EOFError, and
+		// an n > 0, we make sure to take the EOFError returned into consideration
+		// only when n == 0.
+		var fsErr *fsError
+		isFsErr := errors.As(err, &fsErr)
+		if isFsErr {
+			if fsErr.kind == EOFError && n == 0 {
+				resolve(nil)
+			} else {
+				resolve(n)
+			}
+		} else {
+			reject(err)
+		}
+	}()
+
+	return promise
+}

--- a/js/modules/k6/experimental/fs/module_test.go
+++ b/js/modules/k6/experimental/fs/module_test.go
@@ -365,6 +365,87 @@ func TestFile(t *testing.T) {
 
 		assert.NoError(t, err)
 	})
+
+	t.Run("seek with invalid arguments should fail", func(t *testing.T) {
+		t.Parallel()
+
+		runtime, err := newConfiguredRuntime(t)
+		require.NoError(t, err)
+
+		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		fs := newTestFs(t, func(fs afero.Fs) error {
+			return afero.WriteFile(fs, testFilePath, []byte("hello"), 0o644)
+		})
+		runtime.VU.InitEnvField.FileSystems["file"] = fs
+
+		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(fmt.Sprintf(`
+			const file = await fs.open(%q)
+
+			let newOffset
+
+			// null offset should fail with TypeError.
+			try {
+				newOffset = await file.seek(null)
+				throw "file.seek(null) promise unexpectedly resolved with result: " + newOffset
+			} catch (err) {
+				if (err.name !== 'TypeError') {
+					throw "file.seek(null) rejected with unexpected error: " + err
+				}
+			}
+
+			// undefined offset should fail with TypeError.
+			try {
+				newOffset = await file.seek(undefined)
+				throw "file.seek(undefined) promise unexpectedly promise resolved with result: " + newOffset
+			} catch (err) {
+				if (err.name !== 'TypeError') {
+					throw "file.seek(undefined) rejected with unexpected error: " + err
+				}
+			}
+
+			// Invalid type offset should fail with TypeError.
+			try {
+				newOffset = await file.seek('abc')
+				throw "file.seek('abc') promise unexpectedly resolved with result: " + newOffset 
+			} catch (err) {
+				if (err.name !== 'TypeError') {
+					throw "file.seek('1') rejected with unexpected error: " + err
+				}
+			}
+
+			// Negative offset should fail with TypeError.
+			try {
+				newOffset = await file.seek(-1)
+				throw "file.seek(-1) promise unexpectedly resolved with result: " + newOffset
+			} catch (err) {
+				if (err.name !== 'TypeError') {
+					throw "file.seek(-1) rejected with unexpected error: " + err
+				}
+			}
+
+			// Invalid type whence should fail with TypeError.
+			try {
+				newOffset = await file.seek(1, 'abc')
+				throw "file.seek(1, 'abc') promise unexpectedly resolved with result: " + newOffset
+			} catch (err) {
+				if (err.name !== 'TypeError') {
+					throw "file.seek(1, 'abc') rejected with unexpected error: " + err
+				}
+			}
+
+			// Invalid whence should fail with TypeError.
+			try {
+				newOffset = await file.seek(1, -1)
+				throw "file.seek(1, -1) promise unexpectedly resolved with result: " + newOffset 
+			} catch (err) {
+				if (err.name !== 'TypeError') {
+					throw "file.seek(1, -1) rejected with unexpected error: " + err
+				}
+			}
+		`, testFilePath)))
+
+		assert.NoError(t, err)
+	})
 }
 
 func TestOpenImpl(t *testing.T) {


### PR DESCRIPTION
## What?

This Pull Request builds (and is based) upon #3142 and adds a `read` and a `seek` method, the the `File` object exposed by the `k6/experimental/fs` module. 

### `read`

The `File.read` method allows to read a file into a `Uint8Array`. The amount of bytes read is equal to the size of the provided buffer.

The method resolves to either the number of bytes read during the operation or EOF (represented as `null`) if there is nothing more to read.

### `seek`

The `File.seek` method allows to seek to a specified `offset` within a file under the given `whence`.

The offset is expressed in bytes. Whence allows you to seek from the start of the file (the offset needs to be strictly negative), the current position within the file (offset can be either positive or negative), or from the end of the file (offset needs to be strictly negative). A dedicated `SeekMode` type/enum is exposed to help with it.

The method resolves to the new offset in bytes after the seek operation.

### In action

```javascript
import { open } from "k6/experimental/fs";

export const options = {
	vus: 100,
	iterations: 1000,
};

// As k6 does not support asynchronous code in the init context, yet, we need to
// use a top-level async function to be able to use the `await` keyword.
let file;
(async function () {
	file = await open("bonjour.txt");
})();

export default async function () {
	// About information about the file
	const fileinfo = await file.stat();
	if (fileinfo.name != "bonjour.txt") {
		throw new Error("Unexpected file name");
	}

	// Define a buffer of the same size as the file
	// to read the file content into.
	const buffer = new Uint8Array(fileinfo.size);

	// Read the file's content into the buffer
	const bytesRead = await file.read(buffer);

	// Check that we read the expected number of bytes
	if (bytesRead != fileinfo.size) {
		throw new Error("Unexpected number of bytes read");
	}

	// Seek back to the beginning of the file
	await file.seek(0);
}

```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

ref #3142
ref #2974
fixes #3145 
fixes #3148 
<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
