### PR TITLE
fix line numbers when inline sourcemap is used

### DIFF
--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -216,7 +216,7 @@ func (c *Compiler) compileImpl(
 			conditionalNewLine = "\n"
 			newCode, err := state.updateInlineSourceMap(code, index)
 			if err != nil {
-				c.logger.Warnf("while compiling %q we couldn't update it's inline sourcemap which might lead "+
+				c.logger.Warnf("while compiling %q, couldn't update its inline sourcemap which might lead "+
 					"to some line numbers being off: %s", filename, err)
 			} else {
 				code = newCode

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -216,8 +216,8 @@ func (c *Compiler) compileImpl(
 			conditionalNewLine = "\n"
 			newCode, err := state.updateInlineSourceMap(code, index)
 			if err != nil {
-				c.logger.Warn("while compiling %q we couldn't update it's inline sourcemap which might lead "+
-					"to some line numbers being off", filename)
+				c.logger.Warnf("while compiling %q we couldn't update it's inline sourcemap which might lead "+
+					"to some line numbers being off: %s", filename, err)
 			} else {
 				code = newCode
 			}
@@ -293,7 +293,7 @@ func (c *compilationState) updateInlineSourceMap(code string, index int) (string
 	const base64EncodePrefix = "application/json;base64,"
 	if startOfBase64EncodedSourceMap := strings.Index(mapurl, base64EncodePrefix); startOfBase64EncodedSourceMap != -1 {
 		startOfBase64EncodedSourceMap += len(base64EncodePrefix)
-		b, err := base64.RawStdEncoding.DecodeString(mapurl[startOfBase64EncodedSourceMap:])
+		b, err := base64.StdEncoding.DecodeString(mapurl[startOfBase64EncodedSourceMap:])
 		if err != nil {
 			return code, err
 		}
@@ -301,7 +301,7 @@ func (c *compilationState) updateInlineSourceMap(code string, index int) (string
 		if err != nil {
 			return code, err
 		}
-		encoded := base64.RawStdEncoding.EncodeToString(b)
+		encoded := base64.StdEncoding.EncodeToString(b)
 		code = code[:index] + "//# sourcemappingurl=data:application/json;base64," + encoded + code[nextnewline:]
 	}
 	return code, nil

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -4,6 +4,7 @@ package compiler
 
 import (
 	_ "embed" // we need this for embedding Babel
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -210,9 +211,17 @@ func (c *Compiler) compileImpl(
 	state := compilationState{srcMap: srcMap, compiler: c, wrapped: wrap}
 	if wrap {
 		conditionalNewLine := ""
-		if strings.Contains(code, "//# sourceMappingURL=") {
+		if index := strings.LastIndex(code, "//# sourceMappingURL="); index != -1 {
 			// the lines in the sourcemap (if available) will be fixed by increaseMappingsByOne
 			conditionalNewLine = "\n"
+			newCode, err := state.updateInlineSourceMap(code, index)
+			if err != nil {
+				c.logger.Warn("while compiling %q we couldn't update it's inline sourcemap which might lead "+
+					"to some line numbers being off", filename)
+			} else {
+				code = newCode
+			}
+
 			// if there is no sourcemap - bork only the first line of code, but leave the remaining ones.
 		}
 		code = "(function(module, exports){" + conditionalNewLine + code + "\n})\n"
@@ -273,6 +282,29 @@ func newBabel() (*babel, error) {
 	}
 
 	return result, err
+}
+
+func (c *compilationState) updateInlineSourceMap(code string, index int) (string, error) {
+	nextnewline := strings.Index(code[index:], "\n")
+	if nextnewline == -1 {
+		nextnewline = len(code[index:])
+	}
+	mapurl := code[index : index+nextnewline]
+	const base64EncodePrefix = "application/json;base64,"
+	if startOfBase64EncodedSourceMap := strings.Index(mapurl, base64EncodePrefix); startOfBase64EncodedSourceMap != -1 {
+		startOfBase64EncodedSourceMap += len(base64EncodePrefix)
+		b, err := base64.RawStdEncoding.DecodeString(mapurl[startOfBase64EncodedSourceMap:])
+		if err != nil {
+			return code, err
+		}
+		b, err = c.increaseMappingsByOne(b)
+		if err != nil {
+			return code, err
+		}
+		encoded := base64.RawStdEncoding.EncodeToString(b)
+		code = code[:index] + "//# sourcemappingurl=data:application/json;base64," + encoded + code[nextnewline:]
+	}
+	return code, nil
 }
 
 // increaseMappingsByOne increases the lines in the sourcemap by line so that it fixes the case where we need to wrap a


### PR DESCRIPTION
## What?

Fix sourcemaps when they are inlined.

Before that if there was an inline sourcemap we won't load it and go through the already used method of updating it. 

This isn't a problem if babel actually transpiles it as it will load it, but in case the sourcecode was already transpiled with inline maps this will now update the lines correctly.


## Why?

To have correct lines when people user sourcemaps . 


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#3689 