### PR TITLE
Set `K6_CLOUD_TRACES_ENABLED` to `true` by default

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -169,7 +169,7 @@ func NewConfig() Config {
 		MetricPushInterval:    types.NewNullDuration(1*time.Second, false),
 		MetricPushConcurrency: null.NewInt(1, false),
 
-		TracesEnabled:         null.NewBool(false, false),
+		TracesEnabled:         null.NewBool(true, false),
 		TracesHost:            null.NewString("insights.k6.io:4443", false),
 		TracesPushInterval:    types.NewNullDuration(1*time.Second, false),
 		TracesPushConcurrency: null.NewInt(1, false),


### PR DESCRIPTION
## What?

This commit updates the default value of the `tracesEnabled` option, enabling it by default. 

## Why?

We hope this change can help drive ease of use of the Distributed Tracing in Grafana Cloud k6 feature.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make ci-like-lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Enables request metadata output (https://github.com/grafana/k6/pull/3201, https://github.com/grafana/k6/pull/3202) by default.