### PR TITLE
Add Browser and cloud support information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ Its core features are:
 - **Tests as code.** Reuse scripts, modularize logic, version control, and integrate tests with your CI.
 - **A full-featured API.** The scripting API is packed with features that help you simulate real application traffic.
 - **An embedded JavaScript engine.** The performance of Go, the scripting familiarity of JavaScript.
-- **Multiple Protocol support**. HTTP, WebSockets, gRPC, and more.
+- **Multiple Protocol support**. HTTP, WebSockets, gRPC, Browser, and more.
 - **Large extension ecosystem.** You can extend k6 to support your needs. And many people have already shared their extensions with the community!
 - **Flexible metrics storage and visualization**. Summary statistics or granular metrics, exported to the service of your choice.
+- **Native integration with Grafana cloud**. [SaaS solution](https://grafana.com/products/cloud/k6/) for test execution, metrics correlation, data analysis, and more. 
 
 This is what load testing looks like in the 21st century.
 


### PR DESCRIPTION
## Why?
- We encounter k6 OSS users who don't know we have cloud. 
- Browser wasn't mentioned. 