### PR TITLE
Add browser#1406 to v0.54.0 release notes

### DIFF
--- a/release notes/v0.54.0.md
+++ b/release notes/v0.54.0.md
@@ -33,8 +33,7 @@ _Format as `<number> <present_verb> <object>. <credit>`_:
 
 ## Bug fixes
 
-_Format as `<number> <present_verb> <object>. <credit>`_:
-- _`#111` fixes race condition in runtime_
+- [browser#1406](https://github.com/grafana/xk6-browser/pull/1406) Fix panic on iframe attach when iframe didn't contain any UI elements.
 
 ## Maintenance and internal improvements
 


### PR DESCRIPTION
## What?

Adding https://github.com/grafana/xk6-browser/pull/1406 to the release notes.

## Why?

Keep users up to date with fixes in the browser module.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/xk6-browser/pull/1406