### PR TITLE
Fix browser not found err in TestBrowserPermissions

### DIFF
--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -2204,7 +2204,7 @@ func TestBrowserPermissions(t *testing.T) {
 				},
 			}`,
 			expectedExitCode: 108,
-			expectedError:    "error building browser on IterStart: launching browser: exec: \"k6-browser-fake-cmd\": executable file not found",
+			expectedError:    "k6-browser-fake-cmd",
 		},
 	}
 


### PR DESCRIPTION
## What?

Fixes `TestBrowserPermissions` [failure](https://github.com/grafana/k6/actions/runs/7500578048/job/20419551355?pr=3537). Expects the fake command to be in the error message rather than looking for the entire message to be more resilient for future changes.

## Why?

We've changed the browser not found error message in grafana/xk6-browser#1136. So, this PR (#3537) that includes the new changes currently fails without this fix.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`), and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

grafana/xk6-browser#1136