### PR TITLE
Refactor group and check to not be tightly coupled

### DIFF
--- a/api/v1/group_routes.go
+++ b/api/v1/group_routes.go
@@ -6,7 +6,7 @@ import (
 )
 
 func handleGetGroups(cs *ControlSurface, rw http.ResponseWriter, _ *http.Request) {
-	root := NewGroup(cs.RunState.Runner.GetDefaultGroup(), nil)
+	root := NewGroup(cs.RunState.GroupSummary.Group(), nil)
 	groups := FlattenGroup(root)
 
 	data, err := json.Marshal(newGroupsJSONAPI(groups))
@@ -18,7 +18,7 @@ func handleGetGroups(cs *ControlSurface, rw http.ResponseWriter, _ *http.Request
 }
 
 func handleGetGroup(cs *ControlSurface, rw http.ResponseWriter, _ *http.Request, id string) {
-	root := NewGroup(cs.RunState.Runner.GetDefaultGroup(), nil)
+	root := NewGroup(cs.RunState.GroupSummary.Group(), nil)
 	groups := FlattenGroup(root)
 
 	var group *Group

--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -66,7 +66,7 @@ func TestGetGroups(t *testing.T) {
 	t.Parallel()
 
 	cs := getControlSurface(t, getTestRunState(t, lib.Options{}, &minirunner.MiniRunner{}))
-	_ = cs.RunState.GroupSummary.Start()
+    require.NoError(t, cs.RunState.GroupSummary.Start())
 	cs.RunState.GroupSummary.AddMetricSamples([]metrics.SampleContainer{
 		metrics.Sample{
 			TimeSeries: metrics.TimeSeries{
@@ -87,7 +87,7 @@ func TestGetGroups(t *testing.T) {
 			},
 		},
 	})
-	_ = cs.RunState.GroupSummary.Stop()
+	require.NoError(t, cs.RunState.GroupSummary.Stop())
 
 	g0, err := lib.NewGroup("", nil)
 	assert.NoError(t, err)

--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -66,7 +66,7 @@ func TestGetGroups(t *testing.T) {
 	t.Parallel()
 
 	cs := getControlSurface(t, getTestRunState(t, lib.Options{}, &minirunner.MiniRunner{}))
-    require.NoError(t, cs.RunState.GroupSummary.Start())
+	require.NoError(t, cs.RunState.GroupSummary.Start())
 	cs.RunState.GroupSummary.AddMetricSamples([]metrics.SampleContainer{
 		metrics.Sample{
 			TimeSeries: metrics.TimeSeries{

--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -37,6 +37,7 @@ func getTestRunState(tb testing.TB, options lib.Options, runner lib.Runner) *lib
 		TestPreInitState: piState,
 		Options:          options,
 		Runner:           runner,
+		GroupSummary:     lib.NewGroupSummary(piState.Logger),
 		RunTags:          piState.Registry.RootTagSet().WithTagsFromMap(options.RunTags),
 	}
 }
@@ -64,14 +65,36 @@ func getControlSurface(tb testing.TB, testState *lib.TestRunState) *ControlSurfa
 func TestGetGroups(t *testing.T) {
 	t.Parallel()
 
+	cs := getControlSurface(t, getTestRunState(t, lib.Options{}, &minirunner.MiniRunner{}))
+	_ = cs.RunState.GroupSummary.Start()
+	cs.RunState.GroupSummary.AddMetricSamples([]metrics.SampleContainer{
+		metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: cs.RunState.BuiltinMetrics.GroupDuration,
+				Tags:   cs.RunState.Registry.RootTagSet().With("group", "::group 1"),
+			},
+		},
+		metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: cs.RunState.BuiltinMetrics.GroupDuration,
+				Tags:   cs.RunState.Registry.RootTagSet().With("group", ""),
+			},
+		},
+		metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: cs.RunState.BuiltinMetrics.GroupDuration,
+				Tags:   cs.RunState.Registry.RootTagSet().With("group", "::group 1::group 2"),
+			},
+		},
+	})
+	_ = cs.RunState.GroupSummary.Stop()
+
 	g0, err := lib.NewGroup("", nil)
 	assert.NoError(t, err)
 	g1, err := g0.Group("group 1")
 	assert.NoError(t, err)
 	g2, err := g1.Group("group 2")
 	assert.NoError(t, err)
-
-	cs := getControlSurface(t, getTestRunState(t, lib.Options{}, &minirunner.MiniRunner{Group: g0}))
 
 	t.Run("list", func(t *testing.T) {
 		t.Parallel()

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -165,6 +165,8 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 		return err
 	}
 
+	outputs = append(outputs, testRunState.GroupSummary)
+
 	metricsEngine, err := engine.NewMetricsEngine(testRunState.Registry, logger)
 	if err != nil {
 		return err
@@ -192,7 +194,7 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 			logger.Debug("Generating the end-of-test summary...")
 			summaryResult, hsErr := test.initRunner.HandleSummary(globalCtx, &lib.Summary{
 				Metrics:         metricsEngine.ObservedMetrics,
-				RootGroup:       testRunState.Runner.GetDefaultGroup(),
+				RootGroup:       testRunState.GroupSummary.Group(),
 				TestRunDuration: executionState.GetCurrentTestRunDuration(),
 				NoColor:         c.gs.Flags.NoColor,
 				UIState: lib.UIState{

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -277,6 +277,7 @@ func (lct *loadedAndConfiguredTest) buildTestRunState(
 		Runner:           lct.initRunner,
 		Options:          lct.derivedConfig.Options, // we will always run with the derived options
 		RunTags:          lct.preInitState.Registry.RootTagSet().WithTagsFromMap(configToReinject.RunTags),
+		GroupSummary:     lib.NewGroupSummary(lct.preInitState.Logger),
 	}, nil
 }
 

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -114,7 +114,8 @@ func printExecutionDescription(
 	default:
 		for _, out := range outputs {
 			desc := out.Description()
-			if desc == engine.IngesterDescription {
+			switch desc {
+			case engine.IngesterDescription, lib.GroupSummaryDescription:
 				continue
 			}
 			if strings.HasPrefix(desc, dashboard.OutputName) {

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -342,9 +342,6 @@ func TestRequestWithBinaryFile(t *testing.T) {
 	bi, err := b.Instantiate(context.Background(), 0)
 	require.NoError(t, err)
 
-	root, err := lib.NewGroup("", nil)
-	require.NoError(t, err)
-
 	logger := logrus.New()
 	logger.Level = logrus.DebugLevel
 	logger.Out = io.Discard
@@ -354,7 +351,6 @@ func TestRequestWithBinaryFile(t *testing.T) {
 	bi.moduleVUImpl.state = &lib.State{
 		Options: lib.Options{},
 		Logger:  logger,
-		Group:   root,
 		Transport: &http.Transport{
 			DialContext: (netext.NewDialer(
 				net.Dialer{
@@ -488,9 +484,6 @@ func TestRequestWithMultipleBinaryFiles(t *testing.T) {
 	bi, err := b.Instantiate(context.Background(), 0)
 	require.NoError(t, err)
 
-	root, err := lib.NewGroup("", nil)
-	require.NoError(t, err)
-
 	logger := logrus.New()
 	logger.Level = logrus.DebugLevel
 	logger.Out = io.Discard
@@ -500,7 +493,6 @@ func TestRequestWithMultipleBinaryFiles(t *testing.T) {
 	bi.moduleVUImpl.state = &lib.State{
 		Options: lib.Options{},
 		Logger:  logger,
-		Group:   root,
 		Transport: &http.Transport{
 			DialContext: (netext.NewDialer(
 				net.Dialer{

--- a/js/modules/k6/grpc/params_test.go
+++ b/js/modules/k6/grpc/params_test.go
@@ -148,15 +148,12 @@ func newParamsTestRuntime(t *testing.T, paramsJSON string) (*modulestest.Runtime
 
 	testRuntime := modulestest.NewRuntime(t)
 	registry := metrics.NewRegistry()
-	root, err := lib.NewGroup("", nil)
-	require.NoError(t, err)
 
 	logger := logrus.New()
 	logger.SetLevel(logrus.InfoLevel)
 	logger.Out = io.Discard
 
 	state := &lib.State{
-		Group: root,
 		Options: lib.Options{
 			SystemTags: metrics.NewSystemTagSet(
 				metrics.TagName,
@@ -171,7 +168,7 @@ func newParamsTestRuntime(t *testing.T, paramsJSON string) (*modulestest.Runtime
 
 	testRuntime.MoveToVUContext(state)
 
-	_, err = testRuntime.VU.Runtime().RunString(`let params = ` + paramsJSON + `;`)
+	_, err := testRuntime.VU.Runtime().RunString(`let params = ` + paramsJSON + `;`)
 	require.NoError(t, err)
 
 	params := testRuntime.VU.Runtime().Get("params")

--- a/js/modules/k6/grpc/teststate_test.go
+++ b/js/modules/k6/grpc/teststate_test.go
@@ -142,13 +142,8 @@ func newTestState(t *testing.T) testState {
 // ToVUContext moves the test state to the VU context.
 func (ts *testState) ToVUContext() {
 	registry := metrics.NewRegistry()
-	root, err := lib.NewGroup("", nil)
-	if err != nil {
-		panic(err)
-	}
 
 	state := &lib.State{
-		Group:     root,
 		Dialer:    ts.httpBin.Dialer,
 		TLSConfig: ts.httpBin.TLSClientConfig,
 		Samples:   ts.samples,

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -128,8 +128,6 @@ type httpTestCase struct {
 func newTestCase(t testing.TB) *httpTestCase {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 
-	root, err := lib.NewGroup("", nil)
-	require.NoError(t, err)
 	registry := metrics.NewRegistry()
 
 	logger := logrus.New()
@@ -152,13 +150,12 @@ func newTestCase(t testing.TB) *httpTestCase {
 	state := &lib.State{
 		Options:    options,
 		Logger:     logger,
-		Group:      root,
 		TLSConfig:  tb.TLSClientConfig,
 		Transport:  tb.HTTPTransport,
 		BufferPool: lib.NewBufferPool(),
 		Samples:    samples,
 		Tags: lib.NewVUStateTags(registry.RootTagSet().WithTagsFromMap(map[string]string{
-			"group": root.Path,
+			"group": lib.RootGroupPath,
 		})),
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 	}

--- a/js/modules/k6/http/response_test.go
+++ b/js/modules/k6/http/response_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
 )
 
@@ -109,7 +110,6 @@ func TestResponse(t *testing.T) {
 	samples := ts.samples
 	rt := ts.runtime.VU.Runtime()
 	state := ts.runtime.VU.State()
-	root := state.Group
 	sr := tb.Replacer.Replace
 
 	tb.Mux.HandleFunc("/myforms/get", myFormHandler)
@@ -147,17 +147,14 @@ func TestResponse(t *testing.T) {
 		})
 
 		t.Run("group", func(t *testing.T) {
-			g, err := root.Group("my group")
+			groupName, err := lib.NewGroupPath(lib.RootGroupPath, "my group")
 			require.NoError(t, err)
-			old := state.Group
-			state.Group = g
 			state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
-				tagsAndMeta.SetTag("group", g.Path)
+				tagsAndMeta.SetTag("group", groupName)
 			})
 			defer func() {
-				state.Group = old
 				state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
-					tagsAndMeta.SetTag("group", old.Path)
+					tagsAndMeta.SetTag("group", "")
 				})
 			}()
 

--- a/js/modules/k6/k6.go
+++ b/js/modules/k6/k6.go
@@ -5,13 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"sync/atomic"
+	"strings"
 	"time"
 
 	"github.com/dop251/goja"
 
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
 )
 
@@ -105,25 +106,23 @@ func (mi *K6) Group(name string, val goja.Value) (goja.Value, error) {
 	if common.IsAsyncFunction(mi.vu.Runtime(), val) {
 		return goja.Undefined(), fmt.Errorf(asyncFunctionNotSupportedMsg, "group")
 	}
-	g, err := state.Group.Group(name)
+	oldGroupName, _ := state.Tags.GetCurrentValues().Tags.Get(metrics.TagGroup.String())
+	// TODO: what are we doing if group is not tagged
+	newGroupName, err := lib.NewGroupPath(oldGroupName, name)
 	if err != nil {
 		return goja.Undefined(), err
 	}
 
-	old := state.Group
-	state.Group = g
-
 	shouldUpdateTag := state.Options.SystemTags.Has(metrics.TagGroup)
 	if shouldUpdateTag {
 		state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
-			tagsAndMeta.SetSystemTagOrMeta(metrics.TagGroup, g.Path)
+			tagsAndMeta.SetSystemTagOrMeta(metrics.TagGroup, newGroupName)
 		})
 	}
 	defer func() {
-		state.Group = old
 		if shouldUpdateTag {
 			state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
-				tagsAndMeta.SetSystemTagOrMeta(metrics.TagGroup, old.Path)
+				tagsAndMeta.SetSystemTagOrMeta(metrics.TagGroup, oldGroupName)
 			})
 		}
 	}()
@@ -148,8 +147,6 @@ func (mi *K6) Group(name string, val goja.Value) (goja.Value, error) {
 }
 
 // Check will emit check metrics for the provided checks.
-//
-//nolint:funlen
 func (mi *K6) Check(arg0, checks goja.Value, extras ...goja.Value) (bool, error) {
 	state := mi.vu.State()
 	if state == nil {
@@ -174,17 +171,14 @@ func (mi *K6) Check(arg0, checks goja.Value, extras ...goja.Value) (bool, error)
 	var exc error
 	obj := checks.ToObject(rt)
 	for _, name := range obj.Keys() {
-		val := obj.Get(name)
-
-		// Resolve the check record.
-		check, err := state.Group.Check(name)
-		if err != nil {
-			return false, err
+		if strings.Contains(name, lib.GroupSeparator) {
+			return false, lib.ErrNameContainsGroupSeparator
 		}
+		val := obj.Get(name)
 
 		tags := commonTagsAndMeta.Tags
 		if state.Options.SystemTags.Has(metrics.TagCheck) {
-			tags = tags.With("check", check.Name)
+			tags = tags.With("check", name)
 		}
 
 		if common.IsAsyncFunction(rt, val) {
@@ -207,28 +201,19 @@ func (mi *K6) Check(arg0, checks goja.Value, extras ...goja.Value) (bool, error)
 			succ = false
 		}
 
-		// Emit! (But only if we have a valid context.)
-		select {
-		case <-ctx.Done():
-		default:
-			sample := metrics.Sample{
-				TimeSeries: metrics.TimeSeries{
-					Metric: state.BuiltinMetrics.Checks,
-					Tags:   tags,
-				},
-				Time:     t,
-				Metadata: commonTagsAndMeta.Metadata,
-				Value:    0,
-			}
-			if booleanVal {
-				atomic.AddInt64(&check.Passes, 1)
-				sample.Value = 1
-			} else {
-				atomic.AddInt64(&check.Fails, 1)
-			}
-
-			metrics.PushIfNotDone(ctx, state.Samples, sample)
+		sample := metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: state.BuiltinMetrics.Checks,
+				Tags:   tags,
+			},
+			Time:     t,
+			Metadata: commonTagsAndMeta.Metadata,
 		}
+		if booleanVal {
+			sample.Value = 1
+		}
+
+		metrics.PushIfNotDone(ctx, state.Samples, sample)
 
 		if exc != nil {
 			return false, exc

--- a/js/modules/k6/ws/ws_test.go
+++ b/js/modules/k6/ws/ws_test.go
@@ -85,11 +85,8 @@ func newTestState(t testing.TB) testState {
 	testRuntime := modulestest.NewRuntime(t)
 	samples := make(chan metrics.SampleContainer, 1000)
 
-	root, err := lib.NewGroup("", nil)
-	require.NoError(t, err)
 	registry := metrics.NewRegistry()
 	state := &lib.State{
-		Group:  root,
 		Dialer: tb.Dialer,
 		Options: lib.Options{
 			SystemTags: metrics.NewSystemTagSet(

--- a/lib/models.go
+++ b/lib/models.go
@@ -18,8 +18,11 @@ import (
 // GroupSeparator for group IDs.
 const GroupSeparator = "::"
 
+// RootGroupPath is the id of the root group
+const RootGroupPath = ""
+
 // ErrNameContainsGroupSeparator is emitted if you attempt to instantiate a Group or Check that contains the separator.
-var ErrNameContainsGroupSeparator = errors.New("group and check names may not contain '::'")
+var ErrNameContainsGroupSeparator = errors.New("group and check names may not contain '" + GroupSeparator + "'")
 
 // StageFields defines the fields used for a Stage; this is a dumb hack to make the JSON code
 // cleaner. pls fix.
@@ -107,13 +110,13 @@ type Group struct {
 // The root group must be created with the name "" and parent set to nil; this is the only case
 // where a nil parent or empty name is allowed.
 func NewGroup(name string, parent *Group) (*Group, error) {
-	if strings.Contains(name, GroupSeparator) {
-		return nil, ErrNameContainsGroupSeparator
-	}
-
-	path := name
+	old := RootGroupPath
 	if parent != nil {
-		path = parent.Path + GroupSeparator + path
+		old = parent.Path
+	}
+	path, err := NewGroupPath(old, name)
+	if err != nil {
+		return nil, err
 	}
 
 	hash := md5.Sum([]byte(path)) //nolint:gosec
@@ -145,6 +148,17 @@ func (g *Group) Group(name string) (*Group, error) {
 		g.OrderedGroups = append(g.OrderedGroups, group)
 	}
 	return group, nil
+}
+
+// NewGroupPath ...
+func NewGroupPath(old, path string) (string, error) {
+	if strings.Contains(path, GroupSeparator) {
+		return "", ErrNameContainsGroupSeparator
+	}
+	if old == RootGroupPath && path == RootGroupPath {
+		return RootGroupPath, nil
+	}
+	return old + GroupSeparator + path, nil
 }
 
 // Check creates a child check belonging to this group.

--- a/lib/models.go
+++ b/lib/models.go
@@ -19,6 +19,9 @@ import (
 const GroupSeparator = "::"
 
 // RootGroupPath is the id of the root group
+//
+// Note(@mstoykov): the constant shouldn't be used in all tests in order to not couple the tests too much with it.
+// Changing this will be a breaking change and in this way it will be more obvious.
 const RootGroupPath = ""
 
 // ErrNameContainsGroupSeparator is emitted if you attempt to instantiate a Group or Check that contains the separator.

--- a/lib/runner.go
+++ b/lib/runner.go
@@ -49,8 +49,6 @@ type VUActivationParams struct {
 //
 // interfacebloat: We may evaluate in the future to move out some methods;
 // but considering how central it is, it would require a huge effort.
-//
-//nolint:interfacebloat
 type Runner interface {
 	// Creates an Archive of the runner. There should be a corresponding NewFromArchive() function
 	// that will restore the runner from the archive.
@@ -72,9 +70,6 @@ type Runner interface {
 
 	// Runs post-test teardown, if applicable.
 	Teardown(ctx context.Context, out chan<- metrics.SampleContainer) error
-
-	// Returns the default (root) Group.
-	GetDefaultGroup() *Group
 
 	// Get and set options. The initial value will be whatever the script specifies (for JS,
 	// `export let options = {}`); cmd/run.go will mix this in with CLI-, config- and env-provided

--- a/lib/test_state.go
+++ b/lib/test_state.go
@@ -2,6 +2,8 @@ package lib
 
 import (
 	"io"
+	"strings"
+	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/event"
@@ -31,6 +33,118 @@ type TestRunState struct {
 	Runner  Runner // TODO: rename to something better, see type comment
 	RunTags *metrics.TagSet
 
+	GroupSummary *GroupSummary // TODO(@mstoykov): move and rename
+
 	// TODO: add other properties that are computed or derived after init, e.g.
 	// thresholds?
+}
+
+// GroupSummaryDescription is the description of the GroupSummary used to identify and ignore it
+// for the purposes of the cli descriptions.
+const GroupSummaryDescription = "Internal Group Summary output"
+
+// GroupSummary is an internal output implementation that facilitates the aggregation of
+// group and check metrics for the purposes of the end of test summary and the REST API
+type GroupSummary struct {
+	group   *Group // TODO(@mstoykov): move the whole type outside of lib later
+	ch      chan []metrics.SampleContainer
+	stopped chan struct{}
+	logger  logrus.FieldLogger
+}
+
+// NewGroupSummary returns new GroupSummary ready to be started.
+func NewGroupSummary(logger logrus.FieldLogger) *GroupSummary {
+	group, _ := NewGroup(RootGroupPath, nil)
+	return &GroupSummary{
+		group:   group,
+		ch:      make(chan []metrics.SampleContainer, 1000),
+		stopped: make(chan struct{}),
+		logger:  logger,
+	}
+}
+
+// Group returns the underlying group that has been aggregated
+func (gs *GroupSummary) Group() *Group {
+	return gs.group
+}
+
+// Description is part of the output.Output interface
+func (gs *GroupSummary) Description() string {
+	return GroupSummaryDescription
+}
+
+func buildGroup(rootGroup *Group, groupName string) (*Group, error) {
+	group := rootGroup
+	groups := strings.Split(groupName, "::")
+	var err error
+	for _, groupName := range groups[1:] {
+		group, err = group.Group(groupName)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return group, nil
+}
+
+func (gs *GroupSummary) handleSample(sample metrics.Sample) error {
+	switch sample.Metric.Name {
+	case "group_duration", "checks":
+		groupName, ok := sample.Tags.Get(metrics.TagGroup.String())
+		if !ok {
+			return nil
+		}
+		group, err := buildGroup(gs.group, groupName)
+		if err != nil {
+			return err
+		}
+
+		if sample.Metric.Name != "checks" {
+			return nil
+		}
+
+		checkName, ok := sample.Tags.Get(metrics.TagCheck.String())
+		if !ok {
+			return nil
+		}
+		check, err := group.Check(checkName)
+		if err != nil {
+			return err
+		}
+		if sample.Value == 0 {
+			atomic.AddInt64(&check.Fails, 1)
+		} else {
+			atomic.AddInt64(&check.Passes, 1)
+		}
+	}
+	return nil
+}
+
+// Start is part of the output.Output interface
+func (gs *GroupSummary) Start() error {
+	go func() {
+		defer close(gs.stopped)
+		for containers := range gs.ch {
+			for _, container := range containers {
+				for _, sample := range container.GetSamples() {
+					err := gs.handleSample(sample)
+					if err != nil {
+						gs.logger.WithError(err).Warn("couldn't handle a sample as part of group summary")
+					}
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+// Stop is part of the output.Output interface
+func (gs *GroupSummary) Stop() error {
+	close(gs.ch)
+	<-gs.stopped
+	return nil
+}
+
+// AddMetricSamples is part of the output.Output interface
+func (gs *GroupSummary) AddMetricSamples(samples []metrics.SampleContainer) {
+	gs.ch <- samples
 }

--- a/lib/testutils/minirunner/minirunner.go
+++ b/lib/testutils/minirunner/minirunner.go
@@ -28,7 +28,6 @@ type MiniRunner struct {
 
 	SetupData []byte
 
-	Group        *lib.Group
 	Options      lib.Options
 	PreInitState *lib.TestPreInitState
 
@@ -84,14 +83,6 @@ func (r MiniRunner) Teardown(ctx context.Context, out chan<- metrics.SampleConta
 		return fn(ctx, out)
 	}
 	return nil
-}
-
-// GetDefaultGroup returns the default group.
-func (r MiniRunner) GetDefaultGroup() *lib.Group {
-	if r.Group == nil {
-		r.Group = &lib.Group{}
-	}
-	return r.Group
 }
 
 // IsExecutable satisfies lib.Runner, but is mocked for MiniRunner since

--- a/lib/vu_state.go
+++ b/lib/vu_state.go
@@ -42,9 +42,6 @@ type State struct {
 	// Logger instance for every VU.
 	Logger logrus.FieldLogger
 
-	// Current group; all emitted metrics are tagged with this.
-	Group *Group
-
 	// Networking equipment.
 	Dialer DialContexter
 


### PR DESCRIPTION
## What?

Group and check were tightly coupled between them and also to the end of test summary and the REST API.

This change the tight coupling is removed. Group and check no longer interact with each other while being run.

In order to keep the same end of test summary and REST API behavior the code makes the same aggregation it used to be but *only* based on the metrics emitted by `check` and `group`.

There are several breaking changes still in it as a bunch of things are no longer useful, and technically not implementable if we want to remove the tight coupling.

The only one that is relevant though is that
`lib.State` no longer has `Group`.

There are 2 extensions using that and both of them use it to use the "magic" that tight `group` and `check` together.

## Why?

The previous code apart from having problems code smell wise, meant that you can't implement this functionality in JS.

Which also means that they act very strangely especially as if you do not look closely it just seems like they set a few tags and emit metrics. 

While working on #2728 it became apparent that it is unlikely we will get a perfect solution and one of the big problems is that you can't even experiment without having to write a fairly complicated async go code.

So this also makes that issue a bit more actionable. And definitely a thing that now people can have not perfect or even 80%, but still workable for them solutions.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#2869