### PR TITLE
Warnings about options.cloud

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -111,13 +111,18 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Cloud config
-	cloudConfig, _, err := cloudapi.GetConsolidatedConfig(
+	cloudConfig, warn, err := cloudapi.GetConsolidatedConfig(
 		test.derivedConfig.Collectors["cloud"], c.gs.Env, "", arc.Options.Cloud, arc.Options.External)
 	if err != nil {
 		return err
 	}
 	if !cloudConfig.Token.Valid {
 		return errors.New("Not logged in, please use `k6 login cloud`.") //nolint:golint,revive,stylecheck
+	}
+
+	// Display config warning if needed
+	if warn != "" {
+		modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Warning: "+warn))
 	}
 
 	if cloudConfig.Token.Valid {

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -55,10 +55,14 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 
 			// We want to use this fully consolidated config for things like
 			// host addresses, so users can overwrite them with env vars.
-			consolidatedCurrentConfig, _, err := cloudapi.GetConsolidatedConfig(
+			consolidatedCurrentConfig, warn, err := cloudapi.GetConsolidatedConfig(
 				currentJSONConfigRaw, gs.Env, "", nil, nil)
 			if err != nil {
 				return err
+			}
+
+			if warn != "" {
+				gs.Logger.Warn(warn)
 			}
 
 			// But we don't want to save them back to the JSON file, we only

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -30,15 +30,13 @@ export const options = {
   // See https://grafana.com/docs/grafana-cloud/k6/get-started/run-cloud-tests-from-the-cli/
   // to learn about authoring and running k6 test scripts in Grafana k6 Cloud.
   //
-  // ext: {
-  //   loadimpact: {
-  //     // The ID of the project to which the test is assigned in the k6 Cloud UI.
-  //     // By default tests are executed in default project.
-  //     projectID: "",
-  //     // The name of the test in the k6 Cloud UI.
-  //     // Test runs with the same name will be grouped.
-  //     name: "{{ .ScriptName }}"
-  //   }
+  // cloud: {
+  //   // The ID of the project to which the test is assigned in the k6 Cloud UI.
+  //   // By default tests are executed in default project.
+  //   projectID: "",
+  //   // The name of the test in the k6 Cloud UI.
+  //   // Test runs with the same name will be grouped.
+  //   name: "{{ .ScriptName }}"
   // },
 
   // Uncomment this section to enable the use of Browser API in your tests.

--- a/cmd/tests/cmd_cloud_test.go
+++ b/cmd/tests/cmd_cloud_test.go
@@ -246,21 +246,19 @@ func TestCloudWithArchive(t *testing.T) {
 
 		metadata := struct {
 			Options struct {
-				Ext struct {
-					LoadImpact struct {
-						Name      string `json:"name"`
-						Note      string `json:"note"`
-						ProjectID int    `json:"projectID"`
-					} `json:"loadimpact"`
-				} `json:"ext"`
+				Cloud struct {
+					Name      string `json:"name"`
+					Note      string `json:"note"`
+					ProjectID int    `json:"projectID"`
+				} `json:"cloud"`
 			} `json:"options"`
 		}{}
 
 		// then unpacked metadata should not contain any environment variables passed at the moment of archive creation
 		require.NoError(t, json.Unmarshal(metadataRaw, &metadata))
-		require.Equal(t, "my load test", metadata.Options.Ext.LoadImpact.Name)
-		require.Equal(t, "lorem ipsum", metadata.Options.Ext.LoadImpact.Note)
-		require.Equal(t, 124, metadata.Options.Ext.LoadImpact.ProjectID)
+		require.Equal(t, "my load test", metadata.Options.Cloud.Name)
+		require.Equal(t, "lorem ipsum", metadata.Options.Cloud.Note)
+		require.Equal(t, 124, metadata.Options.Cloud.ProjectID)
 
 		// respond with the test run ID
 		resp.WriteHeader(http.StatusOK)

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -77,7 +77,7 @@ func New(params output.Params) (output.Output, error) {
 
 // New creates a new cloud output.
 func newOutput(params output.Params) (*Output, error) {
-	conf, _, err := cloudapi.GetConsolidatedConfig(
+	conf, warn, err := cloudapi.GetConsolidatedConfig(
 		params.JSONConfig,
 		params.Environment,
 		params.ConfigArgument,
@@ -86,6 +86,10 @@ func newOutput(params output.Params) (*Output, error) {
 	)
 	if err != nil {
 		return nil, err
+	}
+
+	if warn != "" {
+		params.Logger.Warn(warn)
 	}
 
 	if err := validateRequiredSystemTags(params.ScriptOptions.SystemTags); err != nil {
@@ -98,7 +102,7 @@ func newOutput(params output.Params) (*Output, error) {
 		scriptPath := params.ScriptPath.String()
 		if scriptPath == "" {
 			// Script from stdin without a name, likely from stdin
-			return nil, errors.New("script name not set, please specify K6_CLOUD_NAME or options.ext.loadimpact.name")
+			return nil, errors.New("script name not set, please specify K6_CLOUD_NAME or options.cloud.name")
 		}
 
 		conf.Name = null.StringFrom(filepath.Base(scriptPath))


### PR DESCRIPTION
## What?

These changes aim to start promoting the `options.cloud`. It's the state when it's safe to say to customers that it's safe to use. 

These changes were originally part of #3348, but there is a chance that we could merge #3348, but we won't be ready to start offering usage of the `options.cloud`.

## Why?

Reduce the scope and try to make #3348 mergable.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] **Check the status** #3394 that could bring additional usage of the `options.ext.loadimapct` and adjust this PR if need
- [ ] Ensure that we can promote the `options.cloud` (backend ready)
- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

* #3348 
* #3394

<!-- Thanks for your contribution! 🙏🏼 -->
