### PR TITLE
Generate certificates at runtime for runner test

### DIFF
--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -1714,7 +1714,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	t.Parallel()
 
 	// Generate CA key and certificate
-	caCertPem, caKeyPem := GenerateTLSCertificate(t, "ca.localhost", time.Now(), time.Hour)
+	caCertPem, caKeyPem := GenerateTLSCertificate(t, "127.0.0.1", time.Now(), time.Hour)
 
 	caCertBlock, _ := pem.Decode(caCertPem)
 	caCert, err := x509.ParseCertificate(caCertBlock.Bytes)
@@ -1727,10 +1727,10 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	require.True(t, ok)
 
 	// Generate server key and certificate
-	srvCertPem, srvKeyPem := GenerateTLSCertificateWithCA(t, "server.localhost", time.Now(), time.Hour, caCert, caKey)
+	srvCertPem, srvKeyPem := GenerateTLSCertificateWithCA(t, "127.0.0.1", time.Now(), time.Hour, caCert, caKey)
 
 	// Generate client Key and Certificate
-	clCertPem, clKeyPem := GenerateTLSCertificateWithCA(t, "client.localhost", time.Now(), time.Hour, caCert, caKey)
+	clCertPem, clKeyPem := GenerateTLSCertificateWithCA(t, "127.0.0.1", time.Now(), time.Hour, caCert, caKey)
 
 	clientCAPool := x509.NewCertPool()
 	assert.True(t, clientCAPool.AppendCertsFromPEM(caCertPem))


### PR DESCRIPTION
## What?

It modifies the `TestVUIntegrationClientCerts` test on `runner_test.go` in order to generate certificates at runtime, instead of using pre-generated ones.

## Why?

This test is currently failing when `runtime.GOOS == "darwin"`, because it expects the `"certificate signed by unknown authority"` error but it gets `"certificate is not standards compliant"` instead, because the pre-generated certificate has a validity of 1000 years since 2022, and that's not considered standards compliant by Apple.

So, instead of having a pre-generated certificate that expires every year (so we'd need to update it every year), this makes the test to generate the required certificates at runtime (so always up to date), which also seems to be fine for MacOS.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

I think it fixes https://github.com/grafana/k6/issues/2578, cause with this I no longer see errors on MacOS.