### PR TITLE
golangci-lint: enable fatcontext and canonicalheader

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,7 @@ issues:
    # files (due to common repeats and long functions in test code)
    - path: _(test|gen)\.go
      linters:
+       - canonicalheader
        - cyclop
        - dupl
        - gocognit
@@ -68,6 +69,7 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
+    - canonicalheader
     - contextcheck
     - cyclop
     - dogsled
@@ -79,6 +81,7 @@ linters:
     - errorlint
     - exhaustive
     - exportloopref
+    - fatcontext
     - forbidigo
     - forcetypeassert
     - funlen

--- a/cloudapi/client.go
+++ b/cloudapi/client.go
@@ -20,7 +20,7 @@ const (
 	// MaxRetries specifies max retry attempts
 	MaxRetries = 3
 
-	k6IdempotencyKeyHeader = "k6-Idempotency-Key"
+	k6IdempotencyKeyHeader = "K6-Idempotency-Key"
 )
 
 // Client handles communication with the k6 Cloud API.

--- a/cloudapi/logs.go
+++ b/cloudapi/logs.go
@@ -101,7 +101,7 @@ func (c *Config) logtailConn(ctx context.Context, referenceID string, since time
 	headers := make(http.Header)
 	headers.Add("Sec-WebSocket-Protocol", "token="+c.Token.String)
 	headers.Add("Authorization", "token "+c.Token.String)
-	headers.Add("X-K6TestRun-Id", referenceID)
+	headers.Add("X-K6testrun-Id", referenceID)
 
 	var conn *websocket.Conn
 	err = retry(sleeperFunc(time.Sleep), 3, 5*time.Second, 2*time.Minute, func() (err error) {

--- a/lib/executor/vu_handle.go
+++ b/lib/executor/vu_handle.go
@@ -225,7 +225,7 @@ func (vh *vuHandle) runLoopsIfPossible(runIter func(context.Context, lib.ActiveV
 				// we need to cancel the context, to return the vu
 				// and because *we* did, lets reinitialize it
 				cancel()
-				vh.ctx, vh.cancel = context.WithCancel(vh.parentCtx)
+				vh.ctx, vh.cancel = context.WithCancel(vh.parentCtx) //nolint:fatcontext // isn't actually on the same context
 			}
 			fallthrough // to set the state
 		case toHardStop:


### PR DESCRIPTION
## What?

Add new linters from golangci-lint update 

## Why?

- fatcontext prevents a problem we had in the past where you keep adding variables to a context 
- canonicalheader has some performance improvements as it doesn't require go to canonize the header on each invocation

Those are the only new linters since last we updated

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
