### PR TITLE
golangci-lint: Disable forcetypeassert for tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ issues:
        - gocognit
        - funlen
        - lll
+       - forcetypeassert
    - path: js\/modules\/k6\/http\/.*_test\.go
      linters:
        # k6/http module's tests are quite complex because they often have several nested levels.

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -454,7 +454,7 @@ BigInt(1231412444)`,
 			require.Len(t, entries, 1)
 			assert.Equal(t, logrus.WarnLevel, entries[0].Level)
 			assert.Contains(t, entries[0].Message, "There were unknown fields")
-			assert.Contains(t, entries[0].Data["error"].(error).Error(), "unknown field \"something\"") //nolint:forcetypeassert
+			assert.Contains(t, entries[0].Data["error"].(error).Error(), "unknown field \"something\"")
 		})
 	})
 }

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -573,7 +573,7 @@ func TestRequest(t *testing.T) {
 			logEntry := ts.hook.LastEntry()
 			require.NotNil(t, logEntry)
 			assert.Equal(t, logrus.WarnLevel, logEntry.Level)
-			assert.ErrorContains(t, logEntry.Data["error"].(error), expErr) //nolint:forcetypeassert
+			assert.ErrorContains(t, logEntry.Data["error"].(error), expErr)
 			assert.Equal(t, "Request Failed", logEntry.Message)
 		})
 
@@ -599,7 +599,7 @@ func TestRequest(t *testing.T) {
 			logEntry := ts.hook.LastEntry()
 			require.NotNil(t, logEntry)
 			assert.Equal(t, logrus.WarnLevel, logEntry.Level)
-			assert.ErrorContains(t, logEntry.Data["error"].(error), expErr) //nolint:forcetypeassert
+			assert.ErrorContains(t, logEntry.Data["error"].(error), expErr)
 			assert.Equal(t, "Request Failed", logEntry.Message)
 		})
 	})
@@ -2084,7 +2084,7 @@ func TestRequestAndBatchTLS(t *testing.T) {
 				return hosts
 			}(),
 		}
-		client.Transport.(*http.Transport).DialContext = state.Dialer.DialContext //nolint:forcetypeassert
+		client.Transport.(*http.Transport).DialContext = state.Dialer.DialContext
 		_, err = rt.RunString(`throw JSON.stringify(http.get("https://expired.localhost/"));`)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "x509: certificate has expired or is not yet valid")
@@ -2136,7 +2136,7 @@ func TestRequestAndBatchTLS(t *testing.T) {
 			state.Dialer = &netext.Dialer{Hosts: hosts}
 			state.Transport = client.Transport
 			state.TLSConfig = s.TLS
-			client.Transport.(*http.Transport).DialContext = state.Dialer.DialContext //nolint:forcetypeassert
+			client.Transport.(*http.Transport).DialContext = state.Dialer.DialContext
 			realURL := "https://" + versionTest.URL + "/"
 			_, err = rt.RunString(fmt.Sprintf(`
             var res = http.get("%s");
@@ -2181,7 +2181,7 @@ func TestRequestAndBatchTLS(t *testing.T) {
 			state.Dialer = &netext.Dialer{Hosts: hosts}
 			state.Transport = client.Transport
 			state.TLSConfig = s.TLS
-			client.Transport.(*http.Transport).DialContext = state.Dialer.DialContext //nolint:forcetypeassert
+			client.Transport.(*http.Transport).DialContext = state.Dialer.DialContext
 			realURL := "https://" + cipherSuiteTest.URL + "/"
 			_, err = rt.RunString(fmt.Sprintf(`
 					var res = http.get("%s");

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -1091,8 +1091,8 @@ func TestVUIntegrationInsecureRequests(t *testing.T) {
 					defer cancel()
 					initVU, err := r.NewVU(ctx, 1, 1, make(chan metrics.SampleContainer, 100))
 					require.NoError(t, err)
-					initVU.(*VU).TLSConfig.RootCAs = x509.NewCertPool() //nolint:forcetypeassert
-					initVU.(*VU).TLSConfig.RootCAs.AddCert(cert)        //nolint:forcetypeassert
+					initVU.(*VU).TLSConfig.RootCAs = x509.NewCertPool()
+					initVU.(*VU).TLSConfig.RootCAs.AddCert(cert)
 
 					vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 					err = vu.RunOnce()
@@ -1428,8 +1428,8 @@ func TestVUIntegrationTLSConfig(t *testing.T) {
 					defer cancel()
 					initVU, err := r.NewVU(ctx, 1, 1, make(chan metrics.SampleContainer, 100))
 					require.NoError(t, err)
-					initVU.(*VU).TLSConfig.RootCAs = x509.NewCertPool() //nolint:forcetypeassert
-					initVU.(*VU).TLSConfig.RootCAs.AddCert(cert)        //nolint:forcetypeassert
+					initVU.(*VU).TLSConfig.RootCAs = x509.NewCertPool()
+					initVU.(*VU).TLSConfig.RootCAs.AddCert(cert)
 					vu := initVU.Activate(&lib.VUActivationParams{RunContext: ctx})
 					err = vu.RunOnce()
 					if data.errMsg != "" {

--- a/lib/executor/constant_vus_test.go
+++ b/lib/executor/constant_vus_test.go
@@ -33,7 +33,7 @@ func TestConstantVUsRun(t *testing.T) {
 		default:
 		}
 		currIter, _ := result.LoadOrStore(state.VUID, uint64(0))
-		result.Store(state.VUID, currIter.(uint64)+1) //nolint:forcetypeassert
+		result.Store(state.VUID, currIter.(uint64)+1)
 		time.Sleep(210 * time.Millisecond)
 		return nil
 	})
@@ -45,7 +45,7 @@ func TestConstantVUsRun(t *testing.T) {
 
 	var totalIters uint64
 	result.Range(func(_, value interface{}) bool {
-		vuIters := value.(uint64) //nolint:forcetypeassert
+		vuIters := value.(uint64)
 		assert.Equal(t, uint64(5), vuIters)
 		totalIters += vuIters
 		return true

--- a/lib/executor/executors_test.go
+++ b/lib/executor/executors_test.go
@@ -345,7 +345,7 @@ var configMapTestCases = []configMapTestCase{
 		`{"carrival": {"executor": "constant-arrival-rate", "rate": 10, "duration": "10m", "preAllocatedVUs": 20}}`,
 		exp{custom: func(t *testing.T, cm lib.ScenarioConfigs) {
 			assert.Empty(t, cm["carrival"].Validate())
-			require.EqualValues(t, 20, cm["carrival"].(*ConstantArrivalRateConfig).MaxVUs.Int64) //nolint:forcetypeassert
+			require.EqualValues(t, 20, cm["carrival"].(*ConstantArrivalRateConfig).MaxVUs.Int64)
 		}},
 	},
 	{`{"carrival": {"executor": "constant-arrival-rate", "rate": 10, "duration": "10m", "maxVUs": 30}}`, exp{validationError: true}},
@@ -397,7 +397,7 @@ var configMapTestCases = []configMapTestCase{
 		`{"varrival": {"executor": "ramping-arrival-rate", "preAllocatedVUs": 20, "stages": [{"duration": "5m", "target": 10}]}}`,
 		exp{custom: func(t *testing.T, cm lib.ScenarioConfigs) {
 			assert.Empty(t, cm["varrival"].Validate())
-			require.EqualValues(t, 20, cm["varrival"].(*RampingArrivalRateConfig).MaxVUs.Int64) //nolint:forcetypeassert
+			require.EqualValues(t, 20, cm["varrival"].(*RampingArrivalRateConfig).MaxVUs.Int64)
 		}},
 	},
 	{`{"varrival": {"executor": "ramping-arrival-rate", "maxVUs": 50, "stages": [{"duration": "5m", "target": 10}]}}`, exp{validationError: true}},

--- a/lib/executor/externally_controlled_test.go
+++ b/lib/executor/externally_controlled_test.go
@@ -58,7 +58,7 @@ func TestExternallyControlledRun(t *testing.T) {
 			MaxVUs:   null.IntFrom(maxVUs),
 			Duration: types.NullDurationFrom(2 * time.Second),
 		}
-		err := test.executor.(*ExternallyControlled).UpdateConfig(test.ctx, newConfig) //nolint:forcetypeassert
+		err := test.executor.(*ExternallyControlled).UpdateConfig(test.ctx, newConfig)
 		if errMsg != "" {
 			assert.EqualError(t, err, errMsg)
 		} else {

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -32,7 +32,7 @@ func TestPerVUIterationsRun(t *testing.T) {
 
 	runner := simpleRunner(func(_ context.Context, state *lib.State) error {
 		currIter, _ := result.LoadOrStore(state.VUID, uint64(0))
-		result.Store(state.VUID, currIter.(uint64)+1) //nolint:forcetypeassert
+		result.Store(state.VUID, currIter.(uint64)+1)
 		return nil
 	})
 
@@ -44,7 +44,7 @@ func TestPerVUIterationsRun(t *testing.T) {
 
 	var totalIters uint64
 	result.Range(func(_, value interface{}) bool {
-		vuIters := value.(uint64) //nolint:forcetypeassert
+		vuIters := value.(uint64)
 		assert.Equal(t, uint64(100), vuIters)
 		totalIters += vuIters
 		return true
@@ -66,7 +66,7 @@ func TestPerVUIterationsRunVariableVU(t *testing.T) {
 			time.Sleep(200 * time.Millisecond)
 		}
 		currIter, _ := result.LoadOrStore(state.VUID, uint64(0))
-		result.Store(state.VUID, currIter.(uint64)+1) //nolint:forcetypeassert
+		result.Store(state.VUID, currIter.(uint64)+1)
 		return nil
 	})
 
@@ -81,7 +81,7 @@ func TestPerVUIterationsRunVariableVU(t *testing.T) {
 
 	var totalIters uint64
 	result.Range(func(key, value interface{}) bool {
-		vuIters := value.(uint64) //nolint:forcetypeassert
+		vuIters := value.(uint64)
 		if key != slowVUID {
 			assert.Equal(t, uint64(100), vuIters)
 		}

--- a/lib/executor/shared_iterations_test.go
+++ b/lib/executor/shared_iterations_test.go
@@ -63,7 +63,7 @@ func TestSharedIterationsRunVariableVU(t *testing.T) {
 			time.Sleep(200 * time.Millisecond)
 		}
 		currIter, _ := result.LoadOrStore(state.VUID, uint64(0))
-		result.Store(state.VUID, currIter.(uint64)+1) //nolint:forcetypeassert
+		result.Store(state.VUID, currIter.(uint64)+1)
 		return nil
 	})
 
@@ -74,7 +74,7 @@ func TestSharedIterationsRunVariableVU(t *testing.T) {
 
 	var totalIters uint64
 	result.Range(func(_, value interface{}) bool {
-		totalIters += value.(uint64) //nolint:forcetypeassert
+		totalIters += value.(uint64)
 		return true
 	})
 

--- a/lib/executor/vu_handle_test.go
+++ b/lib/executor/vu_handle_test.go
@@ -138,7 +138,7 @@ func TestVUHandleStartStopRace(t *testing.T) {
 	}
 
 	returnVU := func(v lib.InitializedVU) {
-		require.Equal(t, atomic.LoadUint64(&vuID), v.(*minirunner.VU).ID) //nolint:forcetypeassert
+		require.Equal(t, atomic.LoadUint64(&vuID), v.(*minirunner.VU).ID)
 		close(returned)
 	}
 	var interruptedIter int64

--- a/lib/netext/httpext/error_codes_test.go
+++ b/lib/netext/httpext/error_codes_test.go
@@ -297,7 +297,7 @@ func TestHTTP2ConnectionError(t *testing.T) {
 
 	// Pre-configure the HTTP client transport with the dialer and TLS config (incl. HTTP2 support)
 	tb.Mux.HandleFunc("/tsr", func(_ http.ResponseWriter, req *http.Request) {
-		conn := req.Context().Value(connKey).(*tls.Conn) //nolint:forcetypeassert
+		conn := req.Context().Value(connKey).(*tls.Conn)
 		f := http2.NewFramer(conn, conn)
 		require.NoError(t, f.WriteData(3213, false, []byte("something")))
 	})
@@ -317,7 +317,7 @@ func TestHTTP2GoAwayError(t *testing.T) {
 
 	tb := getHTTP2ServerWithCustomConnContext(t)
 	tb.Mux.HandleFunc("/tsr", func(_ http.ResponseWriter, req *http.Request) {
-		conn := req.Context().Value(connKey).(*tls.Conn) //nolint:forcetypeassert
+		conn := req.Context().Value(connKey).(*tls.Conn)
 		f := http2.NewFramer(conn, conn)
 		require.NoError(t, f.WriteGoAway(4, http2.ErrCodeInadequateSecurity, []byte("whatever")))
 		require.NoError(t, conn.CloseWrite())

--- a/log/file_test.go
+++ b/log/file_test.go
@@ -108,7 +108,7 @@ func TestFileHookFromConfigLine(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.NotNil(t, res.(*fileHook).w) //nolint:forcetypeassert
+			assert.NotNil(t, res.(*fileHook).w)
 		})
 	}
 }

--- a/metrics/engine/ingester_test.go
+++ b/metrics/engine/ingester_test.go
@@ -43,7 +43,7 @@ func TestIngesterOutputFlushMetrics(t *testing.T) {
 	require.NotNil(t, metric.Sink)
 	assert.Equal(t, testMetric, metric)
 
-	sink := metric.Sink.(*metrics.TrendSink) //nolint:forcetypeassert
+	sink := metric.Sink.(*metrics.TrendSink)
 	assert.Equal(t, 42.0, sink.Total())
 }
 


### PR DESCRIPTION
## What?

Disable forcetypeassert on tests.

## Why?

It seems most core developers agree this isn't really a good linter for tests and makes a lot of them more complicated or longer.

see https://github.com/grafana/k6/pull/3701#discussion_r1574671547


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
