### PR TITLE
ci: temporary disable running tests on macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.21.x]
-        platform: [ubuntu-latest, windows-2019, macos-latest]
+        platform: [ubuntu-latest, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-latest, windows-2019, macos-latest]
+        platform: [ubuntu-latest, windows-2019]
     runs-on: ${{ matrix.platform }}
     continue-on-error: true
     steps:
@@ -87,7 +87,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x]
-        platform: [ubuntu-latest, windows-2019, macos-latest]
+        platform: [ubuntu-latest, windows-2019]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What?

This PR temporarily disables running the tests in CI on the Mac OS platform because it's too flaky right now.

If this PR is approved after the merge, I'll open a separate issue for investigation and bring Mac OS tests back.

## Why?

Unfortunately, Mac OS tests failed for many runs. Constantly failing tests are destructive for the project since people tend to trust test runs less, and we could miss something essential.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
