### PR TITLE
Erroring on modules with no scheme

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -198,11 +198,8 @@ func Load(
 				return nil, err
 			}
 		case moduleSpecifier.Scheme == "":
-			logger.Warningf(`The moduleSpecifier "%s" has no scheme but we will try to resolve it as remote module. `+
-				`This is deprecated and will be removed in v0.48.0 - all remote modules will `+
-				`need to explicitly be prepended with "https://".`, originalModuleSpecifier)
-			*finalModuleSpecifierURL = *moduleSpecifier
-			finalModuleSpecifierURL.Scheme = scheme
+			return nil, errors.New(`The moduleSpecifier "` + originalModuleSpecifier + `" has no scheme. ` +
+				`All remote modules should explicitly be prepended with "https://".`)
 		default:
 			finalModuleSpecifierURL = moduleSpecifier
 		}


### PR DESCRIPTION
## What?

As was planned in the https://github.com/grafana/k6/issues/3287 we removed the support of adding `https://` for the module resolution.

## Why?

https://github.com/grafana/k6/issues/3287

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #3287

<!-- Thanks for your contribution! 🙏🏼 -->
