### PR TITLE
Add CPU and Network throttling to release notes

### DIFF
--- a/release notes/v0.48.0.md
+++ b/release notes/v0.48.0.md
@@ -136,6 +136,20 @@ export default async function () {
 }
 ```
 
+### Add support for browser module's `page.throttleCPU` [browser#1095](https://github.com/grafana/xk6-browser/pull/1095)
+
+Allows users to throttle the CPU from chrome/chromium's perspective, which helps emulate slower devices when testing the website's frontend. The mandatory argument is of type `CPUProfile`, which is made up of one field named `rate` that is a slow down factor, where `1` means no throttling, and `2` means 2x slowdown, and so on. The documentation for this API can be found [here](https://grafana.com/docs/k6/v0.48.x/javascript-api/k6-experimental/browser/page/throttlecpu).
+
+```js
+...
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    page.throttleCPU({ rate: 4 });
+...
+```
+
 ## UX improvements and enhancements
 
 - [browser#1074](https://github.com/grafana/xk6-browser/pull/1074) Adds a new `browser.closeContext()` [method](https://k6.io/docs/javascript-api/k6-experimental/browser/closecontext/) to facilitate closing the current active browser context.

--- a/release notes/v0.48.0.md
+++ b/release notes/v0.48.0.md
@@ -150,6 +150,44 @@ Allows users to throttle the CPU from chrome/chromium's perspective, which helps
 ...
 ```
 
+### Add support for browser module's `page.throttleNetwork` [browser#1094](https://github.com/grafana/xk6-browser/pull/1094)
+
+Allows users to throttle the characteristics of the network from chrome/chromium's perspective, which helps emulate poor network connections when testing the website's frontend. The mandatory argument is of type `NetworkProfile` and is defined as:
+
+```ts
+export interface NetworkProfile {
+    /*
+     * Minimum latency from request sent to response headers received (ms).
+     */
+    latency: number;
+    
+    /*
+     * Maximal aggregated download throughput (bytes/sec). -1 disables download
+     * throttling.
+     */
+    download: number;
+    
+    /*
+     * Maximal aggregated upload throughput (bytes/sec). -1 disables upload
+     * throttling.
+     */
+    upload: number;
+}
+```
+
+You can either define your own network profiles or use the ones we have defined by importing `networkProfiles` from the `browser` module. The documentation for this API can be found [here](https://grafana.com/docs/k6/v0.48.x/javascript-api/k6-experimental/browser/page/throttlenetwork).
+
+```js
+import { browser, networkProfiles } from 'k6/experimental/browser';
+...
+  const context = browser.newContext();
+  const page = context.newPage();
+
+  try {
+    page.throttleNetwork(networkProfiles['Slow 3G']);
+...
+```
+
 ## UX improvements and enhancements
 
 - [browser#1074](https://github.com/grafana/xk6-browser/pull/1074) Adds a new `browser.closeContext()` [method](https://k6.io/docs/javascript-api/k6-experimental/browser/closecontext/) to facilitate closing the current active browser context.


### PR DESCRIPTION
## What?

Adds the `page.throttleCPU` and `page.throttleNetwork` changes to the release notes which were implemented in the browser module.

## Why?

To notify users of the latest new feature.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

Updates: https://github.com/grafana/xk6-browser/issues/887