### PR TITLE
Log as debug the case when we can't get terminal size

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -263,13 +263,13 @@ func showProgress(ctx context.Context, gs *state.GlobalState, pbs []*pb.Progress
 		return
 	}
 
-	var errTermGetSize bool
+	var terminalSizeUnknown bool
 	termWidth := defaultTermWidth
 	if gs.Stdout.IsTTY {
 		tw, _, err := term.GetSize(gs.Stdout.RawOutFd)
 		if !(tw > 0) || err != nil {
-			errTermGetSize = true
-			logger.WithError(err).Warn("error getting terminal size")
+			terminalSizeUnknown = true
+			logger.WithError(err).Debug("can't get terminal size")
 		} else {
 			termWidth = tw
 		}
@@ -353,7 +353,7 @@ func showProgress(ctx context.Context, gs *state.GlobalState, pbs []*pb.Progress
 			gs.OutMutex.Unlock()
 			return
 		case <-winch:
-			if gs.Stdout.IsTTY && !errTermGetSize {
+			if gs.Stdout.IsTTY && !terminalSizeUnknown {
 				// More responsive progress bar resizing on platforms with SIGWINCH (*nix)
 				tw, _, err := term.GetSize(stdoutFD)
 				if tw > 0 && err == nil {
@@ -362,7 +362,7 @@ func showProgress(ctx context.Context, gs *state.GlobalState, pbs []*pb.Progress
 			}
 		case <-ticker.C:
 			// Default ticker-based progress bar resizing
-			if gs.Stdout.IsTTY && !errTermGetSize && winch == nil {
+			if gs.Stdout.IsTTY && !terminalSizeUnknown && winch == nil {
 				tw, _, err := term.GetSize(stdoutFD)
 				if tw > 0 && err == nil {
 					termWidth = tw


### PR DESCRIPTION
## What?

This PR switches to debug the log level of the case when we can't get the terminal size.

## Why?

As was shown in #3796, there could be no error, but we still can't determine the size of the terminal. It seems that it's not important since it's just switching some of the rendering features. However, having this as the `warning` in CI pipelines affects UX usage.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #3796

<!-- Thanks for your contribution! 🙏🏼 -->
