### PR TITLE
Deprecate k6/experimental/tracing

### DIFF
--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -46,7 +46,11 @@ func getInternalJSModules() map[string]interface{} {
 			"The exports of `k6/experimental/timers` are globally available, so no need to import them."+
 				" The module will be removed after September 23rd, 2024 (v0.54.0). Ensure your scripts are migrated by then."+
 				" There are no API changes, so this is a drop-in replacement and is also available under `k6/timers`."),
-		"k6/experimental/tracing": tracing.New(),
+		"k6/experimental/tracing": newWarnExperimentalModule(tracing.New(),
+			"k6/experimental/tracing is now deprecated. All of it functionality is available as pure javascript module."+
+				" More info available at the docs:"+
+				" https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-tempo"+
+				" The module will be removed after November 11th, 2024 (v0.55.0). Ensure your scripts are migrated by then."),
 		"k6/experimental/browser": newWarnExperimentalModule(browser.NewSync(),
 			"Please update your imports to use k6/browser instead of k6/experimental/browser,"+
 				" which will be removed after September 23rd, 2024 (v0.54.0). Ensure your scripts are migrated by then."+

--- a/js/jsmodules.go
+++ b/js/jsmodules.go
@@ -47,7 +47,7 @@ func getInternalJSModules() map[string]interface{} {
 				" The module will be removed after September 23rd, 2024 (v0.54.0). Ensure your scripts are migrated by then."+
 				" There are no API changes, so this is a drop-in replacement and is also available under `k6/timers`."),
 		"k6/experimental/tracing": newWarnExperimentalModule(tracing.New(),
-			"k6/experimental/tracing is now deprecated. All of it functionality is available as pure javascript module."+
+			"k6/experimental/tracing is now deprecated. All of its functionality is available as pure javascript module."+
 				" More info available at the docs:"+
 				" https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-tempo"+
 				" The module will be removed after November 11th, 2024 (v0.55.0). Ensure your scripts are migrated by then."),


### PR DESCRIPTION
## What?

Deprecate k6/experimental/tracing. 

## Why?

The module is now fully available as javacript implementation from https://jslib.k6.io/ and documented [here](https://grafana.com/docs/k6/latest/javascript-api/jslib/http-instrumentation-tempo/)
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Closes #3212
