### PR TITLE
Adds the K6_INFLUXDB_PROXY environment variable support, closes #3418

### DIFF
--- a/output/influxdb/config.go
+++ b/output/influxdb/config.go
@@ -17,6 +17,7 @@ import (
 type Config struct {
 	// Connection.
 	Addr             null.String        `json:"addr" envconfig:"K6_INFLUXDB_ADDR"`
+	Proxy            null.String        `json:"proxy,omitempty" envconfig:"K6_INFLUXDB_PROXY"`
 	Username         null.String        `json:"username,omitempty" envconfig:"K6_INFLUXDB_USERNAME"`
 	Password         null.String        `json:"password,omitempty" envconfig:"K6_INFLUXDB_PASSWORD"`
 	Insecure         null.Bool          `json:"insecure,omitempty" envconfig:"K6_INFLUXDB_INSECURE"`
@@ -56,6 +57,9 @@ func NewConfig() Config {
 func (c Config) Apply(cfg Config) Config {
 	if cfg.Addr.Valid {
 		c.Addr = cfg.Addr
+	}
+	if cfg.Proxy.Valid {
+		c.Proxy = cfg.Proxy
 	}
 	if cfg.Username.Valid {
 		c.Username = cfg.Username

--- a/output/influxdb/config_test.go
+++ b/output/influxdb/config_test.go
@@ -51,3 +51,26 @@ func TestParseURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGetConsolidatedConfigHTTPProxy(t *testing.T) {
+	t.Parallel()
+	t.Run("Valid Proxy URL", func(t *testing.T) {
+		t.Parallel()
+		testdata := map[string]string{
+			"K6_INFLUXDB_PROXY": "http://localhost:3128",
+		}
+		config, err := GetConsolidatedConfig(nil, testdata, "")
+		assert.NoError(t, err)
+		assert.Equal(t, "http://localhost:3128", config.Proxy.String)
+	})
+	t.Run("Invalid Proxy URL", func(t *testing.T) {
+		t.Parallel()
+		testdata := map[string]string{
+			"K6_INFLUXDB_PROXY": "http://foo\x7f.com/",
+		}
+		config, err := GetConsolidatedConfig(nil, testdata, "")
+		assert.NoError(t, err)
+		_, err = MakeClient(config)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## What?

This PR closes #3418 by adding the K6_INFLUXDB_PROXY environment variable support.

## Why?

This PR fixes the problem when your InfluxDB server is not opened for direct connections and requires a connection through proxy.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes #3418 
