### PR TITLE
Drop old linter setting (GRPC's reflection)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,12 +32,9 @@ issues:
    - path: js\/modules\/k6\/http\/.*_test\.go
      linters:
        # k6/http module's tests are quite complex because they often have several nested levels.
-       # The module is in maintainance mode, so we don't intend to port the tests to a parallel version.
+       # The module is in maintenance mode, so we don't intend to port the tests to a parallel version.
        - paralleltest
        - tparallel
-   - linters:
-     - staticcheck # Tracked in https://github.com/grafana/xk6-grpc/issues/14
-     text: "The entire proto file grpc/reflection/v1alpha/reflection.proto is marked as deprecated."
    - linters:
      - forbidigo
      text: 'use of `os\.(SyscallError|Signal|Interrupt)` forbidden'


### PR DESCRIPTION
## What?

It removes an old linter setting, set for gRPC's reflection.

## Why?

Because the issue used to track it was completed some months ago.
So, it should no longer be required, or we should re-open it create a new issue.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
