### PR TITLE
gRPC reflection v1

### DIFF
--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -667,6 +667,18 @@ func TestClient(t *testing.T) {
 			},
 		},
 		{
+			name: "ReflectV1",
+			setup: func(tb *httpmultibin.HTTPMultiBin) {
+				reflection.RegisterV1(tb.ServerGRPC)
+			},
+			initString: codeBlock{
+				code: `var client = new grpc.Client();`,
+			},
+			vuString: codeBlock{
+				code: `client.connect("GRPCBIN_ADDR", {reflect: true})`,
+			},
+		},
+		{
 			name: "ReflectBadParam",
 			setup: func(tb *httpmultibin.HTTPMultiBin) {
 				reflection.Register(tb.ServerGRPC)

--- a/lib/netext/grpcext/reflect.go
+++ b/lib/netext/grpcext/reflect.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/grpcreflect"
 	"google.golang.org/grpc"
-	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
@@ -18,59 +18,37 @@ type reflectionClient struct {
 // Reflect will use the grpc reflection api to make the file descriptors available to request.
 // It is called in the connect function the first time the Client.Connect function is called.
 func (rc *reflectionClient) Reflect(ctx context.Context) (*descriptorpb.FileDescriptorSet, error) {
-	client := reflectpb.NewServerReflectionClient(rc.Conn)
-	methodClient, err := client.ServerReflectionInfo(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("can't get server info: %w", err)
-	}
-	req := &reflectpb.ServerReflectionRequest{
-		MessageRequest: &reflectpb.ServerReflectionRequest_ListServices{},
-	}
-	resp, err := sendReceive(methodClient, req)
+	client := grpcreflect.NewClientAuto(ctx, rc.Conn)
+
+	services, err := client.ListServices()
 	if err != nil {
 		return nil, fmt.Errorf("can't list services: %w", err)
 	}
-	listResp := resp.GetListServicesResponse()
-	if listResp == nil {
-		return nil, fmt.Errorf("can't list services, nil response")
-	}
-	fdset, err := rc.resolveServiceFileDescriptors(methodClient, listResp)
-	if err != nil {
-		return nil, fmt.Errorf("can't resolve services' file descriptors: %w", err)
-	}
-	return fdset, nil
-}
 
-func (rc *reflectionClient) resolveServiceFileDescriptors(
-	client sendReceiver,
-	res *reflectpb.ListServiceResponse,
-) (*descriptorpb.FileDescriptorSet, error) {
-	services := res.GetService()
 	seen := make(map[fileDescriptorLookupKey]bool, len(services))
 	fdset := &descriptorpb.FileDescriptorSet{
 		File: make([]*descriptorpb.FileDescriptorProto, 0, len(services)),
 	}
 
-	for _, service := range services {
-		req := &reflectpb.ServerReflectionRequest{
-			MessageRequest: &reflectpb.ServerReflectionRequest_FileContainingSymbol{
-				FileContainingSymbol: service.GetName(),
-			},
-		}
-		resp, err := sendReceive(client, req)
+	for _, srv := range services {
+		srvDescriptor, err := client.ResolveService(srv)
 		if err != nil {
-			return nil, fmt.Errorf("can't get method on service %q: %w", service, err)
+			return nil, fmt.Errorf("can't get method on service %q: %w", srv, err)
 		}
-		fdResp := resp.GetFileDescriptorResponse()
-		for _, raw := range fdResp.GetFileDescriptorProto() {
-			var fdp descriptorpb.FileDescriptorProto
-			if err = proto.Unmarshal(raw, &fdp); err != nil {
-				return nil, fmt.Errorf("can't unmarshal proto on service %q: %w", service, err)
-			}
+
+		stack := []*desc.FileDescriptor{srvDescriptor.GetFile()}
+
+		for len(stack) > 0 {
+			fdp := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+
 			fdkey := fileDescriptorLookupKey{
-				Package: *fdp.Package,
-				Name:    *fdp.Name,
+				Package: fdp.GetPackage(),
+				Name:    fdp.GetName(),
 			}
+
+			stack = append(stack, fdp.GetDependencies()...)
+
 			if seen[fdkey] {
 				// When a proto file contains declarations for multiple services
 				// then the same proto file is returned multiple times,
@@ -78,37 +56,11 @@ func (rc *reflectionClient) resolveServiceFileDescriptors(
 				continue
 			}
 			seen[fdkey] = true
-			fdset.File = append(fdset.File, &fdp)
+			fdset.File = append(fdset.File, fdp.AsFileDescriptorProto())
 		}
 	}
+
 	return fdset, nil
-}
-
-// sendReceiver is a smaller interface for decoupling
-// from `reflectpb.ServerReflection_ServerReflectionInfoClient`,
-// that has the dependency from `grpc.ClientStream`,
-// which is too much in the case the requirement is to just make a reflection's request.
-// It makes the API more restricted and with a controlled surface,
-// in this way the testing should be easier also.
-type sendReceiver interface {
-	Send(*reflectpb.ServerReflectionRequest) error
-	Recv() (*reflectpb.ServerReflectionResponse, error)
-}
-
-// sendReceive sends a request to a reflection client and,
-// receives a response.
-func sendReceive(
-	client sendReceiver,
-	req *reflectpb.ServerReflectionRequest,
-) (*reflectpb.ServerReflectionResponse, error) {
-	if err := client.Send(req); err != nil {
-		return nil, fmt.Errorf("can't send request: %w", err)
-	}
-	resp, err := client.Recv()
-	if err != nil {
-		return nil, fmt.Errorf("can't receive response: %w", err)
-	}
-	return resp, nil
 }
 
 type fileDescriptorLookupKey struct {


### PR DESCRIPTION
## What?

This is a back-port of the https://github.com/grafana/xk6-grpc/pull/48

It brings support of reflection v1 to the `k6/net/grpc`.

## Why?

Reflection v1alpha is deprecated

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Resolve #3222

<!-- Thanks for your contribution! 🙏🏼 -->
