### PR TITLE
docs: fix web dashboard default URL port

### DIFF
--- a/release notes/v0.49.0.md
+++ b/release notes/v0.49.0.md
@@ -28,7 +28,7 @@ Activate this feature using the environment variable `K6_WEB_DASHBOARD=true`. Fo
 K6_WEB_DASHBOARD=true k6 run script.js
 ```
 
-Once enabled and the test script is running, navigate to [http://localhost:6565](http://localhost:6565) in your web browser to access the dashboard.
+Once enabled and the test script is running, navigate to [http://localhost:5665](http://localhost:5665) in your web browser to access the dashboard.
 
 ![k6 Web Dashboard Overview](https://github.com/grafana/xk6-dashboard/blob/master/screenshot/k6-dashboard-overview-light.png?raw=true)
 


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

In the `v0.49.0` release notes, the default URL port of the web dashboard was incorrectly `6565`, which was changed to the correct value of `5665`.
