### PR TITLE
output/csv: Remove the support for snake_case options

### DIFF
--- a/output/csv/config.go
+++ b/output/csv/config.go
@@ -15,10 +15,9 @@ import (
 
 // Config is the config for the csv output
 type Config struct {
-	// Samples.
-	FileName     null.String        `json:"file_name" envconfig:"K6_CSV_FILENAME"`
-	SaveInterval types.NullDuration `json:"save_interval" envconfig:"K6_CSV_SAVE_INTERVAL"`
-	TimeFormat   null.String        `json:"time_format" envconfig:"K6_CSV_TIME_FORMAT"`
+	FileName     null.String        `json:"fileName" envconfig:"K6_CSV_FILENAME"`
+	SaveInterval types.NullDuration `json:"saveInterval" envconfig:"K6_CSV_SAVE_INTERVAL"`
+	TimeFormat   null.String        `json:"timeFormat" envconfig:"K6_CSV_TIME_FORMAT"`
 }
 
 // TimeFormat custom enum type
@@ -75,17 +74,11 @@ func ParseArg(arg string, logger logrus.FieldLogger) (Config, error) {
 			return c, fmt.Errorf("couldn't parse %q as argument for csv output", arg)
 		}
 		switch r[0] {
-		case "save_interval":
-			logger.Warnf("CSV output argument '%s' is deprecated, please use 'saveInterval' instead.", r[0])
-			fallthrough
 		case "saveInterval":
 			err := c.SaveInterval.UnmarshalText([]byte(r[1]))
 			if err != nil {
 				return c, err
 			}
-		case "file_name":
-			logger.Warnf("CSV output argument '%s' is deprecated, please use 'fileName' instead.", r[0])
-			fallthrough
 		case "fileName":
 			c.FileName = null.StringFrom(r[1])
 		case "timeFormat":

--- a/output/csv/config_test.go
+++ b/output/csv/config_test.go
@@ -80,16 +80,6 @@ func TestParseArg(t *testing.T) {
 				TimeFormat:   null.NewString("unix", false),
 			},
 		},
-		"save_interval=5s": {
-			config: Config{
-				FileName:     null.NewString("file.csv", false),
-				SaveInterval: types.NullDurationFrom(5 * time.Second),
-				TimeFormat:   null.NewString("unix", false),
-			},
-			expectedLogEntries: []string{
-				"CSV output argument 'save_interval' is deprecated, please use 'saveInterval' instead.",
-			},
-		},
 		"saveInterval=5s": {
 			config: Config{
 				FileName:     null.NewString("file.csv", false),
@@ -97,28 +87,7 @@ func TestParseArg(t *testing.T) {
 				TimeFormat:   null.NewString("unix", false),
 			},
 		},
-		"file_name=test.csv,save_interval=5s": {
-			config: Config{
-				FileName:     null.StringFrom("test.csv"),
-				SaveInterval: types.NullDurationFrom(5 * time.Second),
-				TimeFormat:   null.NewString("unix", false),
-			},
-			expectedLogEntries: []string{
-				"CSV output argument 'file_name' is deprecated, please use 'fileName' instead.",
-				"CSV output argument 'save_interval' is deprecated, please use 'saveInterval' instead.",
-			},
-		},
-		"fileName=test.csv,save_interval=5s": {
-			config: Config{
-				FileName:     null.StringFrom("test.csv"),
-				SaveInterval: types.NullDurationFrom(5 * time.Second),
-				TimeFormat:   null.NewString("unix", false),
-			},
-			expectedLogEntries: []string{
-				"CSV output argument 'save_interval' is deprecated, please use 'saveInterval' instead.",
-			},
-		},
-		"filename=test.csv,save_interval=5s": {
+		"filename=test.csv,saveInterval=5s": {
 			expectedErr: true,
 		},
 		"fileName=test.csv,timeFormat=rfc3339": {


### PR DESCRIPTION
Removed the options using the snake_case format, instead use the alternative camelCase versions.

## What?

Removed the options using the snake_case format (e.g.`file_name`), instead use the alternative camelCase versions (e.g. `fileName`).


## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

Deprecation process.