### PR TITLE
Add browser async breaking change

### DIFF
--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -9,6 +9,17 @@ k6 `v0.50.0` is here 🎉! This release includes:
 - `#pr`, `<small_break_1>`
 - [websockets#60](https://github.com/grafana/xk6-websockets/pull/60) allows manual set `name` tag, which also overwrites `url` tag with `name` value. This is aligning of the logic that was implemented in the k6 v0.41. Thanks, @mkadirtan for contributing!
 
+### Browser APIs to Async
+
+In future release we are going to be moving most of the browser APIs to asynchronous (promisfying them). We expect that this will affect majority of our users, which is why we are posting this upfront before we make the change itself. Here are the reasons for making this large breaking change:
+
+1. Most of the browser APIs use some form of long running IO operation (networking) to perform the requested action on the web browser against the website under test. We need to avoid blocking the javascript's runtime event loop for such operations.
+2. We're going to be adding more asynchronous event based APIs (such as [page.on](https://github.com/grafana/xk6-browser/issues/1227)) that would be blocked with our current synchronous APIs.
+3. To align with how javascript developers expect to work with javascript APIs.
+4. To have better compatibility with Playwright.
+
+You can find a list of all the APIs that we expect to convert to async in a comment in issue [browser#428](https://github.com/grafana/xk6-browser/issues/428#issuecomment-1964020837).
+
 ### (_optional h3_) `<big_breaking_change>` `#pr`
 
 ## New features

--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -11,11 +11,11 @@ k6 `v0.50.0` is here 🎉! This release includes:
 
 ### Browser APIs to Async
 
-In future release we are going to be moving most of the browser APIs to asynchronous (promisfying them). We expect that this will affect majority of our users, which is why we are posting this upfront before we make the change itself. Here are the reasons for making this large breaking change:
+In future releases, we are going to be moving most of the synchronous browser APIs to asynchronous ones (promisifying them). We expect this will affect most of our users, so we are posting this upfront before making the change. Here are the reasons for making this large breaking change:
 
-1. Most of the browser APIs use some form of long running IO operation (networking) to perform the requested action on the web browser against the website under test. We need to avoid blocking the javascript's runtime event loop for such operations.
-2. We're going to be adding more asynchronous event based APIs (such as [page.on](https://github.com/grafana/xk6-browser/issues/1227)) that would be blocked with our current synchronous APIs.
-3. To align with how javascript developers expect to work with javascript APIs.
+1. Most browser APIs use some form of long-running IO operation (networking) to perform the requested action on the web browser against the website under test. We need to avoid blocking Javascript's runtime event loop for such operations.
+2. We're going to add more asynchronous event-based APIs (such as [page.on](https://github.com/grafana/xk6-browser/issues/1227)) that our current synchronous APIs would block.
+3. To align with how developers expect to work with JavaScript APIs.
 4. To have better compatibility with Playwright.
 
 You can find a list of all the APIs that we expect to convert to async in a comment in issue [browser#428](https://github.com/grafana/xk6-browser/issues/428#issuecomment-1964020837).

--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -20,6 +20,8 @@ In future releases, we are going to be moving most of the synchronous browser AP
 
 You can find a list of all the APIs that we expect to convert to async in a comment in issue [browser#428](https://github.com/grafana/xk6-browser/issues/428#issuecomment-1964020837).
 
+Awaiting on something that’s not a thenable just resolves to that value, which means you can add the `await` keyword against APIs that will become async to future proof your test scripts.
+
 ### (_optional h3_) `<big_breaking_change>` `#pr`
 
 ## New features


### PR DESCRIPTION
## What?

This is to notify all browser APIs users that in a future release we will be breaking most of the APIs by moving them to async (`Promise`).

## Why?

To notify users of this change so that they are forewarned of it and maybe start preparing for it.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/xk6-browser/issues/428#issuecomment-1964020837