### PR TITLE
Set working dir to the current one if test is read from stdin

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -85,9 +85,14 @@ func newBundle(
 		CompatibilityMode: compatMode,
 		callableExports:   make(map[string]struct{}),
 		filesystems:       filesystems,
-		pwd:               loader.Dir(src.URL),
+		pwd:               src.PWD,
 		preInitState:      piState,
 	}
+
+	if bundle.pwd == nil {
+		bundle.pwd = loader.Dir(src.URL)
+	}
+
 	c := bundle.newCompiler(piState.Logger)
 	bundle.ModuleResolver = modules.NewModuleResolver(getJSModules(), generateFileLoad(bundle), c)
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -23,6 +23,7 @@ import (
 type SourceData struct {
 	Data []byte
 	URL  *url.URL
+	PWD  *url.URL
 }
 
 type loaderFunc func(logger logrus.FieldLogger, path string, parts []string) (string, error)

--- a/loader/readsource.go
+++ b/loader/readsource.go
@@ -16,6 +16,7 @@ import (
 func ReadSource(
 	logger logrus.FieldLogger, src, pwd string, filesystems map[string]fsext.Fs, stdin io.Reader,
 ) (*SourceData, error) {
+	pwdURL := &url.URL{Scheme: "file", Path: filepath.ToSlash(filepath.Clean(pwd)) + "/"}
 	if src == "-" {
 		data, err := io.ReadAll(stdin)
 		if err != nil {
@@ -27,7 +28,7 @@ func ReadSource(
 		if err != nil {
 			return nil, fmt.Errorf("caching data read from -: %w", err)
 		}
-		return &SourceData{URL: &url.URL{Path: "/-", Scheme: "file"}, Data: data}, err
+		return &SourceData{URL: &url.URL{Path: "/-", Scheme: "file"}, Data: data, PWD: pwdURL}, err
 	}
 	var srcLocalPath string
 	if filepath.IsAbs(src) {
@@ -43,7 +44,6 @@ func ReadSource(
 		return Load(logger, filesystems, &url.URL{Scheme: "file", Path: filepath.ToSlash(srcLocalPath)}, src)
 	}
 
-	pwdURL := &url.URL{Scheme: "file", Path: filepath.ToSlash(filepath.Clean(pwd)) + "/"}
 	srcURL, err := Resolve(pwdURL, filepath.ToSlash(src))
 	if err != nil {
 		var unresolvedError unresolvableURLError

--- a/loader/readsource.go
+++ b/loader/readsource.go
@@ -16,6 +16,7 @@ import (
 func ReadSource(
 	logger logrus.FieldLogger, src, pwd string, filesystems map[string]fsext.Fs, stdin io.Reader,
 ) (*SourceData, error) {
+	// 'ToSlash' is here as URL only use '/' as separators, but on Windows paths use '\'
 	pwdURL := &url.URL{Scheme: "file", Path: filepath.ToSlash(filepath.Clean(pwd)) + "/"}
 	if src == "-" {
 		data, err := io.ReadAll(stdin)

--- a/loader/readsource_test.go
+++ b/loader/readsource_test.go
@@ -44,6 +44,7 @@ func TestReadSourceSTDINCache(t *testing.T) {
 	require.Equal(t, &SourceData{
 		URL:  &url.URL{Scheme: "file", Path: "/-"},
 		Data: data,
+		PWD:  &url.URL{Scheme: "file", Path: "/path/to/pwd/"},
 	}, sourceData)
 	fileData, err := fsext.ReadFile(fs, "/-")
 	require.NoError(t, err)


### PR DESCRIPTION
## What?

Usually the working dir for a given script is set based on it's path.

For test from stdin that path is file:///- so it is basically the root folder. With this change this changes to the directory k6 was ran from.

This means when you do `cat script.js | k6 run -` the working dir will be the same as if you did `k6 run script.js`.

But there is still no way to fix `cat path/to/somewhere/script.js | k6 run -` as k6 can't know where it got it's stdin from.

fixes #1462

## Why?

Fixing the issue and potentially having less people report it 
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

This is marked as breaking change as it changes the behaviour - arguably most people expect the new behaviour, so I expect no users actually depend on the current one.
