### PR TITLE
cloudapi: lint fixes + just use crypto/rand

### DIFF
--- a/cloudapi/client.go
+++ b/cloudapi/client.go
@@ -2,12 +2,12 @@ package cloudapi
 
 import (
 	"bytes"
+	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"time"
 
@@ -230,15 +230,9 @@ func shouldAddIdempotencyKey(req *http.Request) bool {
 
 // randomStrHex returns a hex string which can be used
 // for session token id or idempotency key.
-//
-//nolint:gosec
 func randomStrHex() string {
 	// 16 hex characters
 	b := make([]byte, 8)
 	_, _ = rand.Read(b)
 	return hex.EncodeToString(b)
-}
-
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
 }

--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -101,7 +101,7 @@ func NewConfig() Config {
 
 // Apply saves config non-zero config values from the passed config in the receiver.
 //
-//nolint:funlen,gocognit,cyclop
+//nolint:cyclop
 func (c Config) Apply(cfg Config) Config {
 	if cfg.Token.Valid {
 		c.Token = cfg.Token

--- a/cloudapi/config_test.go
+++ b/cloudapi/config_test.go
@@ -43,7 +43,7 @@ func TestConfigApply(t *testing.T) {
 		TracesEnabled:         null.NewBool(true, true),
 		TracesHost:            null.NewString("TracesHost", true),
 		TracesPushInterval:    types.NewNullDuration(10*time.Second, true),
-		TracesPushConcurrency:           null.NewInt(6, true),
+		TracesPushConcurrency: null.NewInt(6, true),
 	}
 
 	assert.Equal(t, full, full.Apply(empty))


### PR DESCRIPTION
## What?

Some leftover lint fixes and just move to crypto/rand for the idempotency token.

Part of #769


## Why?

Fixes lint issues

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
