### PR TITLE
Simplify the test for gRPC streams metrics tags

### DIFF
--- a/js/modules/k6/grpc/stream_test.go
+++ b/js/modules/k6/grpc/stream_test.go
@@ -417,34 +417,14 @@ func TestStream_MetricsTagsMetadata(t *testing.T) {
 
 	stub := &featureExplorerStub{}
 
-	savedFeatures := []*grpcservice.Feature{
-		{
+	stub.listFeatures = func(_ *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
+		return stream.Send(&grpcservice.Feature{
 			Name: "foo",
 			Location: &grpcservice.Point{
 				Latitude:  1,
 				Longitude: 2,
 			},
-		},
-		{
-			Name: "bar",
-			Location: &grpcservice.Point{
-				Latitude:  3,
-				Longitude: 4,
-			},
-		},
-	}
-
-	stub.listFeatures = func(_ *grpcservice.Rectangle, stream grpcservice.FeatureExplorer_ListFeaturesServer) error {
-		for _, feature := range savedFeatures {
-			// adding a delay to make server response "slower"
-			time.Sleep(200 * time.Millisecond)
-
-			if err := stream.Send(feature); err != nil {
-				return err
-			}
-		}
-
-		return nil
+		})
 	}
 
 	grpcservice.RegisterFeatureExplorerServer(ts.httpBin.ServerGRPC, stub)
@@ -497,7 +477,7 @@ func TestStream_MetricsTagsMetadata(t *testing.T) {
 
 	samplesBuf := metrics.GetBufferedSamples(ts.samples)
 
-	assert.Len(t, samplesBuf, 5)
+	assert.Len(t, samplesBuf, 4)
 	for _, samples := range samplesBuf {
 		for _, sample := range samples.GetSamples() {
 			assertTags(t, sample, expTags)


### PR DESCRIPTION
## What?

This simplifies the test case for the testing gRPC metrics custom tags.

## Why?

Having a more straightforward test helps to keep focus on the critical parts.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/3746

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
