### PR TITLE
Adjust logging of the executor lack of work

### DIFF
--- a/execution/scheduler.go
+++ b/execution/scheduler.go
@@ -53,7 +53,7 @@ func NewScheduler(trs *lib.TestRunState, controller Controller) (*Scheduler, err
 	// Only take executors which have work.
 	for _, sc := range executorConfigs {
 		if !sc.HasWork(et) {
-			trs.Logger.Warnf(
+			trs.Logger.Debugf(
 				"Executor '%s' is disabled for segment %s due to lack of work!",
 				sc.GetName(), options.ExecutionSegment,
 			)


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->
Changes log message level from Warn to Debug

## Why?
In the case of cloud execution, it could confuse the customers since it could not be apparent to them if they should do something to improve or change, mainly because it has a warning level.

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

<img width="1404" alt="image" src="https://github.com/user-attachments/assets/f5a85a56-88c2-4c2d-bf3a-54f5a26ccfdf">

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #3853

<!-- Thanks for your contribution! 🙏🏼 -->

