### PR TITLE
Add `no-sandbox` arg to browser enabled Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,8 @@ ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV CHROME_PATH=/usr/lib/chromium/
 
 ENV K6_BROWSER_HEADLESS=true
+# no-sandbox chrome arg is required to run chrome browser in
+# alpine and avoids the usage of SYS_ADMIN Docker capability
+ENV K6_BROWSER_ARGS=no-sandbox
 
 ENTRYPOINT ["k6"]


### PR DESCRIPTION
## What?

Sets the `no-sandbox` chrome argument by default through the `K6_BROWSER_ARGS` ENV variable in the Dockerfile definition for the browser enabled docker image.

## Why?

In order to allow chrome to execute in the browser enabled image, either `SYS_ADMIN` Docker capability or `no-sandbox` browser argument had to be set. This sets the `no-sandbox` option in the Dockerfile definition itself so this action is no longer necessary to run the Docker container. This is arguably also the better option, as we are running the chrome browser inside a container, versus using the Docker capability.

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
