### PR TITLE
Fixes `undefined` handler passing to the gRPC stream

### DIFF
--- a/js/modules/k6/grpc/stream.go
+++ b/js/modules/k6/grpc/stream.go
@@ -293,9 +293,13 @@ func (s *stream) processSendError(err error) {
 	})
 }
 
-// on registers a listener for a certain event type
-func (s *stream) on(event string, listener func(sobek.Value) (sobek.Value, error)) {
-	if err := s.eventListeners.add(event, listener); err != nil {
+// on registers a handler for a certain event type
+func (s *stream) on(event string, handler func(sobek.Value) (sobek.Value, error)) {
+	if handler == nil {
+		common.Throw(s.vu.Runtime(), fmt.Errorf("handler for %q event isn't a callable function", event))
+	}
+
+	if err := s.eventListeners.add(event, handler); err != nil {
 		s.vu.State().Logger.Warnf("can't register %s event handler: %s", event, err)
 	}
 }

--- a/js/modules/k6/grpc/stream_test.go
+++ b/js/modules/k6/grpc/stream_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/grafana/sobek"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
@@ -362,4 +363,46 @@ func TestStream_Wrappers(t *testing.T) {
 		"Result: Hey John",
 	},
 	)
+}
+
+func TestStream_UndefinedHandler(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestState(t)
+
+	stub := grpc_wrappers_testing.Register(ts.httpBin.ServerGRPC)
+	stub.TestStreamImplementation = func(stream grpc_wrappers_testing.Service_TestStreamServer) error {
+		return stream.SendAndClose(&wrappers.StringValue{
+			Value: "test",
+		})
+	}
+
+	replace := func(code string) (sobek.Value, error) {
+		return ts.VU.Runtime().RunString(ts.httpBin.Replacer.Replace(code))
+	}
+
+	initString := codeBlock{
+		code: `
+		var client = new grpc.Client();
+		client.load([], "../../../../lib/testutils/httpmultibin/grpc_wrappers_testing/test.proto");`,
+	}
+	vuString := codeBlock{
+		code: `
+		client.connect("GRPCBIN_ADDR");
+		let stream = new grpc.Stream(client, "grpc.wrappers.testing.Service/TestStream");
+		stream.on('data', undefined);
+
+		stream.end();
+		`,
+	}
+
+	val, err := replace(initString.code)
+	assertResponse(t, initString, err, val, ts)
+
+	ts.ToVUContext()
+
+	_, err = replace(vuString.code)
+	ts.EventLoop.WaitOnRegistered()
+
+	require.ErrorContains(t, err, "handler for \"data\" event isn't a callable function")
 }


### PR DESCRIPTION
## What?

This PR fixes a panic that happens if pass undefined (null) handler to the `stream.on`

E.g.
```js
stream.on("data", undefined)
```

## Why?

We shouldn't panic

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
