### PR TITLE
Exclude release notes folder from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,8 @@
 # by default the k6-core team is the owner of all files
 * @grafana/k6-core
+
+# The release notes are shared across different teams,
+# especially with the browser team.
+# It turned out to be less noisy if the author picks manually every time
+# the best reviewers based on the context of the working area.
+/release\ notes/


### PR DESCRIPTION
## What?

As the title mentions, it excludes the `release notes` folder from the CODEOWNERS and consequentially from the auto-assignment in case of pull requests.

The authors will have to manually assign the reviewers by picking a team (`k6-core` or `k6-browser`) and/or single team members. 

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

Hopefully, it will make the assignments more relevant to the context of the working area.