### PR TITLE
fix EOF errors on http response with content and encoding headers

### DIFF
--- a/lib/netext/httpext/compression.go
+++ b/lib/netext/httpext/compression.go
@@ -140,6 +140,13 @@ func readResponseBody(
 		_ = respBody.Close()
 	}(resp.Body)
 
+	if (resp.StatusCode >= 100 && resp.StatusCode <= 199) || // 1xx
+		resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotModified {
+		// for all three of this status code there is always no content
+		// https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4.1-8
+		// this also prevents trying to read
+		return nil, nil //nolint:nilnil
+	}
 	contentEncodings := strings.Split(resp.Header.Get("Content-Encoding"), ",")
 	// Transparently decompress the body if it's has a content-encoding we
 	// support. If not, simply return it as it is.


### PR DESCRIPTION
Before this on a response which has a Content-Encoding value, but no body will error out with EOF as we still try to decode it.

As the code and the semantics of network requests mean that we might not know if we are going to be able to read something and whether we got and EOF because of network error or because there was no body - we need to figure out if we should try to read at all.

Unfortunately `Content-Encoding: chunked` exists which makes a more general solution much harder IMO.

As such the current solution is to short circuit on known status codes that do not have content. Namely all 1xx and 204 (aptly named no content) and 304 (not modified).

https://www.rfc-editor.org/rfc/rfc9110.html#section-6.4.1-8

Additionally a bare minimum tests was added reproducing what the user reported.

https://community.grafana.com/t/error-decompressing-response-body-eof-despite-http-request-returning-204/106927

