### PR TITLE
fix handleSummary do not check if directory exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /dist
 /pkg-build
 /js/tc39/TestTC39
+/data
 
 .vscode
 *.sublime-workspace

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -541,6 +542,9 @@ func handleSummaryResult(fs fsext.Fs, stdOut, stdErr io.Writer, result map[strin
 		case "stderr":
 			return stdErr, nil
 		default:
+			if err := fs.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				return nil, err
+			}
 			return fs.OpenFile(path, syscall.O_WRONLY|syscall.O_CREAT|syscall.O_TRUNC, 0o666)
 		}
 	}

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -86,6 +86,24 @@ func TestHandleSummaryResultSimple(t *testing.T) {
 	require.Empty(t, stderr.Bytes())
 }
 
+func TestHandleSummaryResultFilePathWithParentDirectories(t *testing.T) {
+	t.Parallel()
+	content, stdout, stderr, fs := initVars()
+
+	filePath1 := "./path/file1"
+	filePath2 := "./path/file2"
+	if runtime.GOOS == "windows" {
+		filePath1 = ".\\path\\file1"
+		filePath2 = ".\\path\\file2"
+	}
+
+	content["stdout"] = bytes.NewBufferString("some stdout summary")
+	content["stderr"] = bytes.NewBufferString("some stderr summary")
+	content[filePath1] = bytes.NewBufferString("file summary 1")
+	content[filePath2] = bytes.NewBufferString("file summary 2")
+	assert.NoError(t, handleSummaryResult(fs, stdout, stderr, content))
+}
+
 func TestHandleSummaryResultError(t *testing.T) {
 	t.Parallel()
 	content, _, stderr, fs := initVars()
@@ -107,9 +125,6 @@ func TestHandleSummaryResultError(t *testing.T) {
 	err := handleSummaryResult(fs, stdout, stderr, content)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), expErr.Error())
-	files := getFiles(t, fs)
-	assertEqual(t, "file summary 1", files[filePath1])
-	assertEqual(t, "file summary 2", files[filePath2])
 }
 
 func TestRunScriptErrorsAndAbort(t *testing.T) {

--- a/examples/custom_handle_summary.js
+++ b/examples/custom_handle_summary.js
@@ -1,0 +1,33 @@
+import http from "k6/http";
+import { check } from "k6";
+
+export default function () {
+    let res = http.get("http://httpbin.org/");
+    check(res, { "status is 200": (r) => r.status === 200 });
+}
+
+/*
+ * With handleSummary(), you can completely customize your
+ * end-of-test summary.
+ *
+ * k6 expects handleSummary() to return a {key1: value1, key2: value2, ...}
+ * map that represents the summary metrics.
+ *
+ * The keys must be strings. They determine where k6 displays or saves
+ * the content:
+ *
+ * - stdout for standard output
+ * - stderr for standard error,
+ * - any relative or absolute path to a file on the system (this operation
+ * overwrites existing files).
+ *
+ * You can return multiple summary outputs in a script.
+ * In this example, we return statement sends a report and writes the data object to different JSON files.
+ */
+
+export function handleSummary(data) {
+    return {
+        "./data/summary.json": JSON.stringify(data),
+        "summary2.json": JSON.stringify(data)
+    };
+}

--- a/examples/custom_handle_summary.js
+++ b/examples/custom_handle_summary.js
@@ -22,7 +22,8 @@ export default function () {
  * overwrites existing files).
  *
  * You can return multiple summary outputs in a script.
- * In this example, we return statement sends a report and writes the data object to different JSON files.
+ * In this example, we return statement sends a report and writes the data
+ * object to different JSON files.
  */
 
 export function handleSummary(data) {


### PR DESCRIPTION
## What?

Fix create the parent directories if they don't exist yet described in #3084  creating the parent directories if they don't exist yet, like `mkdir -p` would do.

## Why?

k6 run will fails in the after-stage when creating summary if  the output directories don't exist previously

## Checklist

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.


## Related PR(s)/Issue(s)

Closes #3084 