### PR TITLE
Bump golangci-lint to v1.55.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.54.2
+# v1.55.2
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   deadline: 5m


### PR DESCRIPTION
## What?

Bump golangci-lint to the latest version. It contains the fixes for the `gosec` linter, which won't cause false-positive errors.

## Why?

Otherwise, we must make inline exceptions in the projects using the same linter ruleset.

For cases like:

```golang
const distributionKey = "LOREM_IPSUM"
```

it could scream that this is hardcoded credentials.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
