### PR TITLE
Address potential races in `fs.read` and `fs.seek` operations

### DIFF
--- a/js/modules/k6/experimental/fs/file.go
+++ b/js/modules/k6/experimental/fs/file.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"io"
 	"path/filepath"
+	"sync/atomic"
 )
 
 // file is an abstraction for interacting with files.
@@ -13,7 +14,7 @@ type file struct {
 	data []byte
 
 	// offset holds the current offset in the file
-	offset int
+	offset atomic.Int64
 }
 
 // Stat returns a FileInfo describing the named file.
@@ -38,14 +39,16 @@ type FileInfo struct {
 //
 // If the end of the file has been reached, it returns EOFError.
 func (f *file) Read(into []byte) (n int, err error) {
-	start := f.offset
-	if start == len(f.data) {
+	offset := f.offset.Load()
+
+	start := offset
+	if start == f.size() {
 		return 0, newFsError(EOFError, "EOF")
 	}
 
-	end := f.offset + len(into)
-	if end > len(f.data) {
-		end = len(f.data)
+	end := offset + int64(len(into))
+	if end > f.size() {
+		end = f.size()
 		// We align with the [io.Reader.Read] method's behavior
 		// and return EOFError when we reach the end of the
 		// file, regardless of how much data we were able to
@@ -55,7 +58,7 @@ func (f *file) Read(into []byte) (n int, err error) {
 
 	n = copy(into, f.data[start:end])
 
-	f.offset += n
+	f.offset.Store(int64(n))
 
 	return n, err
 }
@@ -71,9 +74,10 @@ var _ io.Reader = (*file)(nil)
 //
 // When using SeekModeStart, the offset must be positive.
 // Negative offsets are allowed when using `SeekModeCurrent` or `SeekModeEnd`.
-func (f *file) Seek(offset int, whence SeekMode) (int, error) {
-	newOffset := f.offset
+func (f *file) Seek(offset int64, whence SeekMode) (int64, error) {
+	startingOffset := f.offset.Load()
 
+	newOffset := startingOffset
 	switch whence {
 	case SeekModeStart:
 		if offset < 0 {
@@ -88,7 +92,7 @@ func (f *file) Seek(offset int, whence SeekMode) (int, error) {
 			return 0, newFsError(TypeError, "offset cannot be positive when using SeekModeEnd")
 		}
 
-		newOffset = len(f.data) + offset
+		newOffset = f.size() + offset
 	default:
 		return 0, newFsError(TypeError, "invalid seek mode")
 	}
@@ -97,17 +101,19 @@ func (f *file) Seek(offset int, whence SeekMode) (int, error) {
 		return 0, newFsError(TypeError, "seeking before start of file")
 	}
 
-	if newOffset > len(f.data) {
+	if newOffset > f.size() {
 		return 0, newFsError(TypeError, "seeking beyond end of file")
 	}
 
 	// Note that the implementation assumes one `file` instance per file/vu.
 	// If that assumption was invalidated, we would need to atomically update
 	// the offset instead.
-	f.offset = newOffset
+	f.offset.Store(newOffset)
 
 	return newOffset, nil
 }
+
+var _ io.Seeker = (*file)(nil)
 
 // SeekMode is used to specify the seek mode when seeking in a file.
 type SeekMode = int
@@ -125,3 +131,7 @@ const (
 	// the end of the file.
 	SeekModeEnd
 )
+
+func (f *file) size() int64 {
+	return int64(len(f.data))
+}

--- a/js/modules/k6/experimental/fs/file.go
+++ b/js/modules/k6/experimental/fs/file.go
@@ -16,6 +16,10 @@ type file struct {
 	data []byte
 
 	// offset holds the current offset in the file
+	//
+	// TODO: using an atomic here does not guarantee ordering of reads and seeks, and leaves
+	// the behavior not strictly defined. This is something we might want to address in the future, and
+	// is tracked as part of #3433.
 	offset atomic.Int64
 }
 
@@ -108,9 +112,7 @@ func (f *file) Seek(offset int64, whence SeekMode) (int64, error) {
 		return 0, newFsError(TypeError, "seeking beyond end of file")
 	}
 
-	// Note that the implementation assumes one `file` instance per file/vu.
-	// If that assumption was invalidated, we would need to atomically update
-	// the offset instead.
+	// Update the file instance's offset to the new selected position
 	f.offset.Store(newOffset)
 
 	return newOffset, nil

--- a/js/modules/k6/experimental/fs/file.go
+++ b/js/modules/k6/experimental/fs/file.go
@@ -58,7 +58,7 @@ func (f *file) Read(into []byte) (n int, err error) {
 
 	n = copy(into, f.data[start:end])
 
-	f.offset.Store(int64(n))
+	f.offset.Store(offset + int64(n))
 
 	return n, err
 }

--- a/js/modules/k6/experimental/fs/file_test.go
+++ b/js/modules/k6/experimental/fs/file_test.go
@@ -18,7 +18,7 @@ func TestFileImpl(t *testing.T) {
 			name     string
 			into     []byte
 			fileData []byte
-			offset   int
+			offset   int64
 			wantInto []byte
 			wantN    int
 			wantErr  errorKind
@@ -105,10 +105,10 @@ func TestFileImpl(t *testing.T) {
 				t.Parallel()
 
 				f := &file{
-					path:   "",
-					data:   tc.fileData,
-					offset: tc.offset,
+					path: "",
+					data: tc.fileData,
 				}
+				f.offset.Store(tc.offset)
 
 				gotN, err := f.Read(tc.into)
 
@@ -138,16 +138,16 @@ func TestFileImpl(t *testing.T) {
 		t.Parallel()
 
 		type args struct {
-			offset int
+			offset int64
 			whence SeekMode
 		}
 
 		// The test file is 100 bytes long
 		tests := []struct {
 			name       string
-			fileOffset int
+			fileOffset int64
 			args       args
-			wantOffset int
+			wantOffset int64
 			wantError  bool
 		}{
 			{
@@ -242,7 +242,8 @@ func TestFileImpl(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				f := &file{data: make([]byte, 100), offset: tt.fileOffset}
+				f := &file{data: make([]byte, 100)}
+				f.offset.Store(tt.fileOffset)
 
 				got, err := f.Seek(tt.args.offset, tt.args.whence)
 				if tt.wantError {

--- a/js/modules/k6/experimental/fs/module.go
+++ b/js/modules/k6/experimental/fs/module.go
@@ -186,8 +186,31 @@ func (f *File) Stat() *goja.Promise {
 //
 // It is possible for a read to successfully return with 0 bytes.
 // This does not indicate EOF.
+//
+//nolint:funlen
 func (f *File) Read(into goja.Value) *goja.Promise {
-	promise, resolve, reject := promises.New(f.vu)
+	// This method performs an asynchronous read operation and modifies the provided Uint8Array in place.
+	// To ensure thread safety and avoid concurrency issues, we take special precautions when creating the promise:
+	//
+	// 1. Instead of using the standard [promises.New] method, we manually create a promise.
+	// 2. We register a callback to be executed by the VU's runtime. This ensures that the modification
+	//    of the JS runtime's `buffer` occurs on the main thread during the promise's resolution.
+	promise, resolveFunc, rejectFunc := f.vu.Runtime().NewPromise()
+	callback := f.vu.RegisterCallback()
+
+	resolve := func(result any) {
+		callback(func() error {
+			resolveFunc(result)
+			return nil
+		})
+	}
+
+	reject := func(reason any) {
+		callback(func() error {
+			rejectFunc(reason)
+			return nil
+		})
+	}
 
 	if common.IsNullish(into) {
 		reject(newFsError(TypeError, "read() failed; reason: into cannot be null or undefined"))
@@ -209,15 +232,28 @@ func (f *File) Read(into goja.Value) *goja.Promise {
 		return promise
 	}
 
-	// Obtain the underlying byte slice from the ArrayBuffer.
-	// Note that this is not a copy, and will be modified by the Read operation
-	// in place.
-	buffer := ab.Bytes()
+	// Copy the ArrayBuffer into a byte slice, so that we can pass it to the
+	// [file.Read] method without risking to modify the original ArrayBuffer, and
+	// running into concurrency issues (data race).
+	intoBytes := ab.Bytes()
+	buffer := make([]byte, len(intoBytes))
+	_ = copy(buffer, intoBytes)
 
 	go func() {
 		n, err := f.file.Read(buffer)
 		if err == nil {
-			resolve(n)
+			// Although the read operation happens as part of the goroutine, we
+			// still need to make sure that:
+			//   1. Any side effects, like modifying the `buffer`, are deferred and
+			//   executed on the main thread via the registered callback.
+			//   2. This approach ensures that while the file read operation can proceed
+			//   asynchronously, any side effects that might interfere with the JS runtime
+			//   are executed in a controlled and sequential manner on the main thread.
+			callback(func() error {
+				_ = copy(intoBytes, buffer)
+				resolveFunc(n)
+				return nil
+			})
 			return
 		}
 
@@ -287,7 +323,7 @@ func (f *File) Seek(offset goja.Value, whence goja.Value) *goja.Promise {
 	}
 
 	go func() {
-		newOffset, err := f.file.Seek(int(intOffset), seekMode)
+		newOffset, err := f.file.Seek(intOffset, seekMode)
 		if err != nil {
 			reject(err)
 			return

--- a/js/modules/k6/experimental/fs/module.go
+++ b/js/modules/k6/experimental/fs/module.go
@@ -237,7 +237,6 @@ func (f *File) Read(into goja.Value) *goja.Promise {
 	// running into concurrency issues (data race).
 	intoBytes := ab.Bytes()
 	buffer := make([]byte, len(intoBytes))
-	_ = copy(buffer, intoBytes)
 
 	go func() {
 		n, err := f.file.Read(buffer)

--- a/js/modules/k6/experimental/fs/module_test.go
+++ b/js/modules/k6/experimental/fs/module_test.go
@@ -366,6 +366,58 @@ func TestFile(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
+	t.Run("read called concurrently and later resolved should safely modify the buffer read into", func(t *testing.T) {
+		t.Parallel()
+
+		runtime, err := newConfiguredRuntime(t)
+		require.NoError(t, err)
+
+		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		fs := newTestFs(t, func(fs afero.Fs) error {
+			return afero.WriteFile(fs, testFilePath, []byte("hello"), 0o644)
+		})
+		runtime.VU.InitEnvField.FileSystems["file"] = fs
+
+		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(fmt.Sprintf(`
+			let file = await fs.open(%q);
+
+			let buffer = new Uint8Array(4)
+			let p1 = file.read(buffer);
+			let p2 = file.read(buffer);
+
+			await Promise.all([p1, p2]);
+		`, testFilePath)))
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("read shouldn't be affected by buffer changes happening before resolution", func(t *testing.T) {
+		t.Parallel()
+
+		runtime, err := newConfiguredRuntime(t)
+		require.NoError(t, err)
+
+		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		fs := newTestFs(t, func(fs afero.Fs) error {
+			return afero.WriteFile(fs, testFilePath, []byte("hello"), 0o644)
+		})
+		runtime.VU.InitEnvField.FileSystems["file"] = fs
+
+		_, err = runtime.RunOnEventLoop(wrapInAsyncLambda(fmt.Sprintf(`
+			let file = await fs.open(%q);
+
+			let buffer = new Uint8Array(5);
+			let p1 = file.read(buffer);
+			buffer[0] = 3;
+
+			const bufferCopy = buffer;
+
+			await p1;
+		`, testFilePath)))
+
+		assert.NoError(t, err)
+	})
+
 	t.Run("seek with invalid arguments should fail", func(t *testing.T) {
 		t.Parallel()
 

--- a/js/modules/k6/experimental/fs/module_test.go
+++ b/js/modules/k6/experimental/fs/module_test.go
@@ -16,6 +16,8 @@ import (
 	"go.k6.io/k6/metrics"
 )
 
+const testFileName = "bonjour.txt"
+
 func TestOpen(t *testing.T) {
 	t.Parallel()
 
@@ -29,18 +31,18 @@ func TestOpen(t *testing.T) {
 		}{
 			{
 				name:     "open absolute path",
-				openPath: fsext.FilePathSeparator + "bonjour.txt",
-				wantPath: fsext.FilePathSeparator + "bonjour.txt",
+				openPath: fsext.FilePathSeparator + testFileName,
+				wantPath: fsext.FilePathSeparator + testFileName,
 			},
 			{
 				name:     "open relative path",
-				openPath: filepath.Join(".", fsext.FilePathSeparator, "bonjour.txt"),
-				wantPath: fsext.FilePathSeparator + "bonjour.txt",
+				openPath: filepath.Join(".", fsext.FilePathSeparator, testFileName),
+				wantPath: fsext.FilePathSeparator + testFileName,
 			},
 			{
 				name:     "open path with ..",
-				openPath: fsext.FilePathSeparator + "dir" + fsext.FilePathSeparator + ".." + fsext.FilePathSeparator + "bonjour.txt",
-				wantPath: fsext.FilePathSeparator + "bonjour.txt",
+				openPath: fsext.FilePathSeparator + "dir" + fsext.FilePathSeparator + ".." + fsext.FilePathSeparator + testFileName,
+				wantPath: fsext.FilePathSeparator + testFileName,
 			},
 		}
 
@@ -204,7 +206,7 @@ func TestFile(t *testing.T) {
 		runtime, err := newConfiguredRuntime(t)
 		require.NoError(t, err)
 
-		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		testFilePath := fsext.FilePathSeparator + testFileName
 		fs := newTestFs(t, func(fs afero.Fs) error {
 			return afero.WriteFile(fs, testFilePath, []byte("Bonjour, le monde"), 0o644)
 		})
@@ -232,7 +234,7 @@ func TestFile(t *testing.T) {
 		runtime, err := newConfiguredRuntime(t)
 		require.NoError(t, err)
 
-		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		testFilePath := fsext.FilePathSeparator + testFileName
 		fs := newTestFs(t, func(fs afero.Fs) error {
 			return afero.WriteFile(fs, testFilePath, []byte("hello"), 0o644)
 		})
@@ -275,7 +277,7 @@ func TestFile(t *testing.T) {
 		runtime, err := newConfiguredRuntime(t)
 		require.NoError(t, err)
 
-		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		testFilePath := fsext.FilePathSeparator + testFileName
 		fs := newTestFs(t, func(fs afero.Fs) error {
 			return afero.WriteFile(fs, testFilePath, []byte("hello"), 0o644)
 		})
@@ -307,7 +309,7 @@ func TestFile(t *testing.T) {
 		runtime, err := newConfiguredRuntime(t)
 		require.NoError(t, err)
 
-		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		testFilePath := fsext.FilePathSeparator + testFileName
 		fs := newTestFs(t, func(fs afero.Fs) error {
 			return afero.WriteFile(fs, testFilePath, []byte("Bonjour, le monde"), 0o644)
 		})
@@ -372,7 +374,7 @@ func TestFile(t *testing.T) {
 		runtime, err := newConfiguredRuntime(t)
 		require.NoError(t, err)
 
-		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		testFilePath := fsext.FilePathSeparator + testFileName
 		fs := newTestFs(t, func(fs afero.Fs) error {
 			return afero.WriteFile(fs, testFilePath, []byte("hello"), 0o644)
 		})
@@ -397,7 +399,7 @@ func TestFile(t *testing.T) {
 		runtime, err := newConfiguredRuntime(t)
 		require.NoError(t, err)
 
-		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		testFilePath := fsext.FilePathSeparator + testFileName
 		fs := newTestFs(t, func(fs afero.Fs) error {
 			return afero.WriteFile(fs, testFilePath, []byte("hello"), 0o644)
 		})
@@ -424,7 +426,7 @@ func TestFile(t *testing.T) {
 		runtime, err := newConfiguredRuntime(t)
 		require.NoError(t, err)
 
-		testFilePath := fsext.FilePathSeparator + "bonjour.txt"
+		testFilePath := fsext.FilePathSeparator + testFileName
 		fs := newTestFs(t, func(fs afero.Fs) error {
 			return afero.WriteFile(fs, testFilePath, []byte("hello"), 0o644)
 		})
@@ -517,7 +519,7 @@ func TestOpenImpl(t *testing.T) {
 
 		assert.Panics(t, func() {
 			//nolint:errcheck,gosec
-			mi.openImpl("bonjour.txt")
+			mi.openImpl(testFileName)
 		})
 	})
 
@@ -532,7 +534,7 @@ func TestOpenImpl(t *testing.T) {
 			cache: &cache{},
 		}
 
-		_, err = mi.openImpl("bonjour.txt")
+		_, err = mi.openImpl(testFileName)
 		assert.Error(t, err)
 		var fsError *fsError
 		assert.ErrorAs(t, err, &fsError)


### PR DESCRIPTION
## What?

This Pull Request aims to address #3354, and avoid data races involved in using the [currently proposed implementation of `fs.read` and `fs.seek`](#3309).

## Why?

Namely, it modifies the behavior of the proposed `fs.read` and `fs.seek` methods to avoid data races due to:
1. accessing the `fs.read` buffer argument concurrently
2. updating the file offset concurrently when calling seek

In a nutshell, we addressed _1_ by ensuring that the provided buffer was only modified from the JS runtime's main thread, by performing it as a side-effect of the promise resolution's. We addressed _2_ by making sure the internal file structure's offset is an atomic int that cannot, as a result, be modified by two concurrent operations at the same time.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

ref #3309
ref #2974 
closes #3354

