### PR TITLE
Drop NetTrail - emit iterations metrics in runner instead of dialer

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -867,7 +867,7 @@ func (u *VU) runFn(
 
 	builtinMetrics := u.Runner.preInitState.BuiltinMetrics
 	ctm := u.state.Tags.GetCurrentValues()
-	u.state.Samples <- u.Dialer.Sample(endTime, ctm, builtinMetrics)
+	u.state.Samples <- u.Dialer.IOSamples(endTime, ctm, builtinMetrics)
 
 	if isFullIteration && isDefault {
 		u.state.Samples <- iterationSamples(startTime, endTime, ctm, builtinMetrics)

--- a/js/runner_test.go
+++ b/js/runner_test.go
@@ -794,10 +794,9 @@ func TestVUIntegrationMetrics(t *testing.T) {
 			require.NoError(t, err)
 			sampleCount := 0
 			builtinMetrics := r.preInitState.BuiltinMetrics
-			for i, sampleC := range metrics.GetBufferedSamples(samples) {
-				for j, s := range sampleC.GetSamples() {
-					sampleCount++
-					switch i + j {
+			for _, sampleC := range metrics.GetBufferedSamples(samples) {
+				for _, s := range sampleC.GetSamples() {
+					switch sampleCount {
 					case 0:
 						assert.Equal(t, 5.0, s.Value)
 						assert.Equal(t, "my_metric", s.Metric.Name)
@@ -814,6 +813,7 @@ func TestVUIntegrationMetrics(t *testing.T) {
 						assert.Same(t, builtinMetrics.Iterations, s.Metric, "`iterations` sample is after `iteration_duration`")
 						assert.Equal(t, float64(1), s.Value)
 					}
+					sampleCount++
 				}
 			}
 			assert.Equal(t, sampleCount, 5)

--- a/lib/netext/dialer.go
+++ b/lib/netext/dialer.go
@@ -69,10 +69,10 @@ func (d *Dialer) DialContext(ctx context.Context, proto, addr string) (net.Conn,
 	return conn, err
 }
 
-// Sample creates a new NetTrail instance with the Dialer
-// sent and received data metrics and the supplied times and tags.
-func (d *Dialer) Sample(
-	endTime time.Time, ctm metrics.TagsAndMeta, builtinMetrics *metrics.BuiltinMetrics,
+// IOSamples returns samples for data send and received since it last call and zeros out.
+// It uses the provided time as the sample time and tags and builtinMetrics to build the samples.
+func (d *Dialer) IOSamples(
+	sampleTime time.Time, ctm metrics.TagsAndMeta, builtinMetrics *metrics.BuiltinMetrics,
 ) metrics.SampleContainer {
 	bytesWritten := atomic.SwapInt64(&d.BytesWritten, 0)
 	bytesRead := atomic.SwapInt64(&d.BytesRead, 0)
@@ -82,7 +82,7 @@ func (d *Dialer) Sample(
 				Metric: builtinMetrics.DataSent,
 				Tags:   ctm.Tags,
 			},
-			Time:     endTime,
+			Time:     sampleTime,
 			Metadata: ctm.Metadata,
 			Value:    float64(bytesWritten),
 		},
@@ -91,7 +91,7 @@ func (d *Dialer) Sample(
 				Metric: builtinMetrics.DataReceived,
 				Tags:   ctm.Tags,
 			},
-			Time:     endTime,
+			Time:     sampleTime,
 			Metadata: ctm.Metadata,
 			Value:    float64(bytesRead),
 		},

--- a/output/cloud/insights/collect_test.go
+++ b/output/cloud/insights/collect_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/cloudapi/insights"
-	"go.k6.io/k6/lib/netext"
 	"go.k6.io/k6/lib/netext/httpext"
 	"go.k6.io/k6/metrics"
 )
@@ -50,9 +49,6 @@ func Test_Collector_CollectRequestMetadatas_FiltersAndStoresHTTPTrailsAsRequestM
 		},
 		&httpext.Trail{
 			// HTTP trail without trace ID should be ignored
-		},
-		&netext.NetTrail{
-			// Net trail should be ignored
 		},
 		&httpext.Trail{
 			EndTime:  time.Unix(20, 0),


### PR DESCRIPTION
## What?

Drop the NetTrail container and emit iterations metric in runner instead of in Dialer.

Also fix #1605 

## Why?

As part of looking over issues I found #1250 which has some additional work required. But dropping the specific NetTrail and moving the code around was really simple. 

FIxing some of the test took a bit more time :(

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
#1250 
#1605 
