### PR TITLE
Fix linter errors from newer versions of golangci-lint

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -33,7 +33,7 @@ func newHandler(cs *v1.ControlSurface, profilingEnabled bool) http.Handler {
 func injectProfilerHandler(mux *http.ServeMux, profilingEnabled bool) {
 	var handler http.Handler
 
-	handler = http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	handler = http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.Header().Add("Content-Type", "text/plain; charset=utf-8")
 		_, _ = rw.Write([]byte("To enable profiling, please run k6 with the --profiling-enabled flag"))
 	})
@@ -91,7 +91,7 @@ func withLoggingHandler(l logrus.FieldLogger, next http.Handler) http.HandlerFun
 }
 
 func handlePing(logger logrus.FieldLogger) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.Header().Add("Content-Type", "text/plain; charset=utf-8")
 		if _, err := fmt.Fprint(rw, "ok"); err != nil {
 			logger.WithError(err).Error("Error while printing ok")

--- a/cloudapi/api_test.go
+++ b/cloudapi/api_test.go
@@ -50,7 +50,7 @@ func TestCreateTestRun(t *testing.T) {
 
 func TestFinished(t *testing.T) {
 	t.Parallel()
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fprint(t, w, "")
 	}))
 	defer server.Close()
@@ -70,7 +70,7 @@ func TestFinished(t *testing.T) {
 func TestAuthorizedError(t *testing.T) {
 	t.Parallel()
 	called := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called++
 		w.WriteHeader(http.StatusForbidden)
 		fprint(t, w, `{"error": {"code": 5, "message": "Not allowed"}}`)
@@ -89,7 +89,7 @@ func TestAuthorizedError(t *testing.T) {
 func TestDetailsError(t *testing.T) {
 	t.Parallel()
 	called := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called++
 		w.WriteHeader(http.StatusForbidden)
 		fprint(t, w, `{"error": {"code": 0, "message": "Validation failed", "details": { "name": ["Shorter than minimum length 2."]}}}`)

--- a/cloudapi/insights/client_test.go
+++ b/cloudapi/insights/client_test.go
@@ -138,7 +138,7 @@ func TestClient_Dial_ReturnsNoErrorWithFailingDialer(t *testing.T) {
 			Block:                  true,
 			FailOnNonTempDialError: true,
 			Timeout:                1 * time.Second,
-			Dialer: func(ctx context.Context, s string) (net.Conn, error) {
+			Dialer: func(_ context.Context, _ string) (net.Conn, error) {
 				return nil, &fatalError{}
 			},
 		},

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -68,7 +68,7 @@ func getNullString(flags *pflag.FlagSet, key string) null.String {
 }
 
 func exactArgsWithMsg(n int, msg string) cobra.PositionalArgs {
-	return func(cmd *cobra.Command, args []string) error {
+	return func(_ *cobra.Command, args []string) error {
 		if len(args) != n {
 			return fmt.Errorf("accepts %d arg(s), received %d: %s", n, len(args), msg)
 		}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -16,7 +16,7 @@ func getCmdLogin(gs *state.GlobalState) *cobra.Command {
 Logging into a service changes the default when just "-o [type]" is passed with
 no parameters, you can always override the stored credentials by passing some
 on the commandline.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			return cmd.Usage()
 		},
 	}

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -38,7 +38,7 @@ func getCmdLoginCloud(gs *state.GlobalState) *cobra.Command {
 This will set the default token used when just "k6 run -o cloud" is passed.`,
 		Example: exampleText,
 		Args:    cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			currentDiskConf, err := readDiskConfig(gs)
 			if err != nil {
 				return err

--- a/cmd/login_influxdb.go
+++ b/cmd/login_influxdb.go
@@ -24,7 +24,7 @@ func getCmdLoginInfluxDB(gs *state.GlobalState) *cobra.Command {
 
 This will set the default server used when just "-o influxdb" is passed.`,
 		Args: cobra.MaximumNArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, args []string) error {
 			config, err := readDiskConfig(gs)
 			if err != nil {
 				return err
@@ -40,7 +40,7 @@ This will set the default server used when just "-o influxdb" is passed.`,
 				conf = conf.Apply(jsonConfParsed)
 			}
 			if len(args) > 0 {
-				urlConf, err := influxdb.ParseURL(args[0]) //nolint:govet
+				urlConf, err := influxdb.ParseURL(args[0])
 				if err != nil {
 					return err
 				}

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -44,7 +44,7 @@ func getAllOutputConstructors() (map[string]output.Constructor, error) {
 		builtinOutputCloud.String():    cloud.New,
 		builtinOutputCSV.String():      csv.New,
 		builtinOutputInfluxdb.String(): influxdb.New,
-		builtinOutputKafka.String(): func(params output.Params) (output.Output, error) {
+		builtinOutputKafka.String(): func(_ output.Params) (output.Output, error) {
 			return nil, errors.New("the kafka output was deprecated in k6 v0.32.0 and removed in k6 v0.34.0, " +
 				"please use the new xk6 kafka output extension instead - https://github.com/k6io/xk6-output-kafka")
 		},
@@ -55,7 +55,7 @@ func getAllOutputConstructors() (map[string]output.Constructor, error) {
 				"more info at https://github.com/grafana/k6/issues/2982.")
 			return statsd.New(params)
 		},
-		builtinOutputDatadog.String(): func(params output.Params) (output.Output, error) {
+		builtinOutputDatadog.String(): func(_ output.Params) (output.Output, error) {
 			return nil, errors.New("the datadog output was deprecated in k6 v0.32.0 and removed in k6 v0.34.0, " +
 				"please use the statsd output with env. variable K6_STATSD_ENABLE_TAGS=true instead")
 		},

--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -17,7 +17,7 @@ func getCmdPause(gs *state.GlobalState) *cobra.Command {
 		Long: `Pause a running test.
 
   Use the global --address flag to specify the URL to the API server.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			c, err := client.New(gs.Flags.Address)
 			if err != nil {
 				return err

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -17,7 +17,7 @@ func getCmdResume(gs *state.GlobalState) *cobra.Command {
 		Long: `Resume a paused test.
 
   Use the global --address flag to specify the URL to the API server.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			c, err := client.New(gs.Flags.Address)
 			if err != nil {
 				return err

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -25,7 +25,7 @@ func TestPanicHandling(t *testing.T) {
 	rootCmd := newRootCommand(ts.GlobalState)
 	rootCmd.cmd.AddCommand(&cobra.Command{
 		Use: "panic",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			panic("oh no, oh no, oh no,no,no,no,no")
 		},
 	})

--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -15,7 +15,7 @@ func getCmdStats(gs *state.GlobalState) *cobra.Command {
 		Long: `Show test metrics.
 
   Use the global --address flag to specify the URL to the API server.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			c, err := client.New(gs.Flags.Address)
 			if err != nil {
 				return err

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -15,7 +15,7 @@ func getCmdStatus(gs *state.GlobalState) *cobra.Command {
 		Long: `Show test status.
 
   Use the global --address flag to specify the URL to the API server.`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			c, err := client.New(gs.Flags.Address)
 			if err != nil {
 				return err

--- a/cmd/tests/cmd_cloud_test.go
+++ b/cmd/tests/cmd_cloud_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func cloudTestStartSimple(tb testing.TB, testRunID int) http.Handler {
-	return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+	return http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 		resp.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintf(resp, `{"reference_id": "%d"}`, testRunID)
 		assert.NoError(tb, err)
@@ -43,7 +43,7 @@ func getMockCloud(
 
 	srv := getTestServer(t, map[string]http.Handler{
 		"POST ^/v1/archive-upload$": archiveUpload,
-		testProgressURL: http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		testProgressURL: http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 			testProgress := defaultProgress
 			if progressCallback != nil {
 				testProgress = progressCallback()
@@ -169,7 +169,7 @@ func TestCloudUploadOnly(t *testing.T) {
 func TestCloudWithConfigOverride(t *testing.T) {
 	t.Parallel()
 
-	configOverride := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+	configOverride := http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 		resp.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprint(resp, `{
 			"reference_id": "123",

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -503,7 +503,7 @@ func getCloudTestEndChecker(
 
 	srv := getTestServer(tb, map[string]http.Handler{
 		"POST ^/v1/tests$": testStart,
-		fmt.Sprintf("POST ^/v1/tests/%d$", testRunID): http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		fmt.Sprintf("POST ^/v1/tests/%d$", testRunID): http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 			require.NotNil(tb, req.Body)
 			buf := &bytes.Buffer{}
 			_, err := io.Copy(buf, req.Body)
@@ -829,7 +829,7 @@ func injectMockSignalNotifier(ts *GlobalTestState) (sendSignal chan os.Signal) {
 			close(sendSignal)
 		}()
 	}
-	ts.GlobalState.SignalStop = func(c chan<- os.Signal) { /* noop */ }
+	ts.GlobalState.SignalStop = func(_ chan<- os.Signal) { /* noop */ }
 	return sendSignal
 }
 
@@ -1703,7 +1703,7 @@ func TestRunWithCloudOutputOverrides(t *testing.T) {
 		[]string{"-v", "--log-output=stdout", "--out=cloud", "--out", "json=results.json"}, 0,
 	)
 
-	configOverride := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+	configOverride := http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 		resp.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprint(resp, `{"reference_id": "132", "config": {"webAppURL": "https://bogus.url"}}`)
 		assert.NoError(t, err)
@@ -1841,7 +1841,6 @@ func TestPrometheusRemoteWriteOutput(t *testing.T) {
 func BenchmarkReadResponseBody(b *testing.B) {
 	httpSrv := httpmultibin.NewHTTPMultiBin(b)
 
-	//nolint:goconst
 	script := httpSrv.Replacer.Replace(`
 		import http from "k6/http";
 		import { check, sleep } from "k6";

--- a/cmd/tests/tracing_module_test.go
+++ b/cmd/tests/tracing_module_test.go
@@ -23,7 +23,7 @@ func TestTracingModuleClient(t *testing.T) {
 
 	var gotRequests int64
 
-	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/tracing", func(_ http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&gotRequests, 1)
 		assert.NotEmpty(t, r.Header.Get("traceparent"))
 		assert.Len(t, r.Header.Get("traceparent"), 55)
@@ -69,7 +69,7 @@ func TestTracingClient_DoesNotInterfereWithHTTPModule(t *testing.T) {
 	var gotRequests int64
 	var gotInstrumentedRequests int64
 
-	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/tracing", func(_ http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&gotRequests, 1)
 
 		if r.Header.Get("traceparent") != "" {
@@ -108,7 +108,7 @@ func TestTracingModuleClient_HundredPercentSampling(t *testing.T) {
 	var gotRequests int64
 	var gotSampleFlags int64
 
-	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/tracing", func(_ http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&gotRequests, 1)
 
 		traceparent := r.Header.Get("traceparent")
@@ -161,7 +161,7 @@ func TestTracingModuleClient_NoSamplingSetShouldAlwaysSample(t *testing.T) {
 	var gotRequests int64
 	var gotSampleFlags int64
 
-	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/tracing", func(_ http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&gotRequests, 1)
 
 		traceparent := r.Header.Get("traceparent")
@@ -213,7 +213,7 @@ func TestTracingModuleClient_ZeroPercentSampling(t *testing.T) {
 	var gotRequests int64
 	var gotSampleFlags int64
 
-	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/tracing", func(_ http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&gotRequests, 1)
 
 		traceparent := r.Header.Get("traceparent")
@@ -260,7 +260,7 @@ func TestTracingInstrumentHTTP_W3C(t *testing.T) {
 
 	var gotRequests int64
 
-	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/tracing", func(_ http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&gotRequests, 1)
 		assert.NotEmpty(t, r.Header.Get("traceparent"))
 		assert.Len(t, r.Header.Get("traceparent"), 55)
@@ -304,7 +304,7 @@ func TestTracingInstrumentHTTP_Jaeger(t *testing.T) {
 
 	var gotRequests int64
 
-	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/tracing", func(_ http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&gotRequests, 1)
 		assert.NotEmpty(t, r.Header.Get("uber-trace-id"))
 		assert.Len(t, r.Header.Get("uber-trace-id"), 45)
@@ -348,7 +348,7 @@ func TestTracingInstrumentHTTP_FillsParams(t *testing.T) {
 
 	var gotRequests int64
 
-	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/tracing", func(_ http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&gotRequests, 1)
 
 		assert.NotEmpty(t, r.Header.Get("traceparent"))
@@ -399,7 +399,7 @@ func TestTracingInstrummentHTTP_SupportsMultipleTestScripts(t *testing.T) {
 	var gotRequests int64
 
 	tb := httpmultibin.NewHTTPMultiBin(t)
-	tb.Mux.HandleFunc("/tracing", func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/tracing", func(_ http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&gotRequests, 1)
 
 		assert.NotEmpty(t, r.Header.Get("traceparent"))

--- a/execution/scheduler_ext_test.go
+++ b/execution/scheduler_ext_test.go
@@ -718,11 +718,11 @@ func TestSchedulerSetupTeardownRun(t *testing.T) {
 		setupC := make(chan struct{})
 		teardownC := make(chan struct{})
 		runner := &minirunner.MiniRunner{
-			SetupFn: func(ctx context.Context, out chan<- metrics.SampleContainer) ([]byte, error) {
+			SetupFn: func(_ context.Context, _ chan<- metrics.SampleContainer) ([]byte, error) {
 				close(setupC)
 				return nil, nil
 			},
-			TeardownFn: func(ctx context.Context, out chan<- metrics.SampleContainer) error {
+			TeardownFn: func(_ context.Context, _ chan<- metrics.SampleContainer) error {
 				close(teardownC)
 				return nil
 			},
@@ -739,7 +739,7 @@ func TestSchedulerSetupTeardownRun(t *testing.T) {
 	t.Run("Setup Error", func(t *testing.T) {
 		t.Parallel()
 		runner := &minirunner.MiniRunner{
-			SetupFn: func(ctx context.Context, out chan<- metrics.SampleContainer) ([]byte, error) {
+			SetupFn: func(_ context.Context, _ chan<- metrics.SampleContainer) ([]byte, error) {
 				return nil, errors.New("setup error")
 			},
 		}
@@ -750,10 +750,10 @@ func TestSchedulerSetupTeardownRun(t *testing.T) {
 	t.Run("Don't Run Setup", func(t *testing.T) {
 		t.Parallel()
 		runner := &minirunner.MiniRunner{
-			SetupFn: func(ctx context.Context, out chan<- metrics.SampleContainer) ([]byte, error) {
-				return nil, errors.New("setup error")
+			SetupFn: func(_ context.Context, _ chan<- metrics.SampleContainer) ([]byte, error) {
+				return nil, errors.New("setup _")
 			},
-			TeardownFn: func(ctx context.Context, out chan<- metrics.SampleContainer) error {
+			TeardownFn: func(_ context.Context, _ chan<- metrics.SampleContainer) error {
 				return errors.New("teardown error")
 			},
 		}
@@ -769,10 +769,10 @@ func TestSchedulerSetupTeardownRun(t *testing.T) {
 	t.Run("Teardown Error", func(t *testing.T) {
 		t.Parallel()
 		runner := &minirunner.MiniRunner{
-			SetupFn: func(ctx context.Context, out chan<- metrics.SampleContainer) ([]byte, error) {
+			SetupFn: func(_ context.Context, _ chan<- metrics.SampleContainer) ([]byte, error) {
 				return nil, nil
 			},
-			TeardownFn: func(ctx context.Context, out chan<- metrics.SampleContainer) error {
+			TeardownFn: func(_ context.Context, _ chan<- metrics.SampleContainer) error {
 				return errors.New("teardown error")
 			},
 		}
@@ -787,10 +787,10 @@ func TestSchedulerSetupTeardownRun(t *testing.T) {
 	t.Run("Don't Run Teardown", func(t *testing.T) {
 		t.Parallel()
 		runner := &minirunner.MiniRunner{
-			SetupFn: func(ctx context.Context, out chan<- metrics.SampleContainer) ([]byte, error) {
+			SetupFn: func(_ context.Context, _ chan<- metrics.SampleContainer) ([]byte, error) {
 				return nil, nil
 			},
-			TeardownFn: func(ctx context.Context, out chan<- metrics.SampleContainer) error {
+			TeardownFn: func(_ context.Context, _ chan<- metrics.SampleContainer) error {
 				return errors.New("teardown error")
 			},
 		}
@@ -835,7 +835,7 @@ func TestSchedulerStages(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			runner := &minirunner.MiniRunner{
-				Fn: func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
+				Fn: func(_ context.Context, _ *lib.State, _ chan<- metrics.SampleContainer) error {
 					time.Sleep(100 * time.Millisecond)
 					return nil
 				},
@@ -854,7 +854,7 @@ func TestSchedulerStages(t *testing.T) {
 func TestSchedulerEndTime(t *testing.T) {
 	t.Parallel()
 	runner := &minirunner.MiniRunner{
-		Fn: func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
+		Fn: func(_ context.Context, _ *lib.State, _ chan<- metrics.SampleContainer) error {
 			time.Sleep(100 * time.Millisecond)
 			return nil
 		},
@@ -879,7 +879,7 @@ func TestSchedulerEndTime(t *testing.T) {
 func TestSchedulerRuntimeErrors(t *testing.T) {
 	t.Parallel()
 	runner := &minirunner.MiniRunner{
-		Fn: func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
+		Fn: func(_ context.Context, _ *lib.State, _ chan<- metrics.SampleContainer) error {
 			time.Sleep(10 * time.Millisecond)
 			return errors.New("hi")
 		},
@@ -917,7 +917,7 @@ func TestSchedulerEndErrors(t *testing.T) {
 	exec.GracefulStop = types.NullDurationFrom(0 * time.Second)
 
 	runner := &minirunner.MiniRunner{
-		Fn: func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
+		Fn: func(ctx context.Context, _ *lib.State, _ chan<- metrics.SampleContainer) error {
 			<-ctx.Done()
 			return errors.New("hi")
 		},
@@ -1005,7 +1005,7 @@ func TestSchedulerEndIterations(t *testing.T) {
 func TestSchedulerIsRunning(t *testing.T) {
 	t.Parallel()
 	runner := &minirunner.MiniRunner{
-		Fn: func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
+		Fn: func(ctx context.Context, _ *lib.State, _ chan<- metrics.SampleContainer) error {
 			<-ctx.Done()
 			return nil
 		},
@@ -1110,7 +1110,7 @@ func TestDNSResolverCache(t *testing.T) {
 
 			mr := mockresolver.New(map[string][]net.IP{"myhost": {net.ParseIP(sr("HTTPBIN_IP"))}})
 			var newResolutions uint32
-			resolveHook := func(host string, result []net.IP) {
+			resolveHook := func(_ string, result []net.IP) {
 				require.Len(t, result, 1)
 				if result[0].String() == "127.0.0.1" {
 					mr.Set("myhost", "127.0.0.254")

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -303,7 +303,6 @@ func (b *Bundle) instantiate(vuImpl *moduleVUImpl, vuID uint64) (*goja.Object, e
 	var exportsV goja.Value
 	err = common.RunWithPanicCatching(b.preInitState.Logger, rt, func() error {
 		return vuImpl.eventLoop.Start(func() error {
-			//nolint:govet // here we shadow err on purpose
 			var err error
 			exportsV, err = modSys.RunSourceData(b.sourceData)
 			return err

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -122,7 +122,7 @@ func (c *Compiler) Transform(src, filename string, inputSrcMap []byte) (code str
 		// TODO: drop this code and everything it's connected to when babel is dropped
 		v := os.Getenv(maxSrcLenForBabelSourceMapVarName) //nolint:forbidigo
 		if len(v) > 0 {
-			i, err := strconv.Atoi(v) //nolint:govet // we shadow err on purpose
+			i, err := strconv.Atoi(v)
 			if err != nil {
 				c.logger.Warnf("Tried to parse %q from %s as integer but couldn't %s\n",
 					v, maxSrcLenForBabelSourceMapVarName, err)

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -72,7 +72,7 @@ func getSimpleRunner(tb testing.TB, filename, data string, opts ...interface{}) 
 			RuntimeOptions: rtOpts,
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
-			LookupEnv:      func(key string) (val string, ok bool) { return "", false },
+			LookupEnv:      func(_ string) (val string, ok bool) { return "", false },
 		},
 		&loader.SourceData{
 			URL:  &url.URL{Path: filename, Scheme: "file"},

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -299,7 +299,7 @@ func TestRequestWithBinaryFile(t *testing.T) {
 
 	ch := make(chan bool, 1)
 
-	h := func(w http.ResponseWriter, r *http.Request) {
+	h := func(_ http.ResponseWriter, r *http.Request) {
 		defer func() {
 			ch <- true
 		}()
@@ -387,7 +387,7 @@ func TestRequestWithMultipleBinaryFiles(t *testing.T) {
 
 	ch := make(chan bool, 1)
 
-	h := func(w http.ResponseWriter, r *http.Request) {
+	h := func(_ http.ResponseWriter, r *http.Request) {
 		defer func() {
 			ch <- true
 		}()

--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -242,7 +242,6 @@ func (mi *ModuleInstance) newVUInfo() (*goja.Object, error) {
 	}
 
 	err = o.Set("metrics", metrics)
-
 	if err != nil {
 		return o, err
 	}

--- a/js/modules/k6/experimental/tracing/client.go
+++ b/js/modules/k6/experimental/tracing/client.go
@@ -130,7 +130,6 @@ func (c *Client) Request(method string, url goja.Value, args ...goja.Value) (*ht
 		result, err = c.requestFunc(method, url, args...)
 		return err
 	}, args...)
-
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +145,6 @@ func (c *Client) AsyncRequest(method string, url goja.Value, args ...goja.Value)
 		result, err = c.asyncRequestFunc(method, url, args...)
 		return err
 	}, args...)
-
 	if err != nil {
 		return nil, err
 	}

--- a/js/modules/k6/experimental/tracing/client_test.go
+++ b/js/modules/k6/experimental/tracing/client_test.go
@@ -179,7 +179,7 @@ func TestClientInstrumentedCall(t *testing.T) {
 	})
 	testCase.client.propagator = NewW3CPropagator(NewAlwaysOnSampler())
 
-	callFn := func(args ...goja.Value) error {
+	callFn := func(_ ...goja.Value) error {
 		gotMetadataTraceID, gotTraceIDKey := testCase.client.vu.State().Tags.GetCurrentValues().Metadata["trace_id"]
 		assert.True(t, gotTraceIDKey)
 		assert.NotEmpty(t, gotMetadataTraceID)

--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -323,7 +323,7 @@ func TestClient(t *testing.T) {
 				var client = new grpc.Client();
 				client.load([], "../../../../lib/testutils/httpmultibin/grpc_any_testing/any_test.proto");`},
 			setup: func(tb *httpmultibin.HTTPMultiBin) {
-				tb.GRPCAnyStub.SumFunc = func(ctx context.Context, req *grpcanytesting.SumRequest) (*grpcanytesting.SumReply, error) {
+				tb.GRPCAnyStub.SumFunc = func(_ context.Context, req *grpcanytesting.SumRequest) (*grpcanytesting.SumReply, error) {
 					var sumRequestData grpcanytesting.SumRequestData
 					if err := req.Data.UnmarshalTo(&sumRequestData); err != nil {
 						return nil, err
@@ -622,7 +622,7 @@ func TestClient(t *testing.T) {
 			name: "ReflectInvokeNoExist",
 			setup: func(tb *httpmultibin.HTTPMultiBin) {
 				reflection.Register(tb.ServerGRPC)
-				tb.GRPCStub.EmptyCallFunc = func(ctx context.Context, _ *grpc_testing.Empty) (*grpc_testing.Empty, error) {
+				tb.GRPCStub.EmptyCallFunc = func(_ context.Context, _ *grpc_testing.Empty) (*grpc_testing.Empty, error) {
 					return &grpc_testing.Empty{}, nil
 				}
 			},
@@ -643,7 +643,7 @@ func TestClient(t *testing.T) {
 				// this register both reflection APIs v1 and v1alpha
 				reflection.Register(tb.ServerGRPC)
 
-				tb.GRPCStub.EmptyCallFunc = func(ctx context.Context, _ *grpc_testing.Empty) (*grpc_testing.Empty, error) {
+				tb.GRPCStub.EmptyCallFunc = func(_ context.Context, _ *grpc_testing.Empty) (*grpc_testing.Empty, error) {
 					return &grpc_testing.Empty{}, nil
 				}
 			},
@@ -665,7 +665,7 @@ func TestClient(t *testing.T) {
 				svr := reflection.NewServer(reflection.ServerOptions{Services: s})
 				v1alphagrpc.RegisterServerReflectionServer(s, svr)
 
-				tb.GRPCStub.EmptyCallFunc = func(ctx context.Context, _ *grpc_testing.Empty) (*grpc_testing.Empty, error) {
+				tb.GRPCStub.EmptyCallFunc = func(_ context.Context, _ *grpc_testing.Empty) (*grpc_testing.Empty, error) {
 					return &grpc_testing.Empty{}, nil
 				}
 			},
@@ -685,7 +685,7 @@ func TestClient(t *testing.T) {
 				// this register only reflection APIs v1
 				reflection.RegisterV1(tb.ServerGRPC)
 
-				tb.GRPCStub.EmptyCallFunc = func(ctx context.Context, _ *grpc_testing.Empty) (*grpc_testing.Empty, error) {
+				tb.GRPCStub.EmptyCallFunc = func(_ context.Context, _ *grpc_testing.Empty) (*grpc_testing.Empty, error) {
 					return &grpc_testing.Empty{}, nil
 				}
 			},

--- a/js/modules/k6/grpc/stream_test.go
+++ b/js/modules/k6/grpc/stream_test.go
@@ -50,7 +50,7 @@ func TestStream_RequestHeaders(t *testing.T) {
 
 	var registeredMetadata metadata.MD
 	stub := &featureExplorerStub{}
-	stub.listFeatures = func(rect *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
+	stub.listFeatures = func(_ *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
 		// collect metadata from the stream context
 		md, ok := metadata.FromIncomingContext(stream.Context())
 		if ok {
@@ -122,7 +122,7 @@ func TestStream_ErrorHandling(t *testing.T) {
 		},
 	}
 
-	stub.listFeatures = func(rect *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
+	stub.listFeatures = func(_ *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
 		for _, feature := range savedFeatures {
 			if err := stream.Send(feature); err != nil {
 				return err
@@ -208,7 +208,7 @@ func TestStream_ReceiveAllServerResponsesAfterEnd(t *testing.T) {
 		},
 	}
 
-	stub.listFeatures = func(rect *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
+	stub.listFeatures = func(_ *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
 		for _, feature := range savedFeatures {
 			// adding a delay to make server response "slower"
 			time.Sleep(200 * time.Millisecond)

--- a/js/modules/k6/html/html.go
+++ b/js/modules/k6/html/html.go
@@ -337,7 +337,7 @@ func (s Selection) Val() goja.Value {
 	case SelectTagName:
 		selected := s.sel.First().Find("option[selected]")
 		if _, exists := s.sel.Attr("multiple"); exists {
-			return s.rt.ToValue(selected.Map(func(idx int, opt *goquery.Selection) string { return valueOrHTML(opt) }))
+			return s.rt.ToValue(selected.Map(func(_ int, opt *goquery.Selection) string { return valueOrHTML(opt) }))
 		}
 
 		return s.rt.ToValue(valueOrHTML(selected))
@@ -361,7 +361,7 @@ func (s Selection) Each(v goja.Value) Selection {
 		common.Throw(s.rt, errors.New("the argument to each() must be a function"))
 	}
 
-	fn := func(idx int, sel *goquery.Selection) {
+	fn := func(idx int, _ *goquery.Selection) {
 		if _, err := gojaFn(v, s.rt.ToValue(idx), selToElement(Selection{s.rt, s.sel.Eq(idx), s.URL})); err != nil {
 			common.Throw(s.rt, fmt.Errorf("the function passed to each() failed: %w", err))
 		}

--- a/js/modules/k6/http/async_request_test.go
+++ b/js/modules/k6/http/async_request_test.go
@@ -86,7 +86,7 @@ func TestAsyncRequestResponseCallbackRace(t *testing.T) {
 		})
 	})
 	require.NoError(t, err)
-	err = ts.runtime.VU.Runtime().Set("log", func(s string) {
+	err = ts.runtime.VU.Runtime().Set("log", func(_ string) {
 		// t.Log(s) // uncomment for debugging
 	})
 	require.NoError(t, err)

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -187,7 +187,7 @@ func TestRequest(t *testing.T) {
 	sr := tb.Replacer.Replace
 
 	// Handle paths with custom logic
-	tb.Mux.HandleFunc("/digest-auth/failure", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/digest-auth/failure", http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		time.Sleep(2 * time.Second)
 	}))
 
@@ -446,7 +446,7 @@ func TestRequest(t *testing.T) {
 		})
 		t.Run("custom compression", func(t *testing.T) {
 			// We should not try to decode it
-			tb.Mux.HandleFunc("/customcompression", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tb.Mux.HandleFunc("/customcompression", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Encoding", "custom")
 				_, err := w.Write([]byte(`{"custom": true}`))
 				assert.NoError(t, err)
@@ -696,7 +696,7 @@ func TestRequest(t *testing.T) {
 			t.Run("redirect", func(t *testing.T) {
 				t.Run("set cookie after redirect", func(t *testing.T) {
 					// TODO figure out a way to remove this ?
-					tb.Mux.HandleFunc("/set-cookie-without-redirect", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					tb.Mux.HandleFunc("/set-cookie-without-redirect", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 						cookie := http.Cookie{
 							Name:   "key-foo",
 							Value:  "value-bar",
@@ -1406,7 +1406,7 @@ func TestRequestCompression(t *testing.T) {
 		expectedEncoding string
 		actualEncoding   string
 	)
-	tb.Mux.HandleFunc("/compressed-text", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/compressed-text", http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		require.Equal(t, expectedEncoding, r.Header.Get("Content-Encoding"))
 
 		expectedLength, err := strconv.Atoi(r.Header.Get("Content-Length"))
@@ -1556,12 +1556,12 @@ func TestResponseTypes(t *testing.T) {
 
 	text := `•?((¯°·._.• ţ€$ţɨɲǥ µɲɨȼ๏ď€ ɨɲ Ќ6 •._.·°¯))؟•`
 	textLen := len(text)
-	tb.Mux.HandleFunc("/get-text", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/get-text", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		n, err := w.Write([]byte(text))
 		assert.NoError(t, err)
 		assert.Equal(t, textLen, n)
 	}))
-	tb.Mux.HandleFunc("/compare-text", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/compare-text", http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		assert.Equal(t, text, string(body))
@@ -1572,12 +1572,12 @@ func TestResponseTypes(t *testing.T) {
 	for i := 0; i < binaryLen; i++ {
 		binary[i] = byte(i)
 	}
-	tb.Mux.HandleFunc("/get-bin", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/get-bin", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		n, err := w.Write(binary)
 		assert.NoError(t, err)
 		assert.Equal(t, binaryLen, n)
 	}))
-	tb.Mux.HandleFunc("/compare-bin", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/compare-bin", http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
 		assert.True(t, bytes.Equal(binary, body))
@@ -1814,7 +1814,7 @@ func TestResponseWaitingAndReceivingTimings(t *testing.T) {
 	// We don't expect any failed requests
 	state.Options.Throw = null.BoolFrom(true)
 
-	tb.Mux.HandleFunc("/slow-response", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/slow-response", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		flusher, ok := w.(http.Flusher)
 		require.True(t, ok)
 
@@ -1974,7 +1974,7 @@ func BenchmarkHandlingOfResponseBodies(b *testing.B) {
 	}()
 
 	mbData := bytes.Repeat([]byte("0123456789"), 100000)
-	tb.Mux.HandleFunc("/1mbdata", http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+	tb.Mux.HandleFunc("/1mbdata", http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 		_, err := resp.Write(mbData)
 		if err != nil {
 			b.Error(err)
@@ -2322,9 +2322,9 @@ func GenerateTLSCertificate(t *testing.T, host string, notBefore time.Time, vali
 	return certPem, keyPem
 }
 
-func GetTestServerWithCertificate(t *testing.T, certPem, key []byte, suitesIds ...uint16) (*httptest.Server, *http.Client) {
+func GetTestServerWithCertificate(t *testing.T, certPem, key []byte, suitesIDs ...uint16) (*httptest.Server, *http.Client) {
 	server := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
 		ReadHeaderTimeout: time.Second,
@@ -2345,10 +2345,10 @@ func GetTestServerWithCertificate(t *testing.T, certPem, key []byte, suitesIds .
 	require.NoError(t, err)
 	s.TLS.Certificates = append(s.TLS.Certificates, cert)
 	suites := tls.CipherSuites()
-	if len(suitesIds) > 0 {
-		newSuites := make([]*tls.CipherSuite, 0, len(suitesIds))
+	if len(suitesIDs) > 0 {
+		newSuites := make([]*tls.CipherSuite, 0, len(suitesIDs))
 		for _, suite := range suites {
-			for _, id := range suitesIds {
+			for _, id := range suitesIDs {
 				if id == suite.ID {
 					newSuites = append(newSuites, suite)
 				}
@@ -2372,7 +2372,7 @@ func GetTestServerWithCertificate(t *testing.T, certPem, key []byte, suitesIds .
 			RootCAs:      certpool,
 			MinVersion:   tls.VersionTLS10,
 			MaxVersion:   tls.VersionTLS12, // this so that the ciphersuite work
-			CipherSuites: suitesIds,
+			CipherSuites: suitesIDs,
 		},
 		ForceAttemptHTTP2:     s.EnableHTTP2,
 		TLSHandshakeTimeout:   time.Second,
@@ -2394,7 +2394,7 @@ func TestGzipped204Response(t *testing.T) {
 	state.Options.Throw = null.BoolFrom(true)
 	sr := tb.Replacer.Replace
 	// We should not try to decode it
-	tb.Mux.HandleFunc("/gzipempty", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/gzipempty", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Encoding", "gzip")
 		w.WriteHeader(http.StatusNoContent)
 	}))

--- a/js/modules/k6/http/response_callback_test.go
+++ b/js/modules/k6/http/response_callback_test.go
@@ -283,10 +283,10 @@ func TestResponseCallbackInAction(t *testing.T) {
 				assertRequestMetricsEmittedSingle(t, bufSamples[i], expectedSample.tags, expectedSample.metrics, nil)
 			}
 		}
-		t.Run(name, func(t *testing.T) {
+		t.Run(name, func(_ *testing.T) {
 			runCode(testCase.code)
 		})
-		t.Run("async_"+name, func(t *testing.T) {
+		t.Run("async_"+name, func(_ *testing.T) {
 			runCode(strings.ReplaceAll(testCase.code, "http.request", "http.asyncRequest"))
 		})
 	}

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -167,7 +167,7 @@ func (mi *WS) Connect(url string, args ...goja.Value) (*HTTPResponse, error) {
 	// handlers and for cleanup. See closeConnection.
 	// closeConnection is not set directly as a handler here to
 	// avoid race conditions when calling the Goja runtime.
-	socket.conn.SetCloseHandler(func(code int, text string) error { return nil })
+	socket.conn.SetCloseHandler(func(_ int, _ string) error { return nil })
 
 	// Pass ping/pong events through the main control loop
 	pingChan := make(chan string)

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -977,7 +977,7 @@ func generateTLSCertificateWithCA(t *testing.T, host string, notBefore time.Time
 
 func getTestServerWithCertificate(t *testing.T, certPem, key []byte) *httptest.Server {
 	server := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		}),
 		ReadHeaderTimeout: time.Second,
@@ -1866,7 +1866,7 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	})
 	require.NoError(t, err)
 	srv := &http.Server{ //nolint:gosec
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = fmt.Fprintf(w, "ok")
 		}),
 		ErrorLog: stdlog.New(io.Discard, "", 0),
@@ -2240,7 +2240,7 @@ func TestSystemTags(t *testing.T) {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 
 	// Handle paths with custom logic
-	tb.Mux.HandleFunc("/wrong-redirect", func(w http.ResponseWriter, r *http.Request) {
+	tb.Mux.HandleFunc("/wrong-redirect", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Add("Location", "%")
 		w.WriteHeader(http.StatusTemporaryRedirect)
 	})
@@ -2468,7 +2468,7 @@ func TestComplicatedFileImportsForGRPC(t *testing.T) {
 	t.Parallel()
 	tb := httpmultibin.NewHTTPMultiBin(t)
 
-	tb.GRPCStub.UnaryCallFunc = func(ctx context.Context, sreq *grpc_testing.SimpleRequest) (
+	tb.GRPCStub.UnaryCallFunc = func(_ context.Context, _ *grpc_testing.SimpleRequest) (
 		*grpc_testing.SimpleResponse, error,
 	) {
 		return &grpc_testing.SimpleResponse{

--- a/js/tc39/tc39_test.go
+++ b/js/tc39/tc39_test.go
@@ -690,7 +690,7 @@ func (ctx *tc39TestCtx) runTC39Module(name, src string, includes []string, vm *g
 	comp.Options = compiler.Options{Strict: false, CompatibilityMode: lib.CompatibilityModeExtended}
 
 	mr := modules.NewModuleResolver(nil,
-		func(specifier *url.URL, name string) ([]byte, error) {
+		func(specifier *url.URL, _ string) ([]byte, error) {
 			return fs.ReadFile(currentFS, specifier.Path[1:])
 		},
 		comp)

--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -53,7 +53,7 @@ func setupExecutor(t testing.TB, config lib.ExecutorConfig, es *lib.ExecutionSta
 	testLog.SetOutput(io.Discard)
 	logEntry := logrus.NewEntry(testLog)
 
-	initVUFunc := func(_ context.Context, logger *logrus.Entry) (lib.InitializedVU, error) {
+	initVUFunc := func(_ context.Context, _ *logrus.Entry) (lib.InitializedVU, error) {
 		idl, idg := es.GetUniqueVUIdentifiers()
 		return es.Test.Runner.NewVU(ctx, idl, idg, engineOut)
 	}

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -49,7 +49,7 @@ func getTestConstantArrivalRateConfig() *ConstantArrivalRateConfig {
 func TestConstantArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 	t.Parallel()
 
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		time.Sleep(time.Second)
 		return nil
 	})
@@ -73,7 +73,7 @@ func TestConstantArrivalRateRunCorrectRate(t *testing.T) {
 	t.Parallel()
 
 	var count int64
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		atomic.AddInt64(&count, 1)
 		return nil
 	})
@@ -171,7 +171,7 @@ func TestConstantArrivalRateRunCorrectTiming(t *testing.T) {
 			var count int64
 			startTime := time.Now()
 			expectedTimeInt64 := int64(test.start)
-			runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+			runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 				current := atomic.AddInt64(&count, 1)
 
 				expectedTime := test.start
@@ -242,7 +242,7 @@ func TestArrivalRateCancel(t *testing.T) {
 			errCh := make(chan error, 1)
 			weAreDoneCh := make(chan struct{})
 
-			runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+			runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 				select {
 				case <-ch:
 					<-ch
@@ -339,7 +339,7 @@ func TestConstantArrivalRateGlobalIters(t *testing.T) {
 
 			gotIters := []uint64{}
 			var mx sync.Mutex
-			runner := simpleRunner(func(ctx context.Context, state *lib.State) error {
+			runner := simpleRunner(func(_ context.Context, state *lib.State) error {
 				mx.Lock()
 				gotIters = append(gotIters, state.GetScenarioGlobalVUIter())
 				mx.Unlock()

--- a/lib/executor/constant_vus_test.go
+++ b/lib/executor/constant_vus_test.go
@@ -44,7 +44,7 @@ func TestConstantVUsRun(t *testing.T) {
 	require.NoError(t, test.executor.Run(test.ctx, nil))
 
 	var totalIters uint64
-	result.Range(func(key, value interface{}) bool {
+	result.Range(func(_, value interface{}) bool {
 		vuIters := value.(uint64) //nolint:forcetypeassert
 		assert.Equal(t, uint64(5), vuIters)
 		totalIters += vuIters

--- a/lib/executor/externally_controlled.go
+++ b/lib/executor/externally_controlled.go
@@ -544,6 +544,7 @@ func (mex *ExternallyControlled) Run(parentCtx context.Context, _ chan<- metrics
 	if err != nil {
 		return err
 	}
+	//nolint:contextcheck
 	defer func() { // Make sure we release the VUs at the end
 		err = runState.handleConfigChange(currentControlConfig, ExternallyControlledConfigParams{})
 	}()

--- a/lib/executor/externally_controlled_test.go
+++ b/lib/executor/externally_controlled_test.go
@@ -29,7 +29,7 @@ func TestExternallyControlledRun(t *testing.T) {
 	t.Parallel()
 
 	doneIters := new(uint64)
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		time.Sleep(200 * time.Millisecond)
 		atomic.AddUint64(doneIters, 1)
 		return nil

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -30,7 +30,7 @@ func TestPerVUIterationsRun(t *testing.T) {
 	t.Parallel()
 	var result sync.Map
 
-	runner := simpleRunner(func(ctx context.Context, state *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, state *lib.State) error {
 		currIter, _ := result.LoadOrStore(state.VUID, uint64(0))
 		result.Store(state.VUID, currIter.(uint64)+1) //nolint:forcetypeassert
 		return nil
@@ -43,7 +43,7 @@ func TestPerVUIterationsRun(t *testing.T) {
 	require.NoError(t, test.executor.Run(test.ctx, engineOut))
 
 	var totalIters uint64
-	result.Range(func(key, value interface{}) bool {
+	result.Range(func(_, value interface{}) bool {
 		vuIters := value.(uint64) //nolint:forcetypeassert
 		assert.Equal(t, uint64(100), vuIters)
 		totalIters += vuIters
@@ -61,7 +61,7 @@ func TestPerVUIterationsRunVariableVU(t *testing.T) {
 		slowVUID = uint64(1)
 	)
 
-	runner := simpleRunner(func(ctx context.Context, state *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, state *lib.State) error {
 		if state.VUID == slowVUID {
 			time.Sleep(200 * time.Millisecond)
 		}

--- a/lib/executor/ramping_arrival_rate_test.go
+++ b/lib/executor/ramping_arrival_rate_test.go
@@ -46,7 +46,7 @@ func getTestRampingArrivalRateConfig() *RampingArrivalRateConfig {
 func TestRampingArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 	t.Parallel()
 
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		time.Sleep(time.Second)
 		return nil
 	})
@@ -69,7 +69,7 @@ func TestRampingArrivalRateRunNotEnoughAllocatedVUsWarn(t *testing.T) {
 func TestRampingArrivalRateRunCorrectRate(t *testing.T) {
 	t.Parallel()
 	var count int64
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		atomic.AddInt64(&count, 1)
 		return nil
 	})
@@ -122,7 +122,7 @@ func TestRampingArrivalRateRunUnplannedVUs(t *testing.T) {
 	var count int64
 	ch := make(chan struct{})  // closed when new unplannedVU is started and signal to get to next iterations
 	ch2 := make(chan struct{}) // closed when a second iteration was started on an old VU in order to test it won't start a second unplanned VU in parallel or at all
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		cur := atomic.AddInt64(&count, 1)
 		if cur == 1 {
 			<-ch // wait to start again
@@ -137,7 +137,7 @@ func TestRampingArrivalRateRunUnplannedVUs(t *testing.T) {
 	defer test.cancel()
 
 	engineOut := make(chan metrics.SampleContainer, 1000)
-	test.state.SetInitVUFunc(func(ctx context.Context, logger *logrus.Entry) (lib.InitializedVU, error) {
+	test.state.SetInitVUFunc(func(ctx context.Context, _ *logrus.Entry) (lib.InitializedVU, error) {
 		cur := atomic.LoadInt64(&count)
 		require.Equal(t, cur, int64(1))
 		time.Sleep(time.Second / 2)
@@ -184,7 +184,7 @@ func TestRampingArrivalRateRunCorrectRateWithSlowRate(t *testing.T) {
 
 	var count int64
 	ch := make(chan struct{}) // closed when new unplannedVU is started and signal to get to next iterations
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		cur := atomic.AddInt64(&count, 1)
 		if cur == 1 {
 			<-ch // wait to start again
@@ -197,7 +197,7 @@ func TestRampingArrivalRateRunCorrectRateWithSlowRate(t *testing.T) {
 	defer test.cancel()
 
 	engineOut := make(chan metrics.SampleContainer, 1000)
-	test.state.SetInitVUFunc(func(ctx context.Context, logger *logrus.Entry) (lib.InitializedVU, error) {
+	test.state.SetInitVUFunc(func(ctx context.Context, _ *logrus.Entry) (lib.InitializedVU, error) {
 		t.Log("init")
 		cur := atomic.LoadInt64(&count)
 		require.Equal(t, cur, int64(1))
@@ -236,7 +236,7 @@ func TestRampingArrivalRateRunGracefulStop(t *testing.T) {
 		},
 	}
 
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		time.Sleep(5 * time.Second)
 		return nil
 	})
@@ -273,7 +273,7 @@ func BenchmarkRampingArrivalRateRun(b *testing.B) {
 			}()
 
 			var count int64
-			runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+			runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 				atomic.AddInt64(&count, 1)
 				return nil
 			})
@@ -697,7 +697,7 @@ func TestRampingArrivalRateGlobalIters(t *testing.T) {
 
 			gotIters := []uint64{}
 			var mx sync.Mutex
-			runner := simpleRunner(func(ctx context.Context, state *lib.State) error {
+			runner := simpleRunner(func(_ context.Context, state *lib.State) error {
 				mx.Lock()
 				gotIters = append(gotIters, state.GetScenarioGlobalVUIter())
 				mx.Unlock()

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -108,7 +108,7 @@ func TestRampingVUsRun(t *testing.T) {
 
 	var iterCount int64
 
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		// Sleeping for a weird duration somewhat offset from the
 		// executor ticks to hopefully keep race conditions out of
 		// our control from failing the test.
@@ -388,7 +388,7 @@ func TestRampingVUsRampDownNoWobble(t *testing.T) {
 		},
 	}
 
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		time.Sleep(500 * time.Millisecond)
 		return nil
 	})

--- a/lib/executor/shared_iterations_test.go
+++ b/lib/executor/shared_iterations_test.go
@@ -31,7 +31,7 @@ func TestSharedIterationsRun(t *testing.T) {
 	t.Parallel()
 	var doneIters uint64
 
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
 		atomic.AddUint64(&doneIters, 1)
 		return nil
 	})
@@ -52,7 +52,7 @@ func TestSharedIterationsRunVariableVU(t *testing.T) {
 		slowVUID uint64
 	)
 
-	runner := simpleRunner(func(ctx context.Context, state *lib.State) error {
+	runner := simpleRunner(func(_ context.Context, state *lib.State) error {
 		time.Sleep(10 * time.Millisecond) // small wait to stabilize the test
 		// Pick one VU randomly and always slow it down.
 		sid := atomic.LoadUint64(&slowVUID)
@@ -73,7 +73,7 @@ func TestSharedIterationsRunVariableVU(t *testing.T) {
 	require.NoError(t, test.executor.Run(test.ctx, nil))
 
 	var totalIters uint64
-	result.Range(func(key, value interface{}) bool {
+	result.Range(func(_, value interface{}) bool {
 		totalIters += value.(uint64) //nolint:forcetypeassert
 		return true
 	})
@@ -137,7 +137,7 @@ func TestSharedIterationsGlobalIters(t *testing.T) {
 
 			gotIters := []uint64{}
 			var mx sync.Mutex
-			runner := simpleRunner(func(ctx context.Context, state *lib.State) error {
+			runner := simpleRunner(func(_ context.Context, state *lib.State) error {
 				mx.Lock()
 				gotIters = append(gotIters, state.GetScenarioGlobalVUIter())
 				mx.Unlock()

--- a/lib/executor/vu_handle_test.go
+++ b/lib/executor/vu_handle_test.go
@@ -35,7 +35,7 @@ func TestVUHandleRace(t *testing.T) {
 	logEntry := logrus.NewEntry(testLog)
 
 	runner := &minirunner.MiniRunner{}
-	runner.Fn = func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
+	runner.Fn = func(_ context.Context, _ *lib.State, _ chan<- metrics.SampleContainer) error {
 		return nil
 	}
 
@@ -124,7 +124,7 @@ func TestVUHandleStartStopRace(t *testing.T) {
 	logEntry := logrus.NewEntry(testLog)
 
 	runner := &minirunner.MiniRunner{}
-	runner.Fn = func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
+	runner.Fn = func(_ context.Context, _ *lib.State, _ chan<- metrics.SampleContainer) error {
 		return nil
 	}
 
@@ -367,7 +367,7 @@ func BenchmarkVUHandleIterations(b *testing.B) {
 	}
 
 	runner := &minirunner.MiniRunner{}
-	runner.Fn = func(ctx context.Context, _ *lib.State, out chan<- metrics.SampleContainer) error {
+	runner.Fn = func(_ context.Context, _ *lib.State, _ chan<- metrics.SampleContainer) error {
 		return nil
 	}
 	getVU := func() (lib.InitializedVU, error) {

--- a/lib/fsext/walk.go
+++ b/lib/fsext/walk.go
@@ -32,7 +32,6 @@ func readDirNames(fs afero.Fs, dirname string) ([]string, error) {
 		return nil, err
 	}
 	err = f.Close()
-
 	if err != nil {
 		return nil, err
 	}

--- a/lib/netext/grpcext/conn_test.go
+++ b/lib/netext/grpcext/conn_test.go
@@ -22,7 +22,7 @@ import (
 func TestInvoke(t *testing.T) {
 	t.Parallel()
 
-	helloReply := func(in, out *dynamicpb.Message, _ ...grpc.CallOption) error {
+	helloReply := func(_, out *dynamicpb.Message, _ ...grpc.CallOption) error {
 		err := protojson.Unmarshal([]byte(`{"reply":"text reply"}`), out)
 		require.NoError(t, err)
 
@@ -45,7 +45,7 @@ func TestInvoke(t *testing.T) {
 func TestInvokeWithCallOptions(t *testing.T) {
 	t.Parallel()
 
-	reply := func(in, out *dynamicpb.Message, opts ...grpc.CallOption) error {
+	reply := func(_, _ *dynamicpb.Message, opts ...grpc.CallOption) error {
 		assert.Len(t, opts, 3) // two by default plus one injected
 		return nil
 	}
@@ -63,7 +63,7 @@ func TestInvokeWithCallOptions(t *testing.T) {
 func TestInvokeReturnError(t *testing.T) {
 	t.Parallel()
 
-	helloReply := func(in, out *dynamicpb.Message, _ ...grpc.CallOption) error {
+	helloReply := func(_, _ *dynamicpb.Message, _ ...grpc.CallOption) error {
 		return fmt.Errorf("test error")
 	}
 

--- a/lib/netext/httpext/error_codes_test.go
+++ b/lib/netext/httpext/error_codes_test.go
@@ -180,7 +180,7 @@ func TestHTTP2StreamError(t *testing.T) {
 	t.Parallel()
 	tb := httpmultibin.NewHTTPMultiBin(t)
 
-	tb.Mux.HandleFunc("/tsr", func(rw http.ResponseWriter, req *http.Request) {
+	tb.Mux.HandleFunc("/tsr", func(rw http.ResponseWriter, _ *http.Request) {
 		rw.Header().Set("Content-Length", "100000")
 		rw.WriteHeader(http.StatusOK)
 
@@ -264,7 +264,7 @@ func TestDefaultTLSError(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	go func() {
-		conn, err := l.Accept() //nolint:govet // the shadowing is intentional
+		conn, err := l.Accept()
 		require.NoError(t, err)
 		_, err = conn.Write([]byte("not tls header")) // we just want to get an error
 		require.NoError(t, err)
@@ -296,7 +296,7 @@ func TestHTTP2ConnectionError(t *testing.T) {
 	tb := getHTTP2ServerWithCustomConnContext(t)
 
 	// Pre-configure the HTTP client transport with the dialer and TLS config (incl. HTTP2 support)
-	tb.Mux.HandleFunc("/tsr", func(rw http.ResponseWriter, req *http.Request) {
+	tb.Mux.HandleFunc("/tsr", func(_ http.ResponseWriter, req *http.Request) {
 		conn := req.Context().Value(connKey).(*tls.Conn) //nolint:forcetypeassert
 		f := http2.NewFramer(conn, conn)
 		require.NoError(t, f.WriteData(3213, false, []byte("something")))
@@ -316,7 +316,7 @@ func TestHTTP2GoAwayError(t *testing.T) {
 	t.Parallel()
 
 	tb := getHTTP2ServerWithCustomConnContext(t)
-	tb.Mux.HandleFunc("/tsr", func(rw http.ResponseWriter, req *http.Request) {
+	tb.Mux.HandleFunc("/tsr", func(_ http.ResponseWriter, req *http.Request) {
 		conn := req.Context().Value(connKey).(*tls.Conn) //nolint:forcetypeassert
 		f := http2.NewFramer(conn, conn)
 		require.NoError(t, f.WriteGoAway(4, http2.ErrCodeInadequateSecurity, []byte("whatever")))

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -108,7 +108,7 @@ func TestMakeRequestError(t *testing.T) {
 
 	t.Run("invalid upgrade response", func(t *testing.T) {
 		t.Parallel()
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Add("Connection", "Upgrade")
 			w.Header().Add("Upgrade", "h2c")
 			w.WriteHeader(http.StatusSwitchingProtocols)
@@ -161,7 +161,7 @@ func TestResponseStatus(t *testing.T) {
 			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
-				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(tc.statusCode)
 				}))
 				defer server.Close()
@@ -232,7 +232,7 @@ func TestURL(t *testing.T) {
 
 func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 	t.Parallel()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Add("Content-Length", "100000")
 		w.WriteHeader(http.StatusOK)
 		if f, ok := w.(http.Flusher); ok {
@@ -440,7 +440,7 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 
 func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 	t.Parallel()
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		time.Sleep(100 * time.Millisecond)
 	}))
 	defer srv.Close()
@@ -496,7 +496,7 @@ func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 func TestMakeRequestRPSLimit(t *testing.T) {
 	t.Parallel()
 	var requests int64
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		atomic.AddInt64(&requests, 1)
 	}))
 	defer ts.Close()

--- a/lib/netext/httpext/transport_test.go
+++ b/lib/netext/httpext/transport_test.go
@@ -57,7 +57,7 @@ func BenchmarkMeasureAndEmitMetrics(b *testing.B) {
 		}
 	})
 
-	t.responseCallback = func(n int) bool { return true }
+	t.responseCallback = func(_ int) bool { return true }
 
 	b.Run("responseCallback", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -239,11 +239,11 @@ func TestOptions(t *testing.T) {
 					"CgYIKoZIzj0EAwIDSAAwRQIgSGxnJ+/cLUNTzt7fhr/mjJn7ShsTW33dAdfLM7H2\n" +
 					"z/gCIQDyVf8DePtxlkMBScTxZmIlMQdNc6+6VGZQ4QscruVLmg==\n" +
 					"-----END CERTIFICATE-----",
-				Key: "-----BEGIN EC PRIVATE KEY-----\n" + //nolint:goconst
+				Key: "-----BEGIN EC PRIVATE KEY-----\n" +
 					"MHcCAQEEIAfJeoc+XgcqmYV0b4owmofx0LXwPRqOPXMO+PUKxZSgoAoGCCqGSM49\n" +
 					"AwEHoUQDQgAEtp/EQ6YEeTNup33/RVlf/f2o7bJCrYbPl9pF2/LfyS4swJX70dit\n" +
 					"8zHoZgJnNNQirqHxBc6uWBhOLG5RV+Ek1Q==\n" +
-					"-----END EC PRIVATE KEY-----", //nolint:goconst
+					"-----END EC PRIVATE KEY-----",
 			}, nil},
 			{TLSAuthFields{
 				Domains: []string{"sub.example.com"},

--- a/log/loki.go
+++ b/log/loki.go
@@ -162,7 +162,7 @@ func (h *lokiHook) Listen(ctx context.Context) {
 	defer ticker.Stop()
 	defer close(pushCh)
 
-	go func() {
+	go func() { //nolint:contextcheck
 		defer close(pushDone)
 		oldLogs := make([]tmpMsg, 0, h.limit*2)
 		for ch := range pushCh {

--- a/log/loki_test.go
+++ b/log/loki_test.go
@@ -156,7 +156,7 @@ func TestLokiFlushingOnStop(t *testing.T) {
 	t.Parallel()
 	receivedData := make(chan string, 1)
 	srv := httptest.NewServer(
-		http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 			b, err := io.ReadAll(req.Body)
 			if err != nil {
 				t.Fatal(err)
@@ -196,7 +196,7 @@ func TestLokiHeaders(t *testing.T) {
 	t.Parallel()
 	receivedHeaders := make(chan http.Header, 1)
 	srv := httptest.NewServer(
-		http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 			receivedHeaders <- req.Header
 			close(receivedHeaders) // see comment in TestLokiFlushingOnStop
 		}),

--- a/output/cloud/expv2/metrics_client_test.go
+++ b/output/cloud/expv2/metrics_client_test.go
@@ -17,7 +17,7 @@ func TestMetricsClientPush(t *testing.T) {
 	t.Parallel()
 
 	reqs := 0
-	h := func(rw http.ResponseWriter, r *http.Request) {
+	h := func(_ http.ResponseWriter, r *http.Request) {
 		reqs++
 
 		assert.Equal(t, "/v2/metrics/test-ref-id", r.URL.Path)

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -198,7 +198,7 @@ func TestOutputStartVersionedOutputV1Error(t *testing.T) {
 func TestOutputStartWithTestRunID(t *testing.T) {
 	t.Parallel()
 
-	handler := func(w http.ResponseWriter, r *http.Request) {
+	handler := func(_ http.ResponseWriter, _ *http.Request) {
 		// no calls are expected to the cloud service when
 		// the reference ID is passed
 		t.Error("got unexpected call")

--- a/output/influxdb/output_test.go
+++ b/output/influxdb/output_test.go
@@ -112,7 +112,7 @@ func TestOutput(t *testing.T) {
 		}
 
 		rw.WriteHeader(http.StatusNoContent)
-	}, func(tb testing.TB, c *Output) {
+	}, func(_ testing.TB, c *Output) {
 		samples := make(metrics.Samples, 10)
 		for i := 0; i < len(samples); i++ {
 			samples[i] = metrics.Sample{
@@ -142,7 +142,7 @@ func TestOutputFlushMetricsConcurrency(t *testing.T) {
 	)
 
 	wg := sync.WaitGroup{}
-	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		// block all the received requests
 		// so concurrency will be needed
 		// to not block the flush

--- a/output/statsd/helper_test.go
+++ b/output/statsd/helper_test.go
@@ -44,7 +44,7 @@ func baseTest(t *testing.T,
 			case <-end:
 				return
 			default:
-				n, _, err := listener.ReadFromUDP(buf[:]) //nolint:govet // it is on purpose
+				n, _, err := listener.ReadFromUDP(buf[:])
 				require.NoError(t, err)
 				ch <- string(buf[:n])
 			}

--- a/output/statsd/output.go
+++ b/output/statsd/output.go
@@ -101,7 +101,6 @@ func (o *Output) Start() error {
 	}
 
 	o.client, err = statsd.NewBuffered(o.config.Addr.String, int(o.config.BufferSize.Int64))
-
 	if err != nil {
 		o.logger.Errorf("Couldn't make buffered client, %s", err)
 		return err


### PR DESCRIPTION
## What?

The latest golangci-lint apparently enabled some more lint corner cases. So a bunch of things started complaining.

Most of it is unused parameters

## Why?

Part of #769 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
