### PR TITLE
Add source for uncaught exceptions

### DIFF
--- a/lib/executor/common_test.go
+++ b/lib/executor/common_test.go
@@ -47,7 +47,7 @@ func setupExecutor(t testing.TB, config lib.ExecutorConfig, es *lib.ExecutionSta
 	ctx, cancel := context.WithCancel(context.Background())
 	engineOut := make(chan metrics.SampleContainer, 100) // TODO: return this for more complicated tests?
 
-	logHook := testutils.NewLogHook(logrus.WarnLevel)
+	logHook := testutils.NewLogHook(logrus.WarnLevel, logrus.ErrorLevel)
 	testLog := logrus.New()
 	testLog.AddHook(logHook)
 	testLog.SetOutput(io.Discard)

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -405,7 +405,7 @@ func TestErrorSource(t *testing.T) {
 	test := setupExecutorTest(t, "", "", lib.Options{}, runner, getTestConstantArrivalRateConfig())
 	defer test.cancel()
 
-	engineOut := make(chan metrics.SampleContainer, 1)
+	engineOut := make(chan metrics.SampleContainer, 1000)
 	require.NoError(t, test.executor.Run(test.ctx, engineOut))
 
 	entries := test.logHook.Drain()

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -407,7 +407,7 @@ func TestErrorSource(t *testing.T) {
 
 	engineOut := make(chan metrics.SampleContainer, 1)
 	require.NoError(t, test.executor.Run(test.ctx, engineOut))
-	
+
 	entries := test.logHook.Drain()
 	require.NotEmpty(t, entries)
 	for _, entry := range entries {

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -128,7 +128,7 @@ func getIterationRunner(
 					// TODO don't count this as a full iteration?
 					logger.WithField("source", "stacktrace").Error(exception.StackTrace())
 				} else {
-					logger.Error(err.Error())
+					logger.WithField("source", "throwable").Error(err.Error())
 				}
 				// TODO: investigate context cancelled errors
 			}


### PR DESCRIPTION
## What?

Add source as throwable for uncaught error log messages

## Why?

Log messages for uncaught errors do not have source

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #3842

<!-- Thanks for your contribution! 🙏🏼 -->
