### PR TITLE
Fix auto assign on issue comment

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -24,7 +24,7 @@ jobs:
             const assigneeCount = 1;
 
             // Do not automatically assign users if someone was already assigned or it was opened by a maintainer
-            if (context.payload.issue.assignees.length > 0 || assignees.includes(context.payload.issue.user.login)) {
+            if (context.payload.issue.assignees.length > 0 || assignees.includes(context.actor)) {
               return;
             }
             const crypto = require("node:crypto");


### PR DESCRIPTION


## What?

Previously the action was checking always whether the author of the issue was one of the maintainers instead of whether the comment was created by a none-maintainer.

## Why?

So we do not get assigned issues when we (the maintainers of k6) comment on them. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
