### PR TITLE
Warn on mixing ESM and commonJS

### DIFF
--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -251,7 +251,15 @@ func (c *Compiler) compileImpl(
 			return nil, code, err
 		}
 		// the compatibility mode "decreases" here as we shouldn't transform twice
-		return c.compileImpl(code, filename, wrap, lib.CompatibilityModeBase, state.srcMap)
+		var prg *sobek.Program
+		prg, code, err = c.compileImpl(code, filename, wrap, lib.CompatibilityModeBase, state.srcMap)
+		if err == nil && strings.Contains(src, "module.exports") {
+			c.logger.Warningf(
+				"While compiling %q it was noticed that it mixes import/export syntax (ESM) and commonJS module.exports. "+
+					"This isn't standard behaviour and will soon not work. Please use one or the other.",
+				filename)
+		}
+		return prg, code, err
 	}
 
 	if compatibilityMode == lib.CompatibilityModeExperimentalEnhanced {

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -255,8 +255,10 @@ func (c *Compiler) compileImpl(
 		prg, code, err = c.compileImpl(code, filename, wrap, lib.CompatibilityModeBase, state.srcMap)
 		if err == nil && strings.Contains(src, "module.exports") {
 			c.logger.Warningf(
-				"During the compilation of %q, it has been detected that the file combines ECMAScript modules (ESM)  import/export syntax with commonJS module.exports. "+
-					"Mixing these two module systems is non-standard and will not be supported anymore in future releases. Please ensure to solely one or the other syntax.",
+				"During the compilation of %q, it has been detected that the file combines ECMAScript modules (ESM) "+
+					"import/export syntax with commonJS module.exports. "+
+					"Mixing these two module systems is non-standard and will not be supported anymore in future releases. "+
+					"Please ensure to solely one or the other syntax.",
 				filename)
 		}
 		return prg, code, err

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -255,8 +255,8 @@ func (c *Compiler) compileImpl(
 		prg, code, err = c.compileImpl(code, filename, wrap, lib.CompatibilityModeBase, state.srcMap)
 		if err == nil && strings.Contains(src, "module.exports") {
 			c.logger.Warningf(
-				"While compiling %q it was noticed that it mixes import/export syntax (ESM) and commonJS module.exports. "+
-					"This isn't standard behaviour and will soon not work. Please use one or the other.",
+				"During the compilation of %q, it has been detected that the file combines ECMAScript modules (ESM)  import/export syntax with commonJS module.exports. "+
+					"Mixing these two module systems is non-standard and will not be supported anymore in future releases. Please ensure to solely one or the other syntax.",
 				filename)
 		}
 		return prg, code, err

--- a/js/compiler/compiler.go
+++ b/js/compiler/compiler.go
@@ -258,7 +258,7 @@ func (c *Compiler) compileImpl(
 				"During the compilation of %q, it has been detected that the file combines ECMAScript modules (ESM) "+
 					"import/export syntax with commonJS module.exports. "+
 					"Mixing these two module systems is non-standard and will not be supported anymore in future releases. "+
-					"Please ensure to solely one or the other syntax.",
+					"Please ensure to use solely one or the other syntax.",
 				filename)
 		}
 		return prg, code, err

--- a/js/compiler/compiler_test.go
+++ b/js/compiler/compiler_test.go
@@ -262,5 +262,5 @@ func TestMixingImportExport(t *testing.T) {
 	msg, err := entries[0].String() // we need this in order to get the field error
 	require.NoError(t, err)
 
-	require.Contains(t, msg, `it was noticed that it mixes`)
+	require.Contains(t, msg, `it has been detected that the file combines`)
 }


### PR DESCRIPTION
## What?

As part of testing for #3265 it was noticed this isn't uncommon.



## Why?

As there is no way for this to be supported and it will be against how the specification works we prefer to warn users on this at least for a little while.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
