### PR TITLE
Set `K6_CLOUD_TRACES_HOST` to new hostname

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -170,7 +170,7 @@ func NewConfig() Config {
 		MetricPushConcurrency: null.NewInt(1, false),
 
 		TracesEnabled:         null.NewBool(true, false),
-		TracesHost:            null.NewString("insights.k6.io:4443", false),
+		TracesHost:            null.NewString("grpc-k6-api-prod-prod-us-east-0.grafana.net:443", false),
 		TracesPushInterval:    types.NewNullDuration(1*time.Second, false),
 		TracesPushConcurrency: null.NewInt(1, false),
 


### PR DESCRIPTION
## What?

This commit updates the default value of `K6_CLOUD_TRACES_HOST` to target the new endpoint in Grafana clusters.

## Why?

This change is done as part of the infrastructure migration efforts. Existing customers are not impacted since `insights.k6.io` now uses the CNAME record to redirect to the new hostname.

Output from `dig`:

```bash
dig insights.k6.io

; <<>> DiG 9.10.6 <<>> insights.k6.io
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 58234
;; flags: qr rd ra; QUERY: 1, ANSWER: 4, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 512
;; QUESTION SECTION:
;insights.k6.io.			IN	A

;; ANSWER SECTION:
insights.k6.io.		300	IN	CNAME	grpc-k6-api-prod-prod-us-east-0.grafana.net.
grpc-k6-api-prod-prod-us-east-0.grafana.net. 60	IN CNAME k8s-k6apipro-grpcapis-0ed93049b6-2113765632.us-east-2.elb.amazonaws.com.
k8s-k6apipro-grpcapis-0ed93049b6-2113765632.us-east-2.elb.amazonaws.com. 60 IN A 52.15.202.83
k8s-k6apipro-grpcapis-0ed93049b6-2113765632.us-east-2.elb.amazonaws.com. 60 IN A 13.59.222.127

;; Query time: 94 msec
;; SERVER: 2001:730:3ed2:1000::53#53(2001:730:3ed2:1000::53)
;; WHEN: Thu Nov 02 13:26:13 CET 2023
;; MSG SIZE  rcvd: 217
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
