### PR TITLE
Add screenshot upload release notes

### DIFF
--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -25,11 +25,7 @@ _what, why, and what this means for the user_
 
 ## UX improvements and enhancements
 
-_Format as `<number> <present_verb> <object>. <credit>`_:
-
-- _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
-- `#pr` `<description>`
-- `#pr` `<description>`
+- [browser#1197](https://github.com/grafana/xk6-browser/pull/1197), [browser#1202](https://github.com/grafana/xk6-browser/pull/1202), [browser#1203](https://github.com/grafana/xk6-browser/pull/1203) add the ability to upload screenshots to a remote location instead of persisting them to the local disk.
 
 ## Bug fixes
 

--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -25,7 +25,7 @@ _what, why, and what this means for the user_
 
 ## UX improvements and enhancements
 
-- [browser#1197](https://github.com/grafana/xk6-browser/pull/1197), [browser#1202](https://github.com/grafana/xk6-browser/pull/1202), [browser#1203](https://github.com/grafana/xk6-browser/pull/1203) add the ability to upload screenshots to a remote location instead of persisting them to the local disk.
+- [browser#1197](https://github.com/grafana/xk6-browser/pull/1197), [browser#1202](https://github.com/grafana/xk6-browser/pull/1202), [browser#1203](https://github.com/grafana/xk6-browser/pull/1203) add the ability to upload screenshots to a remote location.
 
 ## Bug fixes
 


### PR DESCRIPTION
## What?

Add screenshot upload release notes.

## Why?

Update users of a UX improvement where by the browser module can be configured to upload screenshot to a remote location.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
