### PR TITLE
Add request interception fix to release notes

### DIFF
--- a/release notes/v0.48.0.md
+++ b/release notes/v0.48.0.md
@@ -33,6 +33,7 @@ If no filename is provided, the default filename `script.js` will be used. The s
 
 - [browser#1077](https://github.com/grafana/xk6-browser/pull/1077) Fixes `browserContext.clearPermissions` to clear permissions without panic.
 - [browser#1042](https://github.com/grafana/xk6-browser/pull/1042) Fixes `browserContext.waitForEvent` which involved promisifying the `waitForEvent` API.
+- [browser#1078](https://github.com/grafana/xk6-browser/pull/1078) Fixes request interception deadlock to improve stability.
 
 ## Maintenance and internal improvements
 


### PR DESCRIPTION
## What?

Add grafana/xk6-browser#1078 to release notes.

## Why?

This adds a note about a network interception deadlock fix.

## Related PR(s)/Issue(s)

grafana/xk6-browser#1072