### PR TITLE
Report ThresholdsHaveFailed on Cloud runs

### DIFF
--- a/cmd/tests/cmd_cloud_test.go
+++ b/cmd/tests/cmd_cloud_test.go
@@ -10,14 +10,14 @@ import (
 	"path/filepath"
 	"testing"
 
-	"go.k6.io/k6/lib/testutils"
-
+	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/cmd"
+	"go.k6.io/k6/errext/exitcodes"
+	"go.k6.io/k6/lib/fsext"
+	"go.k6.io/k6/lib/testutils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.k6.io/k6/cloudapi"
-	"go.k6.io/k6/lib/fsext"
 )
 
 func TestK6Cloud(t *testing.T) {
@@ -235,6 +235,27 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		assert.Contains(t, stdout, `hello world from archive`)
 		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
 		assert.Contains(t, stdout, `test status: Finished`)
+	})
+
+	t.Run("TestCloudThresholdsHaveFailed", func(t *testing.T) {
+		t.Parallel()
+
+		progressCallback := func() cloudapi.TestProgressResponse {
+			return cloudapi.TestProgressResponse{
+				RunStatusText: "Finished",
+				RunStatus:     cloudapi.RunStatusFinished,
+				ResultStatus:  cloudapi.ResultStatusFailed,
+				Progress:      1.0,
+			}
+		}
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil, progressCallback)
+		ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `Thresholds have been crossed`)
 	})
 }
 


### PR DESCRIPTION
_(**Note:** It looks like there is probably a couple of scenarios more that could also be reported more concretely, but I prefer to open a separate pull request for each, so we can discuss them independently)_

## What?

It handles the exceptional case when `testProgress.RunStatus == cloudapi.RunStatusFinished` but with `testProgress.ResultStatus == cloudapi.ResultStatusFailed`, which means that the test run failed due to thresholds being crossed, in order to exit with the specific error code (`ThresholdsHaveFailed = 99`).

**Before**

```
> k6 cloud playground/script.js
...
...
...

     test status: Finished

Run    [======================================] Finished
ERRO[0044] The test has failed                          
exit status 97
```

**After**

```
> k6 cloud playground/script.js
...
...
...

     test status: Finished

Run    [======================================] Finished
ERRO[0042] Thresholds have been crossed                 
exit status 99
```

## Why?

Currently, when a test run executed in the Grafana Cloud k6 fails due to thresholds _being crossed_, it is reported as a generic cloud error (`CloudTestRunFailed = 97`), giving no clue to the user about why the test run did fail. 

In contraposition, when the same test run is executed locally, the user receives some meaningful feedback and the specific error code (`ThresholdsHaveFailed = 99`).

All that said makes, imho, the whole user experience worse, because it's not only inconsistent, and prevents users from reacting on those exit codes, but also because the current feedback is that generic (see below), that gives no clue at all to the user about why the test run did fail:

```
Run    [======================================] Finished
ERRO[0044] The test has failed                          
exit status 97
``` 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
