### PR TITLE
Bump k6 version to v0.50

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.49.0"
+const Version = "0.50.0"
 
 // FullVersion returns the maximally full version and build information for
 // the currently running k6 executable.


### PR DESCRIPTION
## What?

This Pull Request bumps k6's `lib/consts.go` file to reflect version `v0.50.0`.

## Related PR(s)/Issue(s)

#3577 