### PR TITLE
Completely remove experimental GRPC module

### DIFF
--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -52,7 +52,7 @@ func getInternalJSModules() map[string]interface{} {
 		"k6/metrics":              metrics.New(),
 		"k6/ws":                   ws.New(),
 		"k6/experimental/grpc": newRemovedModule(
-			"k6/experimental/grpc has been removed, please use k6/net/grpc instead." +
+			"k6/experimental/grpc has been graduated, please use k6/net/grpc instead." +
 				" See https://grafana.com/docs/k6/latest/javascript-api/k6-net-grpc/ for more information.",
 		),
 	}

--- a/js/modules/k6/grpc/grpc.go
+++ b/js/modules/k6/grpc/grpc.go
@@ -4,7 +4,6 @@ package grpc
 import (
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/dop251/goja"
 	"github.com/mstoykov/k6-taskqueue-lib/taskqueue"
@@ -16,9 +15,7 @@ import (
 type (
 	// RootModule is the global module instance that will create module
 	// instances for each VU.
-	RootModule struct {
-		warnAboutExperimental *sync.Once
-	}
+	RootModule struct{}
 
 	// ModuleInstance represents an instance of the GRPC module for every VU.
 	ModuleInstance struct {
@@ -38,28 +35,12 @@ func New() *RootModule {
 	return &RootModule{}
 }
 
-// NewExperimental returns a pointer to a new RootModule instance.
-func NewExperimental() *RootModule {
-	return &RootModule{
-		warnAboutExperimental: &sync.Once{},
-	}
-}
-
 // NewModuleInstance implements the modules.Module interface to return
 // a new instance for each VU.
 func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	metrics, err := registerMetrics(vu.InitEnv().Registry)
 	if err != nil {
 		common.Throw(vu.Runtime(), fmt.Errorf("failed to register GRPC module metrics: %w", err))
-	}
-
-	if r.warnAboutExperimental != nil {
-		r.warnAboutExperimental.Do(func() {
-			vu.InitEnv().Logger.Warn(
-				"k6/experimental/grpc is now part of the k6 core, please change your imports to use k6/net/grpc instead." +
-					" The k6/experimental/grpc will be removed in k6 v0.51.0",
-			)
-		})
 	}
 
 	mi := &ModuleInstance{


### PR DESCRIPTION
## What?

This change completely removes the experimental GRPC module, as it was announced in https://github.com/grafana/k6/pull/3490

## Why?

The same functionality is in k6-core, and we waited for several releases.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/3490

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
