### PR TITLE
Switch to gh from hub in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -358,9 +358,9 @@ jobs:
           set -x
           assets=()
           for asset in ./dist/*; do
-            assets+=("-a" "$asset")
+            assets+=("$asset")
           done
-          hub release create "${assets[@]}" -m "$VERSION" -m "$(cat ./release\ notes/${VERSION}.md)" "$VERSION"
+          gh release create "$VERSION" "${assets[@]}" --target "$VERSION" -F "./release\ notes/${VERSION}.md"
 
   publish-packages:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What?

Github removed `hub` command from the images and now we should use `gh` 

https://github.com/actions/runner-images/issues/8362

## Why?

So we can make release without installing `hub` back.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
