### PR TITLE
Bump alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.20-alpine3.17 as builder
+FROM golang:1.20-alpine3.18 as builder
 WORKDIR $GOPATH/src/go.k6.io/k6
 COPY . .
 RUN apk --no-cache add git=~2
 RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"
 
 # Runtime stage
-FROM alpine:3.17 as release
+FROM alpine:3.18 as release
 
 # hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates && \


### PR DESCRIPTION
Bump the `alpine` version to 3.18 so we can keep our docker build up to date.