### PR TITLE
v0.47.0 release notes for browser

### DIFF
--- a/release notes/v0.47.0.md
+++ b/release notes/v0.47.0.md
@@ -67,6 +67,7 @@ Allows users to register a handler to be executed every time the `console` API m
 - [#3340](https://github.com/grafana/k6/pull/3340) The k6 ``*-with-browser`` Docker images set now the `no-sandbox` environment variable automatically.
 - [browser#1035](https://github.com/grafana/xk6-browser/pull/1035) Refactor `int64` timeout to `time.Duration` which ensures no confusion as to whether a timeout is in milliseconds or seconds.
 - [browser#1007](https://github.com/grafana/xk6-browser/pull/1007) Inject `window.k6 = {};` to help identify k6 browser module tests.
+- [browser#1022](https://github.com/grafana/xk6-browser/pull/1022) Refactor the `check` in `examples/fillform.js` so that it matches the type definitions and documentation for `check`.
 
 ## Bug fixes
 
@@ -80,7 +81,6 @@ Allows users to register a handler to be executed every time the `console` API m
 - [browser#1038](https://github.com/grafana/xk6-browser/pull/1038) Fix read/write data race for edge case with remote browsers.
 - [browser#1034](https://github.com/grafana/xk6-browser/pull/1034) Fix `page.reload` & `page.setContent` to use the default navigation timeout over the default timeout.
 - [browser#1033](https://github.com/grafana/xk6-browser/pull/1033) Fix the `page` timeouts so it is actually used after being set.
-- [browser#1022](https://github.com/grafana/xk6-browser/pull/1022) Fix the `check` in `examples/fillform.js` so that it matches the type definitions and documentation for `check`.
 
 ## Maintenance and internal improvements
 

--- a/release notes/v0.47.0.md
+++ b/release notes/v0.47.0.md
@@ -59,6 +59,19 @@ console.log(context.cookies.length); // 0
 
 Allows users to register a handler to be executed every time the `console` API methods are called from within the page's JavaScript context. The arguments passed into the handler are defined by the [ConsoleMessage](https://k6.io/docs/javascript-api/k6-experimental/browser/consolemessage/) class.
 
+```js
+page.on('console', msg => {
+    check(msg, {
+        'assertConsoleMessageType': msg => msg.type() == 'log',
+        'assertConsoleMessageText': msg => msg.text() == 'this is a console.log message 42',
+        'assertConsoleMessageArgs0': msg => msg.args()[0].jsonValue() == 'this is a console.log message',
+        'assertConsoleMessageArgs1': msg => msg.args()[1].jsonValue() == 42,
+    });
+});
+
+page.evaluate(() => console.log('this is a console.log message', 42));
+```
+
 ### UX improvements and enhancements
 
 - [#3338](https://github.com/grafana/k6/pull/3338), [xk6-grpc#48](https://github.com/grafana/xk6-grpc/pull/48). Adds a support of the v1 of the gRPC reflection protocol.

--- a/release notes/v0.47.0.md
+++ b/release notes/v0.47.0.md
@@ -106,10 +106,9 @@ page.evaluate(() => console.log('this is a console.log message', 42));
 - [#3311](https://github.com/grafana/k6/pull/3311) Updated the `alpine` image version that is used as the base of the k6 Docker image.
 - [browser#1043](https://github.com/grafana/xk6-browser/pull/1043), [browser#1021](https://github.com/grafana/xk6-browser/pull/1021), [browser#1019](https://github.com/grafana/xk6-browser/pull/1019), [browser#1014](https://github.com/grafana/xk6-browser/pull/1014) Fix tests.
 - [browser#1000](https://github.com/grafana/xk6-browser/pull/1000), [browser#1024](https://github.com/grafana/xk6-browser/pull/1024) Refine issue and PR templates.
-- [browser#1003](https://github.com/grafana/xk6-browser/pull/1003) Internal refactor.
+- [browser#1003](https://github.com/grafana/xk6-browser/pull/1003), [browser#1009](https://github.com/grafana/xk6-browser/pull/1009), [browser#1010](https://github.com/grafana/xk6-browser/pull/1010) Internal changes.
 - [browser#997](https://github.com/grafana/xk6-browser/pull/997) Update readme.
 - [browser#962](https://github.com/grafana/xk6-browser/pull/962) CI fixes.
-- [browser#1009](https://github.com/grafana/xk6-browser/pull/1009), [browser#1010](https://github.com/grafana/xk6-browser/pull/1010) Supporting internal changes.
 
 ## _Optional_ Roadmap
 

--- a/release notes/v0.47.0.md
+++ b/release notes/v0.47.0.md
@@ -78,7 +78,6 @@ page.evaluate(() => console.log('this is a console.log message', 42));
 - [#3290](https://github.com/grafana/k6/pull/3290) Log errors when executing `setup` and `teardown` via REST API.
 - [#3327](https://github.com/grafana/k6/pull/3327) `k6 version` now prints the commit identifier for the build.
 - [#3340](https://github.com/grafana/k6/pull/3340) The k6 ``*-with-browser`` Docker images set now the `no-sandbox` environment variable automatically.
-- [browser#1035](https://github.com/grafana/xk6-browser/pull/1035) Refactor `int64` timeout to `time.Duration` which ensures no confusion as to whether a timeout is in milliseconds or seconds.
 - [browser#1007](https://github.com/grafana/xk6-browser/pull/1007) Inject `window.k6 = {};` to help identify k6 browser module tests.
 - [browser#1022](https://github.com/grafana/xk6-browser/pull/1022) Refactor the `check` in `examples/fillform.js` so that it matches the type definitions and documentation for `check`.
 
@@ -92,6 +91,7 @@ page.evaluate(() => console.log('this is a console.log message', 42));
 - [browser#1031](https://github.com/grafana/xk6-browser/pull/1031) fix the `expires` field while adding cookies using the `context.addCookie()` method.
 - [browser#1039](https://github.com/grafana/xk6-browser/pull/1039) fix Goja conversions while adding and retrieving cookies.
 - [browser#1038](https://github.com/grafana/xk6-browser/pull/1038) Fix read/write data race for edge case with remote browsers.
+- [browser#1035](https://github.com/grafana/xk6-browser/pull/1035) Refactor `int64` timeout to `time.Duration` which ensures no confusion as to whether a timeout is in milliseconds or seconds.
 - [browser#1034](https://github.com/grafana/xk6-browser/pull/1034) Fix `page.reload` & `page.setContent` to use the default navigation timeout over the default timeout.
 - [browser#1033](https://github.com/grafana/xk6-browser/pull/1033) Fix the `page` timeouts so it is actually used after being set.
 

--- a/release notes/v0.47.0.md
+++ b/release notes/v0.47.0.md
@@ -65,6 +65,8 @@ Allows users to register a handler to be executed every time the `console` API m
 - [#3290](https://github.com/grafana/k6/pull/3290) Log errors when executing `setup` and `teardown` via REST API.
 - [#3327](https://github.com/grafana/k6/pull/3327) `k6 version` now prints the commit identifier for the build.
 - [#3340](https://github.com/grafana/k6/pull/3340) The k6 ``*-with-browser`` Docker images set now the `no-sandbox` environment variable automatically.
+- [browser#1035](https://github.com/grafana/xk6-browser/pull/1035) Refactor `int64` timeout to `time.Duration` which ensures no confusion as to whether a timeout is in milliseconds or seconds.
+- [browser#1007](https://github.com/grafana/xk6-browser/pull/1007) Inject `window.k6 = {};` to help identify k6 browser module tests.
 
 ## Bug fixes
 
@@ -75,6 +77,10 @@ Allows users to register a handler to be executed every time the `console` API m
 - [browser#1040](https://github.com/grafana/xk6-browser/pull/1040) fix the `context.clearCookies()` method to clear all cookies from the current browser context.
 - [browser#1031](https://github.com/grafana/xk6-browser/pull/1031) fix the `expires` field while adding cookies using the `context.addCookie()` method.
 - [browser#1039](https://github.com/grafana/xk6-browser/pull/1039) fix Goja conversions while adding and retrieving cookies.
+- [browser#1038](https://github.com/grafana/xk6-browser/pull/1038) Fix read/write race condition for edge case with remote browsers.
+- [browser#1034](https://github.com/grafana/xk6-browser/pull/1034) Fix `page.reload` & `page.setContent` to use the default navigation timeout over the default timeout.
+- [browser#1033](https://github.com/grafana/xk6-browser/pull/1033) Fix the `page` timeouts so it is actually used after being set.
+- [browser#1022](https://github.com/grafana/xk6-browser/pull/1022) Fix the `check` in examples/fillform.js so that it matches the type definitions and documentation for `check`.
 
 ## Maintenance and internal improvements
 
@@ -85,6 +91,11 @@ Allows users to register a handler to be executed every time the `console` API m
 - [#3351](https://github.com/grafana/k6/pull/3351) Updated the version of Prometheus remote write output. Check the specific [release notes](https://github.com/grafana/xk6-output-prometheus-remote/releases/tag/v0.3.0).
 - [#3341](https://github.com/grafana/k6/pull/3341), [#3339](https://github.com/grafana/k6/pull/3339) Updated `goja` that includes Runtime initialization speed-up and a fix for source indexes. 
 - [#3311](https://github.com/grafana/k6/pull/3311) Updated the `alpine` image version that is used as the base of the k6 Docker image.
+- [browser#1043](https://github.com/grafana/xk6-browser/pull/1043), [browser#1021](https://github.com/grafana/xk6-browser/pull/1021), [browser#1019](https://github.com/grafana/xk6-browser/pull/1019), [#1014](https://github.com/grafana/xk6-browser/pull/1014) Fix tests.
+- [browser#1000](https://github.com/grafana/xk6-browser/pull/1000), [browser#1024](https://github.com/grafana/xk6-browser/pull/1024) Refine issue and PR templates.
+- [browser#1003](https://github.com/grafana/xk6-browser/pull/1003) Internal refactor.
+- [browser#997](https://github.com/grafana/xk6-browser/pull/997) Update readme.
+- [browser#962](https://github.com/grafana/xk6-browser/pull/962) CI fixes.
 
 ## _Optional_ Roadmap
 

--- a/release notes/v0.47.0.md
+++ b/release notes/v0.47.0.md
@@ -80,7 +80,7 @@ Allows users to register a handler to be executed every time the `console` API m
 - [browser#1038](https://github.com/grafana/xk6-browser/pull/1038) Fix read/write race condition for edge case with remote browsers.
 - [browser#1034](https://github.com/grafana/xk6-browser/pull/1034) Fix `page.reload` & `page.setContent` to use the default navigation timeout over the default timeout.
 - [browser#1033](https://github.com/grafana/xk6-browser/pull/1033) Fix the `page` timeouts so it is actually used after being set.
-- [browser#1022](https://github.com/grafana/xk6-browser/pull/1022) Fix the `check` in examples/fillform.js so that it matches the type definitions and documentation for `check`.
+- [browser#1022](https://github.com/grafana/xk6-browser/pull/1022) Fix the `check` in `examples/fillform.js` so that it matches the type definitions and documentation for `check`.
 
 ## Maintenance and internal improvements
 
@@ -91,7 +91,7 @@ Allows users to register a handler to be executed every time the `console` API m
 - [#3351](https://github.com/grafana/k6/pull/3351) Updated the version of Prometheus remote write output. Check the specific [release notes](https://github.com/grafana/xk6-output-prometheus-remote/releases/tag/v0.3.0).
 - [#3341](https://github.com/grafana/k6/pull/3341), [#3339](https://github.com/grafana/k6/pull/3339) Updated `goja` that includes Runtime initialization speed-up and a fix for source indexes. 
 - [#3311](https://github.com/grafana/k6/pull/3311) Updated the `alpine` image version that is used as the base of the k6 Docker image.
-- [browser#1043](https://github.com/grafana/xk6-browser/pull/1043), [browser#1021](https://github.com/grafana/xk6-browser/pull/1021), [browser#1019](https://github.com/grafana/xk6-browser/pull/1019), [#1014](https://github.com/grafana/xk6-browser/pull/1014) Fix tests.
+- [browser#1043](https://github.com/grafana/xk6-browser/pull/1043), [browser#1021](https://github.com/grafana/xk6-browser/pull/1021), [browser#1019](https://github.com/grafana/xk6-browser/pull/1019), [browser#1014](https://github.com/grafana/xk6-browser/pull/1014) Fix tests.
 - [browser#1000](https://github.com/grafana/xk6-browser/pull/1000), [browser#1024](https://github.com/grafana/xk6-browser/pull/1024) Refine issue and PR templates.
 - [browser#1003](https://github.com/grafana/xk6-browser/pull/1003) Internal refactor.
 - [browser#997](https://github.com/grafana/xk6-browser/pull/997) Update readme.

--- a/release notes/v0.47.0.md
+++ b/release notes/v0.47.0.md
@@ -77,7 +77,7 @@ Allows users to register a handler to be executed every time the `console` API m
 - [browser#1040](https://github.com/grafana/xk6-browser/pull/1040) fix the `context.clearCookies()` method to clear all cookies from the current browser context.
 - [browser#1031](https://github.com/grafana/xk6-browser/pull/1031) fix the `expires` field while adding cookies using the `context.addCookie()` method.
 - [browser#1039](https://github.com/grafana/xk6-browser/pull/1039) fix Goja conversions while adding and retrieving cookies.
-- [browser#1038](https://github.com/grafana/xk6-browser/pull/1038) Fix read/write race condition for edge case with remote browsers.
+- [browser#1038](https://github.com/grafana/xk6-browser/pull/1038) Fix read/write data race for edge case with remote browsers.
 - [browser#1034](https://github.com/grafana/xk6-browser/pull/1034) Fix `page.reload` & `page.setContent` to use the default navigation timeout over the default timeout.
 - [browser#1033](https://github.com/grafana/xk6-browser/pull/1033) Fix the `page` timeouts so it is actually used after being set.
 - [browser#1022](https://github.com/grafana/xk6-browser/pull/1022) Fix the `check` in `examples/fillform.js` so that it matches the type definitions and documentation for `check`.

--- a/release notes/v0.47.0.md
+++ b/release notes/v0.47.0.md
@@ -96,6 +96,7 @@ Allows users to register a handler to be executed every time the `console` API m
 - [browser#1003](https://github.com/grafana/xk6-browser/pull/1003) Internal refactor.
 - [browser#997](https://github.com/grafana/xk6-browser/pull/997) Update readme.
 - [browser#962](https://github.com/grafana/xk6-browser/pull/962) CI fixes.
+- [browser#1009](https://github.com/grafana/xk6-browser/pull/1009), [browser#1010](https://github.com/grafana/xk6-browser/pull/1010) Supporting internal changes.
 
 ## _Optional_ Roadmap
 


### PR DESCRIPTION
## What?

This adds the changes to the `v1.1.0` tagged browser module to the release notes. It doesn't add the changes for `cookies` and `page.on` since they are being added by two other PRs.

## Why?

We need to update our users of what changes we have made to the browser module.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes. (NA)
- [X] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass. (NA)
- [ ] I have commented on my code, particularly in hard-to-understand areas. (NA)
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Related: https://github.com/grafana/k6/pull/3353 & https://github.com/grafana/k6/pull/3352.

<!-- Thanks for your contribution! 🙏🏼 -->
