### PR TITLE
Bump golangci-lint to 1.57.2 and fix configuration warning

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.55.2
+# v1.57.2
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   deadline: 5m
@@ -44,7 +44,7 @@ linters-settings:
   exhaustive:
     default-signifies-exhaustive: true
   govet:
-    check-shadowing: true
+    shadow: true
   cyclop:
     max-complexity: 25
   maligned:


### PR DESCRIPTION
## What?

Update golangci-lint and fix configuration warning

## Why?

To keep it up to date and also to fix the warning for users who do not run the *exact* version we run in the CI. 

There are some loop var linters around go 1.22 changes in behaviour, but we are not using only go1.22+ so we can't use them.

There is also a new open telemetry span linter which also doesn't seem like a thing we can use.

The configuration change is due to deprecation from 5 years, but golangci-lint just wasn't reporting until 1.57.2.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
