### PR TITLE
Use the commit date for build metadata

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -10,7 +10,7 @@ export OUT_DIR="${1-dist}"
 export VERSION=${2:-$(git describe --tags --always --dirty)}
 
 # To overwrite the version details, pass something as the third arg. Empty string disables it.
-export COMMIT_DATE=$(git log -1 --format=%at $VERSION | { read d ; date -u +"%FT%T%z" -d @"$d" ; })
+export COMMIT_DATE=$(git log -1 --format=%ct $VERSION | { read d ; date -u +"%FT%T%z" -d @"$d" ; })
 export VERSION_DETAILS=${3-"${COMMIT_DATE}/$(git describe --tags --always --long --dirty)"}
 set +x
 

--- a/build-release.sh
+++ b/build-release.sh
@@ -10,7 +10,8 @@ export OUT_DIR="${1-dist}"
 export VERSION=${2:-$(git describe --tags --always --dirty)}
 
 # To overwrite the version details, pass something as the third arg. Empty string disables it.
-export VERSION_DETAILS=${3-"$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"}
+export COMMIT_DATE=$(git log -1 --format=%at $VERSION | { read d ; date -u +"%FT%T%z" -d @"$d" ; })
+export VERSION_DETAILS=${3-"${COMMIT_DATE}/$(git describe --tags --always --long --dirty)"}
 set +x
 
 build() {


### PR DESCRIPTION
## What?

Use the date of the latest commit in the working tree during the build process.

Note: GitHub uses the COMMIT DATE and not the AUTHOR DATE as you see in `git log` classic dump.

## Why?

Previously, the date of the build was generated at runtime blocking the possibility of reproducible builds.

## Related PR(s)/Issue(s)

#1996

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
