### PR TITLE
Add browser's `page.on('console')` to release notes

### DIFF
--- a/release notes/v0.47.0.md
+++ b/release notes/v0.47.0.md
@@ -37,6 +37,10 @@ Thanks, @sapphire-janrain, for contribution!
 
 In some workflows the reflection call should also include some metadata. This PR adds [a new connection parameter `reflectMetadata`](https://k6.io/docs/javascript-api/k6-net-grpc/client/client-connect/#connectparams) that allows to specify the metadata to be sent with the reflection call.
 
+### Add support for browser module's `page.on('console')` [xk6-browser#1006](https://github.com/grafana/xk6-browser/pull/1006)
+
+Allows users to register a handler to be executed every time the `console` API methods are called from within the page JavaScript context.
+
 ### UX improvements and enhancements
 
 _Format as `<number> <present_verb> <object>. <credit>`_:


### PR DESCRIPTION
## What?

Adds an entry for browser module's `page.on('console')` feature to `v0.47.0` release notes.

## Why?

`page.on('console')` method is a new feature for the browser module's API that should be announced in the upcoming k6 release.

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

- https://github.com/grafana/xk6-browser/pull/1006
- https://github.com/grafana/k6-docs/pull/1308
