### PR TITLE
 cmd/archive: output archive to stdout if - is passed as --archive-out 

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -63,7 +63,7 @@ func (c *cmdArchive) flagSet() *pflag.FlagSet {
 	flags.AddFlagSet(runtimeOptionFlagSet(false))
 	flags.StringVarP(
 		&c.archiveOut, "archive-out", "O", c.archiveOut,
-		"archive output filename. The special value - will cause the archive to be output to stdout.",
+		"archive output filename. Dash (-) is a reserved value that causes the archive to be output to stdout.",
 	)
 	flags.BoolVarP(
 		&c.excludeEnvVars,

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -33,15 +33,20 @@ func (c *cmdArchive) run(cmd *cobra.Command, args []string) error {
 
 	// Archive.
 	arc := testRunState.Runner.MakeArchive()
-	f, err := c.gs.FS.Create(c.archiveOut)
-	if err != nil {
-		return err
-	}
 
 	if c.excludeEnvVars {
 		c.gs.Logger.Debug("environment variables will be excluded from the archive")
 
 		arc.Env = nil
+	}
+
+	if c.archiveOut == "-" {
+		return arc.Write(c.gs.Stdout)
+	}
+
+	f, err := c.gs.FS.Create(c.archiveOut)
+	if err != nil {
+		return err
 	}
 
 	err = arc.Write(f)
@@ -56,7 +61,10 @@ func (c *cmdArchive) flagSet() *pflag.FlagSet {
 	flags.SortFlags = false
 	flags.AddFlagSet(optionFlagSet())
 	flags.AddFlagSet(runtimeOptionFlagSet(false))
-	flags.StringVarP(&c.archiveOut, "archive-out", "O", c.archiveOut, "archive output filename")
+	flags.StringVarP(
+		&c.archiveOut, "archive-out", "O", c.archiveOut,
+		"archive output filename. The special value - will cause the archive to be output to stdout.",
+	)
 	flags.BoolVarP(
 		&c.excludeEnvVars,
 		"exclude-env-vars",
@@ -77,7 +85,7 @@ func getCmdArchive(gs *state.GlobalState) *cobra.Command {
 	exampleText := getExampleText(gs, `
   # Archive a test run.
   {{.}} archive -u 10 -d 10s -O myarchive.tar script.js
-  
+
   # Run the resulting archive.
   {{.}} run myarchive.tar`[1:])
 

--- a/cmd/archive_test.go
+++ b/cmd/archive_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -252,4 +253,23 @@ func TestArchiveNotContainsEnv(t *testing.T) {
 	// then unpacked metadata should not contain any environment variables passed at the moment of archive creation
 	require.NoError(t, json.Unmarshal(data, &metadata))
 	require.Len(t, metadata.Env, 0)
+}
+
+func TestArchiveStdout(t *testing.T) {
+	t.Parallel()
+
+	// given some script that will be archived
+	fileName := "script.js"
+	testScript := []byte(`export default function () {}`)
+	ts := tests.NewGlobalTestState(t)
+	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, fileName), testScript, 0o644))
+
+	ts.CmdArgs = []string{"k6", "archive", "-O", "-", fileName}
+
+	newRootCommand(ts.GlobalState).execute()
+
+	_, err := ts.FS.Stat("archive.tar")
+	require.ErrorIs(t, err, fs.ErrNotExist)
+
+	require.GreaterOrEqual(t, len(ts.Stdout.Bytes()), 32)
 }


### PR DESCRIPTION
## What?

This PR allows k6 to output archives to stdout when the special value `-` is used as the argument to `--archive-out`.

## Why?

The only current way I know of to tell k6 to output an archive to stdout is to specify `--archive-out=/dev/stdout`. However, this relies on `/dev` existing, which in some fringe cases may not be the case, e.g. when running inside a chroot.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/sm-k6-archiver/pull/25

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
