### PR TITLE
Graduate to `k6/browser` from an experimental module

### DIFF
--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -2262,7 +2262,7 @@ func TestBrowserPermissions(t *testing.T) {
 			name:             "browser option not set",
 			options:          "",
 			expectedExitCode: 0,
-			expectedError:    "GoError: browser not found in registry. make sure to set browser type option in scenario definition in order to use the browser module",
+			expectedError:    "browser not found in registry. make sure to set browser type option in scenario definition in order to use the browser module",
 		},
 		// When we do supply the correct browser options,
 		// we expect that the browser module will start
@@ -2300,12 +2300,12 @@ func TestBrowserPermissions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			script := fmt.Sprintf(`
-			import { browser } from 'k6/experimental/browser';
+			import { browser } from 'k6/browser';
 
 			%s
 
 			export default function() {
-			  browser.isConnected();
+			  browser.isConnected()
 			};
 			`, tt.options)
 

--- a/examples/experimental/browser.js
+++ b/examples/experimental/browser.js
@@ -1,5 +1,5 @@
 import { check } from 'k6';
-import { browser } from 'k6/experimental/browser';
+import { browser } from 'k6/browser';
 
 export const options = {
   scenarios: {
@@ -18,8 +18,8 @@ export const options = {
 }
 
 export default async function() {
-  const context = browser.newContext();
-  const page = context.newPage();
+  const context = await browser.newContext();
+  const page = await context.newPage();
 
   try {
     // Goto front page, find login link and click it
@@ -29,8 +29,8 @@ export default async function() {
       page.locator('a[href="/my_messages.php"]').click(),
     ]);
     // Enter login credentials and login
-    page.locator('input[name="login"]').type('admin');
-    page.locator('input[name="password"]').type('123');
+    await page.locator('input[name="login"]').type("admin");
+    await page.locator('input[name="password"]').type("123");
     // We expect the form submission to trigger a navigation, so to prevent a
     // race condition, setup a waiter concurrently while waiting for the click
     // to resolve.
@@ -38,10 +38,11 @@ export default async function() {
       page.waitForNavigation(),
       page.locator('input[type="submit"]').click(),
     ]);
-    check(page, {
-      'header': p => p.locator('h2').textContent() == 'Welcome, admin!',
+    const content = await page.locator("h2").textContent();
+    check(content, {
+      'header': content => content == 'Welcome, admin!',
     });
   } finally {
-    page.close();
+    await page.close();
   }
 }

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -49,7 +49,7 @@ func getInternalJSModules() map[string]interface{} {
 		"k6/experimental/browser": newWarnExperimentalModule(browser.NewSync(),
 			"Please update your imports to use k6/browser instead of k6/experimental/browser,"+
 				" which will be removed after September 23rd. Ensure your scripts are migrated by then."+
-				"For more information, see the migration guide at the link:"+
+				" For more information, see the migration guide at the link:"+
 				" https://grafana.com/docs/k6/latest/using-k6-browser/migrating-to-k6-v0-52/"),
 		"k6/browser":         browser.New(),
 		"k6/experimental/fs": fs.New(),

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -48,7 +48,7 @@ func getInternalJSModules() map[string]interface{} {
 		"k6/experimental/tracing": tracing.New(),
 		"k6/experimental/browser": newWarnExperimentalModule(browser.NewSync(),
 			"Please update your imports to use k6/browser instead of k6/experimental/browser,"+
-				" which will be removed after September 23rd. Ensure your scripts are migrated by then."+
+				" which will be removed after September 23rd, 2024. Ensure your scripts are migrated by then."+
 				" For more information, see the migration guide at the link:"+
 				" https://grafana.com/docs/k6/latest/using-k6-browser/migrating-to-k6-v0-52/"),
 		"k6/browser":         browser.New(),

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -48,7 +48,11 @@ func getInternalJSModules() map[string]interface{} {
 		"k6/experimental/tracing": tracing.New(),
 		"k6/experimental/browser": newWarnExperimentalModule(browser.NewSync(),
 			"k6/experimental/browser is now part of the k6 core, please change your imports to use k6/browser instead."+
-				" The k6/experimental/browser will be removed in k6 v0.54.0"),
+				" The k6/experimental/browser will be removed on or after 23rd of September,"+
+				" please ensure your scripts have been migrated to k6/browser by that date."+
+				" Please also see the migration guide at"+
+				" https://grafana.com/docs/k6/latest/using-k6-browser/migrating-to-k6-v0-52/"+
+				" for more information on how to migrate your scripts."),
 		"k6/browser":         browser.New(),
 		"k6/experimental/fs": fs.New(),
 		"k6/net/grpc":        grpc.New(),

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -46,13 +46,16 @@ func getInternalJSModules() map[string]interface{} {
 			"k6/experimental/timers is now part of the k6 core, please change your imports to use k6/timers instead."+
 				" The k6/experimental/timers will be removed in k6 v0.52.0"),
 		"k6/experimental/tracing": tracing.New(),
-		"k6/experimental/browser": browser.NewSync(),
-		"k6/experimental/fs":      fs.New(),
-		"k6/net/grpc":             grpc.New(),
-		"k6/html":                 html.New(),
-		"k6/http":                 http.New(),
-		"k6/metrics":              metrics.New(),
-		"k6/ws":                   ws.New(),
+		"k6/experimental/browser": newWarnExperimentalModule(browser.NewSync(),
+			"k6/experimental/browser is now part of the k6 core, please change your imports to use k6/browser instead."+
+				" The k6/experimental/browser will be removed in k6 v0.54.0"),
+		"k6/browser":         browser.New(),
+		"k6/experimental/fs": fs.New(),
+		"k6/net/grpc":        grpc.New(),
+		"k6/html":            html.New(),
+		"k6/http":            http.New(),
+		"k6/metrics":         metrics.New(),
+		"k6/ws":              ws.New(),
 		"k6/experimental/grpc": newRemovedModule(
 			"k6/experimental/grpc has been graduated, please use k6/net/grpc instead." +
 				" See https://grafana.com/docs/k6/latest/javascript-api/k6-net-grpc/ for more information.",

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -47,12 +47,10 @@ func getInternalJSModules() map[string]interface{} {
 				" The k6/experimental/timers will be removed in k6 v0.52.0"),
 		"k6/experimental/tracing": tracing.New(),
 		"k6/experimental/browser": newWarnExperimentalModule(browser.NewSync(),
-			"k6/experimental/browser is now part of the k6 core, please change your imports to use k6/browser instead."+
-				" The k6/experimental/browser will be removed on or after 23rd of September,"+
-				" please ensure your scripts have been migrated to k6/browser by that date."+
-				" Please also see the migration guide at"+
-				" https://grafana.com/docs/k6/latest/using-k6-browser/migrating-to-k6-v0-52/"+
-				" for more information on how to migrate your scripts."),
+			"Please update your imports to use k6/browser instead of k6/experimental/browser,"+
+				" which will be removed after September 23rd. Ensure your scripts are migrated by then."+
+				"For more information, see the migration guide at the link:"+
+				" https://grafana.com/docs/k6/latest/using-k6-browser/migrating-to-k6-v0-52/"),
 		"k6/browser":         browser.New(),
 		"k6/experimental/fs": fs.New(),
 		"k6/net/grpc":        grpc.New(),


### PR DESCRIPTION
## What?

Provides two JS import paths:
* `k6/experimental/browser`: The k6 browser sync API shipped in k6 0.51 (which we're planning to remove in k6 0.54).
* `k6/browser`: The k6 browser async API.

Closes: #3778

## Why?

* Large breaking changes are no longer expected.
* [Async API](https://github.com/grafana/xk6-browser/issues/428) w/Playwright compatibility and API stability.
* Major runtime stability issues are fixed (although there are still some minor issues).
* Tested on the cloud, and no regressions.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- grafana/xk6-browser#428
- grafana/xk6-browser#1117