### PR TITLE
[fs] Add the `file.close` method to the `fs` module (3/3)

### DIFF
--- a/examples/experimental/fs/fs.js
+++ b/examples/experimental/fs/fs.js
@@ -50,3 +50,7 @@ export default async function () {
 	// Seek back to the beginning of the file
 	await file.seek(0, SeekMode.Start);
 }
+
+export async function teardown() {
+	file.close();
+}

--- a/js/modules/k6/experimental/fs/errors.go
+++ b/js/modules/k6/experimental/fs/errors.go
@@ -37,6 +37,10 @@ const (
 
 	// EOFError is emitted when the end of a file has been reached.
 	EOFError
+
+	// BadResourceError indicates the underlying IO resource is either invalid
+	// or closed, and so the operation could not be performed.
+	BadResourceError
 )
 
 // fsError represents a custom error object emitted by the fs module.

--- a/js/modules/k6/experimental/fs/errors_gen.go
+++ b/js/modules/k6/experimental/fs/errors_gen.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-const _errorKindName = "NotFoundErrorInvalidResourceErrorForbiddenErrorTypeErrorEOFError"
+const _errorKindName = "NotFoundErrorInvalidResourceErrorForbiddenErrorTypeErrorEOFErrorBadResourceError"
 
-var _errorKindIndex = [...]uint8{0, 13, 33, 47, 56, 64}
+var _errorKindIndex = [...]uint8{0, 13, 33, 47, 56, 64, 80}
 
-const _errorKindLowerName = "notfounderrorinvalidresourceerrorforbiddenerrortypeerroreoferror"
+const _errorKindLowerName = "notfounderrorinvalidresourceerrorforbiddenerrortypeerroreoferrorbadresourceerror"
 
 func (i errorKind) String() string {
 	i -= 1
@@ -30,9 +30,10 @@ func _errorKindNoOp() {
 	_ = x[ForbiddenError-(3)]
 	_ = x[TypeError-(4)]
 	_ = x[EOFError-(5)]
+	_ = x[BadResourceError-(6)]
 }
 
-var _errorKindValues = []errorKind{NotFoundError, InvalidResourceError, ForbiddenError, TypeError, EOFError}
+var _errorKindValues = []errorKind{NotFoundError, InvalidResourceError, ForbiddenError, TypeError, EOFError, BadResourceError}
 
 var _errorKindNameToValueMap = map[string]errorKind{
 	_errorKindName[0:13]:       NotFoundError,
@@ -45,6 +46,8 @@ var _errorKindNameToValueMap = map[string]errorKind{
 	_errorKindLowerName[47:56]: TypeError,
 	_errorKindName[56:64]:      EOFError,
 	_errorKindLowerName[56:64]: EOFError,
+	_errorKindName[64:80]:      BadResourceError,
+	_errorKindLowerName[64:80]: BadResourceError,
 }
 
 var _errorKindNames = []string{
@@ -53,6 +56,7 @@ var _errorKindNames = []string{
 	_errorKindName[33:47],
 	_errorKindName[47:56],
 	_errorKindName[56:64],
+	_errorKindName[64:80],
 }
 
 // errorKindString retrieves an enum value from the enum constants string name.

--- a/js/modules/k6/experimental/fs/file.go
+++ b/js/modules/k6/experimental/fs/file.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"io"
 	"path/filepath"
+	"sync/atomic"
 )
 
 // file is an abstraction for interacting with files.
@@ -14,6 +15,9 @@ type file struct {
 
 	// offset holds the current offset in the file
 	offset int
+
+	// closed indicates whether the file has been closed
+	closed atomic.Bool
 }
 
 // Stat returns a FileInfo describing the named file.
@@ -125,3 +129,14 @@ const (
 	// the end of the file.
 	SeekModeEnd
 )
+
+// Close closes the file instance, and marks it as closed.
+func (f *file) Close() error {
+	if f.closed.Load() {
+		return newFsError(BadResourceError, "file already closed")
+	}
+
+	f.closed.Store(true)
+
+	return nil
+}

--- a/js/modules/k6/experimental/fs/module.go
+++ b/js/modules/k6/experimental/fs/module.go
@@ -170,10 +170,16 @@ type File struct {
 // Stat returns a promise that will resolve to a [FileInfo] instance describing
 // the file.
 func (f *File) Stat() *goja.Promise {
-	promise, resolve, _ := promises.New(f.vu)
+	promise, resolve, reject := promises.New(f.vu)
 
 	go func() {
-		resolve(f.file.stat())
+		fileInfo, err := f.file.stat()
+		if err != nil {
+			reject(err)
+			return
+		}
+
+		resolve(fileInfo)
 	}()
 
 	return promise

--- a/js/modules/k6/experimental/fs/registry.go
+++ b/js/modules/k6/experimental/fs/registry.go
@@ -1,0 +1,60 @@
+package fs
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"sync"
+
+	"github.com/spf13/afero"
+)
+
+// registry is a registry of opened files.
+type registry struct {
+	// files holds a safe for concurrent use map of opened files.
+	//
+	// Keys are expected to be strings holding the files' path.
+	// Values are expected to be byte slices holding the files' data.
+	//
+	// That way, we can cache the file's content and avoid opening too many
+	// file descriptor, and re-reading its content every time the file is opened.
+	//
+	// Importantly, this also means that if the
+	// file is modified from outside of k6, the changes will not be reflected in the file's data.
+	// files map[string][]byte
+	files sync.Map
+}
+
+// open opens the named file for reading.
+//
+// If the file was already opened, it returns a pointer to the cached file data. Otherwise, it
+// opens the file, reads its content, caches it, and returns a pointer to it.
+//
+// The file is always opened in read-only mode. The provided file path is cleaned before being
+// used.
+func (fr *registry) open(filename string, fromFs afero.Fs) ([]byte, error) {
+	filename = filepath.Clean(filename)
+
+	if f, ok := fr.files.Load(filename); ok {
+		data, ok := f.([]byte)
+		if !ok {
+			panic(fmt.Errorf("registry's file %s is not stored as a byte slice", filename))
+		}
+
+		return data, nil
+	}
+
+	f, err := fromFs.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, err
+	}
+
+	fr.files.Store(filename, data)
+
+	return data, nil
+}

--- a/js/modules/k6/experimental/fs/registry_test.go
+++ b/js/modules/k6/experimental/fs/registry_test.go
@@ -1,0 +1,52 @@
+package fs
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileRegistryOpen(t *testing.T) {
+	t.Parallel()
+
+	t.Run("open succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		registry := &registry{}
+		fs := newTestFs(t, func(fs afero.Fs) error {
+			return afero.WriteFile(fs, "bonjour.txt", []byte("Bonjour, le monde"), 0o644)
+		})
+
+		_, gotBeforeOk := registry.files.Load("bonjour.txt")
+		gotData, gotErr := registry.open("bonjour.txt", fs)
+		_, gotAfterOk := registry.files.Load("bonjour.txt")
+
+		assert.False(t, gotBeforeOk)
+		assert.NoError(t, gotErr)
+		assert.Equal(t, []byte("Bonjour, le monde"), gotData)
+		assert.True(t, gotAfterOk)
+	})
+
+	t.Run("double open succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		registry := &registry{}
+		fs := newTestFs(t, func(fs afero.Fs) error {
+			return afero.WriteFile(fs, "bonjour.txt", []byte("Bonjour, le monde"), 0o644)
+		})
+
+		firstData, firstErr := registry.open("bonjour.txt", fs)
+		_, gotFirstOk := registry.files.Load("bonjour.txt")
+		secondData, secondErr := registry.open("bonjour.txt", fs)
+		_, gotSecondOk := registry.files.Load("bonjour.txt")
+
+		assert.True(t, gotFirstOk)
+		assert.NoError(t, firstErr)
+		assert.Equal(t, []byte("Bonjour, le monde"), firstData)
+		assert.True(t, gotSecondOk)
+		assert.NoError(t, secondErr)
+		assert.Equal(t, firstData, secondData) // same pointer
+		assert.Equal(t, []byte("Bonjour, le monde"), secondData)
+	})
+}


### PR DESCRIPTION
## What?

This Pull Request builds (and is based) upon https://github.com/grafana/k6/issues/3142 and adds a `close` method to the `File` object exposed by the `k6/experimental/fs` module.

The close method currently does not perform any operations. This is intentional.

## Why?

### Rationale Behind No-Op Close Method:

- **User Expectations**: During our [design discussions](https://github.com/grafana/k6/blob/master/docs/design/019-file-api.md), we identified that users would likely anticipate the presence of a `close` method for consistency. Thus, we're aligning with these expectations.
- **Futureproofing**: Although the method is a no-op now, we might consider enriching its functionality in the future.

### Why Not Implement Functionality Now?

Certainly, functionality can be added. As mentioned in [#3142](https://github.com/grafana/k6/issues/3142), we maintain a file cache that users access through `File` instance pointers. This ensures a more efficient memory utilization across various VUs, compared to our existing `open` method.

Envision a scenario where only one out of several user scenarios opens a file. In such a case, tracking how many VUs haven't closed the file (via reference counting) becomes feasible. When the count hits zero, the file content can be purged from memory.

I've crafted a [proof of concept for this approach](https://github.com/grafana/k6/tree/experimental/fs-ref-counted-close). However, a current k6 limitation hinders its realization. Presently, k6 doesn't support opening files within the VU context (refer to [#3020](https://github.com/grafana/k6/issues/3020)). This implies that even with reference counting via `file.close`, we'd always have an uncollected reference, preventing the count from reaching zero.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

ref #3142 
ref #3149
ref #3165