### PR TITLE
Update StatsD output deprecation (define removal version)

### DIFF
--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -53,7 +53,7 @@ func getAllOutputConstructors() (map[string]output.Constructor, error) {
 				"please use the new xk6 kafka output extension instead - https://github.com/k6io/xk6-output-kafka")
 		},
 		builtinOutputStatsd.String(): func(params output.Params) (output.Output, error) {
-			params.Logger.Warn("The statsd output is deprecated, and will be removed in a future k6 version. " +
+			params.Logger.Warn("The statsd output is deprecated, and will be removed in k6 v0.55.0 " +
 				"Please use the new xk6 statsd output extension instead. " +
 				"It can be found at https://github.com/LeonAdato/xk6-output-statsd and " +
 				"more info at https://github.com/grafana/k6/issues/2982.")

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -61,7 +61,9 @@ func getAllOutputConstructors() (map[string]output.Constructor, error) {
 		},
 		builtinOutputDatadog.String(): func(_ output.Params) (output.Output, error) {
 			return nil, errors.New("the datadog output was deprecated in k6 v0.32.0 and removed in k6 v0.34.0, " +
-				"please use the statsd output with env. variable K6_STATSD_ENABLE_TAGS=true instead")
+				"please use the statsd output extension https://github.com/LeonAdato/xk6-output-statsd with environment " +
+				"variable K6_STATSD_ENABLE_TAGS=true or an experimental opentelemetry output instead",
+			)
 		},
 		builtinOutputExperimentalPrometheusRW.String(): func(params output.Params) (output.Output, error) {
 			return remotewrite.New(params)


### PR DESCRIPTION
## What?

We fixed the version of the k6 where we aimed to remove the statsd output, and it also updates the recommendation for the datadog output 

## Why?

Part of #2982 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
