### PR TITLE
Release notes: Browser async `Tap`

### DIFF
--- a/release notes/v0.51.0.md
+++ b/release notes/v0.51.0.md
@@ -9,6 +9,7 @@ k6 `v0.51.0` is here 🎉! This release includes:
 - `#pr`, `<small_break_1>`
 - `#pr`, `<small_break_2>`
 
+
 ### (_optional h3_) `<big_breaking_change>` `#pr`
 
 ### Browser APIs to Async
@@ -27,6 +28,48 @@ Here are the reasons for making this large breaking change:
 2. We're going to add more asynchronous event-based APIs (such as [page.on](https://github.com/grafana/xk6-browser/issues/1227)) that our current synchronous APIs would block.
 3. To align with how developers expect to work with JavaScript APIs.
 4. To have better compatibility with Playwright.
+
+As a starting point, we have migrated a single API (the `tap` method), which you can find the details below that will help visualize the upcoming breaking changes.
+
+### Browser `Tap` is now an async method grafana/xk6-browser#1268
+
+This release converts the `Tap` method in the `browser` module into an asynchronous method. This change is necessary to ensure that the method can be used in async contexts and to align with the rest of the browser module's planned asynchronous API. To use the `Tap` method, you must now add the `await` keyword before the method call.
+
+Affected components:
+- [`locator.tap`](https://grafana.com/docs/k6/latest/javascript-api/k6-experimental/browser/locator/tap/)
+- [`page.tap`](https://grafana.com/docs/k6/latest/javascript-api/k6-experimental/browser/page/tap/)
+- [`frame.tap`](https://grafana.com/docs/k6/latest/javascript-api/k6-experimental/browser/frame/)
+- [`elementHandle.tap`](https://grafana.com/docs/k6/latest/javascript-api/k6-experimental/browser/elementhandle/)
+
+See the following example for how to use the `Tap` method after this change:
+
+**Before**:
+
+```javascript
+import browser from 'k6/experimental/browser'
+
+// ...
+
+export default function () {
+	// ...
+	page.tap(selector, { modifiers: ["Alt", "Control", "Meta", "Shift"] });
+	// ...
+}
+```
+
+**After**:
+
+```javascript
+import browser from 'k6/experimental/browser'
+
+// ...
+
+export default function () {
+	// ...
+	await page.tap(selector, { modifiers: ["Alt", "Control", "Meta", "Shift"] });
+	// ...
+}
+```
 
 ## New features
 


### PR DESCRIPTION
## What?

Add a breaking-change note for the async `Tap` method.

## Why?

The `Tap` method is converted from sync to async.

## Related PR(s)/Issue(s)

Updates: grafana/xk6-browser#1251