### PR TITLE
js/path_resolution_test: more ESM related tests

### DIFF
--- a/js/path_resolution_test.go
+++ b/js/path_resolution_test.go
@@ -131,6 +131,51 @@ func TestRequirePathResolution(t *testing.T) {
 				`,
 			},
 		},
+		"ESM and require": {
+			fsMap: map[string]any{
+				"/A/B/data.js": "module.exports='export content'",
+				"/A/C/B/script.js": `
+					export default function () {
+						// Here the path is relative to this module but to the one calling
+						return require("./../data.js");
+					}
+				`,
+				"/A/B/B/script.js": `
+					import s from "./../../C/B/script.js"
+					export default require("./../../C/B/script.js").default();
+				`,
+				"/A/A/A/A/script.js": `
+					import data from "./../../../B/B/script.js"
+					if (data != "export content") {
+						throw new Error("wrong content " + data);
+					}
+					export default function() {}
+				`,
+			},
+		},
+		"full ESM": {
+			fsMap: map[string]any{
+				"/A/B/data.js": "export default 'export content'",
+				"/A/C/B/script.js": `
+					export default function () {
+						// Here the path is relative to this module but to the one calling
+						return require("./../data.js").default;
+					}
+				`,
+				"/A/B/B/script.js": `
+					import s from "./../../C/B/script.js"
+					let l = s();
+					export default l;
+				`,
+				"/A/A/A/A/script.js": `
+					import data from "./../../../B/B/script.js"
+					if (data != "export content") {
+						throw new Error("wrong content " + data);
+					}
+					export default function() {}
+				`,
+			},
+		},
 	}
 	for name, testCase := range testCases {
 		name, testCase := name, testCase


### PR DESCRIPTION
## What?

Add more tests for paths and ESM

## Why?

Found corner cases that ESM make harder to handle and/or break.

Other PRs will handle fixing and warning them.  

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
