### PR TITLE
Updated go-sourcemap to v2.1.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/andybalholm/brotli v1.0.6
 	github.com/dop251/goja v0.0.0-20240220182346-e401ed450204
 	github.com/fatih/color v1.16.0
-	github.com/go-sourcemap/sourcemap v2.1.4-0.20211119122758-180fcef48034+incompatible
+	github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 	github.com/golang/protobuf v1.5.3
 	github.com/gorilla/websocket v1.5.1
 	github.com/grafana/xk6-browser v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -71,8 +71,8 @@ github.com/go-logr/logr v1.3.0/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ4
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
-github.com/go-sourcemap/sourcemap v2.1.4-0.20211119122758-180fcef48034+incompatible h1:bopx7t9jyUNX1ebhr0G4gtQWmUOgwQRI0QsYhdYLgkU=
-github.com/go-sourcemap/sourcemap v2.1.4-0.20211119122758-180fcef48034+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
+github.com/go-sourcemap/sourcemap v2.1.4+incompatible h1:a+iTbH5auLKxaNwQFg0B+TCYl6lbukKPc7b5x0n1s6Q=
+github.com/go-sourcemap/sourcemap v2.1.4+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=

--- a/vendor/github.com/go-sourcemap/sourcemap/README.md
+++ b/vendor/github.com/go-sourcemap/sourcemap/README.md
@@ -1,9 +1,11 @@
 # Source maps consumer for Golang
 
-[![Build Status](https://travis-ci.org/go-sourcemap/sourcemap.svg)](https://travis-ci.org/go-sourcemap/sourcemap)
 [![PkgGoDev](https://pkg.go.dev/badge/github.com/go-sourcemap/sourcemap)](https://pkg.go.dev/github.com/go-sourcemap/sourcemap)
 
-> :heart: [**Uptrace.dev** - distributed traces, logs, and errors in one place](https://uptrace.dev)
+> This package is brought to you by :star: [**uptrace/uptrace**](https://github.com/uptrace/uptrace).
+> Uptrace is an open-source APM tool that supports distributed tracing, metrics, and logs. You can
+> use it to monitor applications and set up automatic alerts to receive notifications via email,
+> Slack, Telegram, and others.
 
 ## Installation
 

--- a/vendor/github.com/go-sourcemap/sourcemap/consumer.go
+++ b/vendor/github.com/go-sourcemap/sourcemap/consumer.go
@@ -184,6 +184,10 @@ func (c *Consumer) Source(
 func (c *Consumer) source(
 	m *sourceMap, genLine, genColumn int,
 ) (source, name string, line, column int, ok bool) {
+	if len(m.mappings) == 0 {
+		return
+	}
+
 	i := sort.Search(len(m.mappings), func(i int) bool {
 		m := &m.mappings[i]
 		if int(m.genLine) == genLine {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -129,7 +129,7 @@ github.com/go-logr/logr/funcr
 # github.com/go-logr/stdr v1.2.2
 ## explicit; go 1.16
 github.com/go-logr/stdr
-# github.com/go-sourcemap/sourcemap v2.1.4-0.20211119122758-180fcef48034+incompatible
+# github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 ## explicit
 github.com/go-sourcemap/sourcemap
 github.com/go-sourcemap/sourcemap/internal/base64vlq


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

It bumps the go-sourcemap dependency.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

We fixed a bug on the upstream and we need to fix a panic issue.

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Closes https://github.com/grafana/k6/issues/3556

<!-- Thanks for your contribution! 🙏🏼 -->
