### PR TITLE
WIP Add a `k6 cloud run --local-execution` mode of execution

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -344,19 +344,19 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 	}
 
 	exampleText := getExampleText(gs, `
-  # Authenticate with Grafana k6 Cloud
+  # Authenticate with Grafana Cloud k6
   $ {{.}} cloud login
 
-  # Run a k6 script in the Grafana k6 cloud
+  # Run a k6 script in the Grafana Cloud k6
   $ {{.}} cloud run script.js
 
-  # Run a k6 archive in the Grafana k6 cloud
+  # Run a k6 archive in the Grafana Cloud k6
   $ {{.}} cloud run archive.tar
 
-  # [deprecated] Run a k6 script in the Grafana k6 cloud
+  # [deprecated] Run a k6 script in the Grafana Cloud k6
   $ {{.}} cloud script.js
 
-  # [deprecated] Run a k6 archive in the Grafana k6 cloud
+  # [deprecated] Run a k6 archive in the Grafana Cloud k6
   $ {{.}} cloud archive.tar`[1:])
 
 	cloudCmd := &cobra.Command{
@@ -369,7 +369,7 @@ To run tests in the cloud, users are now invited to migrate to the "k6 cloud run
 
 Run a test on the cloud.
 
-This will execute the test on the k6 cloud service. Use "k6 login cloud" to authenticate.`,
+This will execute the test on the k6 cloud service. Use "k6 cloud login" to authenticate.`,
 		Args:    exactCloudArgs(),
 		PreRunE: c.preRun,
 		RunE:    c.run,
@@ -388,23 +388,11 @@ This will execute the test on the k6 cloud service. Use "k6 login cloud" to auth
 
 func exactCloudArgs() cobra.PositionalArgs {
 	return func(_ *cobra.Command, args []string) error {
-		if len(args) < 1 || len(args) > 2 {
-			return fmt.Errorf("accepts 1 or 2 arg(s), received %d", len(args))
-		}
-
-		var (
-			isRunSubcommand   = args[0] == "run"
-			isLoginSubcommand = args[0] == "login"
-			isScript          = filepath.Ext(args[0]) == ".js"
-			isArchive         = filepath.Ext(args[0]) == ".tar"
-		)
-
-		if len(args) == 1 && !isScript && !isArchive {
-			return fmt.Errorf("unexpected argument: %s", args[0])
-		}
-
-		if len(args) == 2 && !isRunSubcommand && !isLoginSubcommand {
-			return fmt.Errorf("unexpected argument: %s", args[0])
+		if len(args) == 0 {
+			return fmt.Errorf(
+				"the k6 cloud command accepts 1 argument consisting in either in "+
+					"a subcommand such as `run` or `cloud`, or the path to a script/archive, or "+
+					"the `-` symbol, received: %d arguments instead", len(args))
 		}
 
 		return nil

--- a/cmd/cloud_login.go
+++ b/cmd/cloud_login.go
@@ -41,10 +41,10 @@ func getCmdCloudLogin(gs *state.GlobalState) *cobra.Command {
 
 	loginCloudCommand := &cobra.Command{
 		Use:   cloudLoginCommandName,
-		Short: "Authenticate with Grafana k6 Cloud",
+		Short: "Authenticate with Grafana Cloud k6",
 		Long: `Authenticate with Grafana Cloud k6.
 
-This command will authenticate you with Grafana Cloud k6. Once authenticated,
+This command will authenticate you with Grafana Cloud k6.
 Once authenticated you can start running tests in the cloud by using the "k6 cloud"
 command, or by executing a test locally and outputting samples to the cloud using
 the "k6 run -o cloud" command.
@@ -144,7 +144,7 @@ func (c *cmdCloudLogin) run(cmd *cobra.Command, _ []string) error {
 
 		if res.Token == "" {
 			return errors.New("your account does not appear to have an active API token, please consult the " +
-				"Grafana k6 cloud documentation for instructions on how to generate " +
+				"Grafana Cloud k6 documentation for instructions on how to generate " +
 				"one: https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication")
 		}
 

--- a/cmd/cloud_login.go
+++ b/cmd/cloud_login.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"syscall"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+	"gopkg.in/guregu/null.v3"
+
+	"go.k6.io/k6/cloudapi"
+	"go.k6.io/k6/cmd/state"
+	"go.k6.io/k6/lib/consts"
+	"go.k6.io/k6/ui"
+)
+
+const cloudLoginCommandName = "login"
+
+type cmdCloudLogin struct {
+	globalState *state.GlobalState
+}
+
+func getCmdCloudLogin(gs *state.GlobalState) *cobra.Command {
+	c := &cmdCloudLogin{
+		globalState: gs,
+	}
+
+	// loginCloudCommand represents the 'cloud login' command
+	exampleText := getExampleText(gs, `
+  # Log in with an email/password.
+  {{.}} cloud login
+
+  # Store a token in k6's persistent configuration.
+  {{.}} cloud login -t <YOUR_TOKEN>
+
+  # Display the stored token.
+  {{.}} cloud login -s`[1:])
+
+	loginCloudCommand := &cobra.Command{
+		Use:   cloudLoginCommandName,
+		Short: "Authenticate with Grafana k6 Cloud",
+		Long: `Authenticate with Grafana Cloud k6.
+
+This command will authenticate you with Grafana Cloud k6. Once authenticated,
+Once authenticated you can start running tests in the cloud by using the "k6 cloud"
+command, or by executing a test locally and outputting samples to the cloud using
+the "k6 run -o cloud" command.
+`,
+		Example: exampleText,
+		Args:    cobra.NoArgs,
+		RunE:    c.run,
+	}
+
+	loginCloudCommand.Flags().StringP("token", "t", "", "specify `token` to use")
+	loginCloudCommand.Flags().BoolP("show", "s", false, "display saved token and exit")
+	loginCloudCommand.Flags().BoolP("reset", "r", false, "reset token")
+
+	return loginCloudCommand
+}
+
+// run is the code that runs when the user executes `k6 cloud login`
+//
+//nolint:funlen
+func (c *cmdCloudLogin) run(cmd *cobra.Command, _ []string) error {
+	currentDiskConf, err := readDiskConfig(c.globalState)
+	if err != nil {
+		return err
+	}
+
+	currentJSONConfig := cloudapi.Config{}
+	currentJSONConfigRaw := currentDiskConf.Collectors["cloud"]
+	if currentJSONConfigRaw != nil {
+		// We only want to modify this config, see comment below
+		if jsonerr := json.Unmarshal(currentJSONConfigRaw, &currentJSONConfig); jsonerr != nil {
+			return jsonerr
+		}
+	}
+
+	// We want to use this fully consolidated config for things like
+	// host addresses, so users can overwrite them with env vars.
+	consolidatedCurrentConfig, warn, err := cloudapi.GetConsolidatedConfig(
+		currentJSONConfigRaw, c.globalState.Env, "", nil, nil)
+	if err != nil {
+		return err
+	}
+
+	if warn != "" {
+		c.globalState.Logger.Warn(warn)
+	}
+
+	// But we don't want to save them back to the JSON file, we only
+	// want to save what already existed there and the login details.
+	newCloudConf := currentJSONConfig
+
+	show := getNullBool(cmd.Flags(), "show")
+	reset := getNullBool(cmd.Flags(), "reset")
+	token := getNullString(cmd.Flags(), "token")
+	switch {
+	case reset.Valid:
+		newCloudConf.Token = null.StringFromPtr(nil)
+		printToStdout(c.globalState, "  token reset\n")
+	case show.Bool:
+	case token.Valid:
+		newCloudConf.Token = token
+	default:
+		form := ui.Form{
+			Fields: []ui.Field{
+				ui.StringField{
+					Key:   "Email",
+					Label: "Email",
+				},
+				ui.PasswordField{
+					Key:   "Password",
+					Label: "Password",
+				},
+			},
+		}
+		if !term.IsTerminal(int(syscall.Stdin)) { //nolint:unconvert
+			c.globalState.Logger.Warn("Stdin is not a terminal, falling back to plain text input")
+		}
+		var vals map[string]string
+		vals, err = form.Run(c.globalState.Stdin, c.globalState.Stdout)
+		if err != nil {
+			return err
+		}
+		email := vals["Email"]
+		password := vals["Password"]
+
+		client := cloudapi.NewClient(
+			c.globalState.Logger,
+			"",
+			consolidatedCurrentConfig.Host.String,
+			consts.Version,
+			consolidatedCurrentConfig.Timeout.TimeDuration())
+
+		var res *cloudapi.LoginResponse
+		res, err = client.Login(email, password)
+		if err != nil {
+			return err
+		}
+
+		if res.Token == "" {
+			return errors.New("your account does not appear to have an active API token, please consult the " +
+				"Grafana k6 cloud documentation for instructions on how to generate " +
+				"one: https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication")
+		}
+
+		newCloudConf.Token = null.StringFrom(res.Token)
+	}
+
+	if currentDiskConf.Collectors == nil {
+		currentDiskConf.Collectors = make(map[string]json.RawMessage)
+	}
+	currentDiskConf.Collectors["cloud"], err = json.Marshal(newCloudConf)
+	if err != nil {
+		return err
+	}
+	if err := writeDiskConfig(c.globalState, currentDiskConf); err != nil {
+		return err
+	}
+
+	if newCloudConf.Token.Valid {
+		valueColor := getColor(c.globalState.Flags.NoColor || !c.globalState.Stdout.IsTTY, color.FgCyan)
+		if !c.globalState.Flags.Quiet {
+			printToStdout(c.globalState, fmt.Sprintf("  token: %s\n", valueColor.Sprint(newCloudConf.Token.String)))
+		}
+		printToStdout(c.globalState, fmt.Sprintf(
+			"Logged in successfully, token saved in %s\n", c.globalState.Flags.ConfigFilePath,
+		))
+	}
+	return nil
+}

--- a/cmd/cloud_run.go
+++ b/cmd/cloud_run.go
@@ -8,8 +8,21 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
+
+	"gopkg.in/guregu/null.v3"
+
+	"github.com/sirupsen/logrus"
+	"go.k6.io/k6/event"
+	"go.k6.io/k6/execution"
+	"go.k6.io/k6/execution/local"
+	"go.k6.io/k6/js/common"
+	"go.k6.io/k6/lib/trace"
+	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/metrics/engine"
+	"go.k6.io/k6/output"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -28,17 +41,31 @@ import (
 type cmdCloudRun struct {
 	gs *state.GlobalState
 
-	showCloudLogs bool
-	exitOnRunning bool
-	uploadOnly    bool
+	// localExecution is a flag to enable local execution of the test
+	localExecution bool
+	showCloudLogs  bool
+	exitOnRunning  bool
+	uploadOnly     bool
+
+	// FIXME: this is brought directly from the `k6 run` command, and might be irrelevant here.
+	loadLocallyConfiguredTestFn func(*cobra.Command, []string) (*loadedAndConfiguredTest, execution.Controller, error)
 }
 
 func getCmdCloudRun(gs *state.GlobalState) *cobra.Command {
+	loadLocallyConfiguredTestFn := func(
+		cmd *cobra.Command, args []string,
+	) (*loadedAndConfiguredTest, execution.Controller, error) {
+		test, err := loadAndConfigureLocalTest(gs, cmd, args, getCloudRunLocalConfig)
+		return test, local.NewController(), err
+	}
+
 	c := &cmdCloudRun{
-		gs:            gs,
-		showCloudLogs: true,
-		exitOnRunning: false,
-		uploadOnly:    false,
+		gs:                          gs,
+		localExecution:              false,
+		showCloudLogs:               true,
+		exitOnRunning:               false,
+		uploadOnly:                  false,
+		loadLocallyConfiguredTestFn: loadLocallyConfiguredTestFn,
 	}
 
 	exampleText := getExampleText(gs, `
@@ -72,6 +99,33 @@ against Grafana Cloud k6. Use the "k6 cloud login" command to authenticate.`,
 
 	return cloudRunCmd
 }
+
+func (c *cmdCloudRun) flagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	flags.SortFlags = false
+
+	// FIXME @oleiade: we should make a passe over the flags defined there, and define our own set with the ones needed
+	// for local-execution.
+	flags.AddFlagSet(optionFlagSet())
+
+	// FIXME: this is brought directly from the `k6 run` command, and we might want to use a limited set of
+	// those flags here?
+	flags.AddFlagSet(runtimeOptionFlagSet(false))
+
+	// TODO: Figure out a better way to handle the CLI flags
+	flags.BoolVar(&c.exitOnRunning, "exit-on-running", c.exitOnRunning,
+		"exits when test reaches the running status")
+	flags.BoolVar(&c.showCloudLogs, "show-logs", c.showCloudLogs,
+		"enable showing of logs when a test is executed in the cloud")
+	flags.BoolVar(&c.uploadOnly, "upload-only", c.uploadOnly,
+		"only upload the test to the cloud without actually starting a test run")
+	flags.BoolVar(&c.localExecution, "local-execution", c.localExecution,
+		"run the test locally and stream results to the Grafana Cloud k6")
+
+	return flags
+}
+
+const cloudRunCommandName string = "run"
 
 //nolint:dupl // remove this statement once the migration from the `k6 cloud` to the `k6 cloud run` is complete.
 func (c *cmdCloudRun) preRun(cmd *cobra.Command, _ []string) error {
@@ -113,9 +167,15 @@ func (c *cmdCloudRun) preRun(cmd *cobra.Command, _ []string) error {
 }
 
 // TODO: split apart some more
-//
-//nolint:funlen,gocognit,cyclop
 func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
+	if c.localExecution {
+		return c.executeLocally(cmd, args)
+	}
+
+	return c.executeInTheCloud(cmd, args)
+}
+
+func (c *cmdCloudRun) executeInTheCloud(cmd *cobra.Command, args []string) error {
 	printBanner(c.gs)
 
 	progressBar := pb.New(
@@ -361,21 +421,436 @@ func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (c *cmdCloudRun) flagSet() *pflag.FlagSet {
-	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
-	flags.SortFlags = false
-	flags.AddFlagSet(optionFlagSet())
-	flags.AddFlagSet(runtimeOptionFlagSet(false))
+// executeLocally is the function handling the local execution of the cloud tests.
+//
+// It is adapted from the `k6 run` command implementation, with tweaks to make it specific to the
+// `k6 cloud run` command.
+//
+// TODO: We should align the features we activate here with what's needed in a cloud/local-execution context.
+// for instance, is linger needed? is REST API needed?
+func (c *cmdCloudRun) executeLocally(cmd *cobra.Command, args []string) error {
+	var err error
 
-	// TODO: Figure out a better way to handle the CLI flags
-	flags.BoolVar(&c.exitOnRunning, "exit-on-running", c.exitOnRunning,
-		"exits when test reaches the running status")
-	flags.BoolVar(&c.showCloudLogs, "show-logs", c.showCloudLogs,
-		"enable showing of logs when a test is executed in the cloud")
-	flags.BoolVar(&c.uploadOnly, "upload-only", c.uploadOnly,
-		"only upload the test to the cloud without actually starting a test run")
+	var logger logrus.FieldLogger = c.gs.Logger
+	defer func() {
+		if err == nil {
+			logger.Debug("Everything has finished, exiting k6 normally!")
+		} else {
+			logger.WithError(err).Debug("Everything has finished, exiting k6 with an error!")
+		}
+	}()
+	printBanner(c.gs)
 
-	return flags
+	globalCtx, globalCancel := context.WithCancel(c.gs.Ctx)
+	defer globalCancel()
+
+	// lingerCtx is cancelled by Ctrl+C, and is used to wait for that event when
+	// k6 was started with the --linger option.
+	lingerCtx, lingerCancel := context.WithCancel(globalCtx)
+	defer lingerCancel()
+
+	// runCtx is used for the test run execution and is created with the special
+	// execution.NewTestRunContext() function so that it can be aborted even
+	// from sub-contexts while also attaching a reason for the abort.
+	runCtx, runAbort := execution.NewTestRunContext(lingerCtx, logger)
+
+	emitEvent := func(evt *event.Event) func() {
+		waitDone := c.gs.Events.Emit(evt)
+		return func() {
+			waitCtx, waitCancel := context.WithTimeout(globalCtx, waitEventDoneTimeout)
+			defer waitCancel()
+			if werr := waitDone(waitCtx); werr != nil {
+				logger.WithError(werr).Warn()
+			}
+		}
+	}
+
+	defer func() {
+		waitExitDone := emitEvent(&event.Event{
+			Type: event.Exit,
+			Data: &event.ExitData{Error: err},
+		})
+		waitExitDone()
+		c.gs.Events.UnsubscribeAll()
+	}()
+
+	test, controller, err := c.loadLocallyConfiguredTestFn(cmd, args)
+	if err != nil {
+		return err
+	}
+	if test.keyLogger != nil {
+		defer func() {
+			if klErr := test.keyLogger.Close(); klErr != nil {
+				logger.WithError(klErr).Warn("Error while closing the SSLKEYLOGFILE")
+			}
+		}()
+	}
+
+	if err = c.setupTracerProvider(globalCtx, test); err != nil {
+		return err
+	}
+	waitTracesFlushed := func() {
+		ctx, cancel := context.WithTimeout(globalCtx, waitForTracerProviderStopTimeout)
+		defer cancel()
+		if tpErr := test.preInitState.TracerProvider.Shutdown(ctx); tpErr != nil {
+			logger.Errorf("The tracer provider didn't stop gracefully: %v", tpErr)
+		}
+	}
+
+	// Write the full consolidated *and derived* options back to the Runner.
+	conf := test.derivedConfig
+	testRunState, err := test.buildTestRunState(conf.Options)
+	if err != nil {
+		return err
+	}
+
+	// Create a local execution scheduler wrapping the runner.
+	logger.Debug("Initializing the execution scheduler...")
+	execScheduler, err := execution.NewScheduler(testRunState, controller)
+	if err != nil {
+		return err
+	}
+
+	backgroundProcesses := &sync.WaitGroup{}
+	defer backgroundProcesses.Wait()
+
+	// This is manually triggered after the Engine's Run() has completed,
+	// and things like a single Ctrl+C don't affect it. We use it to make
+	// sure that the progressbars finish updating with the latest execution
+	// state one last time, after the test run has finished.
+	progressCtx, progressCancel := context.WithCancel(globalCtx)
+	defer progressCancel()
+
+	initBar := execScheduler.GetInitProgressBar()
+	backgroundProcesses.Add(1)
+	go func() {
+		defer backgroundProcesses.Done()
+		pbs := []*pb.ProgressBar{initBar}
+		for _, s := range execScheduler.GetExecutors() {
+			pbs = append(pbs, s.GetProgress())
+		}
+		showProgress(progressCtx, c.gs, pbs, logger)
+	}()
+
+	// Create all outputs.
+	executionPlan := execScheduler.GetExecutionPlan()
+	outputs, err := createOutputs(c.gs, test, executionPlan)
+	if err != nil {
+		return err
+	}
+
+	outputs = append(outputs, testRunState.GroupSummary)
+
+	metricsEngine, err := engine.NewMetricsEngine(testRunState.Registry, logger)
+	if err != nil {
+		return err
+	}
+
+	// We'll need to pipe metrics to the MetricsEngine and process them if any
+	// of these are enabled: thresholds, end-of-test summary
+	shouldProcessMetrics := (!testRunState.RuntimeOptions.NoSummary.Bool ||
+		!testRunState.RuntimeOptions.NoThresholds.Bool)
+	var metricsIngester *engine.OutputIngester
+	if shouldProcessMetrics {
+		err = metricsEngine.InitSubMetricsAndThresholds(conf.Options, testRunState.RuntimeOptions.NoThresholds.Bool)
+		if err != nil {
+			return err
+		}
+		// We'll need to pipe metrics to the MetricsEngine if either the
+		// thresholds or the end-of-test summary are enabled.
+		metricsIngester = metricsEngine.CreateIngester()
+		outputs = append(outputs, metricsIngester)
+	}
+
+	executionState := execScheduler.GetState()
+	if !testRunState.RuntimeOptions.NoSummary.Bool {
+		defer func() {
+			logger.Debug("Generating the end-of-test summary...")
+			summaryResult, hsErr := test.initRunner.HandleSummary(globalCtx, &lib.Summary{
+				Metrics:         metricsEngine.ObservedMetrics,
+				RootGroup:       testRunState.GroupSummary.Group(),
+				TestRunDuration: executionState.GetCurrentTestRunDuration(),
+				NoColor:         c.gs.Flags.NoColor,
+				UIState: lib.UIState{
+					IsStdOutTTY: c.gs.Stdout.IsTTY,
+					IsStdErrTTY: c.gs.Stderr.IsTTY,
+				},
+			})
+			if hsErr == nil {
+				hsErr = handleSummaryResult(c.gs.FS, c.gs.Stdout, c.gs.Stderr, summaryResult)
+			}
+			if hsErr != nil {
+				logger.WithError(hsErr).Error("failed to handle the end-of-test summary")
+			}
+		}()
+	}
+
+	waitInitDone := emitEvent(&event.Event{Type: event.Init})
+
+	// Create and start the outputs. We do it quite early to get any output URLs
+	// or other details below. It also allows us to ensure when they have
+	// flushed their samples and when they have stopped in the defer statements.
+	initBar.Modify(pb.WithConstProgress(0, "Starting outputs"))
+	outputManager := output.NewManager(outputs, logger, func(err error) {
+		if err != nil {
+			logger.WithError(err).Error("Received error to stop from output")
+		}
+		// TODO: attach run status and exit code?
+		runAbort(err)
+	})
+	samples := make(chan metrics.SampleContainer, test.derivedConfig.MetricSamplesBufferSize.Int64)
+	waitOutputsFlushed, stopOutputs, err := outputManager.Start(samples)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		logger.Debug("Stopping outputs...")
+		// We call waitOutputsFlushed() below because the threshold calculations
+		// need all of the metrics to be sent to the MetricsEngine before we can
+		// calculate them one last time. We need the threshold calculated here,
+		// since they may change the run status for the outputs.
+		stopOutputs(err)
+	}()
+
+	if !testRunState.RuntimeOptions.NoThresholds.Bool {
+		finalizeThresholds := metricsEngine.StartThresholdCalculations(
+			metricsIngester, runAbort, executionState.GetCurrentTestRunDuration,
+		)
+		handleFinalThresholdCalculation := func() {
+			// This gets called after the Samples channel has been closed and
+			// the OutputManager has flushed all of the cached samples to
+			// outputs (including MetricsEngine's ingester). So we are sure
+			// there won't be any more metrics being sent.
+			logger.Debug("Finalizing thresholds...")
+			breachedThresholds := finalizeThresholds()
+			if len(breachedThresholds) == 0 {
+				return
+			}
+			tErr := errext.WithAbortReasonIfNone(
+				errext.WithExitCodeIfNone(
+					fmt.Errorf("thresholds on metrics '%s' have been crossed", strings.Join(breachedThresholds, ", ")),
+					exitcodes.ThresholdsHaveFailed,
+				), errext.AbortedByThresholdsAfterTestEnd)
+
+			if err == nil {
+				err = tErr
+			} else {
+				logger.WithError(tErr).Debug("Crossed thresholds, but test already exited with another error")
+			}
+		}
+		if finalizeThresholds != nil {
+			defer handleFinalThresholdCalculation()
+		}
+	}
+
+	defer func() {
+		logger.Debug("Waiting for metrics and traces processing to finish...")
+		close(samples)
+
+		ww := [...]func(){
+			waitOutputsFlushed,
+			waitTracesFlushed,
+		}
+		var wg sync.WaitGroup
+		wg.Add(len(ww))
+		for _, w := range ww {
+			w := w
+			go func() {
+				w()
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+
+		logger.Debug("Metrics and traces processing finished!")
+	}()
+
+	// NOTE (@oleiade): k6 cloud run --local-execution does not need to spin up the REST API server
+	// Spin up the REST API server, if not disabled.
+	//if c.gs.Flags.Address != "" { //nolint:nestif
+	//	initBar.Modify(pb.WithConstProgress(0, "Init API server"))
+	//
+	//	// We cannot use backgroundProcesses here, since we need the REST API to
+	//	// be down before we can close the samples channel above and finish the
+	//	// processing the metrics pipeline.
+	//	apiWG := &sync.WaitGroup{}
+	//	apiWG.Add(2)
+	//	defer apiWG.Wait()
+	//
+	//	srvCtx, srvCancel := context.WithCancel(globalCtx)
+	//	defer srvCancel()
+	//
+	//	srv := api.GetServer(
+	//		runCtx,
+	//		c.gs.Flags.Address, c.gs.Flags.ProfilingEnabled,
+	//		testRunState,
+	//		samples,
+	//		metricsEngine,
+	//		execScheduler,
+	//	)
+	//	go func() {
+	//		defer apiWG.Done()
+	//		logger.Debugf("Starting the REST API server on %s", c.gs.Flags.Address)
+	//		if c.gs.Flags.ProfilingEnabled {
+	//			logger.Debugf("Profiling exposed on http://%s/debug/pprof/", c.gs.Flags.Address)
+	//		}
+	//		if aerr := srv.ListenAndServe(); aerr != nil && !errors.Is(aerr, http.ErrServerClosed) {
+	//			// Only exit k6 if the user has explicitly set the REST API address
+	//			if cmd.Flags().Lookup("address").Changed {
+	//				logger.WithError(aerr).Error("Error from API server")
+	//				c.gs.OSExit(int(exitcodes.CannotStartRESTAPI))
+	//			} else {
+	//				logger.WithError(aerr).Warn("Error from API server")
+	//			}
+	//		}
+	//	}()
+	//	go func() {
+	//		defer apiWG.Done()
+	//		<-srvCtx.Done()
+	//		shutdCtx, shutdCancel := context.WithTimeout(globalCtx, 1*time.Second)
+	//		defer shutdCancel()
+	//		if aerr := srv.Shutdown(shutdCtx); aerr != nil {
+	//			logger.WithError(aerr).Debug("REST API server did not shut down correctly")
+	//		}
+	//	}()
+	//}
+
+	printExecutionDescription(
+		c.gs, "local", args[0], "", conf, executionState.ExecutionTuple, executionPlan, outputs,
+	)
+
+	// Trap Interrupts, SIGINTs and SIGTERMs.
+	// TODO: move upwards, right after runCtx is created
+	gracefulStop := func(sig os.Signal) {
+		logger.WithField("sig", sig).Debug("Stopping k6 in response to signal...")
+		// first abort the test run this way, to propagate the error
+		runAbort(errext.WithAbortReasonIfNone(
+			errext.WithExitCodeIfNone(
+				fmt.Errorf("test run was aborted because k6 received a '%s' signal", sig), exitcodes.ExternalAbort,
+			), errext.AbortedByUser,
+		))
+		lingerCancel() // cancel this context as well, since the user did Ctrl+C
+	}
+	onHardStop := func(sig os.Signal) {
+		logger.WithField("sig", sig).Error("Aborting k6 in response to signal")
+		globalCancel() // not that it matters, given that os.Exit() will be called right after
+	}
+	stopSignalHandling := handleTestAbortSignals(c.gs, gracefulStop, onHardStop)
+	defer stopSignalHandling()
+
+	// Initialize the VUs and executors
+	stopVUEmission, err := execScheduler.Init(runCtx, samples)
+	if err != nil {
+		return err
+	}
+	defer stopVUEmission()
+
+	// NOTE (@oleiade): k6 cloud run --local-execution does not need to wait for the test to start?
+	//if conf.Linger.Bool {
+	//	defer func() {
+	//		msg := "The test is done, but --linger was enabled, so k6 is waiting for Ctrl+C to continue..."
+	//		select {
+	//		case <-lingerCtx.Done():
+	//			// do nothing, we were interrupted by Ctrl+C already
+	//		default:
+	//			logger.Debug(msg)
+	//			if !c.gs.Flags.Quiet {
+	//				printToStdout(c.gs, msg)
+	//			}
+	//			<-lingerCtx.Done()
+	//			logger.Debug("Ctrl+C received, exiting...")
+	//		}
+	//	}()
+	//}
+
+	waitInitDone()
+
+	waitTestStartDone := emitEvent(&event.Event{Type: event.TestStart})
+	waitTestStartDone()
+
+	// Start the test! However, we won't immediately return if there was an
+	// error, we still have things to do.
+	err = execScheduler.Run(globalCtx, runCtx, samples)
+
+	waitTestEndDone := emitEvent(&event.Event{Type: event.TestEnd})
+	defer waitTestEndDone()
+
+	// Init has passed successfully, so unless disabled, make sure we send a
+	// usage report after the context is done.
+	if !conf.NoUsageReport.Bool {
+		backgroundProcesses.Add(1)
+		go func() {
+			defer backgroundProcesses.Done()
+			reportCtx, reportCancel := context.WithTimeout(globalCtx, 3*time.Second)
+			defer reportCancel()
+			logger.Debug("Sending usage report...")
+
+			if rerr := reportUsage(reportCtx, execScheduler, test); rerr != nil {
+				logger.WithError(rerr).Debug("Error sending usage report")
+			} else {
+				logger.Debug("Usage report sent successfully")
+			}
+		}()
+	}
+
+	// Check what the execScheduler.Run() error is.
+	if err != nil {
+		err = common.UnwrapGojaInterruptedError(err)
+		logger.WithError(err).Debug("Test finished with an error")
+		return err
+	}
+
+	// Warn if no iterations could be completed.
+	if executionState.GetFullIterationCount() == 0 {
+		logger.Warn("No script iterations fully finished, consider making the test duration longer")
+	}
+
+	logger.Debug("Test finished cleanly")
+
+	return nil
 }
 
-const cloudRunCommandName string = "run"
+func (c *cmdCloudRun) setupTracerProvider(ctx context.Context, test *loadedAndConfiguredTest) error {
+	ro := test.preInitState.RuntimeOptions
+	if ro.TracesOutput.String == "none" {
+		test.preInitState.TracerProvider = trace.NewNoopTracerProvider()
+		return nil
+	}
+
+	tp, err := trace.TracerProviderFromConfigLine(ctx, ro.TracesOutput.String)
+	if err != nil {
+		return err
+	}
+	test.preInitState.TracerProvider = tp
+
+	return nil
+}
+
+// getCloudRunLocalConfig is an adaptation of the [getConfig] helper function which
+// has been tailored to the needs of the local execution of cloud tests, and predefine the
+// set of outputs used by k6 to be solely the cloud output.
+func getCloudRunLocalConfig(flags *pflag.FlagSet) (Config, error) {
+	opts, err := getOptions(flags)
+	if err != nil {
+		return Config{}, err
+	}
+
+	// When performing a local execution, we predefine the set of outputs to be
+	// solely the cloud output.
+	outputs := []string{"cloud"}
+
+	return Config{
+		Options: opts,
+		Out:     outputs,
+
+		// FIXME: should we keep this option for cloud local execution?
+		// FIXME: we've currently disabled the option all in all
+		// Linger: getNullBool(flags, "linger"),
+		Linger: null.BoolFrom(false),
+
+		// FIXME: should we keep this option for local execution?
+		NoUsageReport: null.BoolFrom(false),
+
+		WebDashboard: null.BoolFrom(false),
+	}, nil
+}

--- a/cmd/cloud_run.go
+++ b/cmd/cloud_run.go
@@ -24,7 +24,7 @@ import (
 	"go.k6.io/k6/ui/pb"
 )
 
-// cmdCloudRun handles the `k6 cloud` sub-command
+// cmdCloudRun handles the `k6 cloud run` sub-command
 type cmdCloudRun struct {
 	gs *state.GlobalState
 
@@ -42,22 +42,27 @@ func getCmdCloudRun(gs *state.GlobalState) *cobra.Command {
 	}
 
 	exampleText := getExampleText(gs, `
-  # Run a test in the Grafana k6 cloud
+  # Run a test script in Grafana Cloud k6
   $ {{.}} cloud run script.js
 
-  # Run a test in the Grafana k6 cloud with a specific token
-  $ {{.}} cloud run  --token <YOUR_API_TOKEN> script.js`[1:])
+  # Run a test archive in Grafana Cloud k6
+  $ {{.}} cloud run archive.tar
 
-	// FIXME: when the command is "k6 cloud run" without an script/archive, we should display an error and the help
+  # Read a test script or archive from stdin and run it in Grafana Cloud k6
+  $ {{.}} cloud run - < script.js`[1:])
+
 	cloudRunCmd := &cobra.Command{
 		Use:   cloudRunCommandName,
-		Short: "Run a test in the Grafana k6 cloud",
-		Long: `Run a test in the Grafana k6 cloud.
+		Short: "Run a test in Grafana Cloud k6",
+		Long: `Run a test in Grafana Cloud k6.
 
-This will execute the test in the Grafana k6 cloud service. Using this command requires to be authenticated
-against the Grafana k6 cloud. Use the "k6 cloud login" command to authenticate.`,
+This will execute the test in the Grafana Cloud k6 service. Using this command requires to be authenticated
+against Grafana Cloud k6. Use the "k6 cloud login" command to authenticate.`,
 		Example: exampleText,
-		Args:    exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
+		Args: exactArgsWithMsg(1,
+			"the k6 cloud run command expects a single argument consisting in either a path to a script or "+
+				"archive file, or the \"-\" symbol indicating the script or archive should be read from stdin",
+		),
 		PreRunE: c.preRun,
 		RunE:    c.run,
 	}
@@ -154,7 +159,7 @@ func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
 	}
 	if !cloudConfig.Token.Valid {
 		return errors.New( //nolint:golint
-			"not logged in, please login to the Grafana k6 Cloud " +
+			"not logged in, please login to the Grafana Cloud k6 " +
 				"using the `k6 cloud login` command",
 		)
 	}

--- a/cmd/cloud_run.go
+++ b/cmd/cloud_run.go
@@ -1,0 +1,376 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"go.k6.io/k6/cloudapi"
+	"go.k6.io/k6/cmd/state"
+	"go.k6.io/k6/errext"
+	"go.k6.io/k6/errext/exitcodes"
+	"go.k6.io/k6/lib"
+	"go.k6.io/k6/lib/consts"
+	"go.k6.io/k6/ui/pb"
+)
+
+// cmdCloudRun handles the `k6 cloud` sub-command
+type cmdCloudRun struct {
+	gs *state.GlobalState
+
+	showCloudLogs bool
+	exitOnRunning bool
+	uploadOnly    bool
+}
+
+func getCmdCloudRun(gs *state.GlobalState) *cobra.Command {
+	c := &cmdCloudRun{
+		gs:            gs,
+		showCloudLogs: true,
+		exitOnRunning: false,
+		uploadOnly:    false,
+	}
+
+	exampleText := getExampleText(gs, `
+  # Run a test in the Grafana k6 cloud
+  $ {{.}} cloud run script.js
+
+  # Run a test in the Grafana k6 cloud with a specific token
+  $ {{.}} cloud run  --token <YOUR_API_TOKEN> script.js`[1:])
+
+	// FIXME: when the command is "k6 cloud run" without an script/archive, we should display an error and the help
+	cloudRunCmd := &cobra.Command{
+		Use:   cloudRunCommandName,
+		Short: "Run a test in the Grafana k6 cloud",
+		Long: `Run a test in the Grafana k6 cloud.
+
+This will execute the test in the Grafana k6 cloud service. Using this command requires to be authenticated
+against the Grafana k6 cloud. Use the "k6 cloud login" command to authenticate.`,
+		Example: exampleText,
+		Args:    exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
+		PreRunE: c.preRun,
+		RunE:    c.run,
+	}
+
+	cloudRunCmd.Flags().SortFlags = false
+	cloudRunCmd.Flags().AddFlagSet(c.flagSet())
+
+	return cloudRunCmd
+}
+
+//nolint:dupl // remove this statement once the migration from the `k6 cloud` to the `k6 cloud run` is complete.
+func (c *cmdCloudRun) preRun(cmd *cobra.Command, _ []string) error {
+	// TODO: refactor (https://github.com/loadimpact/k6/issues/883)
+	//
+	// We deliberately parse the env variables, to validate for wrong
+	// values, even if we don't subsequently use them (if the respective
+	// CLI flag was specified, since it has a higher priority).
+	if showCloudLogsEnv, ok := c.gs.Env["K6_SHOW_CLOUD_LOGS"]; ok {
+		showCloudLogsValue, err := strconv.ParseBool(showCloudLogsEnv)
+		if err != nil {
+			return fmt.Errorf("parsing K6_SHOW_CLOUD_LOGS returned an error: %w", err)
+		}
+		if !cmd.Flags().Changed("show-logs") {
+			c.showCloudLogs = showCloudLogsValue
+		}
+	}
+
+	if exitOnRunningEnv, ok := c.gs.Env["K6_EXIT_ON_RUNNING"]; ok {
+		exitOnRunningValue, err := strconv.ParseBool(exitOnRunningEnv)
+		if err != nil {
+			return fmt.Errorf("parsing K6_EXIT_ON_RUNNING returned an error: %w", err)
+		}
+		if !cmd.Flags().Changed("exit-on-running") {
+			c.exitOnRunning = exitOnRunningValue
+		}
+	}
+	if uploadOnlyEnv, ok := c.gs.Env["K6_CLOUD_UPLOAD_ONLY"]; ok {
+		uploadOnlyValue, err := strconv.ParseBool(uploadOnlyEnv)
+		if err != nil {
+			return fmt.Errorf("parsing K6_CLOUD_UPLOAD_ONLY returned an error: %w", err)
+		}
+		if !cmd.Flags().Changed("upload-only") {
+			c.uploadOnly = uploadOnlyValue
+		}
+	}
+
+	return nil
+}
+
+// TODO: split apart some more
+//
+//nolint:funlen,gocognit,cyclop
+func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
+	printBanner(c.gs)
+
+	progressBar := pb.New(
+		pb.WithConstLeft("Init"),
+		pb.WithConstProgress(0, "Loading test script..."),
+	)
+	printBar(c.gs, progressBar)
+
+	test, err := loadAndConfigureLocalTest(c.gs, cmd, args, getPartialConfig)
+	if err != nil {
+		return err
+	}
+
+	// It's important to NOT set the derived options back to the runner
+	// here, only the consolidated ones. Otherwise, if the script used
+	// an execution shortcut option (e.g. `iterations` or `duration`),
+	// we will have multiple conflicting execution options since the
+	// derivation will set `scenarios` as well.
+	testRunState, err := test.buildTestRunState(test.consolidatedConfig.Options)
+	if err != nil {
+		return err
+	}
+
+	// TODO: validate for usage of execution segment
+	// TODO: validate for externally controlled executor (i.e. executors that aren't distributable)
+	// TODO: move those validations to a separate function and reuse validateConfig()?
+
+	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Building the archive..."))
+	arc := testRunState.Runner.MakeArchive()
+
+	tmpCloudConfig, err := cloudapi.GetTemporaryCloudConfig(arc.Options.Cloud, arc.Options.External)
+	if err != nil {
+		return err
+	}
+
+	// Cloud config
+	cloudConfig, warn, err := cloudapi.GetConsolidatedConfig(
+		test.derivedConfig.Collectors["cloud"], c.gs.Env, "", arc.Options.Cloud, arc.Options.External)
+	if err != nil {
+		return err
+	}
+	if !cloudConfig.Token.Valid {
+		return errors.New( //nolint:golint
+			"not logged in, please login to the Grafana k6 Cloud " +
+				"using the `k6 cloud login` command",
+		)
+	}
+
+	// Display config warning if needed
+	if warn != "" {
+		modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Warning: "+warn))
+	}
+
+	if cloudConfig.Token.Valid {
+		tmpCloudConfig["token"] = cloudConfig.Token
+	}
+	if cloudConfig.Name.Valid {
+		tmpCloudConfig["name"] = cloudConfig.Name
+	}
+	if cloudConfig.ProjectID.Valid {
+		tmpCloudConfig["projectID"] = cloudConfig.ProjectID
+	}
+
+	if arc.Options.External == nil {
+		arc.Options.External = make(map[string]json.RawMessage)
+	}
+
+	b, err := json.Marshal(tmpCloudConfig)
+	if err != nil {
+		return err
+	}
+
+	arc.Options.Cloud = b
+	arc.Options.External[cloudapi.LegacyCloudConfigKey] = b
+
+	name := cloudConfig.Name.String
+	if !cloudConfig.Name.Valid || cloudConfig.Name.String == "" {
+		name = filepath.Base(test.sourceRootPath)
+	}
+
+	globalCtx, globalCancel := context.WithCancel(c.gs.Ctx)
+	defer globalCancel()
+
+	logger := c.gs.Logger
+
+	// Start cloud test run
+	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Validating script options"))
+	client := cloudapi.NewClient(
+		logger, cloudConfig.Token.String, cloudConfig.Host.String, consts.Version, cloudConfig.Timeout.TimeDuration())
+	if err = client.ValidateOptions(arc.Options); err != nil {
+		return err
+	}
+
+	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Uploading archive"))
+
+	var cloudTestRun *cloudapi.CreateTestRunResponse
+	if c.uploadOnly {
+		cloudTestRun, err = client.UploadTestOnly(name, cloudConfig.ProjectID.Int64, arc)
+	} else {
+		cloudTestRun, err = client.StartCloudTestRun(name, cloudConfig.ProjectID.Int64, arc)
+	}
+
+	if err != nil {
+		return err
+	}
+
+	refID := cloudTestRun.ReferenceID
+	if cloudTestRun.ConfigOverride != nil {
+		cloudConfig = cloudConfig.Apply(*cloudTestRun.ConfigOverride)
+	}
+
+	// Trap Interrupts, SIGINTs and SIGTERMs.
+	gracefulStop := func(sig os.Signal) {
+		logger.WithField("sig", sig).Print("Stopping cloud test run in response to signal...")
+		// Do this in a separate goroutine so that if it blocks, the
+		// second signal can still abort the process execution.
+		go func() {
+			stopErr := client.StopCloudTestRun(refID)
+			if stopErr != nil {
+				logger.WithError(stopErr).Error("Stop cloud test error")
+			} else {
+				logger.Info("Successfully sent signal to stop the cloud test, now waiting for it to actually stop...")
+			}
+			globalCancel()
+		}()
+	}
+	onHardStop := func(sig os.Signal) {
+		logger.WithField("sig", sig).Error("Aborting k6 in response to signal, we won't wait for the test to end.")
+	}
+	stopSignalHandling := handleTestAbortSignals(c.gs, gracefulStop, onHardStop)
+	defer stopSignalHandling()
+
+	et, err := lib.NewExecutionTuple(test.derivedConfig.ExecutionSegment, test.derivedConfig.ExecutionSegmentSequence)
+	if err != nil {
+		return err
+	}
+	testURL := cloudapi.URLForResults(refID, cloudConfig)
+	executionPlan := test.derivedConfig.Scenarios.GetFullExecutionRequirements(et)
+	printExecutionDescription(
+		c.gs, "cloud", test.sourceRootPath, testURL, test.derivedConfig, et, executionPlan, nil,
+	)
+
+	modifyAndPrintBar(
+		c.gs, progressBar,
+		pb.WithConstLeft("Run "), pb.WithConstProgress(0, "Initializing the cloud test"),
+	)
+
+	progressCtx, progressCancel := context.WithCancel(globalCtx)
+	progressBarWG := &sync.WaitGroup{}
+	progressBarWG.Add(1)
+	defer progressBarWG.Wait()
+	defer progressCancel()
+	go func() {
+		showProgress(progressCtx, c.gs, []*pb.ProgressBar{progressBar}, logger)
+		progressBarWG.Done()
+	}()
+
+	var (
+		startTime   time.Time
+		maxDuration time.Duration
+	)
+	maxDuration, _ = lib.GetEndOffset(executionPlan)
+
+	testProgressLock := &sync.Mutex{}
+	var testProgress *cloudapi.TestProgressResponse
+	progressBar.Modify(
+		pb.WithProgress(func() (float64, []string) {
+			testProgressLock.Lock()
+			defer testProgressLock.Unlock()
+
+			if testProgress == nil {
+				return 0, []string{"Waiting..."}
+			}
+
+			statusText := testProgress.RunStatusText
+
+			if testProgress.RunStatus == cloudapi.RunStatusFinished {
+				testProgress.Progress = 1
+			} else if testProgress.RunStatus == cloudapi.RunStatusRunning {
+				if startTime.IsZero() {
+					startTime = time.Now()
+				}
+				spent := time.Since(startTime)
+				if spent > maxDuration {
+					statusText = maxDuration.String()
+				} else {
+					statusText = fmt.Sprintf("%s/%s", pb.GetFixedLengthDuration(spent, maxDuration), maxDuration)
+				}
+			}
+
+			return testProgress.Progress, []string{statusText}
+		}),
+	)
+
+	ticker := time.NewTicker(time.Millisecond * 2000)
+	if c.showCloudLogs {
+		go func() {
+			logger.Debug("Connecting to cloud logs server...")
+			if err := cloudConfig.StreamLogsToLogger(globalCtx, logger, refID, 0); err != nil {
+				logger.WithError(err).Error("error while tailing cloud logs")
+			}
+		}()
+	}
+
+	for range ticker.C {
+		newTestProgress, progressErr := client.GetTestProgress(refID)
+		if progressErr != nil {
+			logger.WithError(progressErr).Error("Test progress error")
+			continue
+		}
+
+		testProgressLock.Lock()
+		testProgress = newTestProgress
+		testProgressLock.Unlock()
+
+		if (newTestProgress.RunStatus > cloudapi.RunStatusRunning) ||
+			(c.exitOnRunning && newTestProgress.RunStatus == cloudapi.RunStatusRunning) {
+			globalCancel()
+			break
+		}
+	}
+
+	if testProgress == nil {
+		//nolint:stylecheck,golint
+		return errext.WithExitCodeIfNone(errors.New("Test progress error"), exitcodes.CloudFailedToGetProgress)
+	}
+
+	if !c.gs.Flags.Quiet {
+		valueColor := getColor(c.gs.Flags.NoColor || !c.gs.Stdout.IsTTY, color.FgCyan)
+		printToStdout(c.gs, fmt.Sprintf(
+			"     test status: %s\n", valueColor.Sprint(testProgress.RunStatusText),
+		))
+	} else {
+		logger.WithField("run_status", testProgress.RunStatusText).Debug("Test finished")
+	}
+
+	if testProgress.ResultStatus == cloudapi.ResultStatusFailed {
+		// TODO: use different exit codes for failed thresholds vs failed test (e.g. aborted by system/limit)
+		//nolint:stylecheck,golint
+		return errext.WithExitCodeIfNone(errors.New("The test has failed"), exitcodes.CloudTestRunFailed)
+	}
+
+	return nil
+}
+
+func (c *cmdCloudRun) flagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	flags.SortFlags = false
+	flags.AddFlagSet(optionFlagSet())
+	flags.AddFlagSet(runtimeOptionFlagSet(false))
+
+	// TODO: Figure out a better way to handle the CLI flags
+	flags.BoolVar(&c.exitOnRunning, "exit-on-running", c.exitOnRunning,
+		"exits when test reaches the running status")
+	flags.BoolVar(&c.showCloudLogs, "show-logs", c.showCloudLogs,
+		"enable showing of logs when a test is executed in the cloud")
+	flags.BoolVar(&c.uploadOnly, "upload-only", c.uploadOnly,
+		"only upload the test to the cloud without actually starting a test run")
+
+	return flags
+}
+
+const cloudRunCommandName string = "run"

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -11,7 +11,10 @@ func getCmdLogin(gs *state.GlobalState) *cobra.Command {
 	loginCmd := &cobra.Command{
 		Use:   "login",
 		Short: "Authenticate with a service",
-		Long: `Authenticate with a service.
+		Long: `[deprecation notice]
+This command is deprecated and will be removed in a future release. Please use the "k6 cloud login" command instead.
+
+Authenticate with a service.
 
 Logging into a service changes the default when just "-o [type]" is passed with
 no parameters, you can always override the stored credentials by passing some

--- a/cmd/login_cloud.go
+++ b/cmd/login_cloud.go
@@ -33,7 +33,11 @@ func getCmdLoginCloud(gs *state.GlobalState) *cobra.Command {
 	loginCloudCommand := &cobra.Command{
 		Use:   "cloud",
 		Short: "Authenticate with k6 Cloud",
-		Long: `Authenticate with k6 Cloud",
+		Long: `[deprecation notice]
+This command is deprecated and will be removed in a future release. Please use the
+"k6 cloud login" command instead.
+
+Authenticate with Grafana Cloud k6.
 
 This will set the default token used when just "k6 run -o cloud" is passed.`,
 		Example: exampleText,

--- a/cmd/tests/cmd_cloud_run_test.go
+++ b/cmd/tests/cmd_cloud_run_test.go
@@ -1,0 +1,248 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/cloudapi"
+	"go.k6.io/k6/cmd"
+	"go.k6.io/k6/lib/fsext"
+	"go.k6.io/k6/lib/testutils"
+)
+
+func TestCloudRunNotLoggedIn(t *testing.T) {
+	t.Parallel()
+
+	ts := getSimpleCloudRunTestState(t, nil, nil, nil, nil)
+	delete(ts.Env, "K6_CLOUD_TOKEN")
+	ts.ExpectedExitCode = -1 // TODO: use a more specific exit code?
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.Contains(t, stdout, `not logged in`)
+}
+
+func TestCloudRunLoggedInWithScriptToken(t *testing.T) {
+	t.Parallel()
+
+	script := `
+		export let options = {
+			ext: {
+				loadimpact: {
+					token: "asdf",
+					name: "my load test",
+					projectID: 124,
+					note: 124,
+				},
+			}
+		};
+
+		export default function() {};
+	`
+
+	ts := getSimpleCloudRunTestState(t, []byte(script), nil, nil, nil)
+	delete(ts.Env, "K6_CLOUD_TOKEN")
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.NotContains(t, stdout, `Not logged in`)
+	assert.Contains(t, stdout, `execution: cloud`)
+	assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+	assert.Contains(t, stdout, `test status: Finished`)
+}
+
+func TestCloudRunExitOnRunning(t *testing.T) {
+	t.Parallel()
+
+	cs := func() cloudapi.TestProgressResponse {
+		return cloudapi.TestProgressResponse{
+			RunStatusText: "Running",
+			RunStatus:     cloudapi.RunStatusRunning,
+		}
+	}
+
+	ts := getSimpleCloudRunTestState(t, nil, []string{"--exit-on-running", "--log-output=stdout"}, nil, cs)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.Contains(t, stdout, `execution: cloud`)
+	assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+	assert.Contains(t, stdout, `test status: Running`)
+}
+
+func TestCloudRunUploadOnly(t *testing.T) {
+	t.Parallel()
+
+	cs := func() cloudapi.TestProgressResponse {
+		return cloudapi.TestProgressResponse{
+			RunStatusText: "Archived",
+			RunStatus:     cloudapi.RunStatusArchived,
+		}
+	}
+
+	ts := getSimpleCloudRunTestState(t, nil, []string{"--upload-only", "--log-output=stdout"}, nil, cs)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.Contains(t, stdout, `execution: cloud`)
+	assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+	assert.Contains(t, stdout, `test status: Archived`)
+}
+
+func TestCloudRunWithConfigOverride(t *testing.T) {
+	t.Parallel()
+
+	configOverride := http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+		resp.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(resp, `{
+			"reference_id": "123",
+			"config": {
+				"webAppURL": "https://bogus.url",
+				"testRunDetails": "something from the cloud"
+			},
+			"logs": [
+				{"level": "invalid", "message": "test debug message"},
+				{"level": "warning", "message": "test warning"},
+				{"level": "error", "message": "test error"}
+			]
+		}`)
+		assert.NoError(t, err)
+	})
+	ts := getSimpleCloudRunTestState(t, nil, nil, configOverride, nil)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.Contains(t, stdout, "execution: cloud")
+	assert.Contains(t, stdout, "output: something from the cloud")
+	assert.Contains(t, stdout, `level=debug msg="invalid message level 'invalid' for message 'test debug message'`)
+	assert.Contains(t, stdout, `level=error msg="test debug message" source=grafana-k6-cloud`)
+	assert.Contains(t, stdout, `level=warning msg="test warning" source=grafana-k6-cloud`)
+	assert.Contains(t, stdout, `level=error msg="test error" source=grafana-k6-cloud`)
+}
+
+// TestCloudRunWithArchive tests that if k6 uses a static archive with the script inside that has cloud options like:
+//
+//	export let options = {
+//		ext: {
+//			loadimpact: {
+//				name: "my load test",
+//				projectID: 124,
+//				note: "lorem ipsum",
+//			},
+//		}
+//	};
+//
+// actually sends to the cloud the archive with the correct metadata (metadata.json), like:
+//
+//	"ext": {
+//		"loadimpact": {
+//	        "name": "my load test",
+//	        "note": "lorem ipsum",
+//	        "projectID": 124
+//	      }
+//	}
+func TestCloudRunWithArchive(t *testing.T) {
+	t.Parallel()
+
+	testRunID := 123
+	ts := NewGlobalTestState(t)
+
+	archiveUpload := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		// check the archive
+		file, _, err := req.FormFile("file")
+		assert.NoError(t, err)
+		assert.NotNil(t, file)
+
+		// temporary write the archive for file system
+		data, err := io.ReadAll(file)
+		assert.NoError(t, err)
+
+		tmpPath := filepath.Join(ts.Cwd, "archive_to_cloud.tar")
+		require.NoError(t, fsext.WriteFile(ts.FS, tmpPath, data, 0o644))
+
+		// check what inside
+		require.NoError(t, testutils.Untar(t, ts.FS, tmpPath, "tmp/"))
+
+		metadataRaw, err := fsext.ReadFile(ts.FS, "tmp/metadata.json")
+		require.NoError(t, err)
+
+		metadata := struct {
+			Options struct {
+				Cloud struct {
+					Name      string `json:"name"`
+					Note      string `json:"note"`
+					ProjectID int    `json:"projectID"`
+				} `json:"cloud"`
+			} `json:"options"`
+		}{}
+
+		// then unpacked metadata should not contain any environment variables passed at the moment of archive creation
+		require.NoError(t, json.Unmarshal(metadataRaw, &metadata))
+		require.Equal(t, "my load test", metadata.Options.Cloud.Name)
+		require.Equal(t, "lorem ipsum", metadata.Options.Cloud.Note)
+		require.Equal(t, 124, metadata.Options.Cloud.ProjectID)
+
+		// respond with the test run ID
+		resp.WriteHeader(http.StatusOK)
+		_, err = fmt.Fprintf(resp, `{"reference_id": "%d"}`, testRunID)
+		assert.NoError(t, err)
+	})
+
+	srv := getMockCloud(t, testRunID, archiveUpload, nil)
+
+	data, err := os.ReadFile(filepath.Join("testdata/archives", "archive_v0.46.0_with_loadimpact_option.tar")) //nolint:forbidigo // it's a test
+	require.NoError(t, err)
+
+	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "archive.tar"), data, 0o644))
+
+	ts.CmdArgs = []string{"k6", "cloud", "--verbose", "--log-output=stdout", "archive.tar"}
+	ts.Env["K6_SHOW_CLOUD_LOGS"] = "false" // no mock for the logs yet
+	ts.Env["K6_CLOUD_HOST"] = srv.URL
+	ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.NotContains(t, stdout, `Not logged in`)
+	assert.Contains(t, stdout, `execution: cloud`)
+	assert.Contains(t, stdout, `hello world from archive`)
+	assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+	assert.Contains(t, stdout, `test status: Finished`)
+}
+
+func getSimpleCloudRunTestState(
+	t *testing.T, script []byte, cliFlags []string,
+	archiveUpload http.Handler, progressCallback func() cloudapi.TestProgressResponse,
+) *GlobalTestState {
+	if script == nil {
+		script = []byte(`export default function() {}`)
+	}
+
+	if cliFlags == nil {
+		cliFlags = []string{"--verbose", "--log-output=stdout"}
+	}
+
+	srv := getMockCloud(t, 123, archiveUpload, progressCallback)
+
+	ts := NewGlobalTestState(t)
+	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), script, 0o644))
+	ts.CmdArgs = append(append([]string{"k6", "cloud", "run"}, cliFlags...), "test.js")
+	ts.Env["K6_SHOW_CLOUD_LOGS"] = "false" // no mock for the logs yet
+	ts.Env["K6_CLOUD_HOST"] = srv.URL
+	ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud
+
+	return ts
+}

--- a/cmd/tests/cmd_cloud_test.go
+++ b/cmd/tests/cmd_cloud_test.go
@@ -288,3 +288,17 @@ func TestCloudWithArchive(t *testing.T) {
 	assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
 	assert.Contains(t, stdout, `test status: Finished`)
 }
+
+// FIXME: This test fails because our test setup leaves stdout empty
+//func TestCloudArgs(t *testing.T) {
+//	t.Parallel()
+//
+//	// ts := NewGlobalTestState(t)
+//	ts := getSimpleCloudTestState(t, nil, nil, nil, nil)
+//	ts.CmdArgs = []string{"k6", "cloud", "run"}
+//	ts.ExpectedExitCode = -1
+//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+//
+//	stdout := ts.Stdout.String()
+//	assert.Contains(t, stdout, `accepts 1 or 2 arg(s), received 0`)
+//}

--- a/cmd/tests/cmd_cloud_test.go
+++ b/cmd/tests/cmd_cloud_test.go
@@ -288,17 +288,3 @@ func TestCloudWithArchive(t *testing.T) {
 	assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
 	assert.Contains(t, stdout, `test status: Finished`)
 }
-
-// FIXME: This test fails because our test setup leaves stdout empty
-//func TestCloudArgs(t *testing.T) {
-//	t.Parallel()
-//
-//	// ts := NewGlobalTestState(t)
-//	ts := getSimpleCloudTestState(t, nil, nil, nil, nil)
-//	ts.CmdArgs = []string{"k6", "cloud", "run"}
-//	ts.ExpectedExitCode = -1
-//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-//
-//	stdout := ts.Stdout.String()
-//	assert.Contains(t, stdout, `accepts 1 or 2 arg(s), received 0`)
-//}


### PR DESCRIPTION
## What?

This PR adds support for a new `--local-execution` flag to the `k6 cloud run` command. Using it, users can run their test script or archive on their local machine, while streaming the results to the cloud.

It is built upon the latter, and ⚠️ cannot be merged before #3813 ⚠️.

In the context of this PR, the goal is to reproduce the behavior of the `k6 run -o cloud` behavior, and depending on the advancement of internal work, to also add support for adding archive upload. In a future PR, at a later point in time, we will also add support for logs and traces streaming to the cloud but are dependent on internal work to be able to do so.

⚠️ This is currently a work-in-progress, and non-functional (yet) PR ⚠️ 

## Why?

We aim to integrate the experience of running tests locally, whilst streaming results to the cloud more intuitive, and integrated in the k6 experience. We also aim to take this opportunity to align some of the logic and behavior involved in running tests in the cloud and running tests locally better.

## Task list

- [ ] We're gonna introduce a couple of options specific to `--local-execution`. One of the ideas we've been having in the k6 v1 UX work stream revolved around the idea of scoping options with a dot separator like in Prometheus: `--local.execution`, `--local.send-archive`, `--local.send-logs`, etc. cc @dgzlopes 
- [ ] Once we're at that point we'd like sending the archive to be **opt-in** (via an option that users need to explicitly pass). Same goes for logs. The reason being that they might contain sensitive info. cc @dgzlopes 
- [ ] When using `k6 cloud run --local-execution`, we should make sure the `outputs` field of the terminal output of the command displays a sensible value (like the URL of the job in the grafana cloud app?). cc @dgzlopes 
- [ ] Should the `k6 cloud run --local-execution` show the same terminal output as `k6 run` or `k6 cloud run`?

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
