### PR TITLE
Bump future metric name length to 128

### DIFF
--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -1575,7 +1575,7 @@ func TestMetricNameWarning(t *testing.T) {
 	t.Log(stdout)
 
 	logEntries := ts.LoggerHook.Drain()
-	expectedMsg := `Metric name should only include ASCII letters, numbers and underscores. This name will stop working in `
+	expectedMsg := `Metric name should only include up to 128 ASCII letters, numbers and/or underscores.`
 	filteredEntries := testutils.FilterEntries(logEntries, logrus.WarnLevel, expectedMsg)
 	require.Len(t, filteredEntries, 2)
 	// we do it this way as ordering is not guaranteed

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -46,8 +46,8 @@ type Bundle struct {
 // https://github.com/grafana/k6/issues/3065
 func (b *Bundle) checkMetricNamesForPrometheusCompatibility() {
 	const (
-		nameRegexString = "^[a-zA-Z_][a-zA-Z0-9_]{1,63}$"
-		badNameWarning  = "Metric name should only include ASCII letters, numbers and underscores. " +
+		nameRegexString = "^[a-zA-Z_][a-zA-Z0-9_]{1,128}$"
+		badNameWarning  = "Metric name should only include up to 128 ASCII letters, numbers and/or underscores. " +
 			"This name will stop working in k6 v0.48.0 (around December 2023)."
 	)
 

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -46,6 +46,8 @@ type Bundle struct {
 // https://github.com/grafana/k6/issues/3065
 func (b *Bundle) checkMetricNamesForPrometheusCompatibility() {
 	const (
+		// The name restrictions are the union of Otel and Prometheus naming restrictions, with the length restrictions of 128
+		// coming from old k6 restrictions where character set was way bigger though.
 		nameRegexString = "^[a-zA-Z_][a-zA-Z0-9_]{1,128}$"
 		badNameWarning  = "Metric name should only include up to 128 ASCII letters, numbers and/or underscores. " +
 			"This name will stop working in k6 v0.48.0 (around December 2023)."


### PR DESCRIPTION
This is inline with the current restriction.

The previous 63 character one came from Otel, but with https://github.com/open-telemetry/opentelemetry-specification/pull/3648 This has been bumped to 255.

Updates #3065