### PR TITLE
Don't "unset" `open` and `require` after the init context

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -276,10 +276,9 @@ func (b *Bundle) instantiate(vuImpl *moduleVUImpl, vuID uint64) (*goja.Object, e
 	}
 
 	modSys := modules.NewModuleSystem(b.ModuleResolver, vuImpl)
-	unbindInit := b.setInitGlobals(rt, vuImpl, modSys)
+	b.setInitGlobals(rt, vuImpl, modSys)
 	vuImpl.initEnv = initenv
 	defer func() {
-		unbindInit()
 		vuImpl.initEnv = nil
 	}()
 
@@ -377,7 +376,7 @@ func (r *requireImpl) require(specifier string) (*goja.Object, error) {
 	return r.internal.Require(specifier)
 }
 
-func (b *Bundle) setInitGlobals(rt *goja.Runtime, vu *moduleVUImpl, modSys *modules.ModuleSystem) (unset func()) {
+func (b *Bundle) setInitGlobals(rt *goja.Runtime, vu *moduleVUImpl, modSys *modules.ModuleSystem) {
 	mustSet := func(k string, v interface{}) {
 		if err := rt.Set(k, v); err != nil {
 			panic(fmt.Errorf("failed to set '%s' global object: %w", k, err))
@@ -404,11 +403,6 @@ func (b *Bundle) setInitGlobals(rt *goja.Runtime, vu *moduleVUImpl, modSys *modu
 		pwd := impl.internal.CurrentlyRequiredModule()
 		return openImpl(rt, b.filesystems["file"], &pwd, filename, args...)
 	})
-
-	return func() {
-		mustSet("require", goja.Undefined())
-		mustSet("open", goja.Undefined())
-	}
 }
 
 func generateFileLoad(b *Bundle) modules.FileLoader {

--- a/js/runner.go
+++ b/js/runner.go
@@ -255,13 +255,6 @@ func (r *Runner) newVU(
 	vu.moduleVUImpl.state = vu.state
 	_ = vu.Runtime.Set("console", vu.Console)
 
-	// This is here mostly so if someone tries they get a nice message
-	// instead of "Value is not an object: undefined  ..."
-	_ = vu.Runtime.GlobalObject().Set("open",
-		func() {
-			common.Throw(vu.Runtime, fmt.Errorf(cantBeUsedOutsideInitContextMsg, "open"))
-		})
-
 	return vu, nil
 }
 


### PR DESCRIPTION
## What?

Stop unsetting `open` and `require` after init context just do redo some of the work.

This still prevents them being used outside of the init context.

## Why?

This was done to prevent them to be used outside of the init context, except that this wasn't enough as you can save them to another variable.

More fixes have been added on top - but in reality there is no need to unset them.

If anything this makes it harder for users to figure out what happens as in the case of `require` it will tell you that you can't call `undefined`.

For `open` this was handled by setting it to a function that just reports it can't be used outside the init context. But this is already the case if it isn't unset and then reset to this function.

So this change makes the whole thing more consistent and doesn't do a bunch of additional and unnecessary operations.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
