### PR TITLE
 cmd/archive: additionally test for non-existence of file named `-`

### DIFF
--- a/cmd/archive_test.go
+++ b/cmd/archive_test.go
@@ -268,8 +268,10 @@ func TestArchiveStdout(t *testing.T) {
 
 	newRootCommand(ts.GlobalState).execute()
 
-	_, err := ts.FS.Stat("archive.tar")
-	require.ErrorIs(t, err, fs.ErrNotExist)
+	for _, filename := range []string{"-", "archive.tar"} {
+		_, err := ts.FS.Stat(filename)
+		require.ErrorIsf(t, err, fs.ErrNotExist, "%q should not exist", filename)
+	}
 
 	require.GreaterOrEqual(t, len(ts.Stdout.Bytes()), 32)
 }


### PR DESCRIPTION
## What?

A follow-up to https://github.com/grafana/k6/pull/3797, which I didn't want to push over as it already has approvals.

## Why?

Additionally to check for non-existence of `archive.tar`, also check for non-existence of a file named `-`, which could happen if the special case of `-` = stdout is mishandled.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/3797

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
