### PR TITLE
Fix ConsoleMessage link in page.on release notes

### DIFF
--- a/release notes/v0.47.0.md
+++ b/release notes/v0.47.0.md
@@ -61,7 +61,7 @@ console.log(context.cookies.length); // 0
 
 ### Add support for browser module's `page.on('console')` [browser#1006](https://github.com/grafana/xk6-browser/pull/1006)
 
-Allows users to register a handler to be executed every time the `console` API methods are called from within the page's JavaScript context. The arguments passed into the handler are defined by the (ConsoleMessage)[https://k6.io/docs/javascript-api/k6-experimental/browser/consolemessage/] class.
+Allows users to register a handler to be executed every time the `console` API methods are called from within the page's JavaScript context. The arguments passed into the handler are defined by the [ConsoleMessage](https://k6.io/docs/javascript-api/k6-experimental/browser/consolemessage/) class.
 
 ### UX improvements and enhancements
 


### PR DESCRIPTION
## What?

Fixes a typo in browser's `page.on` method release notes.

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Related: https://github.com/grafana/k6/pull/3353
