### PR TITLE
Add browser#1291 release notes

### DIFF
--- a/release notes/v0.51.0.md
+++ b/release notes/v0.51.0.md
@@ -250,6 +250,7 @@ No code needs to be changed, but you no longer need to import `k6/timers` to use
 - [#3717](https://github.com/grafana/k6/pull/3717) returns a correct line number when an inlined SourceMap is used.
 - [browser#1261](https://github.com/grafana/xk6-browser/pull/1261) fixes dispose context canceled errors.
 - [browser#1254](https://github.com/grafana/xk6-browser/pull/1254) fixes an indefinite wait when testing websites with iframes.
+- [browser#1291](https://github.com/grafana/xk6-browser/pull/1291) fixes a panic on dispose of resources during a navigation.
 
 ## Maintenance and internal improvements
 


### PR DESCRIPTION
## What?

Add https://github.com/grafana/xk6-browser/pull/1291 to the release notes.

## Why?

Keep users up to date of changes.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/xk6-browser/issues/1144