### PR TITLE
Fix tls min version in tests with go 1.22

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -2115,6 +2115,7 @@ func TestRequestAndBatchTLS(t *testing.T) {
 			default:
 				panic(versionTest.Name + " unsupported")
 			}
+			s.TLS.MinVersion = tls.VersionTLS10
 			go func() {
 				_ = s.Config.Serve(s.Listener)
 			}()


### PR DESCRIPTION
## What?

As part of 1.22 minimum tls version by default is now 1.2, but the test didn't specify lower one, even though they are testing exactly that.
## Why?

While we still haven't set the go directive in go.mod ot 1.22 - we will do it one day and it will be better if things to fail then.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
