### PR TITLE
Revert "Added summary generated event"

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -202,11 +202,6 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 			})
 			if hsErr == nil {
 				hsErr = handleSummaryResult(c.gs.FS, c.gs.Stdout, c.gs.Stderr, summaryResult)
-				waitForSummaryGeneratedEvent := emitEvent(&event.Event{
-					Type: event.TestSummaryGenerated,
-					Data: &event.SummaryData{Summary: summaryResult},
-				})
-				waitForSummaryGeneratedEvent()
 			}
 			if hsErr != nil {
 				logger.WithError(hsErr).Error("failed to handle the end-of-test summary")

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -2073,7 +2073,6 @@ func TestEventSystemOK(t *testing.T) {
 		`got event IterStart with data '{Iteration:4 VUID:1 ScenarioName:default Error:<nil>}'`,
 		`got event IterEnd with data '{Iteration:4 VUID:1 ScenarioName:default Error:<nil>}'`,
 		`got event TestEnd with data '<nil>'`,
-		`got event TestSummaryGenerated with data '&{Summary:map[stdout:]}'`,
 		`got event Exit with data '&{Error:<nil>}'`,
 	}
 	log := ts.LoggerHook.Lines()
@@ -2108,7 +2107,6 @@ func TestEventSystemError(t *testing.T) {
 				"got event IterStart with data '{Iteration:0 VUID:1 ScenarioName:default Error:<nil>}'",
 				"got event IterEnd with data '{Iteration:0 VUID:1 ScenarioName:default Error:test aborted: oops! at file:///-:11:16(6)}'",
 				"got event TestEnd with data '<nil>'",
-				"got event TestSummaryGenerated with data '&{Summary:map[stdout:]}'",
 				"got event Exit with data '&{Error:test aborted: oops! at file:///-:11:16(6)}'",
 				"test aborted: oops! at file:///-:11:16(6)",
 			},
@@ -2145,7 +2143,6 @@ func TestEventSystemError(t *testing.T) {
 				"got event IterEnd with data '{Iteration:1 VUID:1 ScenarioName:default Error:Error: oops!\n\tat file:///-:9:11(3)\n}'",
 				"Error: oops!\n\tat file:///-:9:11(3)\n",
 				"got event TestEnd with data '<nil>'",
-				"got event TestSummaryGenerated with data '&{Summary:map[stdout:]}'",
 				"got event Exit with data '&{Error:<nil>}'",
 			},
 			expExitCode: 0,

--- a/event/type.go
+++ b/event/type.go
@@ -1,7 +1,5 @@
 package event
 
-import "io"
-
 // Type represents the different event types emitted by k6.
 //
 //go:generate enumer -type=Type -trimprefix Type -output type_gen.go
@@ -20,14 +18,12 @@ const (
 	IterEnd
 	// Exit is emitted when the k6 process is about to exit.
 	Exit
-	// TestSummaryGenerated is emitted when the test result summary is generated.
-	TestSummaryGenerated
 )
 
 //nolint:gochecknoglobals
 var (
 	// GlobalEvents are emitted once per test run.
-	GlobalEvents = []Type{Init, TestStart, TestEnd, TestSummaryGenerated, Exit}
+	GlobalEvents = []Type{Init, TestStart, TestEnd, Exit}
 	// VUEvents are emitted multiple times per each VU.
 	VUEvents = []Type{IterStart, IterEnd}
 )
@@ -44,9 +40,4 @@ type IterData struct {
 	VUID         uint64
 	ScenarioName string
 	Error        error
-}
-
-// SummaryData is the data sent in the TestSummaryGenerated event.
-type SummaryData struct {
-	Summary map[string]io.Reader
 }

--- a/event/type_gen.go
+++ b/event/type_gen.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 )
 
-const _TypeName = "InitTestStartTestEndIterStartIterEndExitTestSummaryGenerated"
+const _TypeName = "InitTestStartTestEndIterStartIterEndExit"
 
-var _TypeIndex = [...]uint8{0, 4, 13, 20, 29, 36, 40, 60}
+var _TypeIndex = [...]uint8{0, 4, 13, 20, 29, 36, 40}
 
 func (i Type) String() string {
 	i -= 1
@@ -18,7 +18,7 @@ func (i Type) String() string {
 	return _TypeName[_TypeIndex[i]:_TypeIndex[i+1]]
 }
 
-var _TypeValues = []Type{1, 2, 3, 4, 5, 6, 7}
+var _TypeValues = []Type{1, 2, 3, 4, 5, 6}
 
 var _TypeNameToValueMap = map[string]Type{
 	_TypeName[0:4]:   1,
@@ -27,7 +27,6 @@ var _TypeNameToValueMap = map[string]Type{
 	_TypeName[20:29]: 4,
 	_TypeName[29:36]: 5,
 	_TypeName[36:40]: 6,
-	_TypeName[40:60]: 7,
 }
 
 // TypeString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
# What?

After an internal team discussion, keeping in mind #3730, we decided to revert grafana/k6#3682 and not include it in the upcoming v0.51 release.

# Why?

We want to avoid introducing things that will be changed straight after and, on the other side, have unfortunately no capacity to get the #3730 into an upcoming release

cc: @ameetpal