### PR TITLE
fix: Set console log level to the application one when writing to file

### DIFF
--- a/js/console.go
+++ b/js/console.go
@@ -20,13 +20,14 @@ func newConsole(logger logrus.FieldLogger) *console {
 }
 
 // Creates a console logger with its output set to the file at the provided `filepath`.
-func newFileConsole(filepath string, formatter logrus.Formatter) (*console, error) {
+func newFileConsole(filepath string, formatter logrus.Formatter, level logrus.Level) (*console, error) {
 	f, err := os.OpenFile(filepath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644) //nolint:gosec
 	if err != nil {
 		return nil, err
 	}
 
 	l := logrus.New()
+	l.SetLevel(level)
 	l.SetOutput(f)
 	l.SetFormatter(formatter)
 

--- a/js/runner.go
+++ b/js/runner.go
@@ -445,10 +445,12 @@ func (r *Runner) SetOptions(opts lib.Options) error {
 		// TODO: fix logger hack, see https://github.com/grafana/k6/issues/2958
 		// and https://github.com/grafana/k6/issues/2968
 		var formatter logrus.Formatter = &logrus.JSONFormatter{}
+		level := logrus.InfoLevel
 		if l, ok := r.preInitState.Logger.(*logrus.Logger); ok { //nolint: forbidigo
 			formatter = l.Formatter
+			level = l.Level
 		}
-		c, err := newFileConsole(opts.ConsoleOutput.String, formatter)
+		c, err := newFileConsole(opts.ConsoleOutput.String, formatter, level)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This fixes `console.debug()` messages printing with `--console-output file.txt` and `-v` given to k6 cli.

This already works when it isn't redirected to a file as it goes through the application wide logger.
