### PR TITLE
Add browser patch fixes to release notes 

### DIFF
--- a/release notes/v0.48.0.md
+++ b/release notes/v0.48.0.md
@@ -230,6 +230,8 @@ import { browser, networkProfiles } from 'k6/experimental/browser';
 - [browser#1078](https://github.com/grafana/xk6-browser/pull/1078) fixes request interception deadlock to improve stability.
 - [browser#1101](https://github.com/grafana/xk6-browser/pull/1101) fixes `page.$` so that it returns `null` when no matches with given selector are found.
 - [#3397](https://github.com/grafana/k6/pull/3397), [#3427](https://github.com/grafana/k6/pull/3427), [#3417](https://github.com/grafana/k6/pull/3417) update `goja` dependency. Fixes a possible panic and proper handling circular types at `JSON.stringify`. Fixes an issue about dumping the correct stack trace when an error is re-thrown.
+- [browser#1106](https://github.com/grafana/xk6-browser/pull/1106) fixes an NPE on NavigateFrame when navigate occurs in the same document.
+- [browser#1096](https://github.com/grafana/xk6-browser/pull/1096) fixes a panic when trying to interact within nested `iframe`s.
 
 ## Maintenance and internal improvements
 

--- a/release notes/v0.48.0.md
+++ b/release notes/v0.48.0.md
@@ -231,7 +231,7 @@ import { browser, networkProfiles } from 'k6/experimental/browser';
 - [browser#1101](https://github.com/grafana/xk6-browser/pull/1101) fixes `page.$` so that it returns `null` when no matches with given selector are found.
 - [#3397](https://github.com/grafana/k6/pull/3397), [#3427](https://github.com/grafana/k6/pull/3427), [#3417](https://github.com/grafana/k6/pull/3417) update `goja` dependency. Fixes a possible panic and proper handling circular types at `JSON.stringify`. Fixes an issue about dumping the correct stack trace when an error is re-thrown.
 - [browser#1106](https://github.com/grafana/xk6-browser/pull/1106) fixes an NPE on NavigateFrame when navigate occurs in the same document.
-- [browser#1096](https://github.com/grafana/xk6-browser/pull/1096) fixes a panic when trying to interact within nested `iframe`s.
+- [browser#1096](https://github.com/grafana/xk6-browser/pull/1096) fixes a panic when trying to interact within nested `iframe`s. Thanks, @bandorko!
 
 ## Maintenance and internal improvements
 


### PR DESCRIPTION
## What?

Adds https://github.com/grafana/xk6-browser/pull/1106 and https://github.com/grafana/xk6-browser/pull/1096 to the release notes.

## Why?

These were deemed necessary fixes to go into the release which will benefit users.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
