### PR TITLE
Emit warning if require will not comply with specification

### DIFF
--- a/js/modules/require_impl.go
+++ b/js/modules/require_impl.go
@@ -90,10 +90,10 @@ func (r *LegacyRequireImpl) warnUserOnPathResolutionDifferences(specifier string
 	if err != nil {
 		logger.Warningf("Couldn't get the \"correct\" path to resolve specifier %q against: %q"+
 			"Please report to issue %s. "+
-			"This will not currently break your script but might mean the future it won't work",
+			"This will not currently break your script but it might mean that in the future it won't work",
 			specifier, err, issueLink)
 	} else if r.currentlyRequiredModule.String() != correct.String() {
-		logger.Warningf("The \"wrong\" path (%q) and the actually used by k6 path (%q) to resolve %q are different. "+
+		logger.Warningf("The \"wrong\" path (%q) and the path actually used by k6 (%q) to resolve %q are different. "+
 			"Please report to issue %s. "+
 			"This will not currently break your script but *WILL* in the future, please report this!!!",
 			correct, r.currentlyRequiredModule, specifier, issueLink)
@@ -103,7 +103,7 @@ func (r *LegacyRequireImpl) warnUserOnPathResolutionDifferences(specifier string
 	if err != nil {
 		logger.Warningf("Couldn't get the \"wrong\" path to resolve specifier %q against: %q"+
 			"Please report to issue %s. "+
-			"This will not currently break your script but might mean the future it won't work",
+			"This will not currently break your script but it might mean that in the future it won't work",
 			specifier, err, issueLink)
 		return
 	}
@@ -111,15 +111,15 @@ func (r *LegacyRequireImpl) warnUserOnPathResolutionDifferences(specifier string
 	if err != nil {
 		logger.Warningf("Couldn't get the \"wrong\" path to resolve specifier %q against: %q"+
 			"Please report to issue %s. "+
-			"This will not currently break your script but might mean the future it won't work",
+			"This will not currently break your script but it might mean that in the future it won't work",
 			specifier, err, issueLink)
 		return
 	}
 	if r.currentlyRequiredModule.String() != k6behaviour.String() {
 		// this should always be equal, but check anyway to be certain we won't break something
-		logger.Warningf("The \"wrong\" path (%q) and the actually used by k6 path (%q) to resolve %q are different. "+
+		logger.Warningf("The \"wrong\" path (%q) and the path actually used by k6 (%q) to resolve %q are different. "+
 			"Please report to issue %s. "+
-			"This will not currently break your script but might mean the future it won't work",
+			"This will not currently break your script but it might mean that in the future it won't work",
 			k6behaviour, r.currentlyRequiredModule, specifier, issueLink)
 	}
 }

--- a/js/path_resolution_test.go
+++ b/js/path_resolution_test.go
@@ -135,7 +135,7 @@ func TestRequirePathResolution(t *testing.T) {
 				`,
 			},
 			expectedLogs: []string{
-				`The "wrong" path ("file:///A/C/B/") and the actually used by k6 path ("file:///A/B/B/") to resolve "./../data.js" are different`,
+				`The "wrong" path ("file:///A/C/B/") and the path actually used by k6 ("file:///A/B/B/") to resolve "./../data.js" are different`,
 			},
 		},
 		"ESM and require": {
@@ -160,7 +160,7 @@ func TestRequirePathResolution(t *testing.T) {
 				`,
 			},
 			expectedLogs: []string{
-				`The "wrong" path ("file:///A/C/B/") and the actually used by k6 path ("file:///A/B/B/") to resolve "./../data.js" are different`,
+				`The "wrong" path ("file:///A/C/B/") and the path actually used by k6 ("file:///A/B/B/") to resolve "./../data.js" are different`,
 			},
 		},
 		"full ESM": {
@@ -186,7 +186,7 @@ func TestRequirePathResolution(t *testing.T) {
 				`,
 			},
 			expectedLogs: []string{
-				`The "wrong" path ("file:///A/C/B/") and the actually used by k6 path ("file:///A/B/B/") to resolve "./../data.js" are different`,
+				`The "wrong" path ("file:///A/C/B/") and the path actually used by k6 ("file:///A/B/B/") to resolve "./../data.js" are different`,
 			},
 		},
 	}


### PR DESCRIPTION
## What?

Add warning on require invocations that do not follow the specification.

Depends on https://github.com/grafana/k6/pull/3680

## Why?

As this isn't how it works we would like to fix it.

Also happens to be hard to keep it working once we move to ESM.

part of #3534 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
