### PR TITLE
Bump k6 version to v0.52.0

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.51.0"
+const Version = "0.52.0"
 
 // FullVersion returns the maximally full version and build information for
 // the currently running k6 executable.


### PR DESCRIPTION
## What?

It bumps the k6 version to `v0.52.0`. It is part of the release process https://github.com/grafana/k6/issues/3766.

Closes https://github.com/grafana/k6/issues/3802