### PR TITLE
gRPC async invoke

### DIFF
--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -224,6 +224,22 @@ func TestClient(t *testing.T) {
 			},
 		},
 		{
+			name: "AsyncInvokeInvalidParam",
+			initString: codeBlock{code: `
+				var client = new grpc.Client();
+				client.load([], "../../../../lib/testutils/httpmultibin/grpc_testing/test.proto");`},
+			vuString: codeBlock{
+				code: `
+				client.connect("GRPCBIN_ADDR");
+				client.asyncInvoke("grpc.testing.TestService/EmptyCall", {}, { void: true }).then(function(resp) {
+					throw new Error("should not be here")
+				}, (err) => {
+					throw new Error(err)
+				})`,
+				err: `unknown param: "void"`,
+			},
+		},
+		{
 			name: "InvokeNilRequest",
 			initString: codeBlock{code: `
 				var client = new grpc.Client();
@@ -318,6 +334,33 @@ func TestClient(t *testing.T) {
 			},
 		},
 		{
+			name: "AsyncInvoke",
+			initString: codeBlock{code: `
+				var client = new grpc.Client();
+				client.load([], "../../../../lib/testutils/httpmultibin/grpc_testing/test.proto");`},
+			setup: func(tb *httpmultibin.HTTPMultiBin) {
+				tb.GRPCStub.EmptyCallFunc = func(context.Context, *grpc_testing.Empty) (*grpc_testing.Empty, error) {
+					return &grpc_testing.Empty{}, nil
+				}
+			},
+			vuString: codeBlock{
+				code: `
+				client.connect("GRPCBIN_ADDR");
+				client.asyncInvoke("grpc.testing.TestService/EmptyCall", {}).then(function(resp) {
+					if (resp.status !== grpc.StatusOK) {
+						throw new Error("unexpected error: " + JSON.stringify(resp.error) + "or status: " + resp.status)
+					}
+				}, (err) => {
+					throw new Error("unexpected error: " + err)
+				})
+				`,
+				asserts: func(t *testing.T, rb *httpmultibin.HTTPMultiBin, samples chan metrics.SampleContainer, _ error) {
+					samplesBuf := metrics.GetBufferedSamples(samples)
+					assertMetricEmitted(t, metrics.GRPCReqDurationName, samplesBuf, rb.Replacer.Replace("GRPCBIN_ADDR/grpc.testing.TestService/EmptyCall"))
+				},
+			},
+		},
+		{
 			name: "InvokeAnyProto",
 			initString: codeBlock{code: `
 				var client = new grpc.Client();
@@ -386,6 +429,32 @@ func TestClient(t *testing.T) {
 				if (resp.status !== grpc.StatusOK) {
 					throw new Error("server did not receive the correct request message")
 				}`},
+		},
+		{
+			name: "AsyncRequestMessage",
+			initString: codeBlock{
+				code: `
+				var client = new grpc.Client();
+				client.load([], "../../../../lib/testutils/httpmultibin/grpc_testing/test.proto");`,
+			},
+			setup: func(tb *httpmultibin.HTTPMultiBin) {
+				tb.GRPCStub.UnaryCallFunc = func(_ context.Context, req *grpc_testing.SimpleRequest) (*grpc_testing.SimpleResponse, error) {
+					if req.Payload == nil || string(req.Payload.Body) != "负载测试" {
+						return nil, status.Error(codes.InvalidArgument, "")
+					}
+					return &grpc_testing.SimpleResponse{}, nil
+				}
+			},
+			vuString: codeBlock{code: `
+				client.connect("GRPCBIN_ADDR");
+				client.asyncInvoke("grpc.testing.TestService/UnaryCall", { payload: { body: "6LSf6L295rWL6K+V"} }).then(function(resp) {
+					if (resp.status !== grpc.StatusOK) {
+						throw new Error("server did not receive the correct request message")
+					}
+				}, (err) => {
+					throw new Error("unexpected error: " + err)
+				});
+				`},
 		},
 		{
 			name: "RequestHeaders",
@@ -458,6 +527,37 @@ func TestClient(t *testing.T) {
 				if (!resp.message || resp.message.username !== "" || resp.message.oauthScope !== "水") {
 					throw new Error("unexpected response message: " + JSON.stringify(resp.message))
 				}`,
+				asserts: func(t *testing.T, rb *httpmultibin.HTTPMultiBin, samples chan metrics.SampleContainer, _ error) {
+					samplesBuf := metrics.GetBufferedSamples(samples)
+					assertMetricEmitted(t, metrics.GRPCReqDurationName, samplesBuf, rb.Replacer.Replace("GRPCBIN_ADDR/grpc.testing.TestService/UnaryCall"))
+				},
+			},
+		},
+		{
+			name: "AsyncResponseMessage",
+			initString: codeBlock{
+				code: `
+				var client = new grpc.Client();
+				client.load([], "../../../../lib/testutils/httpmultibin/grpc_testing/test.proto");`,
+			},
+			setup: func(tb *httpmultibin.HTTPMultiBin) {
+				tb.GRPCStub.UnaryCallFunc = func(context.Context, *grpc_testing.SimpleRequest) (*grpc_testing.SimpleResponse, error) {
+					return &grpc_testing.SimpleResponse{
+						OauthScope: "水",
+					}, nil
+				}
+			},
+			vuString: codeBlock{
+				code: `
+				client.connect("GRPCBIN_ADDR");
+				client.asyncInvoke("grpc.testing.TestService/UnaryCall", {}).then(function(resp) {
+					if (!resp.message || resp.message.username !== "" || resp.message.oauthScope !== "水") {
+						throw new Error("unexpected response message: " + JSON.stringify(resp.message))
+					}
+				}, (err) => {
+					throw new Error("unexpected error: " + err)
+				});
+				`,
 				asserts: func(t *testing.T, rb *httpmultibin.HTTPMultiBin, samples chan metrics.SampleContainer, _ error) {
 					samplesBuf := metrics.GetBufferedSamples(samples)
 					assertMetricEmitted(t, metrics.GRPCReqDurationName, samplesBuf, rb.Replacer.Replace("GRPCBIN_ADDR/grpc.testing.TestService/UnaryCall"))
@@ -973,7 +1073,7 @@ func TestClient(t *testing.T) {
 			assertResponse(t, tt.initString, err, val, ts)
 
 			ts.ToVUContext()
-			val, err = ts.Run(tt.vuString.code)
+			val, err = ts.RunOnEventLoop(tt.vuString.code)
 			assertResponse(t, tt.vuString, err, val, ts)
 		})
 	}

--- a/lib/netext/grpcext/conn.go
+++ b/lib/netext/grpcext/conn.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/lib"
@@ -27,28 +28,32 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 )
 
-// Request represents a gRPC request.
-type Request struct {
+// InvokeRequest represents a unary gRPC request.
+type InvokeRequest struct {
+	Method           string
 	MethodDescriptor protoreflect.MethodDescriptor
+	Timeout          time.Duration
 	TagsAndMeta      *metrics.TagsAndMeta
 	Message          []byte
+	Metadata         metadata.MD
+}
+
+// InvokeResponse represents a gRPC response.
+type InvokeResponse struct {
+	Message  interface{}
+	Error    interface{}
+	Headers  map[string][]string
+	Trailers map[string][]string
+	Status   codes.Code
 }
 
 // StreamRequest represents a gRPC stream request.
 type StreamRequest struct {
 	Method           string
 	MethodDescriptor protoreflect.MethodDescriptor
+	Timeout          time.Duration
 	TagsAndMeta      *metrics.TagsAndMeta
 	Metadata         metadata.MD
-}
-
-// Response represents a gRPC response.
-type Response struct {
-	Message  interface{}
-	Error    interface{}
-	Headers  map[string][]string
-	Trailers map[string][]string
-	Status   codes.Code
 }
 
 type clientConnCloser interface {
@@ -97,14 +102,13 @@ func (c *Conn) Reflect(ctx context.Context) (*descriptorpb.FileDescriptorSet, er
 // Invoke executes a unary gRPC request.
 func (c *Conn) Invoke(
 	ctx context.Context,
-	url string,
-	md metadata.MD,
-	req Request,
+	req InvokeRequest,
 	opts ...grpc.CallOption,
-) (*Response, error) {
-	if url == "" {
+) (*InvokeResponse, error) {
+	if req.Method == "" {
 		return nil, fmt.Errorf("url is required")
 	}
+
 	if req.MethodDescriptor == nil {
 		return nil, fmt.Errorf("request method descriptor is required")
 	}
@@ -112,7 +116,13 @@ func (c *Conn) Invoke(
 		return nil, fmt.Errorf("request message is required")
 	}
 
-	ctx = metadata.NewOutgoingContext(ctx, md)
+	if req.Timeout != time.Duration(0) {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, req.Timeout)
+		defer cancel()
+	}
+
+	ctx = metadata.NewOutgoingContext(ctx, req.Metadata)
 
 	reqdm := dynamicpb.NewMessage(req.MethodDescriptor.Input())
 	if err := protojson.Unmarshal(req.Message, reqdm); err != nil {
@@ -128,9 +138,9 @@ func (c *Conn) Invoke(
 	copts = append(copts, opts...)
 	copts = append(copts, grpc.Header(&header), grpc.Trailer(&trailer))
 
-	err := c.raw.Invoke(ctx, url, reqdm, resp, copts...)
+	err := c.raw.Invoke(ctx, req.Method, reqdm, resp, copts...)
 
-	response := Response{
+	response := InvokeResponse{
 		Headers:  header,
 		Trailers: trailer,
 	}

--- a/lib/netext/grpcext/conn_test.go
+++ b/lib/netext/grpcext/conn_test.go
@@ -30,11 +30,13 @@ func TestInvoke(t *testing.T) {
 	}
 
 	c := Conn{raw: invokemock(helloReply)}
-	r := Request{
+	r := InvokeRequest{
+		Method:           "/hello.HelloService/SayHello",
 		MethodDescriptor: methodFromProto("SayHello"),
 		Message:          []byte(`{"greeting":"text request"}`),
+		Metadata:         metadata.New(nil),
 	}
-	res, err := c.Invoke(context.Background(), "/hello.HelloService/SayHello", metadata.New(nil), r)
+	res, err := c.Invoke(context.Background(), r)
 	require.NoError(t, err)
 
 	assert.Equal(t, codes.OK, res.Status)
@@ -51,11 +53,13 @@ func TestInvokeWithCallOptions(t *testing.T) {
 	}
 
 	c := Conn{raw: invokemock(reply)}
-	r := Request{
+	r := InvokeRequest{
+		Method:           "/hello.HelloService/NoOp",
 		MethodDescriptor: methodFromProto("NoOp"),
 		Message:          []byte(`{}`),
+		Metadata:         metadata.New(nil),
 	}
-	res, err := c.Invoke(context.Background(), "/hello.HelloService/NoOp", metadata.New(nil), r, grpc.UseCompressor("fakeone"))
+	res, err := c.Invoke(context.Background(), r, grpc.UseCompressor("fakeone"))
 	require.NoError(t, err)
 	assert.NotNil(t, res)
 }
@@ -68,11 +72,13 @@ func TestInvokeReturnError(t *testing.T) {
 	}
 
 	c := Conn{raw: invokemock(helloReply)}
-	r := Request{
+	r := InvokeRequest{
+		Method:           "/hello.HelloService/SayHello",
 		MethodDescriptor: methodFromProto("SayHello"),
 		Message:          []byte(`{"greeting":"text request"}`),
+		Metadata:         metadata.New(nil),
 	}
-	res, err := c.Invoke(context.Background(), "/hello.HelloService/SayHello", metadata.New(nil), r)
+	res, err := c.Invoke(context.Background(), r)
 	require.NoError(t, err)
 
 	assert.Equal(t, codes.Unknown, res.Status)
@@ -92,49 +98,34 @@ func TestConnInvokeInvalid(t *testing.T) {
 		payload    = []byte(`{"greeting":"test"}`)
 	)
 
-	req := Request{
-		MethodDescriptor: methodDesc,
-		Message:          payload,
-	}
-
 	tests := []struct {
 		name   string
 		ctx    context.Context
-		md     metadata.MD
-		url    string
-		req    Request
+		req    InvokeRequest
 		experr string
 	}{
 		{
 			name:   "EmptyMethod",
 			ctx:    ctx,
-			url:    "",
-			md:     md,
-			req:    req,
+			req:    InvokeRequest{MethodDescriptor: methodDesc, Message: payload, Metadata: md, Method: ""},
 			experr: "url is required",
 		},
 		{
 			name:   "NullMethodDescriptor",
 			ctx:    ctx,
-			url:    url,
-			md:     nil,
-			req:    Request{Message: payload},
+			req:    InvokeRequest{Message: payload, Metadata: nil, Method: url},
 			experr: "method descriptor is required",
 		},
 		{
 			name:   "NullMessage",
 			ctx:    ctx,
-			url:    url,
-			md:     nil,
-			req:    Request{MethodDescriptor: methodDesc},
+			req:    InvokeRequest{MethodDescriptor: methodDesc, Metadata: nil, Method: url},
 			experr: "message is required",
 		},
 		{
 			name:   "EmptyMessage",
 			ctx:    ctx,
-			url:    url,
-			md:     nil,
-			req:    Request{MethodDescriptor: methodDesc, Message: []byte{}},
+			req:    InvokeRequest{MethodDescriptor: methodDesc, Message: []byte{}, Metadata: nil, Method: url},
 			experr: "message is required",
 		},
 	}
@@ -145,7 +136,7 @@ func TestConnInvokeInvalid(t *testing.T) {
 			t.Parallel()
 
 			c := Conn{}
-			res, err := c.Invoke(tt.ctx, tt.url, tt.md, tt.req)
+			res, err := c.Invoke(tt.ctx, tt.req)
 			require.Error(t, err)
 			require.Nil(t, res)
 			assert.Contains(t, err.Error(), tt.experr)


### PR DESCRIPTION
## What?

This PR refactors the logic of the grpc's unary `Invoke` so that it can be reused in the `AsyncInvoke` and also implements `AsyncInvoke` itself.

It's better to check the changes by the commits.

## Why?

At the k6-core, we agreed that the modern way of defining API is the async one.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #3550

<!-- Thanks for your contribution! 🙏🏼 -->
