### PR TITLE
Run CI (tests) on MacOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           go version
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
-          # Run with less concurrency on Windows to minimize flakiness.
+          # Run with less concurrency on Windows/MacOS to minimize flakiness.
           if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos* ]]; then
             unset args[2]
             args[1]="1"
@@ -75,7 +75,7 @@ jobs:
           go version
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
-          # Run with less concurrency on Windows to minimize flakiness.
+          # Run with less concurrency on Windows/MacOS to minimize flakiness.
           if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos* ]]; then
             unset args[2]
             args[1]="1"
@@ -103,7 +103,7 @@ jobs:
           go version
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
-          # Run with less concurrency on Windows to minimize flakiness.
+          # Run with less concurrency on Windows/MacOS to minimize flakiness.
           if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos* ]]; then
             unset args[2]
             args[1]="1"
@@ -126,6 +126,9 @@ jobs:
           CODECOV_BASH_SHA512SUM: d075b412a362a9a2b7aedfec3b8b9a9a927b3b99e98c7c15a2b76ef09862aeb005e91d76a5fd71b511141496d0fd23d1b42095f722ebcd509d768fba030f159e
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
+          if [ "$(uname)" = "Darwin" ]; then
+            alias sha256sum='shasum -a 256'
+          fi
           curl -fsSLO "https://raw.githubusercontent.com/codecov/codecov-bash/${CODECOV_BASH_VERSION}/codecov"
           echo "$CODECOV_BASH_SHA512SUM codecov" | sha512sum -c -
           platform="${{ matrix.platform }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,11 +126,12 @@ jobs:
           CODECOV_BASH_SHA512SUM: d075b412a362a9a2b7aedfec3b8b9a9a927b3b99e98c7c15a2b76ef09862aeb005e91d76a5fd71b511141496d0fd23d1b42095f722ebcd509d768fba030f159e
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
-          if [ "$(uname)" = "Darwin" ]; then
-            alias sha256sum='shasum -a 256'
+          if [[ "${{ matrix.platform }}" == macos* ]]; then
+            shopt -s expand_aliases
+            alias sha512sum='shasum -a 512'
           fi
           curl -fsSLO "https://raw.githubusercontent.com/codecov/codecov-bash/${CODECOV_BASH_VERSION}/codecov"
-          echo "$CODECOV_BASH_SHA512SUM codecov" | sha512sum -c -
+          echo "$CODECOV_BASH_SHA512SUM  codecov" | sha512sum -c -
           platform="${{ matrix.platform }}"
           bash ./codecov -F "${platform%%-*}"
       - name: Generate coverage HTML report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
           # Run with less concurrency on Windows to minimize flakiness.
-          if [[ "${{ matrix.platform }}" == windows* ]]; then
+          if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos* ]]; then
             unset args[2]
             args[1]="1"
             export GOMAXPROCS=1
@@ -76,7 +76,7 @@ jobs:
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
           # Run with less concurrency on Windows to minimize flakiness.
-          if [[ "${{ matrix.platform }}" == windows* ]]; then
+          if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos* ]]; then
             unset args[2]
             args[1]="1"
             export GOMAXPROCS=1
@@ -104,7 +104,7 @@ jobs:
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
           # Run with less concurrency on Windows to minimize flakiness.
-          if [[ "${{ matrix.platform }}" == windows* ]]; then
+          if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos* ]]; then
             unset args[2]
             args[1]="1"
             export GOMAXPROCS=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.20.x]
-        platform: [ubuntu-latest, windows-2019]
+        platform: [ubuntu-latest, windows-2019, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-2019]
+        platform: [ubuntu-latest, windows-2019, macos-latest]
     runs-on: ${{ matrix.platform }}
     continue-on-error: true
     steps:
@@ -88,7 +88,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.21.x]
-        platform: [ubuntu-latest, windows-2019]
+        platform: [ubuntu-latest, windows-2019, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -765,7 +765,7 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 					assert.Contains(t, vuErr.Error(), "context canceled")
 				}()
 				<-ch
-				time.Sleep(time.Millisecond * 1) // NOTE: increase this in case of problems ;)
+				time.Sleep(time.Millisecond * 10) // NOTE: increase this in case of problems ;)
 				newCancel()
 				wg.Wait()
 			}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -765,7 +765,7 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 					assert.Contains(t, vuErr.Error(), "context canceled")
 				}()
 				<-ch
-				time.Sleep(time.Millisecond * 1) // NOTE: increase this in case of problems ;)
+				time.Sleep(time.Microsecond * 1) // NOTE: increase this in case of problems ;)
 				newCancel()
 				wg.Wait()
 			}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -765,7 +765,7 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 					assert.Contains(t, vuErr.Error(), "context canceled")
 				}()
 				<-ch
-				time.Sleep(time.Microsecond * 1) // NOTE: increase this in case of problems ;)
+				time.Sleep(time.Millisecond * 1) // NOTE: increase this in case of problems ;)
 				newCancel()
 				wg.Wait()
 			}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -765,7 +765,7 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 					assert.Contains(t, vuErr.Error(), "context canceled")
 				}()
 				<-ch
-				time.Sleep(time.Millisecond * 100) // NOTE: increase this in case of problems ;)
+				time.Sleep(time.Microsecond * 1) // NOTE: increase this in case of problems ;)
 				newCancel()
 				wg.Wait()
 			}

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -765,7 +765,7 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 					assert.Contains(t, vuErr.Error(), "context canceled")
 				}()
 				<-ch
-				time.Sleep(time.Millisecond * 10) // NOTE: increase this in case of problems ;)
+				time.Sleep(time.Millisecond * 100) // NOTE: increase this in case of problems ;)
 				newCancel()
 				wg.Wait()
 			}


### PR DESCRIPTION
## What?

It enables `macos-latest` for test-related (`test.yml`) CI workflows.

## Why?

Ha, why not? Jokes aside, imho now that MacOS-related issues (https://github.com/grafana/k6/issues/2578 and https://github.com/grafana/k6/issues/1230) have been closed (fixed), and that it looks like MacOS runners have at the very least a performance equivalent to Windows runners' (in fact, [test jobs seems to be taking less time in MacOS runners](https://github.com/grafana/k6/actions/runs/7493056548)), I guess it's good idea to make the check of the good functioning of k6 on MacOS part of the CI checks.

Also, in the worst case we can disable it again, but why not giving it a try?

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

I haven't found any.

<!-- Thanks for your contribution! 🙏🏼 -->
