### PR TITLE
Make errors with scenarios' name more clear

### DIFF
--- a/lib/executor/base_config.go
+++ b/lib/executor/base_config.go
@@ -18,9 +18,9 @@ import (
 // TODO?: Discard? Or make this actually user-configurable somehow? hello #883...
 var DefaultGracefulStopValue = 30 * time.Second //nolint:gochecknoglobals
 
-var executorNameWhitelist = regexp.MustCompile(`^[0-9a-zA-Z_-]+$`)
+var scenarioNameWhitelist = regexp.MustCompile(`^[0-9a-zA-Z_-]+$`)
 
-const executorNameErr = "the executor name should contain only numbers, latin letters, underscores, and dashes"
+const scenarioNameErr = "the scenario name should contain only numbers, latin letters, underscores, and dashes"
 
 // BaseConfig contains the common config fields for all executors
 type BaseConfig struct {
@@ -50,10 +50,10 @@ func (bc BaseConfig) Validate() (errors []error) {
 	// Some just-in-case checks, since those things are likely checked in other places or
 	// even assigned by us:
 	if bc.Name == "" {
-		errors = append(errors, fmt.Errorf("executor name can't be empty"))
+		errors = append(errors, fmt.Errorf("scenario name can't be empty"))
 	}
-	if !executorNameWhitelist.MatchString(bc.Name) {
-		errors = append(errors, fmt.Errorf(executorNameErr))
+	if !scenarioNameWhitelist.MatchString(bc.Name) {
+		errors = append(errors, fmt.Errorf(scenarioNameErr))
 	}
 	if bc.Exec.Valid && bc.Exec.String == "" {
 		errors = append(errors, fmt.Errorf("exec value cannot be empty"))
@@ -71,7 +71,7 @@ func (bc BaseConfig) Validate() (errors []error) {
 	return errors
 }
 
-// GetName returns the name of the executor.
+// GetName returns the name of the scenario.
 func (bc BaseConfig) GetName() string {
 	return bc.Name
 }
@@ -117,7 +117,7 @@ func (bc BaseConfig) GetScenarioOptions() *lib.ScenarioOptions {
 	return bc.Options
 }
 
-// GetTags returns any custom tags configured for the executor.
+// GetTags returns any custom tags configured for the scenario.
 func (bc BaseConfig) GetTags() map[string]string {
 	return bc.Tags
 }


### PR DESCRIPTION
## What?

It slightly modifies the errors related with scenarios' name (like empty or prohibited characters).

## Why?

Because, as stated in #3601, the current error messages are misleading.

I might be wrong, but in my opinion, I understand that every object under the `scenarios` key is a scenario definition, thus the key is the name of the scenario, not the name of the executor (type). Also, that's what can be guessed from [our docs](https://grafana.com/docs/k6/latest/using-k6/scenarios/executors/):

```
export const options = {
  scenarios: {
    arbitrary_scenario_name: {
      //Name of executor
      executor: 'ramping-vus',
      // more configuration here
    },
  },
};
```

So, `arbitrary_scenario_name` is the scenario name, and `ramping-vus` is the executor, it's name/type.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes #3601 

<!-- Thanks for your contribution! 🙏🏼 -->
