### PR TITLE
github: Run the triage process for comments

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   assign-user:
     runs-on: ubuntu-latest
+    # issue_comment triggers for both, issues and prs,
+    # as we need to run only on issues, it filter out prs.
     if: ${{ !github.event.issue.pull_request }}
     steps:
       - uses: actions/github-script@v6

--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -4,6 +4,8 @@ on:
   workflow_call:
   issues:
     types: [opened]
+  issue_comment:
+    types: [created]
 
 permissions:
   issues: write
@@ -11,6 +13,7 @@ permissions:
 jobs:
   assign-user:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.issue.pull_request }}
     steps:
       - uses: actions/github-script@v6
         with:


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

Run the Triage workflow if a comment has been added to an issue without an assignee. It adds an event as described here https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#issue_comment

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

It makes sure comments are not lost and we can react in case needed.

