### PR TITLE
Exclude release notes folder from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,8 @@
 # by default the k6-core team is the owner of all files
 * @grafana/k6-core
+
+# The release notes are shared across different teams,
+# especially with the browser team.
+# It turned out to be less noisy if the author picks manually every time
+# the best reviewers based on the context of the working area.
+/release\ notes/


### PR DESCRIPTION
Updates `CODEOWNERS` for the `release-v0.50.0` branch.

70c151f7 (#3580) added this change only for the `master` but not for the `release-v0.50.0` branch.

We want to prevent the k6-core team from getting notified about browser release notes updates.