### PR TITLE
Implement the --local-execution mode for k6 cloud run

### DIFF
--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -382,7 +382,7 @@ To run tests in the cloud, users are now invited to migrate to the "k6 cloud run
 	}
 
 	// Register `k6 cloud` subcommands
-	cloudCmd.AddCommand(getCmdCloudRun(gs))
+	cloudCmd.AddCommand(getCmdCloudRun(c))
 	cloudCmd.AddCommand(getCmdCloudLogin(gs))
 
 	cloudCmd.Flags().SortFlags = false

--- a/cmd/cloud_run.go
+++ b/cmd/cloud_run.go
@@ -1,21 +1,62 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
-	"go.k6.io/k6/cmd/state"
+	"github.com/spf13/pflag"
+	"go.k6.io/k6/execution"
+	"go.k6.io/k6/execution/local"
 )
 
 const cloudRunCommandName string = "run"
 
-func getCmdCloudRun(gs *state.GlobalState) *cobra.Command {
-	deprecatedCloudCmd := &cmdCloud{
-		gs:            gs,
-		showCloudLogs: true,
-		exitOnRunning: false,
-		uploadOnly:    false,
+type cmdCloudRun struct {
+	// localExecution stores the state of the --local-execution flag.
+	localExecution bool
+
+	// linger stores the state of the --linger flag.
+	linger bool
+
+	// noUsageReport stores the state of the --no-usage-report flag.
+	noUsageReport bool
+
+	// runCmd holds an instance of the k6 run command that we store
+	// in order to be able to call its run method to support
+	// the --local-execution flag mode.
+	runCmd *cmdRun
+
+	// deprecatedCloudCmd holds an instance of the k6 cloud command that we store
+	// in order to be able to call its run method to support the cloud execution
+	// feature, and to have access to its flagSet if necessary.
+	deprecatedCloudCmd *cmdCloud
+}
+
+func getCmdCloudRun(cloudCmd *cmdCloud) *cobra.Command {
+	// We instantiate the run command here to be able to call its run method
+	// when the --local-execution flag is set.
+	runCmd := &cmdRun{
+		gs: cloudCmd.gs,
+
+		// We override the loadConfiguredTest func to use the local execution
+		// configuration which enforces the use of the cloud output among other
+		// side effects.
+		loadConfiguredTest: func(cmd *cobra.Command, args []string) (
+			*loadedAndConfiguredTest,
+			execution.Controller,
+			error,
+		) {
+			test, err := loadAndConfigureLocalTest(cloudCmd.gs, cmd, args, getCloudRunLocalExecutionConfig)
+			return test, local.NewController(), err
+		},
 	}
 
-	exampleText := getExampleText(gs, `
+	cloudRunCmd := &cmdCloudRun{
+		deprecatedCloudCmd: cloudCmd,
+		runCmd:             runCmd,
+	}
+
+	exampleText := getExampleText(cloudCmd.gs, `
   # Run a test script in Grafana Cloud k6
   $ {{.}} cloud run script.js
 
@@ -25,7 +66,7 @@ func getCmdCloudRun(gs *state.GlobalState) *cobra.Command {
   # Read a test script or archive from stdin and run it in Grafana Cloud k6
   $ {{.}} cloud run - < script.js`[1:])
 
-	cloudRunCmd := &cobra.Command{
+	thisCmd := &cobra.Command{
 		Use:   cloudRunCommandName,
 		Short: "Run a test in Grafana Cloud k6",
 		Long: `Run a test in Grafana Cloud k6.
@@ -38,12 +79,87 @@ Use the "k6 cloud login" command to authenticate.`,
 			"the k6 cloud run command expects a single argument consisting in either a path to a script or "+
 				"archive file, or the \"-\" symbol indicating the script or archive should be read from stdin",
 		),
-		PreRunE: deprecatedCloudCmd.preRun,
-		RunE:    deprecatedCloudCmd.run,
+		PreRunE: cloudRunCmd.preRun,
+		RunE:    cloudRunCmd.run,
 	}
 
-	cloudRunCmd.Flags().SortFlags = false
-	cloudRunCmd.Flags().AddFlagSet(deprecatedCloudCmd.flagSet())
+	thisCmd.Flags().SortFlags = false
+	thisCmd.Flags().AddFlagSet(cloudRunCmd.flagSet())
+	thisCmd.Flags().AddFlagSet(cloudCmd.flagSet())
 
-	return cloudRunCmd
+	return thisCmd
+}
+
+func (c *cmdCloudRun) preRun(cmd *cobra.Command, args []string) error {
+	if c.localExecution {
+		return nil
+	}
+
+	if c.linger {
+		return fmt.Errorf("the --linger flag can only be used in conjunction with the --local-execution flag")
+	}
+
+	if c.noUsageReport {
+		return fmt.Errorf("the --no-usage-report can only be used in conjunction with the --local-execution flag")
+	}
+
+	return c.deprecatedCloudCmd.preRun(cmd, args)
+}
+
+func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
+	if c.localExecution {
+		if cmd.Flags().Changed("exit-on-running") {
+			return fmt.Errorf("the --local-execution flag is not compatible with the --exit-on-running flag")
+		}
+
+		if cmd.Flags().Changed("show-logs") {
+			return fmt.Errorf("the --local-execution flag is not compatible with the --show-logs flag")
+		}
+
+		return c.runCmd.run(cmd, args)
+	}
+
+	// When executing in the cloud, we enforce the usage report to be deactivated.
+	c.noUsageReport = true
+
+	return c.deprecatedCloudCmd.run(cmd, args)
+}
+
+func (c *cmdCloudRun) flagSet() *pflag.FlagSet {
+	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
+	flags.SortFlags = false
+
+	flags.BoolVar(&c.localExecution, "local-execution", c.localExecution,
+		"executes the test locally instead of in the cloud")
+	flags.BoolVar(
+		&c.linger,
+		"linger",
+		c.linger,
+		"only when using the local-execution mode, keeps the API server alive past the test end",
+	)
+	flags.BoolVar(
+		&c.noUsageReport,
+		"no-usage-report",
+		c.noUsageReport,
+		"only when using the local-execution mode, don't send anonymous stats to the developers",
+	)
+
+	return flags
+}
+
+func getCloudRunLocalExecutionConfig(flags *pflag.FlagSet) (Config, error) {
+	opts, err := getOptions(flags)
+	if err != nil {
+		return Config{}, err
+	}
+
+	// When running locally, we force the output to be cloud.
+	out := []string{"cloud"}
+
+	return Config{
+		Options:       opts,
+		Out:           out,
+		Linger:        getNullBool(flags, "linger"),
+		NoUsageReport: getNullBool(flags, "no-usage-report"),
+	}, nil
 }

--- a/cmd/tests/cmd_cloud_run_test.go
+++ b/cmd/tests/cmd_cloud_run_test.go
@@ -1,6 +1,11 @@
 package tests
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.k6.io/k6/cmd"
+)
 
 func TestK6CloudRun(t *testing.T) {
 	t.Parallel()
@@ -9,4 +14,50 @@ func TestK6CloudRun(t *testing.T) {
 
 func setupK6CloudRunCmd(cliFlags []string) []string {
 	return append([]string{"k6", "cloud", "run"}, append(cliFlags, "test.js")...)
+}
+
+func TestCloudRunCommandIncompatibleFlags(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name               string
+		cliArgs            []string
+		wantStderrContains string
+	}{
+		{
+			name:               "using --linger should be incompatible with k6 cloud run",
+			cliArgs:            []string{"--linger"},
+			wantStderrContains: "the --linger flag can only be used in conjunction with the --local-execution flag",
+		},
+		{
+			name:               "using --no-usage-report linger should be incompatible with k6 cloud run",
+			cliArgs:            []string{"--no-usage-report"},
+			wantStderrContains: "the --no-usage-report can only be used in conjunction with the --local-execution flag",
+		},
+		{
+			name:               "using --exit-on-running should be incompatible with k6 cloud run --local-execution",
+			cliArgs:            []string{"--local-execution", "--exit-on-running"},
+			wantStderrContains: "the --local-execution flag is not compatible with the --exit-on-running flag",
+		},
+		{
+			name:               "using --show-logs should be incompatible with k6 cloud run --local-execution",
+			cliArgs:            []string{"--local-execution", "--show-logs"},
+			wantStderrContains: "the --local-execution flag is not compatible with the --show-logs flag",
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := getSimpleCloudTestState(t, nil, setupK6CloudRunCmd, tc.cliArgs, nil, nil)
+			ts.ExpectedExitCode = -1
+			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			stderr := ts.Stderr.String()
+			assert.Contains(t, stderr, tc.wantStderrContains)
+		})
+	}
 }


### PR DESCRIPTION
## What?

This PR adds support for a new `--local-execution` flag to the k6 cloud run command. Using it, users can run their test script or archive on their local machine while streaming the results to the cloud.

In the context of this PR, the goal is to reproduce the behavior of the `k6 run -o cloud` behavior; we will add support for archive upload, logs, and trace forwarding in future PRs.

## Considerations and open questions

* During the implementation, we realized with @joanlopez that having a dedicated subcommand, as opposed to a flag, could lead to a more compartimatenlized flag structure, and clearer inter-dependencies between them: with this PR some `k6 cloud run` flags are now only allowed/relevant in conjunction with `--local-execution`. However, after brainstorming, we couldn't find a satisfactory name, that wouldn't feel weird and confusing (I'm looking at you `k6 cloud run-locally`.
* Related to ☝🏻 we imported the `--linger` and `--no-usage-report` options from the `k6 run` command and made them available/functional only when `--local-execution` is passed. Do we consider this approach satisfactory?
* We have overridden the `getConfig` function to enforce the output to be set to `cloud`. This is the most straightforward way we found to do this. If you have a better idea, please feel free to suggest 🙇🏻 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

ref #3818
ref #3282
