### PR TITLE
Add browser tracing release notes

### DIFF
--- a/release notes/v0.49.0.md
+++ b/release notes/v0.49.0.md
@@ -17,9 +17,13 @@ k6 `v0.49.0` is here 🎉! This release includes:
 
 _optional intro here_
 
-### `<big_feature_1>` `#pr`
+### Add tracing to browser module [browser#1100](https://github.com/grafana/xk6-browser/pull/1100)
 
-_what, why, and what this means for the user_
+The browser module now generates traces that provide a representation of its inner workings, such as API methods executed (for example `browser.newPage` and `page.goto`), page navigations, and [Web Vitals](https://grafana.com/docs/k6/latest/using-k6-browser/metrics/#googles-core-web-vitals) measurements.
+
+Take into account that currently the instrumented methods are a subset of all the methods exposed by the browser module API, but this will be extended in the future.
+
+The traces generation for the browser module depends on the overall `k6` traces option introduced in [v0.48.0](https://github.com/grafana/k6/releases/tag/v0.48.0). Check out the [documentation](https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#traces-output) to learn more about it.
 
 ### `<big_feature_n>` `#pr`
 

--- a/release notes/v0.49.0.md
+++ b/release notes/v0.49.0.md
@@ -21,7 +21,7 @@ _optional intro here_
 
 The browser module now generates traces that provide a representation of its inner workings, such as API methods executed (for example `browser.newPage` and `page.goto`), page navigations, and [Web Vitals](https://grafana.com/docs/k6/latest/using-k6-browser/metrics/#googles-core-web-vitals) measurements.
 
-Take into account that currently the instrumented methods are a subset of all the methods exposed by the browser module API, but this will be extended in the future.
+Currently the instrumented methods are a subset of all the methods exposed by the browser module API, but this will be extended in the future.
 
 The traces generation for the browser module depends on the overall `k6` traces option introduced in [v0.48.0](https://github.com/grafana/k6/releases/tag/v0.48.0). Check out the [documentation](https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#traces-output) to learn more about it.
 

--- a/release notes/v0.49.0.md
+++ b/release notes/v0.49.0.md
@@ -33,6 +33,7 @@ _what, why, and what this means for the user_
 
 - [#3440](https://github.com/grafana/k6/pull/3440) use built-in certificates if none are provided by the OS. Thanks to `@mem` for wokring on it!
 - [browser#1135](https://github.com/grafana/xk6-browser/pull/1135) improves the array output from `console` in the k6 logs.
+- [browser#1104](https://github.com/grafana/xk6-browser/pull/1104) adds support for browser module traces metadata. Users can define *key-value* metadata that will be included as attributes in every generated span.
 
 ## Bug fixes
 

--- a/release notes/v0.49.0.md
+++ b/release notes/v0.49.0.md
@@ -17,11 +17,11 @@ k6 `v0.49.0` is here 🎉! This release includes:
 
 _optional intro here_
 
-### Add tracing to browser module [browser#1100](https://github.com/grafana/xk6-browser/pull/1100)
+### Add tracing to the browser module [browser#1100](https://github.com/grafana/xk6-browser/pull/1100)
 
 The browser module now generates traces that provide a representation of its inner workings, such as API methods executed (for example `browser.newPage` and `page.goto`), page navigations, and [Web Vitals](https://grafana.com/docs/k6/latest/using-k6-browser/metrics/#googles-core-web-vitals) measurements.
 
-Currently the instrumented methods are a subset of all the methods exposed by the browser module API, but this will be extended in the future.
+Currently, the instrumented methods are a subset of all the methods exposed by the browser module API, but this will be extended in the future.
 
 The traces generation for the browser module depends on the overall `k6` traces option introduced in [v0.48.0](https://github.com/grafana/k6/releases/tag/v0.48.0). Check out the [documentation](https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/#traces-output) to learn more about it.
 


### PR DESCRIPTION
## What?

Adds release notes for tracing instrumentation implemented in k6 browser module.


## Why?

Required step towards `v0.49.0` release.

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

grafana/xk6-browser#1100
grafana/xk6-browser#1104
