### PR TITLE
Remove the --logformat flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -174,11 +174,6 @@ func rootCmdPersistentFlagSet(gs *state.GlobalState) *pflag.FlagSet {
 		"change the output for k6 logs, possible values are stderr,stdout,none,loki[=host:port],file[=./path.fileformat]")
 	flags.Lookup("log-output").DefValue = gs.DefaultFlags.LogOutput
 
-	flags.StringVar(&gs.Flags.LogFormat, "logformat", gs.Flags.LogFormat, "log output format")
-	oldLogFormat := flags.Lookup("logformat")
-	oldLogFormat.Hidden = true
-	oldLogFormat.Deprecated = "log-format"
-	oldLogFormat.DefValue = gs.DefaultFlags.LogFormat
 	flags.StringVar(&gs.Flags.LogFormat, "log-format", gs.Flags.LogFormat, "log output format")
 	flags.Lookup("log-format").DefValue = gs.DefaultFlags.LogFormat
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -14,30 +13,6 @@ import (
 
 func TestMain(m *testing.M) {
 	tests.Main(m)
-}
-
-func TestDeprecatedOptionWarning(t *testing.T) {
-	t.Parallel()
-
-	ts := tests.NewGlobalTestState(t)
-	ts.CmdArgs = []string{"k6", "--logformat", "json", "run", "-"}
-	ts.Stdin = bytes.NewBuffer([]byte(`
-		console.log('foo');
-		export default function() { console.log('bar'); };
-	`))
-
-	newRootCommand(ts.GlobalState).execute()
-
-	logMsgs := ts.LoggerHook.Drain()
-	assert.True(t, testutils.LogContains(logMsgs, logrus.InfoLevel, "foo"))
-	assert.True(t, testutils.LogContains(logMsgs, logrus.InfoLevel, "bar"))
-	assert.Contains(t, ts.Stderr.String(), `"level":"info","msg":"foo","source":"console"`)
-	assert.Contains(t, ts.Stderr.String(), `"level":"info","msg":"bar","source":"console"`)
-
-	// TODO: after we get rid of cobra, actually emit this message to stderr
-	// and, ideally, through the log, not just print it...
-	assert.False(t, testutils.LogContains(logMsgs, logrus.InfoLevel, "logformat"))
-	assert.Contains(t, ts.Stdout.String(), `--logformat has been deprecated`)
 }
 
 func TestPanicHandling(t *testing.T) {


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->
Removed the deprecated --logformat flag, the --log-format alternative should be used.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

Deprecation process.
