### PR TITLE
Deprecation notice for email & password login (k6 cloud login)

### DIFF
--- a/cmd/cloud_login.go
+++ b/cmd/cloud_login.go
@@ -23,6 +23,13 @@ type cmdCloudLogin struct {
 	globalState *state.GlobalState
 }
 
+const warning = `
+[Warning]
+Support for authentication with email and password will be removed after November 11th, 2024 (v0.55.0). 
+Ensure you migrate to token-based authentication by then.
+
+`
+
 func getCmdCloudLogin(gs *state.GlobalState) *cobra.Command {
 	c := &cmdCloudLogin{
 		globalState: gs,
@@ -45,13 +52,14 @@ func getCmdCloudLogin(gs *state.GlobalState) *cobra.Command {
 	loginCloudCommand := &cobra.Command{
 		Use:   cloudLoginCommandName,
 		Short: "Authenticate with Grafana Cloud k6",
-		Long: `Authenticate with Grafana Cloud k6.
+		Long: fmt.Sprintf(`Authenticate with Grafana Cloud k6.
 
 This command will authenticate you with Grafana Cloud k6.
 Once authenticated you can start running tests in the cloud by using the "k6 cloud run"
 command, or by executing a test locally and outputting samples to the cloud using
 the "k6 run -o cloud" command.
-`,
+%s
+`, warning),
 		Example: exampleText,
 		Args:    cobra.NoArgs,
 		RunE:    c.run,
@@ -68,6 +76,9 @@ the "k6 run -o cloud" command.
 //
 //nolint:funlen
 func (c *cmdCloudLogin) run(cmd *cobra.Command, _ []string) error {
+	warnColor := getColor(c.globalState.Flags.NoColor || !c.globalState.Stdout.IsTTY, color.FgRed)
+	printToStdout(c.globalState, warnColor.Sprint(warning))
+
 	currentDiskConf, err := readDiskConfig(c.globalState)
 	if err != nil {
 		return err

--- a/cmd/cloud_login.go
+++ b/cmd/cloud_login.go
@@ -76,7 +76,7 @@ the "k6 run -o cloud" command.
 //
 //nolint:funlen
 func (c *cmdCloudLogin) run(cmd *cobra.Command, _ []string) error {
-	warnColor := getColor(c.globalState.Flags.NoColor || !c.globalState.Stdout.IsTTY, color.FgRed)
+	warnColor := getColor(c.globalState.Flags.NoColor || !c.globalState.Stdout.IsTTY, color.FgYellow)
 	printToStdout(c.globalState, warnColor.Sprint(warning))
 
 	currentDiskConf, err := readDiskConfig(c.globalState)


### PR DESCRIPTION
## What?

Displays a warning, telling the user that support for email and password authentication will be dropped by v0.55.
Look at the screenshots below:

<img width="1046" alt="image" src="https://github.com/user-attachments/assets/afa65dc6-ae8e-4a00-a9cf-a76db2ff3bda">

<img width="1042" alt="Captura de pantalla 2024-08-01 a las 11 06 04" src="https://github.com/user-attachments/assets/3481eb0f-abd3-4a35-8851-74303dd1ced3">

## Why?

Because we're planning to drop that support (see #3835), and we would like to follow our procedure of warning the users two versions ahead.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
