### PR TITLE
golangci-lint: enable it for all issues not just new

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -28,5 +28,4 @@ runs:
       uses: golangci/golangci-lint-action@349d20632dbaed38f0a492cc991152e3d351e854 # latest commit at the time that uses node20
       with:
         version: ${{ steps.getenv.outputs.GolangCIVersion }}
-        only-new-issues: true
         args: "--config=${{ github.action_path }}/.golangci.yml"

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ check-linter-version:
 ## lint: Runs the linters.
 lint: check-linter-version
 	echo "Running linters..."
-	golangci-lint run --out-format=tab --new-from-rev master ./...
+	golangci-lint run --out-format=tab ./...
 
 ## tests: Executes any unit tests.
 tests:


### PR DESCRIPTION
## What?

Just call golangci-lint over the whole project not just the "new" parts.

## Why?

As now all lint issues are fixed we can enable without that option.

Unfortunately the option only looks at code at and around the places that was changed and if any of it has new lint errors it will trigger.

That does mean that if you update golangci-lint - it won't showcase new lint errors it triggers.

Also won't work if you add a bunch of code to the end an already somewhat long function. As the lint error will be at the beginning of the function.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#769 