### PR TITLE
Add xk6-browser#2066 to release notes

### DIFF
--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -28,6 +28,7 @@ _what, why, and what this means for the user_
 - [browser#1197](https://github.com/grafana/xk6-browser/pull/1197), [browser#1202](https://github.com/grafana/xk6-browser/pull/1202), [browser#1203](https://github.com/grafana/xk6-browser/pull/1203), [browser#1221](https://github.com/grafana/xk6-browser/pull/1221) add the ability to upload screenshots to a remote location.
 - [browser#1209](https://github.com/grafana/xk6-browser/pull/1209) add a shadow DOM usage example.
 - [browser#1233](https://github.com/grafana/xk6-browser/pull/1233) returns actionable errors for `evaluate` APIs.
+- [browser#1228](https://github.com/grafana/xk6-browser/pull/1228), [browser#1232](https://github.com/grafana/xk6-browser/pull/1232), [browser#1235](https://github.com/grafana/xk6-browser/pull/1235) injects the `testRunId` into the `window.k6` object for external applications to query (e.g. Grafana Faro).
 
 ### Browser Context Isolation [browser#1112](https://github.com/grafana/xk6-browser/issues/1112)
 

--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -27,6 +27,7 @@ _what, why, and what this means for the user_
 
 - [browser#1197](https://github.com/grafana/xk6-browser/pull/1197), [browser#1202](https://github.com/grafana/xk6-browser/pull/1202), [browser#1203](https://github.com/grafana/xk6-browser/pull/1203), [browser#1221](https://github.com/grafana/xk6-browser/pull/1221) add the ability to upload screenshots to a remote location.
 - [browser#1209](https://github.com/grafana/xk6-browser/pull/1209) add a shadow DOM usage example.
+- [browser#1233](https://github.com/grafana/xk6-browser/pull/1233) returns actionable errors for `evaluate` APIs.
 
 ### Browser Context Isolation [browser#1112](https://github.com/grafana/xk6-browser/issues/1112)
 

--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -25,8 +25,8 @@ _what, why, and what this means for the user_
 
 ## UX improvements and enhancements
 
-- [browser#1197](https://github.com/grafana/xk6-browser/pull/1197), [browser#1202](https://github.com/grafana/xk6-browser/pull/1202), [browser#1203](https://github.com/grafana/xk6-browser/pull/1203), [browser#1221](https://github.com/grafana/xk6-browser/pull/1221) add the ability to upload screenshots to a remote location.
-- [browser#1209](https://github.com/grafana/xk6-browser/pull/1209) add a shadow DOM usage example.
+- [browser#1197](https://github.com/grafana/xk6-browser/pull/1197), [browser#1202](https://github.com/grafana/xk6-browser/pull/1202), [browser#1203](https://github.com/grafana/xk6-browser/pull/1203), [browser#1221](https://github.com/grafana/xk6-browser/pull/1221) adds the ability to upload screenshots to a remote location.
+- [browser#1209](https://github.com/grafana/xk6-browser/pull/1209) adds a shadow DOM usage example.
 - [browser#1233](https://github.com/grafana/xk6-browser/pull/1233) returns actionable errors for `evaluate` APIs.
 - [browser#1228](https://github.com/grafana/xk6-browser/pull/1228), [browser#1232](https://github.com/grafana/xk6-browser/pull/1232), [browser#1235](https://github.com/grafana/xk6-browser/pull/1235) injects the `testRunId` into the `window.k6` object for external applications to query (e.g. Grafana Faro).
 
@@ -45,10 +45,10 @@ With this release, we have overhauled and (tremendously) improved the performanc
   [browser#1183](https://github.com/grafana/xk6-browser/pull/1183), [browser#1186](https://github.com/grafana/xk6-browser/pull/1186), [browser#1188](https://github.com/grafana/xk6-browser/pull/1188),
   [browser#1189](https://github.com/grafana/xk6-browser/pull/1189), [browser#1190](https://github.com/grafana/xk6-browser/pull/1190), [browser#1191](https://github.com/grafana/xk6-browser/pull/1191),
   [browser#1193](https://github.com/grafana/xk6-browser/pull/1193), [browser#1163](https://github.com/grafana/xk6-browser/pull/1163), [browser#1205](https://github.com/grafana/xk6-browser/pull/1205),
-  [browser#1217](https://github.com/grafana/xk6-browser/pull/1217) refactor internals to improve stability.
+  [browser#1217](https://github.com/grafana/xk6-browser/pull/1217) refactors internals to improve stability.
 - [browser#850](https://github.com/grafana/xk6-browser/pull/850), [browser#1211](https://github.com/grafana/xk6-browser/pull/1211), [browser#1212](https://github.com/grafana/xk6-browser/pull/1212),
-  [browser#1214](https://github.com/grafana/xk6-browser/pull/1214), [browser#1216](https://github.com/grafana/xk6-browser/pull/1216) refactor to work with errors.Join and set the minimum Go version to 1.20.
-- [browser#1220](https://github.com/grafana/xk6-browser/pull/1220) add more logging.
+  [browser#1214](https://github.com/grafana/xk6-browser/pull/1214), [browser#1216](https://github.com/grafana/xk6-browser/pull/1216) refactors to work with errors.Join and sets the minimum Go version to 1.20.
+- [browser#1220](https://github.com/grafana/xk6-browser/pull/1220) adds more logging.
 - [browser#1112](https://github.com/grafana/xk6-browser/issues/1112) fixes deadlock issues when running multiple VUs, iterations, and Chrome instances.
 
 ## _Optional_ Roadmap


### PR DESCRIPTION
## What?

Add xk6-browser#2066 to release notes.

## Why?

Keeps users up to date.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6-cloud/issues/2066