### PR TITLE
Add joanlopez to auto-assign gh workflows

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const assignees = ['mstoykov', 'codebien', 'olegbespalov', 'oleiade'];
+            const assignees = ['mstoykov', 'codebien', 'olegbespalov', 'oleiade', 'joanlopez'];
             const assigneeCount = 1;
 
             // Do not automatically assign users if someone was already assigned or it was opened by a maintainer

--- a/.github/workflows/pr-auto-assign.yml
+++ b/.github/workflows/pr-auto-assign.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/github-script@v6
         with:
           script: |
-            const reviewers = ['mstoykov', 'codebien', 'olegbespalov', 'oleiade'];
+            const reviewers = ['mstoykov', 'codebien', 'olegbespalov', 'oleiade', 'joanlopez'];
             const reviewerCount = 2;
             const crypto = require("node:crypto");
 


### PR DESCRIPTION
## What?

Adds [`joanlopez`](https://github.com/joanlopez) to _auto-assign_ GitHub workflows.

## Why?

Onboarding new maintainer.

## Checklist

N/A

## Related PR(s)/Issue(s)

N/A
