### PR TITLE
Automate experimental module updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       # Keep the experimental modules up-to-date
       - dependency-name: "github.com/grafana/xk6-*"
         dependency-type: "all"
-    target-branch: "master"
     commit-message:
       prefix: "Bump "
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      # Keep the experimental modules up-to-date
+      - dependency-name: "github.com/grafana/xk6-*"
+        dependency-type: "all"
+    target-branch: "master"
+    commit-message:
+      prefix: "Bump "
+      include: "scope"
+    assignees:
+      - "octocat"
+    reviewers:
+      - "grafana/k6-core"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,5 @@ updates:
     commit-message:
       prefix: "Upgrade experimental module "
       include: "scope"
-    assignees:
-      - "octocat"
     reviewers:
       - "grafana/k6-core"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
       - dependency-name: "github.com/grafana/xk6-*"
         dependency-type: "all"
     commit-message:
-      prefix: "Bump "
+      prefix: "Upgrade experimental module "
       include: "scope"
     assignees:
       - "octocat"


### PR DESCRIPTION
## What?

This PR adds Dependabot config to check for experimental module updates daily and create PRs to upgrade them. 

## Why?

The process of releasing a new version of an experimental module, such as xk6-browser or xk6-redis, requires a manual step to upgrade the dependency in k6's `go.mod`, vendor the code and open a PR. This is a routine task that can be automated to avoid human error.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.