### PR TITLE
Update k6/experimental/timers warning and consolidate with browsers

### DIFF
--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -44,12 +44,12 @@ func getInternalJSModules() map[string]interface{} {
 		"k6/experimental/websockets": &expws.RootModule{},
 		"k6/experimental/timers": newWarnExperimentalModule(timers.New(),
 			"Please update your imports to use k6/timers instead of k6/experimental/timers,"+
-				" which will be removed after September 23rd, 2024(v0.54.0). Ensure your scripts are migrated by then."+
+				" which will be removed after September 23rd, 2024 (v0.54.0). Ensure your scripts are migrated by then."+
 				" There are no API changes, so this is a drop in replacement."),
 		"k6/experimental/tracing": tracing.New(),
 		"k6/experimental/browser": newWarnExperimentalModule(browser.NewSync(),
 			"Please update your imports to use k6/browser instead of k6/experimental/browser,"+
-				" which will be removed after September 23rd, 2024(v0.54.0). Ensure your scripts are migrated by then."+
+				" which will be removed after September 23rd, 2024 (v0.54.0). Ensure your scripts are migrated by then."+
 				" For more information, see the migration guide at the link:"+
 				" https://grafana.com/docs/k6/latest/using-k6-browser/migrating-to-k6-v0-52/"),
 		"k6/browser":         browser.New(),

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -43,12 +43,13 @@ func getInternalJSModules() map[string]interface{} {
 		"k6/experimental/webcrypto":  webcrypto.New(),
 		"k6/experimental/websockets": &expws.RootModule{},
 		"k6/experimental/timers": newWarnExperimentalModule(timers.New(),
-			"k6/experimental/timers is now part of the k6 core, please change your imports to use k6/timers instead."+
-				" The k6/experimental/timers will be removed in k6 v0.52.0"),
+			"Please update your imports to use k6/timers instead of k6/experimental/timers,"+
+				" which will be removed after September 23rd, 2024(v0.54.0). Ensure your scripts are migrated by then."+
+				" There are no API changes, so this is a drop in replacement."),
 		"k6/experimental/tracing": tracing.New(),
 		"k6/experimental/browser": newWarnExperimentalModule(browser.NewSync(),
 			"Please update your imports to use k6/browser instead of k6/experimental/browser,"+
-				" which will be removed after September 23rd, 2024. Ensure your scripts are migrated by then."+
+				" which will be removed after September 23rd, 2024(v0.54.0). Ensure your scripts are migrated by then."+
 				" For more information, see the migration guide at the link:"+
 				" https://grafana.com/docs/k6/latest/using-k6-browser/migrating-to-k6-v0-52/"),
 		"k6/browser":         browser.New(),


### PR DESCRIPTION
## What?

Update k6/experimental/timers warning as we missed to dropp it in v0.52.0 and it seems to still be fairly used. 

Also mae it the same as for experimental/browser

## Why?

To give more time to users and to be more useful.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
