### PR TITLE
Add 'negative' value type for negative events

### DIFF
--- a/js/summary.js
+++ b/js/summary.js
@@ -230,12 +230,14 @@ function nonTrendMetricValueForSum(metric, timeUnit) {
         'min=' + humanizeValue(metric.values.min, metric, timeUnit),
         'max=' + humanizeValue(metric.values.max, metric, timeUnit),
       ]
-    case 'rate':
-      return [
-        humanizeValue(metric.values.rate, metric, timeUnit),
-        succMark + ' ' + metric.values.passes,
-        failMark + ' ' + metric.values.fails,
-      ]
+	  case 'rate':
+		  const passesMark = metric.contains === 'negative' ? failMark : succMark;
+		  const failsMark = metric.contains === 'negative' ? succMark : failMark;
+		  return [
+			  humanizeValue(metric.values.rate, metric, timeUnit),
+			  passesMark + ' ' + metric.values.passes,
+			  failsMark + ' ' + metric.values.fails,
+		  ]
     default:
       return ['[no data]']
   }

--- a/metrics/builtin.go
+++ b/metrics/builtin.go
@@ -87,7 +87,7 @@ func RegisterBuiltinMetrics(registry *Registry) *BuiltinMetrics {
 		GroupDuration: registry.MustNewMetric(GroupDurationName, Trend, Time),
 
 		HTTPReqs:              registry.MustNewMetric(HTTPReqsName, Counter),
-		HTTPReqFailed:         registry.MustNewMetric(HTTPReqFailedName, Rate),
+		HTTPReqFailed:         registry.MustNewMetric(HTTPReqFailedName, Rate, Negative),
 		HTTPReqDuration:       registry.MustNewMetric(HTTPReqDurationName, Trend, Time),
 		HTTPReqBlocked:        registry.MustNewMetric(HTTPReqBlockedName, Trend, Time),
 		HTTPReqConnecting:     registry.MustNewMetric(HTTPReqConnectingName, Trend, Time),

--- a/metrics/metric_type.go
+++ b/metrics/metric_type.go
@@ -22,9 +22,10 @@ const (
 	trendString   = "trend"
 	rateString    = "rate"
 
-	defaultString = "default"
-	timeString    = "time"
-	dataString    = "data"
+	defaultString  = "default"
+	timeString     = "time"
+	dataString     = "data"
+	negativeString = "negative"
 )
 
 // MarshalJSON serializes a MetricType as a human readable string.

--- a/metrics/value_type.go
+++ b/metrics/value_type.go
@@ -4,9 +4,10 @@ import "errors"
 
 // Possible values for ValueType.
 const (
-	Default = ValueType(iota) // Values are presented as-is
-	Time                      // Values are time durations (milliseconds)
-	Data                      // Values are data amounts (bytes)
+	Default  = ValueType(iota) // Values are presented as-is
+	Time                       // Values are time durations (milliseconds)
+	Data                       // Values are data amounts (bytes)
+	Negative                   // Values represent negative events (e.g. failed requests)
 )
 
 // ErrInvalidValueType indicates the serialized value type is invalid.
@@ -33,6 +34,8 @@ func (t ValueType) MarshalText() ([]byte, error) {
 		return []byte(timeString), nil
 	case Data:
 		return []byte(dataString), nil
+	case Negative:
+		return []byte(negativeString), nil
 	default:
 		return nil, ErrInvalidValueType
 	}
@@ -47,6 +50,8 @@ func (t *ValueType) UnmarshalText(data []byte) error {
 		*t = Time
 	case dataString:
 		*t = Data
+	case negativeString:
+		*t = Negative
 	default:
 		return ErrInvalidValueType
 	}
@@ -62,6 +67,8 @@ func (t ValueType) String() string {
 		return timeString
 	case Data:
 		return dataString
+	case Negative:
+		return negativeString
 	default:
 		return "[INVALID]"
 	}


### PR DESCRIPTION
## What?

It adds a new value type `negative` for those metrics that represent negative events, and uses it in the default `handleSummary` to display either ✓ or ✗ for the amount of passes/fails based on that.

## Why?

Now the `handleSummary` always displays ✓ for passes and ✗ for fails, but that's not accurate (and even confusing) for those metrics that represent negative events (like `http_req_failed`).

So, I decided to give a try to [@na--'s proposal](https://github.com/grafana/k6/issues/2306#issuecomment-997728913) on the reported issue, as a solution that can be used by any other `Rate` metric, not only by `http_req_failed`.

Also, because I feel that using a label instead of ✓ or ✗ might be more difficult to generalize. For instance, what would `fails` or `passes` (to give an example) mean in the context of `http_req_failed`? Or having to parameterize that (the labels) would start making the metric model a little bit more complex with no clear value.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes #2306

