### PR TITLE
Use pre-compiled Go tip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,10 +60,15 @@ jobs:
         with:
           go-version: 1.x
           check-latest: true
+      - name: Download Go tip
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: "grafana/gotip"
+          tag: "${{ matrix.platform }}"
+          fileName: go.zip
       - name: Install Go tip
         run: |
-          go install golang.org/dl/gotip@latest
-          gotip download
+          unzip go.zip -d $HOME/sdk
           echo "GOROOT=$HOME/sdk/gotip" >> "$GITHUB_ENV"
           echo "GOPATH=$HOME/go" >> "$GITHUB_ENV"
           echo "$HOME/go/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,11 +55,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.x
-          check-latest: true
       - name: Download Go tip
         uses: robinraju/release-downloader@v1.8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Download Go tip
-        uses: robinraju/release-downloader@v1.8
+        uses: robinraju/release-downloader@efa4cd07bd0195e6cc65e9e30c251b49ce4d3e51 # v1.8
         with:
           repository: "grafana/gotip"
           tag: "${{ matrix.platform }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,11 +56,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Download Go tip
-        uses: robinraju/release-downloader@efa4cd07bd0195e6cc65e9e30c251b49ce4d3e51 # v1.8
-        with:
-          repository: "grafana/gotip"
-          tag: "${{ matrix.platform }}"
-          fileName: go.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download ${{ matrix.platform }} --repo grafana/gotip --pattern 'go.zip'
       - name: Install Go tip
         run: |
           unzip go.zip -d $HOME/sdk


### PR DESCRIPTION
## What?

It adds the use of pre-compiled Go tip (https://github.com/grafana/gotip).

## Why?

To speed up the Go tip related CI jobs runs (_it is much faster to download the artifacts and unzip them, than downloading the source code and building it on CI_).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
