### PR TITLE
fix zip-slip noise in tests

### DIFF
--- a/lib/testutils/untar.go
+++ b/lib/testutils/untar.go
@@ -38,9 +38,12 @@ func Untar(t *testing.T, fileSystem fsext.Fs, fileName string, destination strin
 			continue
 		}
 
-		// as long as this code in a test helper, we can safely
-		// omit G305: File traversal when extracting zip/tar archive
-		target := filepath.Join(destination, header.Name) //nolint:gosec
+		fileName := header.Name
+		if !filepath.IsLocal(fileName) {
+			return errors.New("tar file contains non-local file names")
+		}
+
+		target := filepath.Join(destination, filepath.Clean(fileName))
 
 		switch header.Typeflag {
 		case tar.TypeDir:


### PR DESCRIPTION
## What?

This attempts to fix the "noise" from the security tab (CodeQL reported).

## Why?

Fixing such cases helps us focus on the right things.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
