### PR TITLE
Adressing linter issues in `netext`, `netext/httpext` packages

### DIFF
--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -495,7 +495,6 @@ func (c *Client) Batch(reqsV ...goja.Value) (interface{}, error) {
 	errs := httpext.MakeBatchRequests(
 		c.moduleInstance.vu.Context(), state, batchReqs, reqCount,
 		int(state.Options.Batch.Int64), int(state.Options.BatchPerHost.Int64),
-		c.processResponse,
 	)
 
 	for i := 0; i < reqCount; i++ {

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -205,7 +205,7 @@ func (d *Dialer) getConfiguredHost(addr, host, port string) (*types.Host, error)
 		return &newRemote, nil
 	}
 
-	return nil, nil
+	return nil, nil //nolint:nilnil
 }
 
 // NetTrail contains information about the exchanged data size and length of a

--- a/lib/netext/httpext/batch.go
+++ b/lib/netext/httpext/batch.go
@@ -22,13 +22,10 @@ type BatchParsedHTTPRequest struct {
 // pre-initialized. In addition, each processed request would emit either a nil
 // value, or an error, via the returned errors channel. The goroutines exit when
 // the requests channel is closed.
-// The processResponse callback can be used to modify the response, e.g.
-// to replace the body.
 func MakeBatchRequests(
 	ctx context.Context, state *lib.State,
 	requests []BatchParsedHTTPRequest,
 	reqCount, globalLimit, perHostLimit int,
-	processResponse func(*Response, ResponseType),
 ) <-chan error {
 	workers := globalLimit
 	if reqCount < workers {

--- a/lib/netext/httpext/error_codes_syscall_posix.go
+++ b/lib/netext/httpext/error_codes_syscall_posix.go
@@ -8,6 +8,6 @@ import (
 	"os"
 )
 
-func getOSSyscallErrorCode(e *net.OpError, se *os.SyscallError) (errCode, string) {
+func getOSSyscallErrorCode(_ *net.OpError, _ *os.SyscallError) (errCode, string) {
 	return 0, ""
 }

--- a/lib/netext/httpext/error_codes_test.go
+++ b/lib/netext/httpext/error_codes_test.go
@@ -184,7 +184,11 @@ func TestHTTP2StreamError(t *testing.T) {
 		rw.Header().Set("Content-Length", "100000")
 		rw.WriteHeader(http.StatusOK)
 
-		rw.(http.Flusher).Flush()
+		f, ok := rw.(http.Flusher)
+		if !ok {
+			panic("expected http.ResponseWriter to be http.Flusher")
+		}
+		f.Flush()
 		time.Sleep(time.Millisecond * 2)
 		panic("expected internal error")
 	})
@@ -376,7 +380,7 @@ func getHTTP2ServerWithCustomConnContext(t *testing.T) *httpmultibin.HTTPMultiBi
 		Replacer: strings.NewReplacer(
 			"HTTP2BIN_IP_URL", http2Srv.URL,
 			"HTTP2BIN_DOMAIN", http2Domain,
-			"HTTP2BIN_URL", fmt.Sprintf("https://%s:%s", http2Domain, http2URL.Port()),
+			"HTTP2BIN_URL", fmt.Sprintf("https://%s", net.JoinHostPort(http2Domain, http2URL.Port())),
 			"HTTP2BIN_IP", http2IP.String(),
 			"HTTP2BIN_PORT", http2URL.Port(),
 		),

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -351,7 +351,10 @@ func TestTrailFailed(t *testing.T) {
 			require.NotNil(t, res)
 			require.Len(t, samples, 1)
 			sample := <-samples
-			trail := sample.(*Trail)
+
+			trail, ok := sample.(*Trail)
+			require.True(t, ok)
+
 			require.Equal(t, failed, trail.Failed)
 
 			var httpReqFailedSampleValue null.Bool

--- a/lib/netext/httpext/tracer.go
+++ b/lib/netext/httpext/tracer.go
@@ -344,14 +344,15 @@ func (t *Tracer) Done() *Trail {
 		trail.TLSHandshaking = time.Duration(tlsHandshakeDone - tlsHandshakeStart)
 	}
 	if wroteRequest != 0 {
-		if tlsHandshakeDone != 0 {
+		switch {
+		case tlsHandshakeDone != 0:
 			// If the request was sent over TLS, we need to use
 			// TLS Handshake Done time to calculate sending duration
 			trail.Sending = time.Duration(wroteRequest - tlsHandshakeDone)
-		} else if connectDone != 0 {
+		case connectDone != 0:
 			// Otherwise, use the end of the normal connection
 			trail.Sending = time.Duration(wroteRequest - connectDone)
-		} else {
+		default:
 			// Finally, this handles the strange HTTP/2 case where the GotConn() hook
 			// gets called first, but with Reused=false
 			trail.Sending = time.Duration(wroteRequest - gotConn)

--- a/lib/netext/httpext/tracer.go
+++ b/lib/netext/httpext/tracer.go
@@ -40,7 +40,7 @@ type Trail struct {
 	Samples  []metrics.Sample
 }
 
-// SaveSamples populates the Trail's sample slice so they're accesible via GetSamples()
+// SaveSamples populates the Trail's sample slice so they're accessible via GetSamples()
 func (tr *Trail) SaveSamples(builtinMetrics *metrics.BuiltinMetrics, ctm *metrics.TagsAndMeta) {
 	tr.Tags = ctm.Tags
 	tr.Metadata = ctm.Metadata
@@ -184,7 +184,7 @@ func now() int64 {
 // Keep in mind that GetConn won't be called if a connection
 // is reused though, for example when there's a redirect.
 // If it's called, it will be called before all other hooks.
-func (t *Tracer) GetConn(hostPort string) {
+func (t *Tracer) GetConn(_ string) {
 	t.getConn = now()
 }
 
@@ -194,7 +194,7 @@ func (t *Tracer) GetConn(hostPort string) {
 //
 // If the connection is reused, this won't be called. Otherwise,
 // it will be called after GetConn() and before ConnectDone().
-func (t *Tracer) ConnectStart(network, addr string) {
+func (t *Tracer) ConnectStart(_, _ string) {
 	// If using dual-stack dialing, it's possible to get this
 	// multiple times, so the atomic compareAndSwap ensures
 	// that only the first call's time is recorded
@@ -210,7 +210,7 @@ func (t *Tracer) ConnectStart(network, addr string) {
 // If the connection is reused, this won't be called. Otherwise,
 // it will be called after ConnectStart() and before either
 // TLSHandshakeStart() (for TLS connections) or GotConn().
-func (t *Tracer) ConnectDone(network, addr string, err error) {
+func (t *Tracer) ConnectDone(_, _ string, err error) {
 	// If using dual-stack dialing, it's possible to get this
 	// multiple times, so the atomic compareAndSwap ensures
 	// that only the first call's time is recorded
@@ -239,7 +239,7 @@ func (t *Tracer) TLSHandshakeStart() {
 // it will be called after TLSHandshakeStart() and before GotConn().
 // If the request was cancelled, this could be called after the
 // RoundTrip() method has returned.
-func (t *Tracer) TLSHandshakeDone(state tls.ConnectionState, err error) {
+func (t *Tracer) TLSHandshakeDone(_ tls.ConnectionState, err error) {
 	if err == nil {
 		atomic.CompareAndSwapInt64(&t.tlsHandshakeDone, 0, now())
 	}

--- a/lib/netext/httpext/tracer_test.go
+++ b/lib/netext/httpext/tracer_test.go
@@ -244,7 +244,7 @@ func TestTracerError(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, srv.URL+"/get", nil)
 	require.NoError(t, err)
 
-	_, err = http.DefaultTransport.RoundTrip(
+	_, err = http.DefaultTransport.RoundTrip( //nolint:bodyclose
 		req.WithContext(
 			httptrace.WithClientTrace(
 				context.Background(),

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -1,3 +1,4 @@
+// Package httpext provides extensions to the standard net/http package
 package httpext
 
 import (

--- a/lib/netext/httpext/transport_test.go
+++ b/lib/netext/httpext/transport_test.go
@@ -16,8 +16,8 @@ func BenchmarkMeasureAndEmitMetrics(b *testing.B) {
 	defer cancel()
 	samples := make(chan metrics.SampleContainer, 10)
 	defer close(samples)
-	go func() {
-		for range samples {
+	go func() { // discard all metrics
+		for range samples { //nolint:revive
 		}
 	}()
 	logger := logrus.New()

--- a/lib/netext/resolver_test.go
+++ b/lib/netext/resolver_test.go
@@ -73,7 +73,8 @@ func TestResolver(t *testing.T) {
 
 				if tc.ttl > 0 {
 					require.IsType(t, &cacheResolver{}, r)
-					cr := r.(*cacheResolver)
+					cr, ok := r.(*cacheResolver)
+					assert.True(t, ok)
 					assert.Len(t, cr.cache, 1)
 					assert.Equal(t, tc.ttl, cr.ttl)
 					firstLookup := cr.cache[host].lastLookup

--- a/lib/netext/tls.go
+++ b/lib/netext/tls.go
@@ -1,3 +1,4 @@
+// Package netext provides extensions to the standard net package
 package netext
 
 import (
@@ -8,7 +9,7 @@ import (
 	"go.k6.io/k6/lib"
 )
 
-//nolint:golint
+//nolint:golint,revive,stylecheck // we want to keep these constants as they are
 const (
 	OCSP_STATUS_GOOD                   = "good"
 	OCSP_STATUS_REVOKED                = "revoked"
@@ -30,10 +31,13 @@ const (
 	TLS_1_3                            = "tls1.3"
 )
 
+// TLSInfo keeps TLS details
 type TLSInfo struct {
 	Version     string
 	CipherSuite string
 }
+
+// OCSP keeps Online Certificate Status Protocol (OCSP) details
 type OCSP struct {
 	ProducedAt       int64  `json:"produced_at"`
 	ThisUpdate       int64  `json:"this_update"`
@@ -43,6 +47,7 @@ type OCSP struct {
 	Status           string `json:"status"`
 }
 
+// ParseTLSConnState parses tls.ConnectionState and returns TLS and OCSP details
 func ParseTLSConnState(tlsState *tls.ConnectionState) (TLSInfo, OCSP) {
 	tlsInfo := TLSInfo{}
 	switch tlsState.Version {


### PR DESCRIPTION
## What?

This PR addresses the linter issues in the `netext` package.

It's better to do a review by commits. I've tried to combine them for the impact.

The first commit is applying simple changes.

Everything else deserves a more focused look since it also contains some refactorings.

Note: one linter issue is still there:
```
lib/netext/httpext/request.go:122:2                nestif             `if preq.Body != nil` has complex nested blocks (complexity: 6)
```

Since the function it deserves a separate PR, it's more complicated.

https://github.com/grafana/k6/blob/856a767bda62fe5a0f1fd6ee6e354e39539ea97d/lib/netext/httpext/request.go#L109-L114

Also, `grpcext` package's linter issues have yet to be touched since I'm planning to address them in #3152 

## Why?

As we agreed, we have to fix the linter issues presented in the `master` branch.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Part of #769 

<!-- Thanks for your contribution! 🙏🏼 -->
