### PR TITLE
Fix race in http.batch after latest goja update

### DIFF
--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -503,6 +503,12 @@ func (c *Client) Batch(reqsV ...goja.Value) (interface{}, error) {
 			err = e
 		}
 	}
+	for i, req := range batchReqs {
+		if req.Response != nil {
+			c.processResponse(req.Response, req.ParsedHTTPRequest.ResponseType)
+		}
+		batchReqs[i] = req
+	}
 	return results, err
 }
 

--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -503,11 +503,10 @@ func (c *Client) Batch(reqsV ...goja.Value) (interface{}, error) {
 			err = e
 		}
 	}
-	for i, req := range batchReqs {
+	for _, req := range batchReqs {
 		if req.Response != nil {
 			c.processResponse(req.Response, req.ParsedHTTPRequest.ResponseType)
 		}
-		batchReqs[i] = req
 	}
 	return results, err
 }

--- a/lib/netext/httpext/batch.go
+++ b/lib/netext/httpext/batch.go
@@ -45,7 +45,6 @@ func MakeBatchRequests(
 
 		resp, err := MakeRequest(ctx, state, req.ParsedHTTPRequest)
 		if resp != nil {
-			processResponse(resp, req.ParsedHTTPRequest.ResponseType)
 			*req.Response = *resp
 		}
 		result <- err


### PR DESCRIPTION
Previous http.batch code did call `runtime.NewArrayBuffer` concurrently.

Which never has been guaranteed to be safe, but with the latest goja changes to having prototypes created on demand it races.

The fix *might* have some performance implications, but they are likely to be very small as `NewArrayBuffer` mostly wraps stuff so ... hopefully not a big deal.

