### PR TITLE
Lock module resolution after initialization

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -112,6 +112,7 @@ func newBundle(
 	if err != nil {
 		return nil, err
 	}
+	bundle.ModuleResolver.Lock()
 
 	err = bundle.populateExports(updateOptions, exports)
 	if err != nil {

--- a/js/modules/resolution.go
+++ b/js/modules/resolution.go
@@ -89,7 +89,7 @@ func (mr *ModuleResolver) resolveLoaded(basePWD *url.URL, arg string, data []byt
 
 // Lock locks the module's resolution from any further new resolving operation.
 // It means that it relays only its internal cache and on the fact that it has already
-// seen previously the module during the initialization. 
+// seen previously the module during the initialization.
 // It is the same approach used for opening file operations.
 func (mr *ModuleResolver) Lock() {
 	mr.locked = true

--- a/js/modules/resolution.go
+++ b/js/modules/resolution.go
@@ -87,8 +87,8 @@ func (mr *ModuleResolver) resolveLoaded(basePWD *url.URL, arg string, data []byt
 	return mod, err
 }
 
-// Lock locks the resolved from making any further new resolving and now depends only on it's cache
-// This to facilitate loading all the modules a test needs in it's initilization the same as with openning files.
+// Lock locks the module's resolution from any further new resolving operation. It means that it relays only its internal cache and on the fact that it has already seen previously the module during the initialization. 
+// It is the same approach used for opening file operations.
 func (mr *ModuleResolver) Lock() {
 	mr.locked = true
 }

--- a/js/modules/resolution.go
+++ b/js/modules/resolution.go
@@ -87,7 +87,9 @@ func (mr *ModuleResolver) resolveLoaded(basePWD *url.URL, arg string, data []byt
 	return mod, err
 }
 
-// Lock locks the module's resolution from any further new resolving operation. It means that it relays only its internal cache and on the fact that it has already seen previously the module during the initialization. 
+// Lock locks the module's resolution from any further new resolving operation.
+// It means that it relays only its internal cache and on the fact that it has already
+// seen previously the module during the initialization. 
 // It is the same approach used for opening file operations.
 func (mr *ModuleResolver) Lock() {
 	mr.locked = true

--- a/js/modules/resolution.go
+++ b/js/modules/resolution.go
@@ -10,6 +10,8 @@ import (
 	"go.k6.io/k6/loader"
 )
 
+const notPreviouslyResolvedModule = "the module %q was not previously resolved during initialization (__VU==0)"
+
 // FileLoader is a type alias for a function that returns the contents of the referenced file.
 type FileLoader func(specifier *url.URL, name string) ([]byte, error)
 
@@ -32,6 +34,7 @@ type ModuleResolver struct {
 	goModules map[string]interface{}
 	loadCJS   FileLoader
 	compiler  *compiler.Compiler
+	locked    bool
 }
 
 // NewModuleResolver returns a new module resolution instance that will resolve.
@@ -55,6 +58,9 @@ func (mr *ModuleResolver) resolveSpecifier(basePWD *url.URL, arg string) (*url.U
 }
 
 func (mr *ModuleResolver) requireModule(name string) (module, error) {
+	if mr.locked {
+		return nil, fmt.Errorf(notPreviouslyResolvedModule, name)
+	}
 	mod, ok := mr.goModules[name]
 	if !ok {
 		return nil, fmt.Errorf("unknown module: %s", name)
@@ -81,6 +87,12 @@ func (mr *ModuleResolver) resolveLoaded(basePWD *url.URL, arg string, data []byt
 	return mod, err
 }
 
+// Lock locks the resolved from making any further new resolving and now depends only on it's cache
+// This to facilitate loading all the modules a test needs in it's initilization the same as with openning files.
+func (mr *ModuleResolver) Lock() {
+	mr.locked = true
+}
+
 func (mr *ModuleResolver) resolve(basePWD *url.URL, arg string) (module, error) {
 	if cached, ok := mr.cache[arg]; ok {
 		return cached.mod, cached.err
@@ -102,6 +114,9 @@ func (mr *ModuleResolver) resolve(basePWD *url.URL, arg string) (module, error) 
 			return cached.mod, cached.err
 		}
 
+		if mr.locked {
+			return nil, fmt.Errorf(notPreviouslyResolvedModule, arg)
+		}
 		// Fall back to loading
 		data, err := mr.loadCJS(specifier, arg)
 		if err != nil {

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -1569,6 +1569,101 @@ func TestVUDoesNonExistingPathnUnderConditions(t *testing.T) {
 	assert.Contains(t, err.Error(), "open() can't be used with files that weren't previously opened during initialization (__VU==0)")
 }
 
+func TestVUDoesRequireUnderV0Condition(t *testing.T) {
+	t.Parallel()
+
+	baseFS := fsext.NewMemMapFs()
+	data := `
+			if (__VU == 0) {
+				let data = require("/home/somebody/test.js");
+			}
+			exports.default = function() {
+				console.log("hey")
+			}
+		`
+	require.NoError(t, fsext.WriteFile(baseFS, "/home/somebody/test.js", []byte(`exports=42`), fs.ModePerm))
+	require.NoError(t, fsext.WriteFile(baseFS, "/script.js", []byte(data), fs.ModePerm))
+
+	fs := fsext.NewCacheOnReadFs(baseFS, fsext.NewMemMapFs(), 0)
+
+	r, err := getSimpleRunner(t, "/script.js", data, fs)
+	require.NoError(t, err)
+
+	_, err = r.NewVU(context.Background(), 1, 1, make(chan metrics.SampleContainer, 100))
+	require.NoError(t, err)
+}
+
+func TestVUDoesNotRequireUnderConditions(t *testing.T) {
+	t.Parallel()
+
+	baseFS := fsext.NewMemMapFs()
+	data := `
+			if (__VU > 0) {
+				let data = require("/home/somebody/test.js");
+			}
+			exports.default = function() {
+				console.log("hey")
+			}
+		`
+	require.NoError(t, fsext.WriteFile(baseFS, "/home/somebody/test.js", []byte(`exports=42`), fs.ModePerm))
+	require.NoError(t, fsext.WriteFile(baseFS, "/script.js", []byte(data), fs.ModePerm))
+
+	fs := fsext.NewCacheOnReadFs(baseFS, fsext.NewMemMapFs(), 0)
+
+	r, err := getSimpleRunner(t, "/script.js", data, fs)
+	require.NoError(t, err)
+
+	_, err = r.NewVU(context.Background(), 1, 1, make(chan metrics.SampleContainer, 100))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), " was not previously resolved during initialization (__VU==0)")
+}
+
+func TestVUDoesRequireUnderConditions(t *testing.T) {
+	t.Parallel()
+
+	baseFS := fsext.NewMemMapFs()
+	data := `
+			if (__VU == 0) {
+				require("/home/somebody/test.js");
+				require("/home/somebody/test2.js");
+			}
+
+			if (__VU % 2 == 1) {
+				require("/home/somebody/test.js");
+			}
+
+			if (__VU % 2 == 0) {
+				require("/home/somebody/test2.js");
+			}
+
+			exports.default = function() {
+				console.log("hey")
+			}
+		`
+	require.NoError(t, fsext.WriteFile(baseFS, "/home/somebody/test.js", []byte(`console.log("test.js", __VU)`), fs.ModePerm))
+	require.NoError(t, fsext.WriteFile(baseFS, "/home/somebody/test2.js", []byte(`console.log("test2.js", __VU)`), fs.ModePerm))
+	require.NoError(t, fsext.WriteFile(baseFS, "/script.js", []byte(data), fs.ModePerm))
+
+	fs := fsext.NewCacheOnReadFs(baseFS, fsext.NewMemMapFs(), 0)
+
+	logger, hook := testutils.NewLoggerWithHook(t, logrus.InfoLevel)
+	r, err := getSimpleRunner(t, "/script.js", data, fs, logger)
+	require.NoError(t, err)
+	logs := hook.Drain()
+	require.Len(t, logs, 2)
+
+	_, err = r.NewVU(context.Background(), 1, 1, make(chan metrics.SampleContainer, 100))
+	require.NoError(t, err)
+	logs = hook.Drain()
+	require.Len(t, logs, 1)
+	require.Contains(t, logs[0].Message, "test.js 1")
+	_, err = r.NewVU(context.Background(), 2, 2, make(chan metrics.SampleContainer, 100))
+	require.NoError(t, err)
+	logs = hook.Drain()
+	require.Len(t, logs, 1)
+	require.Contains(t, logs[0].Message, "test2.js 2")
+}
+
 func TestVUIntegrationCookiesReset(t *testing.T) {
 	t.Parallel()
 	tb := httpmultibin.NewHTTPMultiBin(t)


### PR DESCRIPTION
## What?

Make it an error to try to resolve not previously resolved modules, after initialization

## Why?

Partly because it should be given how we make k6 work and want `k6 archive` and `k6 cloud` to "just work".

Partly because this ended up being the only not completely hackish way to know that we are past the initialization state which was needed in order to make a warning only in the init context. 

See https://github.com/grafana/k6/pull/3681 


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
