### PR TITLE
Browser: Update release notes for chrome not installed errors

### DIFF
--- a/release notes/v0.49.0.md
+++ b/release notes/v0.49.0.md
@@ -29,6 +29,7 @@ _what, why, and what this means for the user_
 
 - [#3440](https://github.com/grafana/k6/pull/3440) use built-in certificates if none are provided by the OS. Thanks to `@mem` for wokring on it!
 - [browser#1135](https://github.com/grafana/xk6-browser/pull/1135) improves the array output from `console` in the k6 logs.
+- [browser#1137](https://github.com/grafana/xk6-browser/pull/1137), [browser#1145](https://github.com/grafana/xk6-browser/pull/1145) improves the error messages displayed when Chrome or Chromium isn't found.
 
 ## Bug fixes
 


### PR DESCRIPTION
## What?

Updates v0.49.0 release notes for the PRs: grafana/xk6-browser#1137 and grafana/xk6-browser#1145.


## Why?

Provides better error messages when Chromium/Chrome isn't found.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

grafana/xk6-browser#1136