### PR TITLE
Add internal browser change

### DIFF
--- a/release notes/v0.48.0.md
+++ b/release notes/v0.48.0.md
@@ -37,7 +37,7 @@ _what, why, and what this means for the user_
 - [browser#1075](https://github.com/grafana/xk6-browser/pull/1075), [browser#1076](https://github.com/grafana/xk6-browser/pull/1076) Refactors `clearPermissions` and `grantPermissions`.
 - [browser#1043](https://github.com/grafana/xk6-browser/pull/1043) Refine tests.
 - [browser#1047](https://github.com/grafana/xk6-browser/pull/1047) Update dependencies.
-- [browser#1069](https://github.com/grafana/xk6-browser/pull/1069) Internal refactors.
+- [browser#1069](https://github.com/grafana/xk6-browser/pull/1069), [browser#1090](https://github.com/grafana/xk6-browser/pull/1090) Internal refactors.
 
 ## _Optional_ Roadmap
 


### PR DESCRIPTION
## What?

This adds an internal change to the release notes. This adds https://github.com/grafana/xk6-browser/pull/1090 which moves from `ioutil` to `io` and `os` packages.

## Why?

To keep the maintainers informed of release changes.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
