### PR TITLE
Fix metrics for GRPC streams do not correctly include tags when stream ends

### DIFF
--- a/js/modules/k6/grpc/stream.go
+++ b/js/modules/k6/grpc/stream.go
@@ -75,11 +75,10 @@ func defineStream(rt *sobek.Runtime, s *stream) {
 }
 
 func (s *stream) beginStream(p *callParams) error {
-	tags := s.vu.State().Tags.GetCurrentValues()
 	req := &grpcext.StreamRequest{
 		Method:           s.method,
 		MethodDescriptor: s.methodDescriptor,
-		TagsAndMeta:      &tags,
+		TagsAndMeta:      &p.TagsAndMeta,
 		Metadata:         p.Metadata,
 	}
 

--- a/js/modules/k6/grpc/stream_test.go
+++ b/js/modules/k6/grpc/stream_test.go
@@ -10,6 +10,7 @@ import (
 
 	"go.k6.io/k6/lib/testutils/grpcservice"
 	"go.k6.io/k6/lib/testutils/httpmultibin/grpc_wrappers_testing"
+	"go.k6.io/k6/metrics"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/grafana/sobek"
@@ -405,4 +406,109 @@ func TestStream_UndefinedHandler(t *testing.T) {
 	ts.EventLoop.WaitOnRegistered()
 
 	require.ErrorContains(t, err, "handler for \"data\" event isn't a callable function")
+}
+
+// TestStream_MetricsTagsMetadata tests that the metrics tags are correctly
+// added to samples.
+func TestStream_MetricsTagsMetadata(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestState(t)
+
+	stub := &featureExplorerStub{}
+
+	savedFeatures := []*grpcservice.Feature{
+		{
+			Name: "foo",
+			Location: &grpcservice.Point{
+				Latitude:  1,
+				Longitude: 2,
+			},
+		},
+		{
+			Name: "bar",
+			Location: &grpcservice.Point{
+				Latitude:  3,
+				Longitude: 4,
+			},
+		},
+	}
+
+	stub.listFeatures = func(_ *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
+		for _, feature := range savedFeatures {
+			// adding a delay to make server response "slower"
+			time.Sleep(200 * time.Millisecond)
+
+			if err := stream.Send(feature); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	grpcservice.RegisterFeatureExplorerServer(ts.httpBin.ServerGRPC, stub)
+
+	initString := codeBlock{
+		code: `
+		var client = new grpc.Client();
+		client.load([], "../../../../lib/testutils/grpcservice/route_guide.proto");`,
+	}
+	vuString := codeBlock{
+		code: `
+		client.connect("GRPCBIN_ADDR");
+
+		let params = {
+			tags: { "tag1": "value1" },
+		};
+
+		let stream = new grpc.Stream(client, "main.FeatureExplorer/ListFeatures", params)
+		stream.on('data', function (data) {
+			call('Feature:' + data.name);
+		});
+		stream.on('end', function () {
+			call('End called');
+		});
+
+		stream.write({
+			lo: {
+			  latitude: 1,
+			  longitude: 2,
+			},
+			hi: {
+			  latitude: 1,
+			  longitude: 2,
+			},
+		});
+		stream.end();
+		`,
+	}
+
+	val, err := ts.Run(initString.code)
+	assertResponse(t, initString, err, val, ts)
+
+	ts.ToVUContext()
+
+	val, err = ts.RunOnEventLoop(vuString.code)
+
+	assertResponse(t, vuString, err, val, ts)
+
+	expTags := map[string]string{"tag1": "value1"}
+
+	samplesBuf := metrics.GetBufferedSamples(ts.samples)
+
+	assert.Len(t, samplesBuf, 5)
+	for _, samples := range samplesBuf {
+		for _, sample := range samples.GetSamples() {
+			assertTags(t, sample, expTags)
+		}
+	}
+}
+
+func assertTags(t *testing.T, sample metrics.Sample, tags map[string]string) {
+	for k, v := range tags {
+		tag, ok := sample.Tags.Get(k)
+		assert.True(t, ok)
+		assert.Equal(t, tag, v)
+	}
 }


### PR DESCRIPTION
## What?

Update the grpc stream being call to pass tags and params that include custom tags and method information

## Why?

Addresses https://github.com/grafana/k6/issues/3745

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/issues/3745

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Closes #3745 

<!-- Thanks for your contribution! 🙏🏼 -->
