### PR TITLE
Update the Support page

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@ Types of questions and where to ask:
 - I got this error, why? -- [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6)
 - I got this error and I'm sure it's a bug -- [open a new issue](https://github.com/grafana/k6/issues), if there isn't one for this specific bug already
 - I have an idea/request -- search the [GitHub issues](https://github.com/grafana/k6/issues) to see if it was already requested and give the issue a :+1: if so. If it wasn't, search [community.k6.io](https://community.k6.io/) or post a forum thread to discuss the idea with the developers before creating a GitHub issue.
-- Why do you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6.io/slack)
-- When will you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6.io/slack)
+- Why do you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6io.slack.com)
+- When will you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6io.slack.com)
 
-If your questions are related to the commercial [k6-cloud](https://k6.io/cloud/) service, you can contact <support@k6.io> or write in the `#k6-cloud` channel in [Slack](https://k6.io/slack).
+If your questions are related to the commercial [k6-cloud](https://k6.io/cloud/) service, you can contact <support@k6.io> or write in the `#k6-cloud` channel in [Slack](https://k6io.slack.com).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,7 +6,7 @@ Types of questions and where to ask:
 - I got this error, why? -- [community.k6.io](https://community.k6.io/) or [Stack Overflow](https://stackoverflow.com/questions/tagged/k6)
 - I got this error and I'm sure it's a bug -- [open a new issue](https://github.com/grafana/k6/issues), if there isn't one for this specific bug already
 - I have an idea/request -- search the [GitHub issues](https://github.com/grafana/k6/issues) to see if it was already requested and give the issue a :+1: if so. If it wasn't, search [community.k6.io](https://community.k6.io/) or post a forum thread to discuss the idea with the developers before creating a GitHub issue.
-- Why do you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6io.slack.com)
-- When will you? -- [community.k6.io](https://community.k6.io/) or [Slack](https://k6io.slack.com)
+- Why do you? -- [community.k6.io](https://community.k6.io/)
+- When will you? -- check the [public roadmap](https://github.com/orgs/grafana/projects/443/views/1). They are not development promises, they are insights of what is on the radar for the team.
 
-If your questions are related to the commercial [k6-cloud](https://k6.io/cloud/) service, you can contact <support@k6.io> or write in the `#k6-cloud` channel in [Slack](https://k6io.slack.com).
+If your questions are related to the commercial [Grafana Cloud k6](https://grafana.com/products/cloud/k6) service, check the available options on the dedicated page on [Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/account-management/support).


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

~~The Slack link on our support page works for all the already registered users but it doesn't work anymore for new users. I replaced the link based on the k6io domain with the workspace's link under slack.com domain.~~

Update: we decided to drop the links to Slack k6io workspace. It isn't anymore an official channel supported by the core team. 

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Closes #3887 

<!-- Thanks for your contribution! 🙏🏼 -->
