### PR TITLE
Bump the k6 version to v0.47.0

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.46.0"
+const Version = "0.47.0"
 
 // FullVersion returns the maximally full version and build information for
 // the currently running k6 executable.


### PR DESCRIPTION
## What?

Bump k6 version as defined by https://github.com/grafana/k6/issues/3274:

>Open a separate PR for bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/9fa50b2d1f259cdccff5cc7bc18a236d31c345ac/lib/consts/consts.go#L11).
