### PR TITLE
docker: Use go build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20-alpine3.18 as builder
 WORKDIR $GOPATH/src/go.k6.io/k6
 COPY . .
 RUN apk --no-cache add git=~2
-RUN CGO_ENABLED=0 go install -a -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X go.k6.io/k6/lib/consts.VersionDetails=$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)" -o /go/bin/k6
 
 # Runtime stage
 FROM alpine:3.18 as release


### PR DESCRIPTION
## What?

- Uses `go build`
- https://tip.golang.org/doc/go1.20#cgo  It drops CGO_ENABLED=0 as it is now the default (TODO: do the same for the build-release.sh). EDIT: I decided to postpone this change after v0.47.0 release. We already applied many changes to our release process for v0.47.0 release.

## Why?

Keep build processes consistent

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
