### PR TITLE
Align release branch names

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -14,7 +14,7 @@ labels: ["release"]
 ### At the beginning of the cycle
 
 - [ ] Obtain the Release coordinator's contact from the `@k6-browser` team and co-assign the issue to them.
-- [ ] Create a new `release-notes-v0.4x.0` long-lived branch and add a new release notes file using the available [template](/grafana/k6/tree/master/release%20notes/template.md) to the [repository's `release notes` folder](/grafana/k6/tree/master/release%20notes).
+- [ ] Create a new `release-v0.4x.0` long-lived branch and add a new release notes file using the available [template](/grafana/k6/tree/master/release%20notes/template.md) to the [repository's `release notes` folder](/grafana/k6/tree/master/release%20notes).
 - [ ] Go through the potential [dependencies updates](Dependencies.md) and create a dedicated PR if any of them is relevant to this release.
 - [ ] Create a new `release-v0.4x.0` long-lived branch on the [k6-docs](https://github.com/grafana/k6-docs) repository. Try to keep it synchronized with `main` throughout the development cycle to prevent it from becoming outdated and to avoid numerous conflicts.
 - [ ] Create a new `release-v0.4x.0` long-lived branch on the [grafana/k6-DefinitelyTyped](https://github.com/grafana/k6-DefinitelyTyped) fork repository.


### PR DESCRIPTION
## What?

Aligns release branch names by renaming the `release-notes` branch name to `release`.

## Why?

To prevent [confusion](https://github.com/grafana/k6/issues/3382#issuecomment-1787364005).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

#3382