### PR TITLE
converter/har: remove redundant nil check

### DIFF
--- a/converter/har/converter.go
+++ b/converter/har/converter.go
@@ -228,13 +228,11 @@ func Convert(h HAR, options lib.Options, minSleep, maxSleep uint, enableChecks b
 						}
 					}
 
-					if e.Response.Headers != nil {
-						for _, header := range e.Response.Headers {
-							if header.Name == "Location" {
-								fprintf(w, "\t\tredirectUrl = res.headers.Location;\n")
-								recordedRedirectURL = header.Value
-								break
-							}
+					for _, header := range e.Response.Headers {
+						if header.Name == "Location" {
+							fprintf(w, "\t\tredirectUrl = res.headers.Location;\n")
+							recordedRedirectURL = header.Value
+							break
 						}
 					}
 


### PR DESCRIPTION
## What?

From the Go specification:

> "1. For a nil slice, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/mMkayUyJe69

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
