### PR TITLE
Introducing options.cloud

### DIFF
--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -23,10 +23,10 @@ func getCmdLoginCloud(gs *state.GlobalState) *cobra.Command {
 	exampleText := getExampleText(gs, `
   # Show the stored token.
   {{.}} login cloud -s
-  
+
   # Store a token.
   {{.}} login cloud -t YOUR_TOKEN
-  
+
   # Log in with an email/password.
   {{.}} login cloud`[1:])
 
@@ -55,11 +55,12 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 
 			// We want to use this fully consolidated config for things like
 			// host addresses, so users can overwrite them with env vars.
-			consolidatedCurrentConfig, err := cloudapi.GetConsolidatedConfig(
-				currentJSONConfigRaw, gs.Env, "", nil)
+			consolidatedCurrentConfig, _, err := cloudapi.GetConsolidatedConfig(
+				currentJSONConfigRaw, gs.Env, "", nil, nil)
 			if err != nil {
 				return err
 			}
+
 			// But we don't want to save them back to the JSON file, we only
 			// want to save what already existed there and the login details.
 			newCloudConf := currentJSONConfig

--- a/lib/options.go
+++ b/lib/options.go
@@ -307,6 +307,10 @@ type Options struct {
 	// iteration is shorter than the specified value.
 	MinIterationDuration types.NullDuration `json:"minIterationDuration" envconfig:"K6_MIN_ITERATION_DURATION"`
 
+	// Cloud is the config for the cloud
+	// formally known as ext.loadimpact
+	Cloud json.RawMessage `json:"cloud,omitempty" ignored:"true"`
+
 	// These values are for third party collectors' benefit.
 	// Can't be set through env vars.
 	External map[string]json.RawMessage `json:"ext" ignored:"true"`

--- a/lib/options.go
+++ b/lib/options.go
@@ -309,7 +309,7 @@ type Options struct {
 
 	// Cloud is the config for the cloud
 	// formally known as ext.loadimpact
-	Cloud json.RawMessage `json:"cloud,omitempty" ignored:"true"`
+	Cloud json.RawMessage `json:"cloud,omitempty"`
 
 	// These values are for third party collectors' benefit.
 	// Can't be set through env vars.
@@ -471,6 +471,9 @@ func (o Options) Apply(opts Options) Options {
 	}
 	if opts.NoCookiesReset.Valid {
 		o.NoCookiesReset = opts.NoCookiesReset
+	}
+	if opts.Cloud != nil {
+		o.Cloud = opts.Cloud
 	}
 	if opts.External != nil {
 		o.External = opts.External

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -77,8 +77,13 @@ func New(params output.Params) (output.Output, error) {
 
 // New creates a new cloud output.
 func newOutput(params output.Params) (*Output, error) {
-	conf, err := cloudapi.GetConsolidatedConfig(
-		params.JSONConfig, params.Environment, params.ConfigArgument, params.ScriptOptions.External)
+	conf, _, err := cloudapi.GetConsolidatedConfig(
+		params.JSONConfig,
+		params.Environment,
+		params.ConfigArgument,
+		params.ScriptOptions.Cloud,
+		params.ScriptOptions.External,
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What?

This is an attempt to introduce the new option `cloud`, which should start the process of sunsetting the `options.ext.loadimpact`

## Why?

The `options.ext.loadimpact` is the legacy option, and we should migrate from it to something more neutral like `cloud`

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #1155

<!-- Thanks for your contribution! 🙏🏼 -->
