### PR TITLE
Fixed the tests reference in the all rule of the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MAKEFLAGS += --silent
 GOLANGCI_LINT_VERSION = $(shell head -n 1 .golangci.yml | tr -d '\# ')
 
-all: clean format test build
+all: clean format tests build
 
 ## build: Builds the 'k6' binary.
 build:


### PR DESCRIPTION
## What?

Tiny fix for the makefile.

Current behavior:
```bash
❯ make all
cleaning
make: *** No rule to make target `test', needed by `all'.  Stop.
```

New behavior: Runs all commands

## Why?

Make all should succeed

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.


## Related PR(s)/Issue(s)

