### PR TITLE
Add browser 850 and other Go 1.20 PRs to release notes

### DIFF
--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -40,6 +40,8 @@ _what, why, and what this means for the user_
   [browser#1189](https://github.com/grafana/xk6-browser/pull/1189), [browser#1190](https://github.com/grafana/xk6-browser/pull/1190), [browser#1191](https://github.com/grafana/xk6-browser/pull/1191),
   [browser#1193](https://github.com/grafana/xk6-browser/pull/1193), [browser#1163](https://github.com/grafana/xk6-browser/pull/1163), [browser#1205](https://github.com/grafana/xk6-browser/pull/1205),
   [browser#1217](https://github.com/grafana/xk6-browser/pull/1217) refactor internals to improve stability.
+- [browser#850](https://github.com/grafana/xk6-browser/pull/850), [browser#1211](https://github.com/grafana/xk6-browser/pull/1211), [browser#1212](https://github.com/grafana/xk6-browser/pull/1212),
+  [browser#1214](https://github.com/grafana/xk6-browser/pull/1214), [browser#1216](https://github.com/grafana/xk6-browser/pull/1216) refactor to work with errors.Join and set the minimum Go version to 1.20.
 
 ## _Optional_ Roadmap
 


### PR DESCRIPTION
Update release notes for https://github.com/grafana/xk6-browser/pull/850.

Should we combine this with the big refactor internals?