### PR TITLE
Remove Makefile's `ci-like-lint` target

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@ and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 
 - [ ] I have performed a self-review of my code.
 - [ ] I have added tests for my changes.
-- [ ] I have run linter locally (`make ci-like-lint`) and all checks pass.
+- [ ] I have run linter locally (`make lint`) and all checks pass.
 - [ ] I have run tests locally (`make tests`) and all tests pass.
 - [ ] I have commented on my code, particularly in hard-to-understand areas.
 <!-- - [ ] Any other relevant item -->

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.54.1
+# v1.54.2
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   deadline: 5m

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,6 @@ We make use of the [golangci-lint](https://github.com/golangci/golangci-lint) to
 make lint
 ```
 
-You can also run the linter inside the docker container, which will benefit from the version of the linter being the same as it will be in CI.
-
-```bash
-make ci-like-lint
-```
-
 #### Running the test suite
 
 To exercise the entire test suite, please run the following command

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,45 @@
+MAKEFLAGS += --silent
 GOLANGCI_LINT_VERSION = $(shell head -n 1 .golangci.yml | tr -d '\# ')
-TMPDIR ?= /tmp
 
-all: build
+all: clean format test build
 
-build :
+## build: Builds the 'k6' binary.
+build:
 	go build
 
-format :
+## format: Applies Go formatting to code.
+format:
 	find . -name '*.go' -exec gofmt -s -w {} +
 
-ci-like-lint :
-	@docker run --rm -t -v $(shell pwd):/app \
-		-v $(TMPDIR)/golangci-cache-$(GOLANGCI_LINT_VERSION):/golangci-cache \
-		--env "GOLANGCI_LINT_CACHE=/golangci-cache" \
-		-w /app golangci/golangci-lint:$(GOLANGCI_LINT_VERSION) \
-		make lint
+## check-linter-version: Checks if the linter version is the same as the one specified in the linter config.
+check-linter-version:
+	(golangci-lint version | grep "version $(shell head -n 1 .golangci.yml | tr -d '\# ')") || echo "Your installation of golangci-lint is different from the one that is specified in k6's linter config (there it's $(shell head -n 1 .golangci.yml | tr -d '\# ')). Results could be different in the CI."
 
-lint :
+## lint: Runs the linters.
+lint: check-linter-version
+	echo "Running linters..."
 	golangci-lint run --out-format=tab --new-from-rev master ./...
 
-tests :
+## tests: Executes any unit tests.
+tests:
 	go test -race -timeout 210s ./...
 
-check : ci-like-lint tests
+## check: Runs the linters and tests.
+check: lint tests
 
-.PHONY: build format ci-like-lint lint tests check
+## help: Prints a list of available build targets.
+help:
+	echo "Usage: make <OPTIONS> ... <TARGETS>"
+	echo ""
+	echo "Available targets are:"
+	echo ''
+	sed -n 's/^##//p' ${PWD}/Makefile | column -t -s ':' | sed -e 's/^/ /'
+	echo
+	echo "Targets run by default are: `sed -n 's/^all: //p' ./Makefile | sed -e 's/ /, /g' | sed -e 's/\(.*\), /\1, and /'`"
+
+## clean: Removes any previously created build artifacts.
+clean:
+	@echo "cleaning"
+	rm -f ./k6
+
+.PHONY: build format lint tests check check-linter-version help


### PR DESCRIPTION
## What?

We introduced the `ci-like-lint` target a while ago #2316. Since then, our linter's config didn't have the list of used linters, and upgrading the golangci-lint could cause triggering issues that were never seen before, which slowed the process of the actual work.

In #2715 we switched to the close-list of the linters that we run, and using different versions of the golangci-lint shouldn't cause a significant difference.

It seems safe to remove the `ci-like-lint` and keep only the `lint` target which runs on the host machine.

Also, this PR updates the version of the golangci and refactors a bit the Makefile, making it self-explanatory. 

## Why?

Removing the `ci-like-lint` we do a cleanup and simplify the process. It also improves the developer UX since the `make lint` is more common and intuitive for the developers. Last, but not least running the linters on the host machine is simply faster than inside the docker.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
