### PR TITLE
More Goja to Sobek substitutions

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -419,7 +419,7 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 
 	// Check what the execScheduler.Run() error is.
 	if err != nil {
-		err = common.UnwrapGojaInterruptedError(err)
+		err = common.UnwrapSobekInterruptedError(err)
 		logger.WithError(err).Debug("Test finished with an error")
 		return err
 	}

--- a/js/common/interrupt_error.go
+++ b/js/common/interrupt_error.go
@@ -6,8 +6,8 @@ import (
 	"github.com/grafana/sobek"
 )
 
-// UnwrapGojaInterruptedError returns the internal error handled by Sobek.
-func UnwrapGojaInterruptedError(err error) error {
+// UnwrapSobekInterruptedError returns the internal error handled by Sobek.
+func UnwrapSobekInterruptedError(err error) error {
 	var sobekErr *sobek.InterruptedError
 	if errors.As(err, &sobekErr) {
 		if e, ok := sobekErr.Value().(error); ok {

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -101,7 +101,7 @@ func extractLogger(vu lib.ActiveVU) *logrus.Logger {
 	}
 }
 
-func TestConsoleLogWithGojaNativeObject(t *testing.T) {
+func TestConsoleLogWithSobekNativeObject(t *testing.T) {
 	t.Parallel()
 
 	rt := sobek.New()

--- a/js/modules/k6/experimental/streams/errors.go
+++ b/js/modules/k6/experimental/streams/errors.go
@@ -28,7 +28,7 @@ func newJsError(rt *sobek.Runtime, base sobek.Value, kind errorKind, message str
 //
 // We need to use it because whenever we need to return a [TypeError]
 // or a [RangeError], we want to use original JS errors, which can be
-// retrieved from Goja, for instance with: sobek.Runtime.Get("TypeError").
+// retrieved from Sobek, for instance with: sobek.Runtime.Get("TypeError").
 //
 // However, that is implemented as a [*sobek.Object], but sometimes we
 // need to return that error as a Go [error], or even keep the instance

--- a/js/modules/k6/experimental/streams/readable_stream_reader.go
+++ b/js/modules/k6/experimental/streams/readable_stream_reader.go
@@ -23,7 +23,7 @@ type ReadableStreamReader interface {
 //
 // It implements the [ReadableStreamReaderGeneric] mixin from the specification.
 //
-// Because we are in the context of Goja, we cannot really define properties
+// Because we are in the context of Sobek, we cannot really define properties
 // the same way as in the spec, so we use getters/setters instead.
 //
 // [ReadableStreamReaderGeneric]: https://streams.spec.whatwg.org/#readablestreamgenericreader

--- a/js/modules/k6/experimental/streams/tests/testharness.js.patch
+++ b/js/modules/k6/experimental/streams/tests/testharness.js.patch
@@ -8,7 +8,7 @@ index c5c375e17..57d201b57 100644
          Promise.resolve().then(function() {
 -            this.all_loaded = true
 +            // This is the test environment used when we run tests from Go
-+            // code and with the Goja/k6 runtime. However, we don't want
++            // code and with the Sobek/k6 runtime. However, we don't want
 +            // all tests to be marked as loaded "by default", as it would
 +            // make some of the tests to not be executed at all.
 +            // this.all_loaded = true

--- a/js/modules/k6/html/gen/gen_elements.go
+++ b/js/modules/k6/html/gen/gen_elements.go
@@ -331,11 +331,11 @@ func main() {
 			TemplateType       templateType
 			TemplateArgs       []templateArg
 		}
-		TemplateTypes struct{ String, URL, Enum, Bool, GojaEnum, Int, Const templateType }
+		TemplateTypes struct{ String, URL, Enum, Bool, SobekEnum, Int, Const templateType }
 	}{
 		collector.elemInfos,
 		funcDefs,
-		struct{ String, URL, Enum, Bool, GojaEnum, Int, Const templateType }{
+		struct{ String, URL, Enum, Bool, SobekEnum, Int, Const templateType }{
 			stringTemplate, urlTemplate, enumTemplate, boolTemplate, nullableEnumTemplate, intTemplate, constTemplate,
 		},
 	})
@@ -408,7 +408,7 @@ func ({{ receiverName $funcDef.Elem }} {{$funcDef.Elem}}) {{$funcDef.Method}}() 
 	default:
 		return "{{ index $funcDef.TemplateArgs 0 }}"
 	}
-{{- else if eq $funcDef.TemplateType $templateTypes.GojaEnum }}
+{{- else if eq $funcDef.TemplateType $templateTypes.SobekEnum }}
 	attrVal, exists := {{ receiverName $funcDef.Elem }}.sel.sel.Attr("{{ $funcDef.Attr }}")
 	if !exists {
 		return sobek.Undefined()

--- a/js/modules/k6/ws/ws.go
+++ b/js/modules/k6/ws/ws.go
@@ -166,7 +166,7 @@ func (mi *WS) Connect(url string, args ...sobek.Value) (*HTTPResponse, error) {
 	// since we use custom closing logic to call user's event
 	// handlers and for cleanup. See closeConnection.
 	// closeConnection is not set directly as a handler here to
-	// avoid race conditions when calling the Goja runtime.
+	// avoid race conditions when calling the Sobek runtime.
 	socket.conn.SetCloseHandler(func(_ int, _ string) error { return nil })
 
 	// Pass ping/pong events through the main control loop


### PR DESCRIPTION
## What?

Some places where Goja was uppercased have been missed in the previous times this was accessed.

## Why?

It will be confusing some places mentioning Goja and some Sobek

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
#3817 