### PR TITLE
cmd/version: Commit hash

### DIFF
--- a/build-release.sh
+++ b/build-release.sh
@@ -9,8 +9,6 @@ export OUT_DIR="${1-dist}"
 # To override the latest git tag as the version, pass something else as the second arg.
 export VERSION=${2:-$(git describe --tags --always --dirty)}
 
-# To overwrite the version details, pass something as the third arg. Empty string disables it.
-export VERSION_DETAILS=${3-"$(date -u +"%FT%T%z")/$(git describe --tags --always --long --dirty)"}
 set +x
 
 build() {
@@ -18,9 +16,6 @@ build() {
     local NAME="k6-${VERSION}-${ALIAS}"
 
     local BUILD_ARGS=(-o "${OUT_DIR}/${NAME}/k6${SUFFIX}" -trimpath)
-    if [ -n "$VERSION_DETAILS" ]; then
-        BUILD_ARGS+=(-ldflags "-X go.k6.io/k6/lib/consts.VersionDetails=$VERSION_DETAILS")
-    fi
 
     local PACKAGE_FORMATS
     IFS="," read -ra PACKAGE_FORMATS <<< "${3}"

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -10,9 +10,6 @@ import (
 // Version contains the current semantic version of k6.
 const Version = "0.46.0"
 
-// VersionDetails can be set externally as part of the build process
-var VersionDetails = "" //nolint:gochecknoglobals
-
 // FullVersion returns the maximally full version and build information for
 // the currently running k6 executable.
 func FullVersion() string {


### PR DESCRIPTION
## What?

Before we were injecting the version details via ldflags. go1.18 introduced the ability to detect the commit directly from the code.

An example of the new format:
```
k6 v0.46.0 (commit/a7aa07c26b, go1.21.0, linux/amd64)
```

## Why?

We benefit from it for simplifying our build process and making it more reproducible. It now prints the commit hash instead of the timestamp, in this way should be easier to use in case of troubleshooting and reports.

## Related PR(s)/Issue(s)

The original discussion where it started https://github.com/grafana/k6/pull/3322#discussion_r1318510114
