### PR TITLE
Drop experimental timers

### DIFF
--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -42,10 +42,8 @@ func getInternalJSModules() map[string]interface{} {
 		"k6/experimental/streams":    streams.New(),
 		"k6/experimental/webcrypto":  webcrypto.New(),
 		"k6/experimental/websockets": &expws.RootModule{},
-		"k6/experimental/timers": newWarnExperimentalModule(timers.New(),
-			"The exports of `k6/experimental/timers` are globally available, so no need to import them."+
-				" The module will be removed after September 23rd, 2024 (v0.54.0). Ensure your scripts are migrated by then."+
-				" There are no API changes, so this is a drop-in replacement and is also available under `k6/timers`."),
+		"k6/experimental/timers": newRemovedModule(
+			"k6/experimental/timers has been graduated, please use k6/timers instead."),
 		"k6/experimental/tracing": newWarnExperimentalModule(tracing.New(),
 			"k6/experimental/tracing is now deprecated. All of its functionality is available as pure javascript module."+
 				" More info available at the docs:"+


### PR DESCRIPTION
## What?

Drop k6/experimental/timers

## Why?
We have stabilized the API and it is now available for k6/timers for some time. We would like to stop supporting the old import path.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
