### PR TITLE
Fix k6-insights enabled check

### DIFF
--- a/output/cloud/expv2/integration/integration_test.go
+++ b/output/cloud/expv2/integration/integration_test.go
@@ -54,7 +54,7 @@ func TestOutputFlush(t *testing.T) {
 	// init and start the output
 	o, err := expv2.New(logger, conf, cc)
 	require.NoError(t, err)
-	o.SetTestRunID("my-test-run-id-123")
+	o.SetTestRunID("123")
 	require.NoError(t, o.Start())
 
 	// collect and flush samples

--- a/output/cloud/expv2/integration/testdata/metricset.json
+++ b/output/cloud/expv2/integration/testdata/metricset.json
@@ -1,5 +1,5 @@
 {
-  "testRunId": "my-test-run-id-123",
+  "testRunId": "123",
   "aggregationPeriod": 3,
   "metrics": [
     {

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -300,7 +300,7 @@ func TestOutputStopWithTestError(t *testing.T) {
 	o, err := New(logger, config, cc)
 	require.NoError(t, err)
 
-	o.SetTestRunID("ref-id-123")
+	o.SetTestRunID("1234")
 	require.NoError(t, o.Start())
 	require.NoError(t, o.StopWithTestError(errors.New("an error")))
 }

--- a/output/cloud/insights/enable.go
+++ b/output/cloud/insights/enable.go
@@ -14,5 +14,5 @@ func Enabled(config cloudapi.Config) bool {
 	//
 	// We currently don't have a backend API to check this
 	// information.
-	return config.TracesEnabled.ValueOrZero()
+	return config.TracesEnabled.Bool
 }

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -96,13 +96,13 @@ func TestOutputCreateTestWithConfigOverwrite(t *testing.T) {
 		switch r.URL.Path {
 		case "/v1/tests":
 			fmt.Fprintf(w, `{
-"reference_id": "cloud-create-test",
+"reference_id": "12345",
 "config": {
 	"metricPushInterval": "10ms",
 	"aggregationPeriod": "1s"
 }
 }`)
-		case "/v1/tests/cloud-create-test":
+		case "/v1/tests/12345":
 			w.WriteHeader(http.StatusOK)
 		default:
 			http.Error(w, "not expected path", http.StatusInternalServerError)
@@ -216,7 +216,7 @@ func TestOutputStartWithTestRunID(t *testing.T) {
 		Logger: testutils.NewLogger(t),
 		Environment: map[string]string{
 			"K6_CLOUD_HOST":        ts.URL,
-			"K6_CLOUD_PUSH_REF_ID": "my-passed-id",
+			"K6_CLOUD_PUSH_REF_ID": "12345",
 		},
 		ScriptOptions: lib.Options{
 			SystemTags: &metrics.DefaultSystemTagSet,
@@ -252,7 +252,7 @@ func TestOutputStopWithTestError(t *testing.T) {
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/v1/tests/test-ref-id-1234":
+		case "/v1/tests/1234":
 			b, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
 
@@ -282,7 +282,7 @@ func TestOutputStopWithTestError(t *testing.T) {
 	require.NoError(t, err)
 
 	calledStopFn := false
-	out.testRunID = "test-ref-id-1234"
+	out.testRunID = "1234"
 	out.versionedOutput = versionedOutputMock{
 		callback: func(fn string) {
 			if fn == "StopWithTestError" {


### PR DESCRIPTION
## What?

Use raw `Bool` instead of `ValueOrZero`.

## Why?

If the value hasn't been set by the user, the default value set to `true` in https://github.com/grafana/k6/pull/3398 was not respected.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Fixes a bug introduced in https://github.com/grafana/k6/pull/3398.