### PR TITLE
Add async api breaking change notice to release notes

### DIFF
--- a/release notes/v0.51.0.md
+++ b/release notes/v0.51.0.md
@@ -6,10 +6,22 @@ k6 `v0.51.0` is here 🎉! This release includes:
 
 ## Breaking changes
 
-- `#pr`, `<small_break_1>`
-- `#pr`, `<small_break_2>`
+### Browser APIs to Async
 
-### (_optional h3_) `<big_breaking_change>` `#pr`
+In the last release notes we mentioned this breaking change, and we wanted to remind and update you on the plan. In the **next** release, most of the synchronous browser APIs will be migrated to be asynchronous (promisifying them). We expect this will affect most if not all of our users.
+
+This breaking change will require you to add `await` in front of most of the browser module APIs. Without this `await` you will witness undocumented and unknown behavior during the runtime. To make the migration simpler we advise that you work with the latest [k6 type definitions](https://grafana.com/docs/k6/latest/set-up/configure-k6-intellisense/).
+
+You can find a list of all the APIs that we expect to convert to async in a comment in issue [browser#428](https://github.com/grafana/xk6-browser/issues/428#issuecomment-1964020837).
+
+Awaiting on something that’s not a thenable just returns that value, which means you can add the `await` keyword today on the APIs that will become async to future proof your test scripts.
+
+Here are the reasons for making this large breaking change:
+
+1. Most browser APIs use some form of long-running IO operation (networking) to perform the requested action on the web browser against the website under test. We need to avoid blocking JavaScript's runtime event loop for such operations.
+2. We're going to add more asynchronous event-based APIs (such as [page.on](https://github.com/grafana/xk6-browser/issues/1227)) that our current synchronous APIs would block.
+3. To align with how developers expect to work with JavaScript APIs.
+4. To have better compatibility with Playwright.
 
 ## New features
 


### PR DESCRIPTION
## What?

Adding the async api breaking change notice to release notes

## Why?

We need to inform as many of our users of this large breaking change so that that they are ready for it.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
