### PR TITLE
Move the improvements section as h2

### DIFF
--- a/release notes/template.md
+++ b/release notes/template.md
@@ -23,7 +23,7 @@ _what, why, and what this means for the user_
 
 _what, why, and what this means for the user_
 
-### UX improvements and enhancements
+## UX improvements and enhancements
 
 _Format as `<number> <present_verb> <object>. <credit>`_:
 


### PR DESCRIPTION
## What?

UX section as h2 in release notes

## Why?

https://github.com/grafana/k6/pull/3360#discussion_r1344582568 and it is how we did in the previous versions https://github.com/grafana/k6/blob/master/release%20notes/v0.46.0.md#ux-improvements-and-enhancements