### PR TITLE
Don't print empty goja stacktraces on captured panics

### DIFF
--- a/js/common/util.go
+++ b/js/common/util.go
@@ -65,21 +65,15 @@ func ToString(data interface{}) (string, error) {
 }
 
 // RunWithPanicCatching catches panic and converts into an InterruptError error that should abort a script
-func RunWithPanicCatching(logger logrus.FieldLogger, rt *goja.Runtime, fn func() error) (err error) {
+func RunWithPanicCatching(logger logrus.FieldLogger, _ *goja.Runtime, fn func() error) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			gojaStack := rt.CaptureCallStack(20, nil)
-
 			err = &errext.InterruptError{Reason: fmt.Sprintf("a panic occurred during JS execution: %s", r)}
 			// TODO figure out how to use PanicLevel without panicing .. this might require changing
 			// the logger we use see
 			// https://github.com/sirupsen/logrus/issues/1028
 			// https://github.com/sirupsen/logrus/issues/993
-			b := new(bytes.Buffer)
-			for _, s := range gojaStack {
-				s.Write(b)
-			}
-			logger.Error("panic: ", r, "\n", string(debug.Stack()), "\nGoja stack:\n", b.String())
+			logger.Error("panic: ", r, "\n", string(debug.Stack()))
 		}
 	}()
 


### PR DESCRIPTION
## What?

Stop printing an empty stacktrace of goja when capturing panics.

## Why?

This has been broken for years after some goja refactoring.

There doesn't seem to be a way for this to be fixed without a lot of boilerplate all over the code. And this functionality has not been used in the last few years in my experience.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
