### PR TITLE
Make options.hosts case insensitive

### DIFF
--- a/lib/types/hosts.go
+++ b/lib/types/hosts.go
@@ -97,7 +97,7 @@ type Hosts struct {
 // NewHosts returns new Hosts from given addresses.
 func NewHosts(source map[string]Host) (*Hosts, error) {
 	h := &Hosts{
-		source: source,
+		source: toLowerKeys(source),
 		n: &trieNode{
 			children: make(map[rune]*trieNode),
 		},
@@ -111,6 +111,14 @@ func NewHosts(source map[string]Host) (*Hosts, error) {
 	}
 
 	return h, nil
+}
+
+func toLowerKeys(source map[string]Host) map[string]Host {
+	result := make(map[string]Host, len(source))
+	for k, v := range source {
+		result[strings.ToLower(k)] = v
+	}
+	return result
 }
 
 // Regex description of domain(:port)? pattern to enforce blocks by.

--- a/lib/types/hosts_test.go
+++ b/lib/types/hosts_test.go
@@ -49,6 +49,7 @@ func TestHosts(t *testing.T) {
 		"specific.wildcard.io":   {IP: net.ParseIP("90.100.110.120")},
 		"*wildcard-2.io":         {IP: net.ParseIP("13.14.15.16")},
 		"specific.wildcard-2.io": {IP: net.ParseIP("130.140.150.160")},
+		"with-UPPER-case.io":     {IP: net.ParseIP("17.18.19.20")},
 
 		// IPv6
 		"simple-ipv6.io":              {IP: net.ParseIP("aa::bb")},
@@ -77,6 +78,8 @@ func TestHosts(t *testing.T) {
 				{"only-port.io", "", NotInHosts},
 				{"only-port.io:443", "5.6.7.8:8443", DifferentPortMapping},
 				{"only-port.io:9999", "", NotGivenPortMapping},
+				{"with-upper-case.io", "17.18.19.20:0", EmptyPortMapping},
+				{"with-UPPER-case.io", "17.18.19.20:0", EmptyPortMapping},
 			}
 			runTcs(t, hosts, tcs)
 		})


### PR DESCRIPTION
## What?

It updates the `Hosts` type constructor `NewHosts` store `source` keys (i.e. hosts) lowercased, to consider them case insensitive. The internal trie, and the [`Hosts.Match`](https://github.com/grafana/k6/blob/master/lib/types/hosts.go#L142-L157) is already considering them insensitive, as they're treated as lowercase.

## Why?

Because otherwise, `options.hosts` doesn't work well with non-lowercase hosts.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes https://github.com/grafana/k6/issues/3651

Also related with https://github.com/grafana/k6/issues/3620

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
