### PR TITLE
Global timers

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -283,6 +283,7 @@ func (b *Bundle) instantiate(vuImpl *moduleVUImpl, vuID uint64) (*goja.Object, e
 
 	modSys := modules.NewModuleSystem(b.ModuleResolver, vuImpl)
 	b.setInitGlobals(rt, vuImpl, modSys)
+	modules.ExportGloballyModule(rt, modSys, "k6/timers")
 	vuImpl.initEnv = initenv
 	defer func() {
 		vuImpl.initEnv = nil

--- a/js/modules/k6/timers/timers.go
+++ b/js/modules/k6/timers/timers.go
@@ -62,10 +62,12 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 func (e *Timers) Exports() modules.Exports {
 	return modules.Exports{
 		Named: map[string]interface{}{
-			"setTimeout":    e.setTimeout,
-			"clearTimeout":  e.clearTimeout,
-			"setInterval":   e.setInterval,
-			"clearInterval": e.clearInterval,
+			// TODO the usage of `ToValue` here is so that goja doesn't do it automatically later
+			// which will effectively create new instance each time it is accessed.
+			"setTimeout":    e.vu.Runtime().ToValue(e.setTimeout),
+			"clearTimeout":  e.vu.Runtime().ToValue(e.clearTimeout),
+			"setInterval":   e.vu.Runtime().ToValue(e.setInterval),
+			"clearInterval": e.vu.Runtime().ToValue(e.clearInterval),
 		},
 	}
 }

--- a/js/modules/resolution.go
+++ b/js/modules/resolution.go
@@ -194,3 +194,15 @@ func (ms *ModuleSystem) RunSourceData(source *loader.SourceData) (goja.Value, er
 	}
 	return ms.Require(pwd, specifier)
 }
+
+// ExportGloballyModule sets all exports of the provided module name on the globalThis.
+// effectively making them globally available
+func ExportGloballyModule(rt *goja.Runtime, modSys *ModuleSystem, moduleName string) {
+	t, _ := modSys.Require(nil, moduleName)
+
+	for _, key := range t.Keys() {
+		if err := rt.Set(key, t.Get(key)); err != nil {
+			panic(fmt.Errorf("failed to set '%s' global object: %w", key, err))
+		}
+	}
+}


### PR DESCRIPTION
## What?

Make k6/timers globally available

## Why?

This is in general what most users expect - just being able to use `setTimeout` directly.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#3589 