### PR TITLE
Stop using deprecated net.Dialer.DualStack

### DIFF
--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -360,7 +360,6 @@ func TestRequestWithBinaryFile(t *testing.T) {
 				net.Dialer{
 					Timeout:   10 * time.Second,
 					KeepAlive: 60 * time.Second,
-					DualStack: true,
 				},
 				netext.NewResolver(net.LookupIP, 0, types.DNSfirst, types.DNSpreferIPv4),
 			)).DialContext,
@@ -507,7 +506,6 @@ func TestRequestWithMultipleBinaryFiles(t *testing.T) {
 				net.Dialer{
 					Timeout:   10 * time.Second,
 					KeepAlive: 60 * time.Second,
-					DualStack: true,
 				},
 				netext.NewResolver(net.LookupIP, 0, types.DNSfirst, types.DNSpreferIPv4),
 			)).DialContext,

--- a/js/runner.go
+++ b/js/runner.go
@@ -97,7 +97,6 @@ func NewFromBundle(piState *lib.TestPreInitState, b *Bundle) (*Runner, error) {
 		BaseDialer: net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
-			DualStack: true,
 		},
 		console: newConsole(piState.Logger),
 		Resolver: netext.NewResolver(

--- a/lib/netext/httpext/error_codes_test.go
+++ b/lib/netext/httpext/error_codes_test.go
@@ -362,7 +362,6 @@ func getHTTP2ServerWithCustomConnContext(t *testing.T) *httpmultibin.HTTPMultiBi
 	dialer := netext.NewDialer(net.Dialer{
 		Timeout:   2 * time.Second,
 		KeepAlive: 10 * time.Second,
-		DualStack: true,
 	}, netext.NewResolver(net.LookupIP, 0, types.DNSfirst, types.DNSpreferIPv4))
 	dialer.Hosts, err = types.NewHosts(map[string]types.Host{
 		http2Domain: *http2DomainValue,

--- a/lib/netext/httpext/tracer.go
+++ b/lib/netext/httpext/tracer.go
@@ -190,7 +190,7 @@ func (t *Tracer) GetConn(_ string) {
 
 // ConnectStart is called when a new connection's Dial begins.
 // If net.Dialer.DualStack (IPv6 "Happy Eyeballs") support is
-// enabled, this may be called multiple times.
+// enabled (default), this may be called multiple times.
 //
 // If the connection is reused, this won't be called. Otherwise,
 // it will be called after GetConn() and before ConnectDone().
@@ -203,9 +203,9 @@ func (t *Tracer) ConnectStart(_, _ string) {
 
 // ConnectDone is called when a new connection's Dial
 // completes. The provided err indicates whether the
-// connection completedly successfully.
+// connection completed successfully.
 // If net.Dialer.DualStack ("Happy Eyeballs") support is
-// enabled, this may be called multiple times.
+// enabled (default), this may be called multiple times.
 //
 // If the connection is reused, this won't be called. Otherwise,
 // it will be called after ConnectStart() and before either

--- a/lib/testutils/httpmultibin/httpmultibin.go
+++ b/lib/testutils/httpmultibin/httpmultibin.go
@@ -1,4 +1,4 @@
-// Package httpmultibin is indended only for use in tests, do not import in production code!
+// Package httpmultibin is intended only for use in tests, do not import in production code!
 package httpmultibin
 
 import (
@@ -350,7 +350,6 @@ func NewHTTPMultiBin(t testing.TB) *HTTPMultiBin {
 	dialer := netext.NewDialer(net.Dialer{
 		Timeout:   2 * time.Second,
 		KeepAlive: 10 * time.Second,
-		DualStack: true,
 	}, netext.NewResolver(net.LookupIP, 0, types.DNSfirst, types.DNSpreferIPv4))
 	dialer.Hosts, err = types.NewHosts(map[string]types.Host{
 		httpDomain:  *httpDomainValue,


### PR DESCRIPTION
## What?

It removes all the uses of `net.Dialer.DualStack`, because now it's deprecated, and the desired behavior (enabled) is now by default. It also slightly modifies few comments to make that more clear.

## Why?

Not sure why `staticcheck` is not complaining, but I guess it's always good idea to stop using a deprecated field, especially in this case that I can't see any pain.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

N/A

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
