### PR TITLE
Add recent browser PR merges to release notes

### DIFF
--- a/release notes/v0.51.0.md
+++ b/release notes/v0.51.0.md
@@ -35,8 +35,8 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 
 ## Maintenance and internal improvements
 
-- [browser#1262](https://github.com/grafana/xk6-browser/pull/1262) fixes a flakey test.
-- [browser#1264](https://github.com/grafana/xk6-browser/pull/1264) removes unimplemented apis.
+- [browser#1262](https://github.com/grafana/xk6-browser/pull/1262) fixes a flaky test.
+- [browser#1264](https://github.com/grafana/xk6-browser/pull/1264) removes unimplemented APIs.
 
 ## _Optional_ Roadmap
 

--- a/release notes/v0.51.0.md
+++ b/release notes/v0.51.0.md
@@ -27,19 +27,16 @@ _what, why, and what this means for the user_
 
 _Format as `<number> <present_verb> <object>. <credit>`_:
 
-- _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
-- `#pr` `<description>`
-- `#pr` `<description>`
+- [browser#1259](https://github.com/grafana/xk6-browser/pull/1259), [browser#1260](https://github.com/grafana/xk6-browser/pull/1260) adds errors to the traces that the browser module generates.
 
 ## Bug fixes
 
-_Format as `<number> <present_verb> <object>. <credit>`_:
-- _`#111` fixes race condition in runtime_
+- [browser#1261](https://github.com/grafana/xk6-browser/pull/1261) fixes dispose context canceled errors.
 
 ## Maintenance and internal improvements
 
-_Format as `<number> <present_verb> <object>. <credit>`_:
-- _`#2770` Refactors parts of the JS module._
+- [browser#1262](https://github.com/grafana/xk6-browser/pull/1262) fixes a flakey test.
+- [browser#1264](https://github.com/grafana/xk6-browser/pull/1264) removes unimplemented apis.
 
 ## _Optional_ Roadmap
 


### PR DESCRIPTION
## What?

Add recent browser PR merges to release notes.

## Why?

To keep users up to date with browser related changes.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/xk6-browser/pull/1259
https://github.com/grafana/xk6-browser/pull/1260
https://github.com/grafana/xk6-browser/pull/1261
https://github.com/grafana/xk6-browser/pull/1262
https://github.com/grafana/xk6-browser/pull/1264