### PR TITLE
Expose profiling endpoints

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -185,6 +185,12 @@ func rootCmdPersistentFlagSet(gs *state.GlobalState) *pflag.FlagSet {
 	flags.BoolVarP(&gs.Flags.Verbose, "verbose", "v", gs.DefaultFlags.Verbose, "enable verbose logging")
 	flags.BoolVarP(&gs.Flags.Quiet, "quiet", "q", gs.DefaultFlags.Quiet, "disable progress updates")
 	flags.StringVarP(&gs.Flags.Address, "address", "a", gs.DefaultFlags.Address, "address for the REST API server")
+	flags.BoolVar(
+		&gs.Flags.ProfilingEnabled,
+		"profiling-enabled",
+		gs.DefaultFlags.ProfilingEnabled,
+		"enable profiling (pprof) endpoints, k6's REST API should be enabled as well",
+	)
 
 	return flags
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -270,10 +270,20 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 		srvCtx, srvCancel := context.WithCancel(globalCtx)
 		defer srvCancel()
 
-		srv := api.GetServer(runCtx, c.gs.Flags.Address, testRunState, samples, metricsEngine, execScheduler)
+		srv := api.GetServer(
+			runCtx,
+			c.gs.Flags.Address, c.gs.Flags.ProfilingEnabled,
+			testRunState,
+			samples,
+			metricsEngine,
+			execScheduler,
+		)
 		go func() {
 			defer apiWG.Done()
 			logger.Debugf("Starting the REST API server on %s", c.gs.Flags.Address)
+			if c.gs.Flags.ProfilingEnabled {
+				logger.Debugf("Profiling exposed on http://%s/debug/pprof/", c.gs.Flags.Address)
+			}
 			if aerr := srv.ListenAndServe(); aerr != nil && !errors.Is(aerr, http.ErrServerClosed) {
 				// Only exit k6 if the user has explicitly set the REST API address
 				if cmd.Flags().Lookup("address").Changed {

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -134,21 +134,23 @@ func NewGlobalState(ctx context.Context) *GlobalState {
 
 // GlobalFlags contains global config values that apply for all k6 sub-commands.
 type GlobalFlags struct {
-	ConfigFilePath string
-	Quiet          bool
-	NoColor        bool
-	Address        string
-	LogOutput      string
-	LogFormat      string
-	Verbose        bool
+	ConfigFilePath   string
+	Quiet            bool
+	NoColor          bool
+	Address          string
+	ProfilingEnabled bool
+	LogOutput        string
+	LogFormat        string
+	Verbose          bool
 }
 
 // GetDefaultFlags returns the default global flags.
 func GetDefaultFlags(homeDir string) GlobalFlags {
 	return GlobalFlags{
-		Address:        "localhost:6565",
-		ConfigFilePath: filepath.Join(homeDir, "loadimpact", "k6", defaultConfigFileName),
-		LogOutput:      "stderr",
+		Address:          "localhost:6565",
+		ProfilingEnabled: false,
+		ConfigFilePath:   filepath.Join(homeDir, "loadimpact", "k6", defaultConfigFileName),
+		LogOutput:        "stderr",
 	}
 }
 

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -124,6 +124,10 @@ func printExecutionDescription(
 	}
 
 	fmt.Fprintf(buf, "     output: %s\n", valueColor.Sprint(strings.Join(outputDescriptions, ", ")))
+	if gs.Flags.ProfilingEnabled && gs.Flags.Address != "" {
+		fmt.Fprintf(buf, "  profiling: %s\n", valueColor.Sprintf("http://%s/debug/pprof/", gs.Flags.Address))
+	}
+
 	fmt.Fprintf(buf, "\n")
 
 	maxDuration, _ := lib.GetEndOffset(execPlan)


### PR DESCRIPTION
## What?

This change exposes profiling endpoints for the k6.

## Why?

This won't have significant performance implications (if the endpoints are not used), so we could expose them by default.

But having this endpoint allows efficient development of k6 (and extension) 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #1692

<!-- Thanks for your contribution! 🙏🏼 -->
