### PR TITLE
docker/build: Restore --target flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,7 @@ jobs:
             --platform linux/amd64,linux/arm64 \
             --bootstrap --use
           docker buildx build \
+            --target release \
             --platform linux/amd64,linux/arm64 \
             -t $DOCKER_IMAGE_ID .
       - name: Check
@@ -175,6 +176,7 @@ jobs:
         run: |
           echo "Publish $GHCR_IMAGE_ID:master* images"
           docker buildx build --push \
+            --target release \
             --platform linux/amd64,linux/arm64 \
             -t $DOCKER_IMAGE_ID:master \
             -t ghcr.io/$GHCR_IMAGE_ID:master .
@@ -185,6 +187,7 @@ jobs:
             -t ghcr.io/$GHCR_IMAGE_ID:master-with-browser .
           # LoadImpact images are deprecated, we don't build arm64 for it.
           docker buildx build --push \
+            --target legacy \
             --platform linux/amd64 \
             -t $LI_DOCKER_IMAGE_ID:master .
       - name: Publish tagged version images
@@ -193,6 +196,7 @@ jobs:
           VERSION="${VERSION#v}"
           echo "Publish $GHCR_IMAGE_ID:$VERSION images"
           docker buildx build --push \
+            --target release \
             --platform linux/amd64,linux/arm64 \
             -t $DOCKER_IMAGE_ID:$VERSION \
             -t ghcr.io/$GHCR_IMAGE_ID:$VERSION .
@@ -203,12 +207,14 @@ jobs:
             -t ghcr.io/$GHCR_IMAGE_ID:$VERSION-with-browser .
           # LoadImpact images are deprecated, we don't build arm64 for it.
           docker buildx build --push \
+            --target legacy \
             --platform linux/amd64 \
             -t $LI_DOCKER_IMAGE_ID:$VERSION .
           # We also want to tag the latest stable version as latest
           if [[ ! "$VERSION" =~ (RC|rc) ]]; then
             echo "Publish $GHCR_IMAGE_ID:latest"
             docker buildx build --push \
+              --target release \
               --platform linux/amd64,linux/arm64 \
               -t $DOCKER_IMAGE_ID:latest \
               -t ghcr.io/$GHCR_IMAGE_ID:latest .
@@ -219,6 +225,7 @@ jobs:
               -t ghcr.io/$GHCR_IMAGE_ID:latest-with-browser .
             # LoadImpact images are deprecated, we don't build arm64 for it.
             docker buildx build --push \
+              --target legacy \
               --platform linux/amd64 \
               -t $LI_DOCKER_IMAGE_ID:latest .
           fi


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

Restoring the `target` flag for building dedicated images.


## Why?

https://hub.docker.com/layers/grafana/k6/master/images/sha256-fc2e78b49a3018ed0d3f79f2b58fdd4c64fde8e03f28e7f60715ac53b4e25f3e?context=explore

Check the size here, is higher than expected.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
