### PR TITLE
Fix report test

### DIFF
--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/execution"
+	"go.k6.io/k6/execution/local"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/lib/executor"
@@ -42,7 +43,7 @@ func TestCreateReport(t *testing.T) {
 			Logger: logger,
 		},
 		Options: opts,
-	})
+	}, local.NewController())
 	require.NoError(t, err)
 	s.GetState().ModInitializedVUsCount(6)
 	s.GetState().AddFullIterations(uint64(opts.Iterations.Int64))


### PR DESCRIPTION
## What?

This PR adds an argument that was introduced in #3204

## Why?

Currently, the test fails with:

```
 # go.k6.io/k6/cmd [go.k6.io/k6/cmd.test]
Error: cmd/report_test.go:40:35: not enough arguments in call to execution.NewScheduler
```

https://github.com/grafana/k6/actions/runs/7488727602/job/20383819709?pr=3530

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/3525

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
