### PR TITLE
Remove no longer needed CI job (Homebrew)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -287,25 +287,6 @@ jobs:
             packaging/k6-*.msi
           retention-days: 7
 
-  # Disabled until #1997 and #1998 are addressed.
-  # publish-macos:
-  #   runs-on: macos-latest
-  #   needs: [configure, build]
-  #   if: ${{ startsWith(github.ref, 'refs/tags/v') && github.event_name != 'workflow_dispatch' }}
-  #   env:
-  #     VERSION: ${{ needs.configure.outputs.k6_version }}
-  #     HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_GITHUB_API_TOKEN }}
-  #   steps:
-  #     - name: Download source code archive
-  #       run: curl -fsSL "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/archive/${VERSION}.tar.gz" -o "${VERSION}.tar.gz"
-  #     - name: Set up Homebrew
-  #       uses: Homebrew/actions/setup-homebrew@2eb78889a50ba021d744837934f1af2d8c4458ec
-  #     - name: Create version bump PR
-  #       run: |
-  #         brew bump-formula-pr k6 \
-  #           --url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/archive/${VERSION}.tar.gz" \
-  #           --sha256="$(shasum -a 256 ${VERSION}.tar.gz | cut -d' ' -f1)"
-
   publish-github:
     runs-on: ubuntu-latest
     needs: [configure, build, package-windows]


### PR DESCRIPTION
## What?

It removes the (_already commented out_) `publish-macos` CI job that was originally added to automate k6 releases publication to [Homebrew](https://brew.sh/).

## Why?

Because it's no longer needed, as now Homebrew [has a recurrent (every 3h) CI job](https://github.com/Homebrew/homebrew-core/blob/master/.github/workflows/autobump.yml) that goes over all the Homebrew projects and checks for updates.

Look at [this PR](https://github.com/Homebrew/homebrew-core/pull/167104), as an example, from the latest k6 release (v0.50.0).

## Checklist

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes #1998 
