### PR TITLE
k6/execution:Don't panic on accessing test.options

### DIFF
--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -176,8 +176,12 @@ func (mi *ModuleInstance) newTestInfo() (*goja.Object, error) {
 			}
 		},
 		"options": func() interface{} {
+			vuState := mi.vu.State()
+			if vuState == nil {
+				common.Throw(rt, fmt.Errorf("getting test options in the init context is not supported"))
+			}
 			if optionsObject == nil {
-				opts, err := optionsAsObject(rt, mi.vu.State().Options)
+				opts, err := optionsAsObject(rt, vuState.Options)
 				if err != nil {
 					common.Throw(rt, err)
 				}

--- a/js/modules/k6/execution/execution.go
+++ b/js/modules/k6/execution/execution.go
@@ -127,12 +127,15 @@ func (mi *ModuleInstance) newScenarioInfo() (*goja.Object, error) {
 	return newInfoObj(rt, si)
 }
 
+//nolint:lll,gochecknoglobals
+var instanceInfoInitContextErr = common.NewInitContextError("getting instance information in the init context is not supported")
+
 // newInstanceInfo returns a goja.Object with property accessors to retrieve
 // information about the local instance stats.
 func (mi *ModuleInstance) newInstanceInfo() (*goja.Object, error) {
 	es := lib.GetExecutionState(mi.vu.Context())
 	if es == nil {
-		return nil, errors.New("getting instance information in the init context is not supported")
+		return nil, instanceInfoInitContextErr
 	}
 	rt := mi.vu.Runtime()
 
@@ -157,6 +160,9 @@ func (mi *ModuleInstance) newInstanceInfo() (*goja.Object, error) {
 	return newInfoObj(rt, ti)
 }
 
+//nolint:gochecknoglobals
+var testInfoInitContextErr = common.NewInitContextError("getting test options in the init context is not supported")
+
 // newTestInfo returns a goja.Object with property accessors to retrieve
 // information and control execution of the overall test run.
 func (mi *ModuleInstance) newTestInfo() (*goja.Object, error) {
@@ -178,7 +184,7 @@ func (mi *ModuleInstance) newTestInfo() (*goja.Object, error) {
 		"options": func() interface{} {
 			vuState := mi.vu.State()
 			if vuState == nil {
-				common.Throw(rt, fmt.Errorf("getting test options in the init context is not supported"))
+				common.Throw(rt, testInfoInitContextErr)
 			}
 			if optionsObject == nil {
 				opts, err := optionsAsObject(rt, vuState.Options)
@@ -194,12 +200,15 @@ func (mi *ModuleInstance) newTestInfo() (*goja.Object, error) {
 	return newInfoObj(rt, ti)
 }
 
+//nolint:gochecknoglobals
+var vuInfoInitContextErr = common.NewInitContextError("getting VU information in the init context is not supported")
+
 // newVUInfo returns a goja.Object with property accessors to retrieve
 // information about the currently executing VU.
 func (mi *ModuleInstance) newVUInfo() (*goja.Object, error) {
 	vuState := mi.vu.State()
 	if vuState == nil {
-		return nil, errors.New("getting VU information in the init context is not supported")
+		return nil, vuInfoInitContextErr
 	}
 	rt := mi.vu.Runtime()
 

--- a/js/modules/k6/execution/execution_test.go
+++ b/js/modules/k6/execution/execution_test.go
@@ -444,6 +444,23 @@ func TestScenarioNoAvailableInInitContext(t *testing.T) {
 	}
 }
 
+func TestOptionsNoAvailableInInitContext(t *testing.T) {
+	t.Parallel()
+
+	rt := goja.New()
+	m, ok := New().NewModuleInstance(
+		&modulestest.VU{
+			RuntimeField: rt,
+			CtxField:     context.Background(),
+		},
+	).(*ModuleInstance)
+	require.True(t, ok)
+	require.NoError(t, rt.Set("exec", m.Exports().Default))
+
+	_, err := rt.RunString("exec.test.options")
+	require.ErrorContains(t, err, "getting test options in the init context is not supported")
+}
+
 func TestVUDefaultDetails(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What?

Fixes a panic when accessing `k6/execution`.test.options in the init context.

## Why?

Not to panic but give an exception.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
