### PR TITLE
Upgrade xk6-dashboard to v0.7.4 (sobek)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/websocket v1.5.1
-	github.com/grafana/sobek v0.0.0-20240606091932-2da0e9e5f3e7
+	github.com/grafana/sobek v0.0.0-20240607083612-4f0cd64f4e78
 	github.com/grafana/xk6-browser v1.5.1
-	github.com/grafana/xk6-dashboard v0.7.3
+	github.com/grafana/xk6-dashboard v0.7.4
 	github.com/grafana/xk6-output-prometheus-remote v0.3.1
 	github.com/grafana/xk6-redis v0.2.0
 	github.com/grafana/xk6-webcrypto v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -85,10 +85,14 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/grafana/sobek v0.0.0-20240606091932-2da0e9e5f3e7 h1:Ed0df3dkkPsjL0RKagJAv/821vrTBiB6GBk+198pxi4=
 github.com/grafana/sobek v0.0.0-20240606091932-2da0e9e5f3e7/go.mod h1:6ZH0b0iOxyigeTh+/IlGoL0Hd3lVXA94xoXf0ldNgCM=
+github.com/grafana/sobek v0.0.0-20240607083612-4f0cd64f4e78 h1:rVCZdB+13G+aQoGm3CBVaDGl0uxZxfjvQgEJy4IeHTA=
+github.com/grafana/sobek v0.0.0-20240607083612-4f0cd64f4e78/go.mod h1:6ZH0b0iOxyigeTh+/IlGoL0Hd3lVXA94xoXf0ldNgCM=
 github.com/grafana/xk6-browser v1.5.1 h1:wexnBtx1raDniYcXkRQ9zfXvuJGjvixZag4kmiYG3tg=
 github.com/grafana/xk6-browser v1.5.1/go.mod h1:hD9H1zpe1Fvs6RCENKnaPqpObh6alz+hX00Xf5qvDE4=
 github.com/grafana/xk6-dashboard v0.7.3 h1:47dxL87eMhpCIHSJTOnohTq3WIfCwvNriRTDvYNlsHY=
 github.com/grafana/xk6-dashboard v0.7.3/go.mod h1:7HLAY4udlWGXGDQL5gWIi+In3eZRljXi8AnHt1Z+lFM=
+github.com/grafana/xk6-dashboard v0.7.4 h1:0ZRPTAXW+6A3Xqq/a/OaIZhxUt1SOMwUFff0IPwBHrs=
+github.com/grafana/xk6-dashboard v0.7.4/go.mod h1:300QyQ+OQAYz/L/AzB5tKzPeBY5eKh2wl1NsRmCbsx4=
 github.com/grafana/xk6-output-prometheus-remote v0.3.1 h1:X23rQzlJD8dXWB31DkxR4uPnuRFo8L0Y0H22fSG9xl0=
 github.com/grafana/xk6-output-prometheus-remote v0.3.1/go.mod h1:0JLAm4ONsNUlNoxJXAwOCfA6GtDwTPs557OplAvE+3o=
 github.com/grafana/xk6-redis v0.2.0 h1:iXmAKVlAxafZ/h8ptuXTFhGu63IFsyDI8QjUgWm66BU=

--- a/vendor/github.com/grafana/sobek/aliases.go
+++ b/vendor/github.com/grafana/sobek/aliases.go
@@ -126,3 +126,5 @@ type (
 	Symbol             = goja.Symbol
 	Value              = goja.Value
 )
+
+func UncapFieldNameMapper() FieldNameMapper { return goja.UncapFieldNameMapper() }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -173,7 +173,7 @@ github.com/google/uuid
 # github.com/gorilla/websocket v1.5.1
 ## explicit; go 1.20
 github.com/gorilla/websocket
-# github.com/grafana/sobek v0.0.0-20240606091932-2da0e9e5f3e7
+# github.com/grafana/sobek v0.0.0-20240607083612-4f0cd64f4e78
 ## explicit; go 1.20
 github.com/grafana/sobek
 # github.com/grafana/xk6-browser v1.5.1
@@ -189,8 +189,8 @@ github.com/grafana/xk6-browser/keyboardlayout
 github.com/grafana/xk6-browser/log
 github.com/grafana/xk6-browser/storage
 github.com/grafana/xk6-browser/trace
-# github.com/grafana/xk6-dashboard v0.7.3
-## explicit; go 1.19
+# github.com/grafana/xk6-dashboard v0.7.4
+## explicit; go 1.20
 github.com/grafana/xk6-dashboard/dashboard
 # github.com/grafana/xk6-output-prometheus-remote v0.3.1
 ## explicit; go 1.18


### PR DESCRIPTION
## What?

Upgrade xk6-dashboard to v0.7.4

## Why?

v0.7.4 release created to use sobek instead of goja.

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- https://github.com/grafana/k6/issues/3772
- https://github.com/grafana/k6/issues/3773

