### PR TITLE
Erroring if gRPC parameters contains headers key

### DIFF
--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -465,7 +465,7 @@ func (c *Client) parseInvokeParams(paramsVal goja.Value) (*invokeParams, error) 
 				return result, fmt.Errorf("invalid timeout value: %w", err)
 			}
 		case "headers":
-			return result, errors.New("you should use metadata param instead of headers")
+			return result, errors.New("headers param is not supported anymore. Please, use metadata param instead")
 		default:
 			return result, fmt.Errorf("unknown param: %q", k)
 		}

--- a/js/modules/k6/grpc/client.go
+++ b/js/modules/k6/grpc/client.go
@@ -446,9 +446,6 @@ func (c *Client) parseInvokeParams(paramsVal goja.Value) (*invokeParams, error) 
 	params := paramsVal.ToObject(rt)
 	for _, k := range params.Keys() {
 		switch k {
-		case "headers":
-			c.vu.State().Logger.Warn("The headers property is deprecated, replace it with the metadata property, please.")
-			fallthrough
 		case "metadata":
 			md, err := newMetadata(params.Get(k))
 			if err != nil {
@@ -467,6 +464,8 @@ func (c *Client) parseInvokeParams(paramsVal goja.Value) (*invokeParams, error) 
 			if err != nil {
 				return result, fmt.Errorf("invalid timeout value: %w", err)
 			}
+		case "headers":
+			return result, errors.New("you should use metadata param instead of headers")
 		default:
 			return result, fmt.Errorf("unknown param: %q", k)
 		}


### PR DESCRIPTION
## What?

In #2371 we deprecated the `headers`  param in favor of `metadata`. 

https://github.com/grafana/k6/blob/1892f9120b4a414cf7847a83126b3b02b60e65ff/js/modules/k6/grpc/client.go#L449-L452

Since it seems like a long time passed, we could finally remove the support of the `headers`.

And as the first step, we could start erroring if the `headers` param is presented. 

Once this PR is merged, I'll open the PR with the far-away milestone to clean the error advising the use of `metadata`.

## Why?

We should clean up the `headers`

## Changelog

_Minor breaking change_: Previously, gRPC invoke's `headers` param was deprecated and fell through to the `metadata`. Since this version of k6, using the `headers` param will result in an error. Instead, users should use the `metadata` param.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`), and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/3343#discussion_r1334040663

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
