### PR TITLE
Cleanup comments and some code after ESM merge

### DIFF
--- a/cmd/runtime_options.go
+++ b/cmd/runtime_options.go
@@ -24,9 +24,8 @@ func runtimeOptionFlagSet(includeSysEnv bool) *pflag.FlagSet {
 	flags.Bool("include-system-env-vars", includeSysEnv, "pass the real system environment variables to the runtime")
 	flags.String("compatibility-mode", "extended",
 		`JavaScript compiler compatibility mode, "extended" or "base" or "experimental_enhanced"
-base: pure Sobek - Golang JS VM supporting ES5.1+
-extended: base + Babel with parts of ES2015 preset
-		  slower to compile in case the script uses syntax unsupported by base
+base: pure Sobek - Golang JS VM supporting ES6+
+extended: base + sets "global" as alias for "globalThis"
 experimental_enhanced: esbuild-based transpiling for TypeScript and ES6+ support
 `)
 	flags.StringP("type", "t", "", "override test type, \"js\" or \"archive\"")

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -281,7 +281,6 @@ func (b *Bundle) newCompiler(logger logrus.FieldLogger) *compiler.Compiler {
 	c := compiler.New(logger)
 	c.Options = compiler.Options{
 		CompatibilityMode: b.CompatibilityMode,
-		Strict:            true,
 		SourceMapLoader:   generateSourceMapLoader(logger, b.filesystems),
 	}
 	return c

--- a/js/initcontext_test.go
+++ b/js/initcontext_test.go
@@ -631,69 +631,6 @@ export default function () {
 	require.Equal(t, "cool is cool\n\tat webpack:///./test1.ts:2:4(2)\n\tat webpack:///./test1.ts:5:4(3)\n\tat default (file:///script.js:4:4(3))\n", exception.String())
 }
 
-func TestSourceMapsExternalExtented(t *testing.T) {
-	t.Parallel()
-	fs := fsext.NewMemMapFs()
-	// This example is created through the template-typescript
-	// but was exported to use import/export syntax so it has to go through babel
-	require.NoError(t, fsext.WriteFile(fs, "/test1.js", []byte(`
-var o={d:(e,r)=>{for(var t in r)o.o(r,t)&&!o.o(e,t)&&Object.defineProperty(e,t,{enumerable:!0,get:r[t]})},o:(o,e)=>Object.prototype.hasOwnProperty.call(o,e)},e={};o.d(e,{Z:()=>r});const r=()=>{!function(o){throw"cool is cool"}()};var t=e.Z;export{t as default};
-//# sourceMappingURL=test1.js.map
-`[1:]), 0o644))
-	require.NoError(t, fsext.WriteFile(fs, "/test1.js.map", []byte(`
-{"version":3,"sources":["webpack:///webpack/bootstrap","webpack:///webpack/runtime/define property getters","webpack:///webpack/runtime/hasOwnProperty shorthand","webpack:///./test1.ts"],"names":["__webpack_require__","exports","definition","key","o","Object","defineProperty","enumerable","get","obj","prop","prototype","hasOwnProperty","call","s","coolThrow"],"mappings":"AACA,IAAIA,EAAsB,CCA1B,EAAwB,CAACC,EAASC,KACjC,IAAI,IAAIC,KAAOD,EACXF,EAAoBI,EAAEF,EAAYC,KAASH,EAAoBI,EAAEH,EAASE,IAC5EE,OAAOC,eAAeL,EAASE,EAAK,CAAEI,YAAY,EAAMC,IAAKN,EAAWC,MCJ3E,EAAwB,CAACM,EAAKC,IAAUL,OAAOM,UAAUC,eAAeC,KAAKJ,EAAKC,I,sBCGlF,cAHA,SAAmBI,GACf,KAAM,eAGNC,I","file":"test1.js","sourcesContent":["// The require scope\nvar __webpack_require__ = {};\n\n","// define getter functions for harmony exports\n__webpack_require__.d = (exports, definition) => {\n\tfor(var key in definition) {\n\t\tif(__webpack_require__.o(definition, key) && !__webpack_require__.o(exports, key)) {\n\t\t\tObject.defineProperty(exports, key, { enumerable: true, get: definition[key] });\n\t\t}\n\t}\n};","__webpack_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))","function coolThrow(s: string) {\n    throw \"cool \"+ s\n}\nexport default () => {\n    coolThrow(\"is cool\")\n};\n"],"sourceRoot":""}
-`[1:]), 0o644))
-	data := `
-import l from "./test1.js"
-
-export default function () {
-		l()
-};
-`[1:]
-	b, err := getSimpleBundle(t, "/script.js", data, fs)
-	require.NoError(t, err)
-
-	bi, err := b.Instantiate(context.Background(), 0)
-	require.NoError(t, err)
-	_, err = bi.getCallableExport(consts.DefaultFn)(sobek.Undefined())
-	require.Error(t, err)
-	exception := new(sobek.Exception)
-	require.ErrorAs(t, err, &exception)
-	// TODO figure out why those are not the same as the one in the previous test TestSourceMapsExternal
-	// likely settings in the transpilers
-	require.Equal(t, "cool is cool\n\tat webpack:///./test1.ts:2:4(2)\n\tat r (webpack:///./test1.ts:5:4(3))\n\tat default (file:///script.js:4:4(3))\n", exception.String())
-}
-
-func TestSourceMapsExternalExtentedInlined(t *testing.T) {
-	t.Parallel()
-	fs := fsext.NewMemMapFs()
-	// This example is created through the template-typescript
-	// but was exported to use import/export syntax so it has to go through babel
-	require.NoError(t, fsext.WriteFile(fs, "/test1.js", []byte(`
-var o={d:(e,r)=>{for(var t in r)o.o(r,t)&&!o.o(e,t)&&Object.defineProperty(e,t,{enumerable:!0,get:r[t]})},o:(o,e)=>Object.prototype.hasOwnProperty.call(o,e)},e={};o.d(e,{Z:()=>r});const r=()=>{!function(o){throw"cool is cool"}()};var t=e.Z;export{t as default};
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIndlYnBhY2s6Ly8vd2VicGFjay9ib290c3RyYXAiLCJ3ZWJwYWNrOi8vL3dlYnBhY2svcnVudGltZS9kZWZpbmUgcHJvcGVydHkgZ2V0dGVycyIsIndlYnBhY2s6Ly8vd2VicGFjay9ydW50aW1lL2hhc093blByb3BlcnR5IHNob3J0aGFuZCIsIndlYnBhY2s6Ly8vLi90ZXN0MS50cyJdLCJuYW1lcyI6WyJfX3dlYnBhY2tfcmVxdWlyZV9fIiwiZXhwb3J0cyIsImRlZmluaXRpb24iLCJrZXkiLCJvIiwiT2JqZWN0IiwiZGVmaW5lUHJvcGVydHkiLCJlbnVtZXJhYmxlIiwiZ2V0Iiwib2JqIiwicHJvcCIsInByb3RvdHlwZSIsImhhc093blByb3BlcnR5IiwiY2FsbCIsInMiLCJjb29sVGhyb3ciXSwibWFwcGluZ3MiOiJBQUNBLElBQUlBLEVBQXNCLENDQTFCLEVBQXdCLENBQUNDLEVBQVNDLEtBQ2pDLElBQUksSUFBSUMsS0FBT0QsRUFDWEYsRUFBb0JJLEVBQUVGLEVBQVlDLEtBQVNILEVBQW9CSSxFQUFFSCxFQUFTRSxJQUM1RUUsT0FBT0MsZUFBZUwsRUFBU0UsRUFBSyxDQUFFSSxZQUFZLEVBQU1DLElBQUtOLEVBQVdDLE1DSjNFLEVBQXdCLENBQUNNLEVBQUtDLElBQVVMLE9BQU9NLFVBQVVDLGVBQWVDLEtBQUtKLEVBQUtDLEksc0JDR2xGLGNBSEEsU0FBbUJJLEdBQ2YsS0FBTSxlQUdOQyxJIiwiZmlsZSI6InRlc3QxLmpzIiwic291cmNlc0NvbnRlbnQiOlsiLy8gVGhlIHJlcXVpcmUgc2NvcGVcbnZhciBfX3dlYnBhY2tfcmVxdWlyZV9fID0ge307XG5cbiIsIi8vIGRlZmluZSBnZXR0ZXIgZnVuY3Rpb25zIGZvciBoYXJtb255IGV4cG9ydHNcbl9fd2VicGFja19yZXF1aXJlX18uZCA9IChleHBvcnRzLCBkZWZpbml0aW9uKSA9PiB7XG5cdGZvcih2YXIga2V5IGluIGRlZmluaXRpb24pIHtcblx0XHRpZihfX3dlYnBhY2tfcmVxdWlyZV9fLm8oZGVmaW5pdGlvbiwga2V5KSAmJiAhX193ZWJwYWNrX3JlcXVpcmVfXy5vKGV4cG9ydHMsIGtleSkpIHtcblx0XHRcdE9iamVjdC5kZWZpbmVQcm9wZXJ0eShleHBvcnRzLCBrZXksIHsgZW51bWVyYWJsZTogdHJ1ZSwgZ2V0OiBkZWZpbml0aW9uW2tleV0gfSk7XG5cdFx0fVxuXHR9XG59OyIsIl9fd2VicGFja19yZXF1aXJlX18ubyA9IChvYmosIHByb3ApID0+IChPYmplY3QucHJvdG90eXBlLmhhc093blByb3BlcnR5LmNhbGwob2JqLCBwcm9wKSkiLCJmdW5jdGlvbiBjb29sVGhyb3coczogc3RyaW5nKSB7XG4gICAgdGhyb3cgXCJjb29sIFwiKyBzXG59XG5leHBvcnQgZGVmYXVsdCAoKSA9PiB7XG4gICAgY29vbFRocm93KFwiaXMgY29vbFwiKVxufTtcbiJdLCJzb3VyY2VSb290IjoiIn0=
-`[1:]), 0o644))
-	data := `
-import l from "./test1.js"
-
-export default function () {
-		l()
-};
-`[1:]
-	b, err := getSimpleBundle(t, "/script.js", data, fs)
-	require.NoError(t, err)
-
-	bi, err := b.Instantiate(context.Background(), 0)
-	require.NoError(t, err)
-	_, err = bi.getCallableExport(consts.DefaultFn)(sobek.Undefined())
-	require.Error(t, err)
-	exception := new(sobek.Exception)
-	require.ErrorAs(t, err, &exception)
-	// TODO figure out why those are not the same as the one in the previous test TestSourceMapsExternal
-	// likely settings in the transpilers
-	require.Equal(t, "cool is cool\n\tat webpack:///./test1.ts:2:4(2)\n\tat r (webpack:///./test1.ts:5:4(3))\n\tat default (file:///script.js:4:4(3))\n", exception.String())
-}
-
 func TestSourceMapsInlinedCJS(t *testing.T) {
 	t.Parallel()
 	fs := fsext.NewMemMapFs()

--- a/js/tc39/README.md
+++ b/js/tc39/README.md
@@ -1,6 +1,6 @@
 # Introduction to a k6's TC39 testing
 
-This module tests k6 [Sobek](https://github.com/grafana/sobek) and the k6 Sobek+esbuild combo against the tc39 test suite.
+`js/tc39` package tests k6 [Sobek](https://github.com/grafana/sobek) and the k6 Sobek+esbuild combo against the tc39 test suite.
 
 Ways to use it:
 1. run ./checkout.sh to checkout the last commit sha of [test262](https://github.com/tc39/test262)
@@ -8,7 +8,7 @@ Ways to use it:
 2. Run `go test &> out.log`
 
 The full list of failing tests, and the error, is in `breaking_test_errors-*.json`. All errors list there with the corresponding error will *not* be counted as errors - this is what the test expects, those specific errors.
-Due to changes to Sobek it is not uncommon for the error to change, or there to be now a new error on previously passing test, or (hopefully) a test that was not passing but now is.
+Due to changes to Sobek it's common for the error to change, or there to be now a new error on the previously passing test, or (hopefully) a test that was not passing but now is.
 In all of those cases `breaking_test_errors-*.json` needs to be updated. Run the test with `-update` flag to update: `go test -update`
 
 NOTE: some text editors/IDEs will try to parse files ending in `json` as JSON, which given the size of `breaking_test_errors-*.json` might be a problem when it's not actually a JSON (before the edit). So it might be a better idea to name it something different if editing by hand and fix it later.
@@ -27,6 +27,6 @@ This also means that, if the
 previous breakage was something a user can work around in a certain way, it now might be something
 else that the user can't workaround or have another problem.
 
-Starting v0.53 k6 doesn't use babel, it is mostly for testing esbuild, but also due to Sobek not testing a lot more stuff. It is still possible that we drop this whole package in the future.
+Starting v0.53 k6 doesn't use Babel anymore, it now serves tests for `esbuild`, and for the parts uncovered by Sobek's test suite. It is still possible that we drop the whole package in the future.
 
 For these reasons, I decided that recording what breaks and checking that it doesn't change is better.

--- a/js/tc39/README.md
+++ b/js/tc39/README.md
@@ -1,6 +1,6 @@
 # Introduction to a k6's TC39 testing
 
-The point of this module is to test k6 Sobek+babel and k6 Sobek+esbuild combo against the tc39 test suite.
+The point of this module is to test k6 Sobek and k6 Sobek+esbuild combo against the tc39 test suite.
 
 Ways to use it:
 1. run ./checkout.sh to checkout the last commit sha of [test262](https://github.com/tc39/test262)
@@ -8,7 +8,7 @@ Ways to use it:
 2. Run `go test &> out.log`
 
 The full list of failing tests, and the error, is in `breaking_test_errors-*.json`. All errors list there with the corresponding error will *not* be counted as errors - this is what the test expects, those specific errors.
-Due to changes to soben it is not uncommon for the error to change, or there to be now a new error on previously passing test, or (hopefully) a test that was not passing but now is.
+Due to changes to Sobek it is not uncommon for the error to change, or there to be now a new error on previously passing test, or (hopefully) a test that was not passing but now is.
 In all of those cases `breaking_test_errors-*.json` needs to be updated. Run the test with `-update` flag to update: `go test -update`
 
 NOTE: some text editors/IDEs will try to parse files ending in `json` as JSON, which given the size of `breaking_test_errors-*.json` might be a problem when it's not actually a JSON (before the edit). So it might be a better idea to name it something different if editing by hand and fix it later.
@@ -27,6 +27,6 @@ This also means that, if the
 previous breakage was something a user can work around in a certain way, it now might be something
 else that the user can't workaround or have another problem.
 
-On top of that this more or less exist as k6 add babel to the mix and that changes which tests pass and how some of them fail. When we remove babel, it's very likely we will also remove this package as it won't be relevant anymore.
+Now that k6 doesn't use babel, it is mostly for testing esbuild, but also due to Sobek not testing a lot more stuff. It is still possible we might drop this whole package in the future.
 
 For these reasons, I decided that recording what breaks and checking that it doesn't change is better.

--- a/js/tc39/README.md
+++ b/js/tc39/README.md
@@ -1,6 +1,6 @@
 # Introduction to a k6's TC39 testing
 
-The point of this module is to test k6 Sobek and k6 Sobek+esbuild combo against the tc39 test suite.
+This module tests k6 [Sobek](https://github.com/grafana/sobek) and the k6 Sobek+esbuild combo against the tc39 test suite.
 
 Ways to use it:
 1. run ./checkout.sh to checkout the last commit sha of [test262](https://github.com/tc39/test262)
@@ -27,6 +27,6 @@ This also means that, if the
 previous breakage was something a user can work around in a certain way, it now might be something
 else that the user can't workaround or have another problem.
 
-Now that k6 doesn't use babel, it is mostly for testing esbuild, but also due to Sobek not testing a lot more stuff. It is still possible we might drop this whole package in the future.
+Starting v0.53 k6 doesn't use babel, it is mostly for testing esbuild, but also due to Sobek not testing a lot more stuff. It is still possible that we drop this whole package in the future.
 
 For these reasons, I decided that recording what breaks and checking that it doesn't change is better.

--- a/lib/runtime_options.go
+++ b/lib/runtime_options.go
@@ -13,9 +13,9 @@ import (
 type CompatibilityMode uint8
 
 const (
-	// CompatibilityModeExtended achieves ES6+ compatibility with Babel
+	// CompatibilityModeExtended adds global as alias for globalThis on top of the base
 	CompatibilityModeExtended CompatibilityMode = iota + 1
-	// CompatibilityModeBase is standard Sobek ES5.1+
+	// CompatibilityModeBase is standard Sobek
 	CompatibilityModeBase
 	// CompatibilityModeExperimentalEnhanced achieves TypeScript and ES6+ compatibility with esbuild
 	CompatibilityModeExperimentalEnhanced
@@ -28,7 +28,7 @@ type RuntimeOptions struct {
 	// Whether to pass the actual system environment variables to the JS runtime
 	IncludeSystemEnvVars null.Bool `json:"includeSystemEnvVars"`
 
-	// JS compatibility mode: "extended" (Goja+Babel) or "base" (plain Goja)
+	// JS compatibility mode: "extended" (Sobek+global) or "base" (plain Sobek)
 	//
 	// TODO: when we resolve https://github.com/k6io/k6/issues/883, we probably
 	// should use the CompatibilityMode type directly... but by then, we'd need to have

--- a/lib/runtime_options.go
+++ b/lib/runtime_options.go
@@ -13,9 +13,9 @@ import (
 type CompatibilityMode uint8
 
 const (
-	// CompatibilityModeExtended adds global as alias for globalThis on top of the base
+	// CompatibilityModeExtended adds `global` as an alias for `globalThis` on top of the base mode
 	CompatibilityModeExtended CompatibilityMode = iota + 1
-	// CompatibilityModeBase is standard Sobek
+	// CompatibilityModeBase is standard Sobek, which means pure vanilla JS following ECMAScript standards.
 	CompatibilityModeBase
 	// CompatibilityModeExperimentalEnhanced achieves TypeScript and ES6+ compatibility with esbuild
 	CompatibilityModeExperimentalEnhanced


### PR DESCRIPTION
## What?

Cleanup comments and messages around ESM merge

## Why?

A lot of those comments no longer make sense with Babel gone and some refactoring of the internals

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
