### PR TITLE
Fix cloud command not listed in k6 command's help text

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -366,16 +366,15 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 	cloudCmd := &cobra.Command{
 		Use:   "cloud",
 		Short: "Run a test on the cloud",
-		Long: `Run a test in the Grafana Cloud k6.
+		Long: `The original behavior of the "k6 cloud" command described below is deprecated.
+In future versions, the "cloud" command will only display a help text and will no longer run tests
+in Grafana Cloud k6. To continue running tests in the cloud, please transition to using the "k6 cloud run" command.
+
+Run a test in the Grafana Cloud k6.
 
 This will archive test script(s), including all necessary resources, and execute the test in the Grafana Cloud k6
 service. Be sure to run the "k6 cloud login" command prior to authenticate with Grafana Cloud k6.`,
-		Args: exactCloudArgs(),
-		Deprecated: `the k6 team is in the process of modifying and deprecating the "k6 cloud" command behavior.
-In the future, the "cloud" command will only display a help text, instead of running tests in the Grafana Cloud k6.
-
-To run tests in the cloud, users are now invited to migrate to the "k6 cloud run" command instead.
-`,
+		Args:    exactCloudArgs(),
 		PreRunE: c.preRun,
 		RunE:    c.run,
 		Example: exampleText,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.k6.io/k6/cmd/tests"
+	"go.k6.io/k6/errext/exitcodes"
+)
+
+func TestRootCommandHelpDisplayCommands(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                  string
+		extraArgs             []string
+		wantExitCode          exitcodes.ExitCode
+		wantStdoutContains    string
+		wantStdoutNotContains string
+	}{
+		{
+			name:               "should have archive command",
+			wantStdoutContains: "  archive     Create an archive",
+		},
+		{
+			name:               "should have cloud command",
+			wantStdoutContains: "  cloud       Run a test on the cloud",
+		},
+		{
+			name:               "should have completion command",
+			wantStdoutContains: "  completion  Generate the autocompletion script for the specified shell",
+		},
+		{
+			name:               "should have help command",
+			wantStdoutContains: "  help        Help about any command",
+		},
+		{
+			name:               "should have inspect command",
+			wantStdoutContains: "  inspect     Inspect a script or archive",
+		},
+		{
+			name:               "should have new command",
+			wantStdoutContains: "  new         Create and initialize a new k6 script",
+		},
+		{
+			name:               "should have pause command",
+			wantStdoutContains: "  pause       Pause a running test",
+		},
+		{
+			name:               "should have resume command",
+			wantStdoutContains: "  resume      Resume a paused test",
+		},
+		{
+			name:               "should have run command",
+			wantStdoutContains: "  run         Start a test",
+		},
+		{
+			name:               "should have scale command",
+			wantStdoutContains: "  scale       Scale a running test",
+		},
+		{
+			name:               "should have stats command",
+			wantStdoutContains: "  stats       Show test metrics",
+		},
+		{
+			name:               "should have status command",
+			wantStdoutContains: "  status      Show test status",
+		},
+		{
+			name:               "should have version command",
+			wantStdoutContains: "  version     Show application version",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := tests.NewGlobalTestState(t)
+			ts.CmdArgs = []string{"k6", "help"}
+			newRootCommand(ts.GlobalState).execute()
+
+			if tc.wantStdoutContains != "" {
+				assert.Contains(t, ts.Stdout.String(), tc.wantStdoutContains)
+			}
+		})
+	}
+}


### PR DESCRIPTION
When implementing the new cloud command structure, we marked the
k6 cloud command as deprecated by setting the `cobra.Cmd`, `Deprecated`,
option.

By doing so, Cobra took over itself to hide the command all in all from
the help text's output, and users couldn't see the cloud command as
part of the "Available Commands".

This PR removes the Cobra.Cmd Deprecated option usage, and ports
the message to the Long version of the help text.

This PR also rephrases the message to be more accurate. Considering
the cloud command itself is not deprecated, but rather its existing
behavior, we have mentioned the original behavior consisting in taking
a test resource as input is deprecated, specifically.## What?

## Why?

We discovered that while shipping the new cloud command structure, we had missed the cloud command disappearing from the k6 help text.

![CleanShot 2024-08-19 at 16 20 54](https://github.com/user-attachments/assets/8d073a87-4b59-4552-b123-a037f70bf427)

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.

