### PR TITLE
Bump the k6 version to v0.48.0

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -8,7 +8,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.47.0"
+const Version = "0.48.0"
 
 // FullVersion returns the maximally full version and build information for
 // the currently running k6 executable.


### PR DESCRIPTION
## What?

This bumps k6 to v0.48.

## Why?

We're going to release the v0.48.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Part of #3382 

<!-- Thanks for your contribution! 🙏🏼 -->
