### PR TITLE
Switching to grafana URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </p>
 <p align="center">
     <a href="https://github.com/grafana/k6/releases">Download</a> ·
-    <a href="https://k6.io/docs">Documentation</a> ·
+    <a href="https://grafana.com/docs/k6/latest/">Documentation</a> ·
     <a href="https://community.k6.io/">Community Forum</a>
 </p>
 
@@ -72,18 +72,19 @@ You can run scripts like this on the CLI, or in your CI, or across a Kubernetes 
 ## Documentation
 
 The docs cover all aspects of using k6. Some highlights include:
-- [Get Started](https://k6.io/docs). Install, run a test, inspect results.
-- [HTTP requests](https://k6.io/docs/using-k6/http-requests/). Have your virtual users use HTTP methods.
-  Or, check the other [Protocols](https://k6.io/docs/using-k6/protocols/).
-- [Thresholds](https://k6.io/docs/using-k6/thresholds). Set goals for your test, and codify your SLOs.
-- [Options](https://k6.io/docs/using-k6/k6-options). Configure your load, duration, TLS certificates, and much, much more.
-- [Scenarios](https://k6.io/docs/using-k6/scenarios).
-  Choose how to model your workload: open models, closed models, constant RPS, fixed iterations, and more.
-- [Results output](https://k6.io/docs/results-output). Study, filter, and export your test results.
-- [JavaScript API](https://k6.io/docs/javascript-api). Reference and examples of all k6 modules.
-- [Extensions](https://k6.io/docs/extensions). Extend k6 for new protocols and use cases.
 
-These links barely scratch the surface! If you're looking for conceptual information, you can read about [Test types](https://k6.io/docs/test-types/introduction/), [Test strategies](https://k6.io/docs/testing-guides/), or one of the many informative [Blog posts](https://k6.io/blog).
+- [Get Started](https://grafana.com/docs/k6/latest/). Install, run a test, inspect results.
+- [HTTP requests](https://grafana.com/docs/k6/latest/using-k6/http-requests/). Have your virtual users use HTTP methods.
+  Or, check the other [Protocols](https://grafana.com/docs/k6/latest/using-k6/protocols/).
+- [Thresholds](https://grafana.com/docs/k6/latest/using-k6/thresholds/). Set goals for your test, and codify your SLOs.
+- [Options](https://grafana.com/docs/k6/latest/using-k6/k6-options/). Configure your load, duration, TLS certificates, and much, much more.
+- [Scenarios](https://grafana.com/docs/k6/latest/using-k6/scenarios/).
+  Choose how to model your workload: open models, closed models, constant RPS, fixed iterations, and more.
+- [Results output](https://grafana.com/docs/k6/latest/results-output/). Study, filter, and export your test results.
+- [JavaScript API](https://grafana.com/docs/k6/latest/javascript-api/). Reference and examples of all k6 modules.
+- [Extensions](https://grafana.com/docs/k6/latest/extensions/). Extend k6 for new protocols and use cases.
+
+These links barely scratch the surface! If you're looking for conceptual information, you can read about [Test types](https://grafana.com/docs/k6/latest/testing-guides/test-types/), [Test strategies](https://grafana.com/docs/k6/latest/testing-guides/), or one of the many informative [Blog posts](https://k6.io/blog).
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center">
     <a href="https://github.com/grafana/k6/releases">Download</a> ·
     <a href="https://grafana.com/docs/k6/latest/">Documentation</a> ·
-    <a href="https://community.k6.io/">Community Forum</a>
+    <a href="https://community.grafana.com/c/grafana-k6/70">Community Forum</a>
 </p>
 
 <br/>

--- a/js/initcontext.go
+++ b/js/initcontext.go
@@ -13,7 +13,7 @@ import (
 )
 
 const cantBeUsedOutsideInitContextMsg = `the "%s" function is only available in the init stage ` +
-	`(i.e. the global scope), see https://k6.io/docs/using-k6/test-life-cycle for more information`
+	`(i.e. the global scope), see https://grafana.com/docs/k6/latest/using-k6/test-lifecycle/ for more information`
 
 // openImpl implements openImpl() in the init context and will read and return the
 // contents of a file. If the second argument is "b" it returns an ArrayBuffer

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -24,7 +24,7 @@ var (
 )
 
 const asyncFunctionNotSupportedMsg = "%s() does not support async functions as arguments, " +
-	"please see https://k6.io/docs/javascript-api/k6/group/#working-with-async-functions for more info"
+	"please see https://grafana.com/docs/k6/latest/javascript-api/k6/group/#working-with-async-functions for more info"
 
 type (
 	// RootModule is the global module instance that will create module

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -49,7 +49,7 @@ const (
 		`local directory (-v /local/path/:/inside/docker/path) containing ` +
 		`your script and modules so that they're accessible by k6 from ` +
 		`inside of the container, see ` +
-		`https://k6.io/docs/using-k6/modules#using-local-modules-with-docker.`
+		`https://grafana.com/docs/k6/latest/using-k6/modules/#using-local-modules-with-docker.`
 )
 
 type unresolvableURLError string

--- a/metrics/engine/ingester.go
+++ b/metrics/engine/ingester.go
@@ -113,7 +113,10 @@ func (oi *OutputIngester) flushMetrics() {
 				"and could cause high memory usage. "+
 				"Consider not using high-cardinality values like unique IDs as metric tags "+
 				"or, if you need them in the URL, use the name metric tag or URL grouping. "+
-				"See https://k6.io/docs/using-k6/tags-and-groups for details.", oi.cardinality.Count(), timeSeriesFirstLimit)
+				"See https://grafana.com/docs/k6/latest/using-k6/tags-and-groups/ for details.",
+			oi.cardinality.Count(),
+			timeSeriesFirstLimit,
+		)
 	}
 }
 

--- a/metrics/thresholds_parser.go
+++ b/metrics/thresholds_parser.go
@@ -9,7 +9,7 @@ import (
 )
 
 // thresholdExpression holds the parsed result of a threshold expression,
-// as described in: https://k6.io/docs/using-k6/thresholds/#threshold-syntax
+// as described in: https://grafana.com/docs/k6/latest/using-k6/thresholds/#threshold-syntax
 type thresholdExpression struct {
 	// AggregationMethod holds the aggregation method parsed
 	// from the threshold expression. Possible values are described


### PR DESCRIPTION
## What?

This PR switches the URLs from the `k6.io/docs/` to the `grafana.com/docs/k6/latest/`

## Why?

`grafana.com/docs/k6/latest/` is the primary source of the documentation right now.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
