### PR TITLE
dockerfile: Drop K6_BROWSER_ENABLED env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ USER k6
 ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV CHROME_PATH=/usr/lib/chromium/
 
-ENV K6_BROWSER_ENABLED=true
 ENV K6_BROWSER_HEADLESS=true
 
 ENTRYPOINT ["k6"]


### PR DESCRIPTION
## What?

Drop `K6_BROWSER_ENABLED` from the Dockerfile to be consistent with the change documented here https://github.com/grafana/k6/pull/3235.

## Why?

https://github.com/grafana/k6/pull/3235#issuecomment-1667691921 already applied it, but for some reason which I'm not able to get we lost it.
