### PR TITLE
Add `discardResponseMessage` option for gRPC stream

### DIFF
--- a/js/modules/k6/grpc/stream.go
+++ b/js/modules/k6/grpc/stream.go
@@ -76,10 +76,11 @@ func defineStream(rt *sobek.Runtime, s *stream) {
 
 func (s *stream) beginStream(p *callParams) error {
 	req := &grpcext.StreamRequest{
-		Method:           s.method,
-		MethodDescriptor: s.methodDescriptor,
-		TagsAndMeta:      &p.TagsAndMeta,
-		Metadata:         p.Metadata,
+		Method:                 s.method,
+		MethodDescriptor:       s.methodDescriptor,
+		DiscardResponseMessage: p.DiscardResponseMessage,
+		TagsAndMeta:            &p.TagsAndMeta,
+		Metadata:               p.Metadata,
 	}
 
 	ctx := s.vu.Context()

--- a/lib/netext/grpcext/conn.go
+++ b/lib/netext/grpcext/conn.go
@@ -51,11 +51,12 @@ type InvokeResponse struct {
 
 // StreamRequest represents a gRPC stream request.
 type StreamRequest struct {
-	Method           string
-	MethodDescriptor protoreflect.MethodDescriptor
-	Timeout          time.Duration
-	TagsAndMeta      *metrics.TagsAndMeta
-	Metadata         metadata.MD
+	Method                 string
+	MethodDescriptor       protoreflect.MethodDescriptor
+	Timeout                time.Duration
+	DiscardResponseMessage bool
+	TagsAndMeta            *metrics.TagsAndMeta
+	Metadata               metadata.MD
 }
 
 type clientConnCloser interface {
@@ -204,9 +205,10 @@ func (c *Conn) NewStream(
 	}
 
 	return &Stream{
-		raw:              stream,
-		method:           req.Method,
-		methodDescriptor: req.MethodDescriptor,
+		raw:                    stream,
+		method:                 req.Method,
+		methodDescriptor:       req.MethodDescriptor,
+		discardResponseMessage: req.DiscardResponseMessage,
 	}, nil
 }
 


### PR DESCRIPTION
## What?

Adds a new gRPC stream option `discardResponseMessage`. See #3820.

## Why?

Parsing heavy responses can result in high CPU and memory usage.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/3820