### PR TITLE
Add support for --version flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,7 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 		PersistentPreRunE: c.persistentPreRunE,
+		Version:           versionString(),
 	}
 
 	rootCmd.PersistentFlags().AddFlagSet(rootCmdPersistentFlagSet(gs))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,7 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 	}
 
 	rootCmd.SetVersionTemplate(
-		`{{with .Name}}{{printf "%s " .}}{{end}}{{printf "v%s" .Version}}\n`,
+		`{{with .Name}}{{printf "%s " .}}{{end}}{{printf "v%s\n" .Version}}`,
 	)
 	rootCmd.PersistentFlags().AddFlagSet(rootCmdPersistentFlagSet(gs))
 	rootCmd.SetArgs(gs.CmdArgs[1:])

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,9 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 		Version:           versionString(),
 	}
 
+	rootCmd.SetVersionTemplate(
+		`{{with .Name}}{{printf "%s " .}}{{end}}{{printf "v%s" .Version}}\n`,
+	)
 	rootCmd.PersistentFlags().AddFlagSet(rootCmdPersistentFlagSet(gs))
 	rootCmd.SetArgs(gs.CmdArgs[1:])
 	rootCmd.SetOut(gs.Stdout)

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -42,7 +42,7 @@ func TestVersion(t *testing.T) {
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 	stdout := ts.Stdout.String()
-	assert.Contains(t, stdout, "k6 version "+consts.Version)
+	assert.Contains(t, stdout, "k6 v"+consts.Version)
 	assert.Contains(t, stdout, runtime.Version())
 	assert.Contains(t, stdout, runtime.GOOS)
 	assert.Contains(t, stdout, runtime.GOARCH)

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -47,7 +47,6 @@ func TestVersion(t *testing.T) {
 	ts := NewGlobalTestState(t)
 
 	for _, tc := range tests {
-
 		ts.CmdArgs = []string{"k6", tc.args}
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -42,7 +42,7 @@ func TestVersion(t *testing.T) {
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 	stdout := ts.Stdout.String()
-	assert.Contains(t, stdout, "k6 v"+consts.Version)
+	assert.Contains(t, stdout, "k6 version "+consts.Version)
 	assert.Contains(t, stdout, runtime.Version())
 	assert.Contains(t, stdout, runtime.GOOS)
 	assert.Contains(t, stdout, runtime.GOARCH)

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -37,15 +37,26 @@ import (
 func TestVersion(t *testing.T) {
 	t.Parallel()
 
-	ts := NewGlobalTestState(t)
-	ts.CmdArgs = []string{"k6", "version"}
-	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	tests := map[string]struct {
+		args string
+	}{
+		"flag":       {"--version"},
+		"subcommand": {"version"},
+	}
 
-	stdout := ts.Stdout.String()
-	assert.Contains(t, stdout, "k6 v"+consts.Version)
-	assert.Contains(t, stdout, runtime.Version())
-	assert.Contains(t, stdout, runtime.GOOS)
-	assert.Contains(t, stdout, runtime.GOARCH)
+	ts := NewGlobalTestState(t)
+
+	for _, tc := range tests {
+
+		ts.CmdArgs = []string{"k6", tc.args}
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		assert.Contains(t, stdout, "k6 v"+consts.Version)
+		assert.Contains(t, stdout, runtime.Version())
+		assert.Contains(t, stdout, runtime.GOOS)
+		assert.Contains(t, stdout, runtime.GOARCH)
+	}
 
 	assert.Empty(t, ts.Stderr.Bytes())
 	assert.Empty(t, ts.LoggerHook.Drain())

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -31,7 +31,9 @@ func getCmdVersion(gs *state.GlobalState) *cobra.Command {
 		Short: "Show application version",
 		Long:  `Show the application version and exit.`,
 		Run: func(_ *cobra.Command, _ []string) {
-			printToStdout(gs, fmt.Sprintf("k6 v%s\n", versionString()))
+	root := cmd.Root()
+    root.SetArgs([]string{"--version"})
+	root.Execute()
 		},
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -10,6 +10,20 @@ import (
 	"go.k6.io/k6/lib/consts"
 )
 
+func versionString() string {
+	v := consts.FullVersion()
+
+	if exts := ext.GetAll(); len(exts) > 0 {
+		extsDesc := make([]string, 0, len(exts))
+		for _, e := range exts {
+			extsDesc = append(extsDesc, fmt.Sprintf("  %s", e.String()))
+		}
+		v += fmt.Sprintf("\nExtensions:\n%s\n",
+			strings.Join(extsDesc, "\n"))
+	}
+	return v
+}
+
 func getCmdVersion(gs *state.GlobalState) *cobra.Command {
 	// versionCmd represents the version command.
 	return &cobra.Command{
@@ -17,16 +31,7 @@ func getCmdVersion(gs *state.GlobalState) *cobra.Command {
 		Short: "Show application version",
 		Long:  `Show the application version and exit.`,
 		Run: func(_ *cobra.Command, _ []string) {
-			printToStdout(gs, fmt.Sprintf("k6 v%s\n", consts.FullVersion()))
-
-			if exts := ext.GetAll(); len(exts) > 0 {
-				extsDesc := make([]string, 0, len(exts))
-				for _, e := range exts {
-					extsDesc = append(extsDesc, fmt.Sprintf("  %s", e.String()))
-				}
-				printToStdout(gs, fmt.Sprintf("Extensions:\n%s\n",
-					strings.Join(extsDesc, "\n")))
-			}
+			printToStdout(gs, fmt.Sprintf("k6 version %s\n", versionString()))
 		},
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -31,7 +31,7 @@ func getCmdVersion(gs *state.GlobalState) *cobra.Command {
 		Short: "Show application version",
 		Long:  `Show the application version and exit.`,
 		Run: func(_ *cobra.Command, _ []string) {
-			printToStdout(gs, fmt.Sprintf("k6 version %s\n", versionString()))
+			printToStdout(gs, fmt.Sprintf("k6 v%s\n", versionString()))
 		},
 	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -30,10 +30,10 @@ func getCmdVersion(gs *state.GlobalState) *cobra.Command {
 		Use:   "version",
 		Short: "Show application version",
 		Long:  `Show the application version and exit.`,
-		Run: func(_ *cobra.Command, _ []string) {
-	root := cmd.Root()
-    root.SetArgs([]string{"--version"})
-	root.Execute()
+		Run: func(cmd *cobra.Command, _ []string) {
+			root := cmd.Root()
+			root.SetArgs([]string{"--version"})
+			_ = root.Execute()
 		},
 	}
 }


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->
Adds support for `--version` global flag that matches the `version` subcommand.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->
Running the usual Unix-like flags returns an error.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->
<https://github.com/grafana/k6/issues/2352>

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
