### PR TITLE
Add browser 986

### DIFF
--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -168,6 +168,7 @@ With this release, we have overhauled and (tremendously) improved the performanc
   [browser#1214](https://github.com/grafana/xk6-browser/pull/1214), [browser#1216](https://github.com/grafana/xk6-browser/pull/1216) refactors to work with errors.Join and sets the minimum Go version to 1.20.
 - [browser#1220](https://github.com/grafana/xk6-browser/pull/1220) adds more logging.
 - [browser#1112](https://github.com/grafana/xk6-browser/issues/1112) fixes deadlock issues when running multiple VUs, iterations, and Chrome instances.
+- [browser#1246](https://github.com/grafana/xk6-browser/issues/1246) remove logging in-flight requests when a request is failed.
 - [3586](https://github.com/grafana/k6/pull/3586) fixes file traversal for the test.
 - [3588](https://github.com/grafana/k6/pull/3588) updates `codeql` GitHub action to v3.
 * [webcrypto#62](https://github.com/grafana/xk6-webcrypto/pull/62) fixes display error message in the console and does minor maintenance.

--- a/release notes/v0.50.0.md
+++ b/release notes/v0.50.0.md
@@ -168,7 +168,7 @@ With this release, we have overhauled and (tremendously) improved the performanc
   [browser#1214](https://github.com/grafana/xk6-browser/pull/1214), [browser#1216](https://github.com/grafana/xk6-browser/pull/1216) refactors to work with errors.Join and sets the minimum Go version to 1.20.
 - [browser#1220](https://github.com/grafana/xk6-browser/pull/1220) adds more logging.
 - [browser#1112](https://github.com/grafana/xk6-browser/issues/1112) fixes deadlock issues when running multiple VUs, iterations, and Chrome instances.
-- [browser#1246](https://github.com/grafana/xk6-browser/issues/1246) remove logging in-flight requests when a request is failed.
+- [browser#1246](https://github.com/grafana/xk6-browser/issues/1246) removes logging of in-flight requests when a request fails.
 - [3586](https://github.com/grafana/k6/pull/3586) fixes file traversal for the test.
 - [3588](https://github.com/grafana/k6/pull/3588) updates `codeql` GitHub action to v3.
 * [webcrypto#62](https://github.com/grafana/xk6-webcrypto/pull/62) fixes display error message in the console and does minor maintenance.


### PR DESCRIPTION
Updates the release notes for https://github.com/grafana/xk6-browser/pull/1246.