### PR TITLE
handling large vu shifts

### DIFF
--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -76,8 +76,6 @@ func validateStages(stages []Stage) []error {
 			errors = append(errors, fmt.Errorf("stage %d doesn't have a target", stageNum))
 		} else if s.Target.Int64 < 0 {
 			errors = append(errors, fmt.Errorf("the target for stage %d can't be negative", stageNum))
-		} else if s.Target.Int64 > 100000000 {
-			errors = append(errors, fmt.Errorf("the target for stage %d is too large", stageNum))
 		}
 	}
 	return errors

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	// maxConcurrentVus is an arbitrary limit for sanity checks. It prevents running an exaggeratedly large number of concurrent VUs which may lead to an out-of-memory.
-	maxConcurrentVus int = 100_000_000
+	// maxConcurrentVUs is an arbitrary limit for sanity checks. It prevents running an exaggeratedly large number of concurrent VUs which may lead to an out-of-memory.
+	maxConcurrentVUs int = 100_000_000
 )
 
 func sumStagesDuration(stages []Stage) (result time.Duration) {
@@ -40,18 +40,18 @@ func getStagesUnscaledMaxTarget(unscaledStartValue int64, stages []Stage) int64 
 
 // validateTargetShifts validates the VU Target shifts. It will append an error for any VU target that is larger than the maximum value allowed.
 // Each Stage needs a Target value. The stages array can be empty. The Targes could be negative.
-func validateTargetShifts(startVus int64, stages []Stage) []error {
+func validateTargetShifts(startVUs int64, stages []Stage) []error {
 	var errors []error
 
-	if startVus > int64(maxConcurrentVus) {
+	if startVUs > int64(maxConcurrentVUs) {
 		errors = append(errors, fmt.Errorf(
-			"the startVUs exceed max limit of %d", maxConcurrentVus))
+			"the startVUs exceed max limit of %d", maxConcurrentVUs))
 	 }
 
 	for i := 0; i < len(stages); i++ {
-		if stages[i].Target.Int64 > int64(maxConcurrentVus) {
+		if stages[i].Target.Int64 > int64(maxConcurrentVUs) {
 			errors = append(errors, fmt.Errorf(
-				"target for stage %d exceeds max limit of %d", i+1, maxConcurrentVus))
+				"target for stage %d exceeds max limit of %d", i+1, maxConcurrentVUs))
 		}
 	}
 

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -17,7 +17,8 @@ import (
 )
 
 const (
-	// maxConcurrentVUs is an arbitrary limit for sanity checks. It prevents running an exaggeratedly large number of concurrent VUs which may lead to an out-of-memory.
+	// maxConcurrentVUs is an arbitrary limit for sanity checks.
+	// It prevents running an exaggeratedly large number of concurrent VUs which may lead to an out-of-memory.
 	maxConcurrentVUs int = 100_000_000
 )
 
@@ -38,7 +39,8 @@ func getStagesUnscaledMaxTarget(unscaledStartValue int64, stages []Stage) int64 
 	return max
 }
 
-// validateTargetShifts validates the VU Target shifts. It will append an error for any VU target that is larger than the maximum value allowed.
+// validateTargetShifts validates the VU Target shifts.
+// It will append an error for any VU target that is larger than the maximum value allowed.
 // Each Stage needs a Target value. The stages array can be empty. The Targes could be negative.
 func validateTargetShifts(startVUs int64, stages []Stage) []error {
 	var errors []error
@@ -46,7 +48,7 @@ func validateTargetShifts(startVUs int64, stages []Stage) []error {
 	if startVUs > int64(maxConcurrentVUs) {
 		errors = append(errors, fmt.Errorf(
 			"the startVUs exceed max limit of %d", maxConcurrentVUs))
-	 }
+	}
 
 	for i := 0; i < len(stages); i++ {
 		if stages[i].Target.Int64 > int64(maxConcurrentVUs) {

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// this value is an arbitrary limit. It pervenets VU shifts from being too large.
-	maxDeltaVuShifts int = 100_000_000
+	maxDeltaVUShifts int = 100_000_000
 )
 
 func sumStagesDuration(stages []Stage) (result time.Duration) {
@@ -38,26 +38,26 @@ func getStagesUnscaledMaxTarget(unscaledStartValue int64, stages []Stage) int64 
 	return max
 }
 
-// Validates all the VU up and down shifts. For any shift that is larger than maxDeltaVuShifts it will append an error.
-// This includes the shift from 0 to the startVus and the shift from the last stage to 0.
-// It takes the startVus and the stages as input.
+// Validates all the VU up and down shifts. For any shift that is larger than maxDeltaVUShifts it will append an error.
+// This includes the shift from 0 to the startVUs and the shift from the last stage to 0.
+// It takes the startVUs and the stages as input.
 // Each Stage needs a Target value. The stages array can be empty. The Targes could be negative.
-func validateMaxDeltaVu(startVus int64, stages []Stage) []error {
+func validateMaxDeltaVU(startVUs int64, stages []Stage) []error {
 	var errors []error
 
-	vuTargets := []int64{0, startVus}
+	TargetVUs := []int64{0, startVUs}
 	for _, s := range stages {
-		vuTargets = append(vuTargets, s.Target.Int64)
+		TargetVUs = append(TargetVUs, s.Target.Int64)
 	}
-	vuTargets = append(vuTargets, 0)
+	TargetVUs = append(TargetVUs, 0)
 
-	for i := 0; i < len(vuTargets)-1; i++ {
-		currentVus := vuTargets[i]
-		nextVus := vuTargets[i+1]
+	for i := 0; i < len(TargetVUs)-1; i++ {
+		currentVUs := TargetVUs[i]
+		nextVUs := TargetVUs[i+1]
 
-		if absInt64(currentVus-nextVus) > int64(maxDeltaVuShifts) {
+		if absInt64(currentVUs-nextVUs) > int64(maxDeltaVUShifts) {
 			errors = append(errors, fmt.Errorf(
-				"the VU shifts from %d to %d is larger than the maximum allowed %d", currentVus, nextVus, maxDeltaVuShifts))
+				"the VU shifts from %d to %d is larger than the maximum allowed %d", currentVUs, nextVUs, maxDeltaVUShifts))
 		}
 	}
 

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -30,10 +30,10 @@ func sumTotalNumberOfUpAndDonwShifts(startVus int64, stages []Stage) int64 {
 
 	for _, s := range stages {
 		current := big.NewInt(s.Target.Int64)
-		shiftDelta := new(big.Int).Sub(current, prevNumVus)
-		shiftDelta.Abs(shiftDelta)
+		vuDelta := new(big.Int).Sub(current, prevNumVus)
+		vuDelta.Abs(vuDelta)
 
-		totalShifts.Add(totalShifts, shiftDelta)
+		totalShifts.Add(totalShifts, vuDelta)
 
 		prevNumVus = current
 	}

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -38,8 +38,7 @@ func getStagesUnscaledMaxTarget(unscaledStartValue int64, stages []Stage) int64 
 	return max
 }
 
-// validateTargetShifts validates the target up shifts. It will append an error for any shift that is larger than the maximum value allowed.
-// This includes the shift from 0 to the startTarget and the shift from the last stage to 0.
+// validateTargetShifts validates the VU Target shifts. It will append an error for any VU target that is larger than the maximum value allowed.
 // Each Stage needs a Target value. The stages array can be empty. The Targes could be negative.
 func validateTargetShifts(startVus int64, stages []Stage) []error {
 	var errors []error

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// this value is an arbitrary limit. It pervenets VU shifts from being too large.
-	maxVUShift int = 100_000_000
+	maxTargetShift int = 100_000_000
 )
 
 func sumStagesDuration(stages []Stage) (result time.Duration) {
@@ -38,26 +38,26 @@ func getStagesUnscaledMaxTarget(unscaledStartValue int64, stages []Stage) int64 
 	return max
 }
 
-// Validates all the VU up and down shifts. For any shift that is larger than maxVUShift it will append an error.
-// This includes the shift from 0 to the startVUs and the shift from the last stage to 0.
-// It takes the startVUs and the stages as input.
+// Validates target up and down shifts. For any shift that is larger than maxTargetShift, it will append an error.
+// This includes the shift from 0 to the startTarget and the shift from the last stage to 0.
+// Targets can be Vus or iteration rates.
 // Each Stage needs a Target value. The stages array can be empty. The Targes could be negative.
-func validateVUShifts(startVUs int64, stages []Stage) []error {
+func validateTargetShifts(startTarget int64, stages []Stage) []error {
 	var errors []error
+	targets := []int64{0, startTarget}
 
-	TargetVUs := []int64{0, startVUs}
 	for _, s := range stages {
-		TargetVUs = append(TargetVUs, s.Target.Int64)
+		targets = append(targets, s.Target.Int64)
 	}
-	TargetVUs = append(TargetVUs, 0)
+	targets = append(targets, 0)
 
-	for i := 0; i < len(TargetVUs)-1; i++ {
-		currentVUs := TargetVUs[i]
-		nextVUs := TargetVUs[i+1]
+	for i := 0; i < len(targets)-1; i++ {
+		currentTarget := targets[i]
+		nextTarget := targets[i+1]
 
-		if absInt64(currentVUs-nextVUs) > int64(maxVUShift) {
+		if absInt64(currentTarget-nextTarget) > int64(maxTargetShift) {
 			errors = append(errors, fmt.Errorf(
-				"the VU shifts from %d to %d is larger than the maximum allowed %d", currentVUs, nextVUs, maxVUShift))
+				"the target shifts from %d to %d is larger than the maximum allowed %d", currentTarget, nextTarget, maxTargetShift))
 		}
 	}
 

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -35,7 +35,7 @@ func getStagesUnscaledMaxTarget(unscaledStartValue int64, stages []Stage) int64 
 
 func validateNumberOfVuShifts(startVus int64, stages []Stage) []error {
 	const MaxRampingVUShift = 100000000
-	
+
 	var errors []error
 	totalShifts := big.NewInt(startVus)
 	prevNumVus := totalShifts

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// this value is an arbitrary limit. It pervenets VU shifts from being too large.
-	maxDeltaVUShifts int = 100_000_000
+	maxVUShift int = 100_000_000
 )
 
 func sumStagesDuration(stages []Stage) (result time.Duration) {
@@ -38,11 +38,11 @@ func getStagesUnscaledMaxTarget(unscaledStartValue int64, stages []Stage) int64 
 	return max
 }
 
-// Validates all the VU up and down shifts. For any shift that is larger than maxDeltaVUShifts it will append an error.
+// Validates all the VU up and down shifts. For any shift that is larger than maxVUShift it will append an error.
 // This includes the shift from 0 to the startVUs and the shift from the last stage to 0.
 // It takes the startVUs and the stages as input.
 // Each Stage needs a Target value. The stages array can be empty. The Targes could be negative.
-func validateMaxDeltaVU(startVUs int64, stages []Stage) []error {
+func validateVUShifts(startVUs int64, stages []Stage) []error {
 	var errors []error
 
 	TargetVUs := []int64{0, startVUs}
@@ -55,9 +55,9 @@ func validateMaxDeltaVU(startVUs int64, stages []Stage) []error {
 		currentVUs := TargetVUs[i]
 		nextVUs := TargetVUs[i+1]
 
-		if absInt64(currentVUs-nextVUs) > int64(maxDeltaVUShifts) {
+		if absInt64(currentVUs-nextVUs) > int64(maxVUShift) {
 			errors = append(errors, fmt.Errorf(
-				"the VU shifts from %d to %d is larger than the maximum allowed %d", currentVUs, nextVUs, maxDeltaVUShifts))
+				"the VU shifts from %d to %d is larger than the maximum allowed %d", currentVUs, nextVUs, maxVUShift))
 		}
 	}
 

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -16,6 +16,11 @@ import (
 	"go.k6.io/k6/ui/pb"
 )
 
+const (
+	// this value is an arbitrary limit. It pervenets VU shifts from being too large.
+	maxDeltaVuShifts int = 100_000_000
+)
+
 func sumStagesDuration(stages []Stage) (result time.Duration) {
 	for _, s := range stages {
 		result += s.Duration.TimeDuration()
@@ -33,27 +38,27 @@ func getStagesUnscaledMaxTarget(unscaledStartValue int64, stages []Stage) int64 
 	return max
 }
 
-func validateNumberOfVuShifts(startVus int64, stages []Stage) []error {
-	const MaxRampingVUShift = 100000000
-
+// Validates all the VU up and down shifts. For any shift that is larger than maxDeltaVuShifts it will append an error.
+// This includes the shift from 0 to the startVus and the shift from the last stage to 0.
+// It takes the startVus and the stages as input.
+// Each Stage needs a Target value. The stages array can be empty. The Targes could be negative.
+func validateMaxDeltaVu(startVus int64, stages []Stage) []error {
 	var errors []error
-	totalShifts := big.NewInt(startVus)
-	prevNumVus := totalShifts
 
+	vuTargets := []int64{0, startVus}
 	for _, s := range stages {
-		current := big.NewInt(s.Target.Int64)
-		vuDelta := new(big.Int).Sub(current, prevNumVus)
-		vuDelta.Abs(vuDelta)
-
-		totalShifts.Add(totalShifts, vuDelta)
-
-		prevNumVus = current
+		vuTargets = append(vuTargets, s.Target.Int64)
 	}
+	vuTargets = append(vuTargets, 0)
 
-	totalShifts.Add(totalShifts, prevNumVus)
+	for i := 0; i < len(vuTargets)-1; i++ {
+		currentVus := vuTargets[i]
+		nextVus := vuTargets[i+1]
 
-	if totalShifts.Cmp(big.NewInt(MaxRampingVUShift)) > 0 {
-		errors = append(errors, fmt.Errorf("total number of VU shifts is too large"))
+		if absInt64(currentVus-nextVus) > int64(maxDeltaVuShifts) {
+			errors = append(errors, fmt.Errorf(
+				"the VU shifts from %d to %d is larger than the maximum allowed %d", currentVus, nextVus, maxDeltaVuShifts))
+		}
 	}
 
 	return errors

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -95,6 +95,7 @@ func (varc *RampingArrivalRateConfig) Validate() []error {
 		errors = append(errors, fmt.Errorf("the timeUnit must be more than 0"))
 	}
 
+	errors = append(errors, validateNumberOfVuShifts(varc.StartRate.Int64, varc.Stages)...)
 	errors = append(errors, validateStages(varc.Stages)...)
 
 	if !varc.PreAllocatedVUs.Valid {

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -95,8 +95,8 @@ func (varc *RampingArrivalRateConfig) Validate() []error {
 		errors = append(errors, fmt.Errorf("the timeUnit must be more than 0"))
 	}
 
-	errors = append(errors, validateNumberOfVuShifts(varc.StartRate.Int64, varc.Stages)...)
 	errors = append(errors, validateStages(varc.Stages)...)
+	errors = append(errors, validateMaxDeltaVu(varc.StartRate.Int64, varc.Stages)...)
 
 	if !varc.PreAllocatedVUs.Valid {
 		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs isn't specified"))

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -96,7 +96,7 @@ func (varc *RampingArrivalRateConfig) Validate() []error {
 	}
 
 	errors = append(errors, validateStages(varc.Stages)...)
-	errors = append(errors, validateMaxDeltaVU(varc.StartRate.Int64, varc.Stages)...)
+	errors = append(errors, validateVUShifts(varc.StartRate.Int64, varc.Stages)...)
 
 	if !varc.PreAllocatedVUs.Valid {
 		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs isn't specified"))

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -96,7 +96,6 @@ func (varc *RampingArrivalRateConfig) Validate() []error {
 	}
 
 	errors = append(errors, validateStages(varc.Stages)...)
-	errors = append(errors, validateTargetShifts(varc.StartRate.Int64, varc.Stages)...)
 
 	if !varc.PreAllocatedVUs.Valid {
 		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs isn't specified"))

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -96,7 +96,7 @@ func (varc *RampingArrivalRateConfig) Validate() []error {
 	}
 
 	errors = append(errors, validateStages(varc.Stages)...)
-	errors = append(errors, validateVUShifts(varc.StartRate.Int64, varc.Stages)...)
+	errors = append(errors, validateTargetShifts(varc.StartRate.Int64, varc.Stages)...)
 
 	if !varc.PreAllocatedVUs.Valid {
 		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs isn't specified"))

--- a/lib/executor/ramping_arrival_rate.go
+++ b/lib/executor/ramping_arrival_rate.go
@@ -96,7 +96,7 @@ func (varc *RampingArrivalRateConfig) Validate() []error {
 	}
 
 	errors = append(errors, validateStages(varc.Stages)...)
-	errors = append(errors, validateMaxDeltaVu(varc.StartRate.Int64, varc.Stages)...)
+	errors = append(errors, validateMaxDeltaVU(varc.StartRate.Int64, varc.Stages)...)
 
 	if !varc.PreAllocatedVUs.Valid {
 		errors = append(errors, fmt.Errorf("the number of preAllocatedVUs isn't specified"))

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -87,7 +87,7 @@ func (vlvc RampingVUsConfig) Validate() []error {
 	}
 
 	errors = append(errors, validateStages(vlvc.Stages)...)
-	errors = append(errors, validateMaxDeltaVU(vlvc.StartVUs.Int64, vlvc.Stages)...)
+	errors = append(errors, validateVUShifts(vlvc.StartVUs.Int64, vlvc.Stages)...)
 
 	return errors
 }

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -86,8 +86,8 @@ func (vlvc RampingVUsConfig) Validate() []error {
 		errors = append(errors, fmt.Errorf("either startVUs or one of the stages' target values must be greater than 0"))
 	}
 
-	errors = append(errors, validateNumberOfVuShifts(vlvc.StartVUs.Int64, vlvc.Stages)...)
 	errors = append(errors, validateStages(vlvc.Stages)...)
+	errors = append(errors, validateMaxDeltaVu(vlvc.StartVUs.Int64, vlvc.Stages)...)
 
 	return errors
 }

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -87,7 +87,7 @@ func (vlvc RampingVUsConfig) Validate() []error {
 	}
 
 	if sumTotalNumberOfUpAndDonwShifts(vlvc.StartVUs.Int64, vlvc.Stages) > 100000000 {
-		errors = append(errors, fmt.Errorf("total number of VU shift is too large"))
+		errors = append(errors, fmt.Errorf("total number of VU shifts is too large"))
 	}
 
 	return append(errors, validateStages(vlvc.Stages)...)

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -87,7 +87,7 @@ func (vlvc RampingVUsConfig) Validate() []error {
 	}
 
 	errors = append(errors, validateStages(vlvc.Stages)...)
-	errors = append(errors, validateVUShifts(vlvc.StartVUs.Int64, vlvc.Stages)...)
+	errors = append(errors, validateTargetShifts(vlvc.StartVUs.Int64, vlvc.Stages)...)
 
 	return errors
 }

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -87,7 +87,7 @@ func (vlvc RampingVUsConfig) Validate() []error {
 	}
 
 	errors = append(errors, validateStages(vlvc.Stages)...)
-	errors = append(errors, validateMaxDeltaVu(vlvc.StartVUs.Int64, vlvc.Stages)...)
+	errors = append(errors, validateMaxDeltaVU(vlvc.StartVUs.Int64, vlvc.Stages)...)
 
 	return errors
 }

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -86,6 +86,10 @@ func (vlvc RampingVUsConfig) Validate() []error {
 		errors = append(errors, fmt.Errorf("either startVUs or one of the stages' target values must be greater than 0"))
 	}
 
+	if sumTotalNumberOfUpAndDonwShifts(vlvc.StartVUs.Int64, vlvc.Stages) > 100000000 {
+		errors = append(errors, fmt.Errorf("total number of VU shift is too large"))
+	}
+
 	return append(errors, validateStages(vlvc.Stages)...)
 }
 

--- a/lib/executor/ramping_vus.go
+++ b/lib/executor/ramping_vus.go
@@ -86,11 +86,10 @@ func (vlvc RampingVUsConfig) Validate() []error {
 		errors = append(errors, fmt.Errorf("either startVUs or one of the stages' target values must be greater than 0"))
 	}
 
-	if sumTotalNumberOfUpAndDonwShifts(vlvc.StartVUs.Int64, vlvc.Stages) > 100000000 {
-		errors = append(errors, fmt.Errorf("total number of VU shifts is too large"))
-	}
+	errors = append(errors, validateNumberOfVuShifts(vlvc.StartVUs.Int64, vlvc.Stages)...)
+	errors = append(errors, validateStages(vlvc.Stages)...)
 
-	return append(errors, validateStages(vlvc.Stages)...)
+	return errors
 }
 
 // getRawExecutionSteps calculates and returns as execution steps the number of

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -41,7 +41,7 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 	c.StartVUs = null.IntFrom(100000001)
 	errs = c.Validate()
 	require.NotEmpty(t, errs)
-	assert.Contains(t, errs[0].Error(), "number of VU shift is too large")
+	assert.Contains(t, errs[0].Error(), "number of VU shifts is too large")
 
 	c.StartVUs = null.IntFrom(60000000)
 	c.Stages = []Stage{
@@ -49,14 +49,14 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 		{Target: null.IntFrom(50000000), Duration: types.NullDurationFrom(12 * time.Second)},
 	}
 	errs = c.Validate()
-	assert.Contains(t, errs[0].Error(), "number of VU shift is too large")
+	assert.Contains(t, errs[0].Error(), "number of VU shifts is too large")
 
 	c.StartVUs = null.IntFrom(math.MaxInt64)
 	c.Stages = []Stage{
 		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(12 * time.Second)},
 	}
 	errs = c.Validate()
-	assert.Contains(t, errs[0].Error(), "number of VU shift is too large")
+	assert.Contains(t, errs[0].Error(), "number of VU shifts is too large")
 }
 
 func TestRampingVUsRun(t *testing.T) {

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -36,6 +36,26 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 	errs = c.Validate()
 	require.NotEmpty(t, errs)
 	assert.Contains(t, errs[0].Error(), "greater than 0")
+
+	c.StartVUs = null.IntFrom(100000001)
+	errs = c.Validate()
+	require.NotEmpty(t, errs)
+	assert.Contains(t, errs[0].Error(), "number of VU shift is too large")
+
+	c.StartVUs = null.IntFrom(60000000)
+	c.Stages = []Stage{
+		{Target: null.IntFrom(50000000), Duration: types.NullDurationFrom(12 * time.Second)},
+		{Target: null.IntFrom(50000000), Duration: types.NullDurationFrom(12 * time.Second)},
+	}
+	errs = c.Validate()
+	assert.Contains(t, errs[0].Error(), "number of VU shift is too large")
+
+	c.StartVUs = null.IntFrom(9223372036854775807)
+	c.Stages = []Stage{
+		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(12 * time.Second)},
+	}
+	errs = c.Validate()
+	assert.Contains(t, errs[0].Error(), "number of VU shift is too large")
 }
 
 func TestRampingVUsRun(t *testing.T) {

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -37,13 +37,13 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 	require.NotEmpty(t, errs)
 	assert.Contains(t, errs[0].Error(), "greater than 0")
 
-	const maxConcurrentVus = 100_000_000
+	const maxConcurrentVUs = 100_000_000
 
-	t.Run("If startVus are larger than maxConcurrentVus, the validation should return an error", func(t *testing.T) {
+	t.Run("If startVUs are larger than maxConcurrentVUs, the validation should return an error", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
-		c.StartVUs = null.IntFrom(maxConcurrentVus + 1)
+		c.StartVUs = null.IntFrom(maxConcurrentVUs + 1)
 		c.Stages = []Stage{
 			{Target: null.IntFrom(0), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
@@ -53,13 +53,13 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the startVUs exceed max limit of"))
 	})
 
-	t.Run("For multiple VU values larger than maxConcurrentVus, multiple errors are returned", func(t *testing.T) {
+	t.Run("For multiple VU values larger than maxConcurrentVUs, multiple errors are returned", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
-		c.StartVUs = null.IntFrom(maxConcurrentVus + 1)
+		c.StartVUs = null.IntFrom(maxConcurrentVUs + 1)
 		c.Stages = []Stage{
-			{Target: null.IntFrom(maxConcurrentVus + 2), Duration: types.NullDurationFrom(1 * time.Second)},
+			{Target: null.IntFrom(maxConcurrentVUs + 2), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
 
 		errs = c.Validate()
@@ -68,13 +68,13 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 		assert.Contains(t, errs[1].Error(), fmt.Sprintf("target for stage 1 exceeds max limit of "))
 	})
 
-	t.Run("VU values below maxConcurrentVus will pass validation", func(t *testing.T) {
+	t.Run("VU values below maxConcurrentVUs will pass validation", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
 		c.StartVUs = null.IntFrom(0)
 		c.Stages = []Stage{
-			{Target: null.IntFrom(maxConcurrentVus - 1), Duration: types.NullDurationFrom(1 * time.Second)},
+			{Target: null.IntFrom(maxConcurrentVUs - 1), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
 
 		errs = c.Validate()

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -50,7 +50,7 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 
 		errs = c.Validate()
 		require.NotEmpty(t, errs)
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the startVUs exceed max limit of"))
+		assert.Contains(t, errs[0].Error(), "the startVUs exceed max limit of")
 	})
 
 	t.Run("For multiple VU values larger than maxConcurrentVUs, multiple errors are returned", func(t *testing.T) {
@@ -64,8 +64,9 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 
 		errs = c.Validate()
 		require.Equal(t, 2, len(errs))
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the startVUs exceed max limit of"))
-		assert.Contains(t, errs[1].Error(), fmt.Sprintf("target for stage 1 exceeds max limit of "))
+		assert.Contains(t, errs[0].Error(), "the startVUs exceed max limit of")
+
+		assert.Contains(t, errs[1].Error(), "target for stage 1 exceeds max limit of")
 	})
 
 	t.Run("VU values below maxConcurrentVUs will pass validation", func(t *testing.T) {

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -37,64 +37,64 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 	require.NotEmpty(t, errs)
 	assert.Contains(t, errs[0].Error(), "greater than 0")
 
-	const maxDeltaVuShifts = 100_000_000
+	const maxDeltaVUShifts = 100_000_000
 
-	t.Run("VU up shift larger than maxDeltaVuShifts should fail", func(t *testing.T) {
+	t.Run("VU up shift larger than maxDeltaVUShifts should fail", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
-		// the largest upshift will be from 0 to maxDeltaVuShifts + 1 which is larger than maxDeltaVuShifts
-		c.StartVUs = null.IntFrom(maxDeltaVuShifts + 1)
+		// the largest upshift will be from 0 to maxDeltaVUShifts + 1 which is larger than maxDeltaVUShifts
+		c.StartVUs = null.IntFrom(maxDeltaVUShifts + 1)
 		c.Stages = []Stage{
-			// the largest downshift will be just below maxDeltaVuShifts
+			// the largest downshift will be just below maxDeltaVUShifts
 			{Target: null.IntFrom(100_000), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
 
 		errs = c.Validate()
 		require.NotEmpty(t, errs)
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", 0, maxDeltaVuShifts+1))
+		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", 0, maxDeltaVUShifts+1))
 	})
 
-	t.Run("VU down shift larger than maxDeltaVuShifts should fail", func(t *testing.T) {
+	t.Run("VU down shift larger than maxDeltaVUShifts should fail", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
 		c.StartVUs = null.IntFrom(100_000)
 		c.Stages = []Stage{
-			// the largest upshift will be just below maxDeltaVuShifts
-			{Target: null.IntFrom(maxDeltaVuShifts + 2), Duration: types.NullDurationFrom(1 * time.Second)},
-			// the largest downshift will be from maxDeltaVuShifts + 1 to 0 which is larger than maxDeltaVuShifts
+			// the largest upshift will be just below maxDeltaVUShifts
+			{Target: null.IntFrom(maxDeltaVUShifts + 2), Duration: types.NullDurationFrom(1 * time.Second)},
+			// the largest downshift will be from maxDeltaVUShifts + 1 to 0 which is larger than maxDeltaVUShifts
 		}
 
 		errs = c.Validate()
 		require.NotEmpty(t, errs)
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", maxDeltaVuShifts+2, 0))
+		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", maxDeltaVUShifts+2, 0))
 	})
 
-	t.Run("Multiple VU shifts are larger than maxDeltaVuShifts, multiple errors are returned", func(t *testing.T) {
+	t.Run("Multiple VU shifts are larger than maxDeltaVUShifts, multiple errors are returned", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
 		c.StartVUs = null.IntFrom(0)
 		c.Stages = []Stage{
-			// up and down shifts are larger than maxDeltaVuShifts. Multiple errors are returned
-			{Target: null.IntFrom(maxDeltaVuShifts + 3), Duration: types.NullDurationFrom(1 * time.Second)},
+			// up and down shifts are larger than maxDeltaVUShifts. Multiple errors are returned
+			{Target: null.IntFrom(maxDeltaVUShifts + 3), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
 
 		errs = c.Validate()
 		require.Equal(t, 2, len(errs))
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", 0, maxDeltaVuShifts+3))
-		assert.Contains(t, errs[1].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", maxDeltaVuShifts+3, 0))
+		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", 0, maxDeltaVUShifts+3))
+		assert.Contains(t, errs[1].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", maxDeltaVUShifts+3, 0))
 	})
 
-	t.Run("VU shifts smaller than maxDeltaVuShifts will pass", func(t *testing.T) {
+	t.Run("VU shifts smaller than maxDeltaVUShifts will pass", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
 		c.StartVUs = null.IntFrom(0)
 		c.Stages = []Stage{
-			// up and down shifts are smaller than maxDeltaVuShifts
-			{Target: null.IntFrom(maxDeltaVuShifts - 1), Duration: types.NullDurationFrom(1 * time.Second)},
+			// up and down shifts are smaller than maxDeltaVUShifts
+			{Target: null.IntFrom(maxDeltaVUShifts - 1), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
 
 		errs = c.Validate()

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -37,14 +37,14 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 	require.NotEmpty(t, errs)
 	assert.Contains(t, errs[0].Error(), "greater than 0")
 
-	const maxVUShift = 100_000_000
+	const maxTargetShift = 100_000_000
 
 	t.Run("VU up shift larger than maxVUShift should fail", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
 		// the largest upshift will be from 0 to maxVUShift + 1 which is larger than maxVUShift
-		c.StartVUs = null.IntFrom(maxVUShift + 1)
+		c.StartVUs = null.IntFrom(maxTargetShift + 1)
 		c.Stages = []Stage{
 			// the largest downshift will be just below maxVUShift
 			{Target: null.IntFrom(100_000), Duration: types.NullDurationFrom(1 * time.Second)},
@@ -52,7 +52,7 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 
 		errs = c.Validate()
 		require.NotEmpty(t, errs)
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", 0, maxVUShift+1))
+		assert.Contains(t, errs[0].Error(), fmt.Sprintf("shifts from %d to %d is larger than", 0, maxTargetShift+1))
 	})
 
 	t.Run("VU down shift larger than maxVUShift should fail", func(t *testing.T) {
@@ -62,13 +62,13 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 		c.StartVUs = null.IntFrom(100_000)
 		c.Stages = []Stage{
 			// the largest upshift will be just below maxVUShift
-			{Target: null.IntFrom(maxVUShift + 2), Duration: types.NullDurationFrom(1 * time.Second)},
+			{Target: null.IntFrom(maxTargetShift + 2), Duration: types.NullDurationFrom(1 * time.Second)},
 			// the largest downshift will be from maxVUShift + 1 to 0 which is larger than maxVUShift
 		}
 
 		errs = c.Validate()
 		require.NotEmpty(t, errs)
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", maxVUShift+2, 0))
+		assert.Contains(t, errs[0].Error(), fmt.Sprintf("shifts from %d to %d is larger than", maxTargetShift+2, 0))
 	})
 
 	t.Run("Multiple VU shifts are larger than maxVUShift, multiple errors are returned", func(t *testing.T) {
@@ -78,13 +78,13 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 		c.StartVUs = null.IntFrom(0)
 		c.Stages = []Stage{
 			// up and down shifts are larger than maxVUShift. Multiple errors are returned
-			{Target: null.IntFrom(maxVUShift + 3), Duration: types.NullDurationFrom(1 * time.Second)},
+			{Target: null.IntFrom(maxTargetShift + 3), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
 
 		errs = c.Validate()
 		require.Equal(t, 2, len(errs))
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", 0, maxVUShift+3))
-		assert.Contains(t, errs[1].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", maxVUShift+3, 0))
+		assert.Contains(t, errs[0].Error(), fmt.Sprintf("shifts from %d to %d is larger than", 0, maxTargetShift+3))
+		assert.Contains(t, errs[1].Error(), fmt.Sprintf("shifts from %d to %d is larger than", maxTargetShift+3, 0))
 	})
 
 	t.Run("VU shifts smaller than maxVUShift will pass", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 		c.StartVUs = null.IntFrom(0)
 		c.Stages = []Stage{
 			// up and down shifts are smaller than maxVUShift
-			{Target: null.IntFrom(maxVUShift - 1), Duration: types.NullDurationFrom(1 * time.Second)},
+			{Target: null.IntFrom(maxTargetShift - 1), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
 
 		errs = c.Validate()

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 	"math/rand"
 	"sync/atomic"
@@ -50,7 +51,7 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 	errs = c.Validate()
 	assert.Contains(t, errs[0].Error(), "number of VU shift is too large")
 
-	c.StartVUs = null.IntFrom(9223372036854775807)
+	c.StartVUs = null.IntFrom(math.MaxInt64)
 	c.Stages = []Stage{
 		{Target: null.IntFrom(1), Duration: types.NullDurationFrom(12 * time.Second)},
 	}

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -37,64 +37,64 @@ func TestRampingVUsConfigValidation(t *testing.T) {
 	require.NotEmpty(t, errs)
 	assert.Contains(t, errs[0].Error(), "greater than 0")
 
-	const maxDeltaVUShifts = 100_000_000
+	const maxVUShift = 100_000_000
 
-	t.Run("VU up shift larger than maxDeltaVUShifts should fail", func(t *testing.T) {
+	t.Run("VU up shift larger than maxVUShift should fail", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
-		// the largest upshift will be from 0 to maxDeltaVUShifts + 1 which is larger than maxDeltaVUShifts
-		c.StartVUs = null.IntFrom(maxDeltaVUShifts + 1)
+		// the largest upshift will be from 0 to maxVUShift + 1 which is larger than maxVUShift
+		c.StartVUs = null.IntFrom(maxVUShift + 1)
 		c.Stages = []Stage{
-			// the largest downshift will be just below maxDeltaVUShifts
+			// the largest downshift will be just below maxVUShift
 			{Target: null.IntFrom(100_000), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
 
 		errs = c.Validate()
 		require.NotEmpty(t, errs)
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", 0, maxDeltaVUShifts+1))
+		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", 0, maxVUShift+1))
 	})
 
-	t.Run("VU down shift larger than maxDeltaVUShifts should fail", func(t *testing.T) {
+	t.Run("VU down shift larger than maxVUShift should fail", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
 		c.StartVUs = null.IntFrom(100_000)
 		c.Stages = []Stage{
-			// the largest upshift will be just below maxDeltaVUShifts
-			{Target: null.IntFrom(maxDeltaVUShifts + 2), Duration: types.NullDurationFrom(1 * time.Second)},
-			// the largest downshift will be from maxDeltaVUShifts + 1 to 0 which is larger than maxDeltaVUShifts
+			// the largest upshift will be just below maxVUShift
+			{Target: null.IntFrom(maxVUShift + 2), Duration: types.NullDurationFrom(1 * time.Second)},
+			// the largest downshift will be from maxVUShift + 1 to 0 which is larger than maxVUShift
 		}
 
 		errs = c.Validate()
 		require.NotEmpty(t, errs)
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", maxDeltaVUShifts+2, 0))
+		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", maxVUShift+2, 0))
 	})
 
-	t.Run("Multiple VU shifts are larger than maxDeltaVUShifts, multiple errors are returned", func(t *testing.T) {
+	t.Run("Multiple VU shifts are larger than maxVUShift, multiple errors are returned", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
 		c.StartVUs = null.IntFrom(0)
 		c.Stages = []Stage{
-			// up and down shifts are larger than maxDeltaVUShifts. Multiple errors are returned
-			{Target: null.IntFrom(maxDeltaVUShifts + 3), Duration: types.NullDurationFrom(1 * time.Second)},
+			// up and down shifts are larger than maxVUShift. Multiple errors are returned
+			{Target: null.IntFrom(maxVUShift + 3), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
 
 		errs = c.Validate()
 		require.Equal(t, 2, len(errs))
-		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", 0, maxDeltaVUShifts+3))
-		assert.Contains(t, errs[1].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", maxDeltaVUShifts+3, 0))
+		assert.Contains(t, errs[0].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", 0, maxVUShift+3))
+		assert.Contains(t, errs[1].Error(), fmt.Sprintf("the VU shifts from %d to %d is larger than", maxVUShift+3, 0))
 	})
 
-	t.Run("VU shifts smaller than maxDeltaVUShifts will pass", func(t *testing.T) {
+	t.Run("VU shifts smaller than maxVUShift will pass", func(t *testing.T) {
 		t.Parallel()
 
 		c = NewRampingVUsConfig("stage")
 		c.StartVUs = null.IntFrom(0)
 		c.Stages = []Stage{
-			// up and down shifts are smaller than maxDeltaVUShifts
-			{Target: null.IntFrom(maxDeltaVUShifts - 1), Duration: types.NullDurationFrom(1 * time.Second)},
+			// up and down shifts are smaller than maxVUShift
+			{Target: null.IntFrom(maxVUShift - 1), Duration: types.NullDurationFrom(1 * time.Second)},
 		}
 
 		errs = c.Validate()


### PR DESCRIPTION
## What?

It validates the VU values. If a VU is larger than the chosen constant, an error is appended.
This includes the startVU.

## Why?

The conclusion was reached to handle it that way during the discussions of this pull request.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #1693

<!-- Thanks for your contribution! 🙏🏼 -->
