### PR TITLE
Adds trivy scheduled checks

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,34 @@
+name: trivy scan
+
+on:
+  # Enable manually triggering this workflow via the API or web UI
+  workflow_dispatch:
+  schedule:
+    # At 10:00 UTC on every day-of-week from Monday through Friday.
+    - cron:  '0 10 * * 1-5'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: read # for actions/checkout to fetch code
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    name: Build
+    runs-on: ubuntu-latest
+    if: github.repository == 'grafana/k6' # avoid running on forks
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@22d2755f774d925b191a185b74e782a4b0638a41
+        with:
+          image-ref: 'grafana/k6:master'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH,MEDIUM'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
## What?

This adds the trivy security scanner scheduled check to k6 repository. It aims to check the `master` tag (the most up-to-date). 

Inspired by: https://github.com/grafana/agent/blob/main/.github/workflows/trivy.yml

It has no slack integration _yet_, first I'm curious to see the frequency of the reporting. If it's acceptable and we won't be use this actively by-ourselves we could set up the slack integration.

Currently, it shows no issues, so it's a good opportunity to start using it.
```
 trivy image grafana/k6
2023-12-11T15:08:04.324+0100    INFO    Vulnerability scanning is enabled
2023-12-11T15:08:04.324+0100    INFO    Secret scanning is enabled
2023-12-11T15:08:04.324+0100    INFO    If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-12-11T15:08:04.324+0100    INFO    Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2023-12-11T15:08:04.918+0100    INFO    Detected OS: alpine
2023-12-11T15:08:04.918+0100    INFO    Detecting Alpine vulnerabilities...
2023-12-11T15:08:04.919+0100    INFO    Number of language-specific files: 1
2023-12-11T15:08:04.919+0100    INFO    Detecting gobinary vulnerabilities...

grafana/k6 (alpine 3.18.5)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)
```

## Why?

As we agreed, we'd like to be pro-active in terms of fixing security-related issues.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
