### PR TITLE
Bump Prometheus remote write output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/grafana/xk6-browser v1.1.0
 	github.com/grafana/xk6-grpc v0.1.4-0.20230919144024-6ed5daf33509
-	github.com/grafana/xk6-output-prometheus-remote v0.3.0
+	github.com/grafana/xk6-output-prometheus-remote v0.3.1
 	github.com/grafana/xk6-redis v0.1.1
 	github.com/grafana/xk6-timers v0.1.2
 	github.com/grafana/xk6-webcrypto v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -88,8 +88,8 @@ github.com/grafana/xk6-browser v1.1.0 h1:QHXF0zqm/MgUuJXfIBi9xUbJy5Z0molSWcYgtMk
 github.com/grafana/xk6-browser v1.1.0/go.mod h1:D0ybXLDFAnIV+fNFvaQY8LIXy7OqobLA3f810BkUVXU=
 github.com/grafana/xk6-grpc v0.1.4-0.20230919144024-6ed5daf33509 h1:9ujE4S5cA3WDhRJnwNuUDtfk3w9FeWx6PaZ+lb3o46M=
 github.com/grafana/xk6-grpc v0.1.4-0.20230919144024-6ed5daf33509/go.mod h1:sFTwAsHAtp2f1PNiq0wPjJ7HrAIKploI7Y5mOYo+zIQ=
-github.com/grafana/xk6-output-prometheus-remote v0.3.0 h1:uALRRqFGF7hy75Vc0k6TAj04d9x2kt460t7RZirhxjc=
-github.com/grafana/xk6-output-prometheus-remote v0.3.0/go.mod h1:0JLAm4ONsNUlNoxJXAwOCfA6GtDwTPs557OplAvE+3o=
+github.com/grafana/xk6-output-prometheus-remote v0.3.1 h1:X23rQzlJD8dXWB31DkxR4uPnuRFo8L0Y0H22fSG9xl0=
+github.com/grafana/xk6-output-prometheus-remote v0.3.1/go.mod h1:0JLAm4ONsNUlNoxJXAwOCfA6GtDwTPs557OplAvE+3o=
 github.com/grafana/xk6-redis v0.1.1 h1:rvWnLanRB2qzDwuY6NMBe6PXei3wJ3kjYvfCwRJ+q+8=
 github.com/grafana/xk6-redis v0.1.1/go.mod h1:z7el1Tz8advY+ex419KfLbENzSQYgaA2lQYwMlt9yMM=
 github.com/grafana/xk6-timers v0.1.2 h1:YVM6hPDgvy4SkdZQpd+/r9M0kDi1g+QdbSxW5ClfwDk=

--- a/vendor/github.com/grafana/xk6-output-prometheus-remote/pkg/remotewrite/config.go
+++ b/vendor/github.com/grafana/xk6-output-prometheus-remote/pkg/remotewrite/config.go
@@ -145,6 +145,10 @@ func (conf Config) Apply(applied Config) Config {
 		conf.Password = applied.Password
 	}
 
+	if applied.BearerToken.Valid {
+		conf.BearerToken = applied.BearerToken
+	}
+
 	if applied.PushInterval.Valid {
 		conf.PushInterval = applied.PushInterval
 	}
@@ -274,6 +278,10 @@ func parseEnvs(env map[string]string) (Config, error) {
 
 	if clientCertificateKey, certDefined := env["K6_PROMETHEUS_RW_CLIENT_CERTIFICATE_KEY"]; certDefined {
 		c.ClientCertificateKey = null.StringFrom(clientCertificateKey)
+	}
+
+	if token, tokenDefined := env["K6_PROMETHEUS_RW_BEARER_TOKEN"]; tokenDefined {
+		c.BearerToken = null.StringFrom(token)
 	}
 
 	envHeaders := envMap(env, "K6_PROMETHEUS_RW_HEADERS_")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -165,7 +165,7 @@ github.com/grafana/xk6-browser/storage
 ## explicit; go 1.19
 github.com/grafana/xk6-grpc/grpc
 github.com/grafana/xk6-grpc/lib/netext/grpcext
-# github.com/grafana/xk6-output-prometheus-remote v0.3.0
+# github.com/grafana/xk6-output-prometheus-remote v0.3.1
 ## explicit; go 1.18
 github.com/grafana/xk6-output-prometheus-remote/pkg/remote
 github.com/grafana/xk6-output-prometheus-remote/pkg/remotewrite


### PR DESCRIPTION
## What?

Bump Prometheus remote write output's version to v0.3.1 that includes the Bearer Token fix.