### PR TITLE
Add `browser.closeContext()` to v0.48 release notes

### DIFF
--- a/release notes/v0.48.0.md
+++ b/release notes/v0.48.0.md
@@ -25,11 +25,7 @@ _what, why, and what this means for the user_
 
 ## UX improvements and enhancements
 
-_Format as `<number> <present_verb> <object>. <credit>`_:
-
-- _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
-- `#pr` `<description>`
-- `#pr` `<description>`
+- [browser#1074](https://github.com/grafana/xk6-browser/pull/1074) Adds a new `browser.closeContext()` [method](https://k6.io/docs/javascript-api/k6-experimental/browser/closecontext/) to facilitate closing the current active browser context.
 
 ## Bug fixes
 


### PR DESCRIPTION
## What?

Adds an entry for the `browser.closeContext()` method under the _UX improvements and enhancements_ section.

## Why?

So it's properly documented as a new enhancement for the `v0.48.0` release.

## Checklist
- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)
Code: https://github.com/grafana/xk6-browser/pull/1074
Docs: https://github.com/grafana/k6-docs/pull/1376
