### PR TITLE
feat: promote env variable to ProfilingEnabled option

### DIFF
--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -485,6 +485,16 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 			},
 			nil,
 		},
+		{
+			opts{
+				env: []string{"K6_PROFILING_ENABLED=true"},
+				cli: []string{"--profiling-enabled"},
+			},
+			exp{
+				consolidationError: false,
+			},
+			nil,
+		},
 		// TODO: test for differences between flagsets
 		// TODO: more tests in general, especially ones not related to execution parameters...
 	}

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -177,5 +177,8 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string) GlobalFlags {
 	if _, ok := env["NO_COLOR"]; ok {
 		result.NoColor = true
 	}
+	if _, ok := env["K6_PROFILING_ENABLED"]; ok {
+		result.ProfilingEnabled = true
+	}
 	return result
 }


### PR DESCRIPTION
## What?

Add env option K6_PROFILING_ENABLED to enable it in k6

## Why?

Fix issue #3670

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ x] I have run linter locally (`make lint`) and all checks pass.
- [ x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
