### PR TITLE
Drop options.ext.loadimpact references

### DIFF
--- a/cmd/tests/cmd_cloud_test.go
+++ b/cmd/tests/cmd_cloud_test.go
@@ -246,21 +246,19 @@ func TestCloudWithArchive(t *testing.T) {
 
 		metadata := struct {
 			Options struct {
-				Ext struct {
-					LoadImpact struct {
-						Name      string `json:"name"`
-						Note      string `json:"note"`
-						ProjectID int    `json:"projectID"`
-					} `json:"loadimpact"`
-				} `json:"ext"`
+				Cloud struct {
+					Name      string `json:"name"`
+					Note      string `json:"note"`
+					ProjectID int    `json:"projectID"`
+				} `json:"cloud"`
 			} `json:"options"`
 		}{}
 
 		// then unpacked metadata should not contain any environment variables passed at the moment of archive creation
 		require.NoError(t, json.Unmarshal(metadataRaw, &metadata))
-		require.Equal(t, "my load test", metadata.Options.Ext.LoadImpact.Name)
-		require.Equal(t, "lorem ipsum", metadata.Options.Ext.LoadImpact.Note)
-		require.Equal(t, 124, metadata.Options.Ext.LoadImpact.ProjectID)
+		require.Equal(t, "my load test", metadata.Options.Cloud.Name)
+		require.Equal(t, "lorem ipsum", metadata.Options.Cloud.Note)
+		require.Equal(t, 124, metadata.Options.Cloud.ProjectID)
 
 		// respond with the test run ID
 		resp.WriteHeader(http.StatusOK)

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -98,7 +98,7 @@ func newOutput(params output.Params) (*Output, error) {
 		scriptPath := params.ScriptPath.String()
 		if scriptPath == "" {
 			// Script from stdin without a name, likely from stdin
-			return nil, errors.New("script name not set, please specify K6_CLOUD_NAME or options.ext.loadimpact.name")
+			return nil, errors.New("script name not set, please specify K6_CLOUD_NAME or options.cloud.name")
 		}
 
 		conf.Name = null.StringFrom(filepath.Base(scriptPath))


### PR DESCRIPTION
## What?

A follow-up PR to use `options.cloud` instead of `options.ext.loadimpact`.

## Why?

The legacy `options.ext.loadimpact` is superseded by `options.cloud`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.


## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/3348