### PR TITLE
Releasing process updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/hotfix-release.md
+++ b/.github/ISSUE_TEMPLATE/hotfix-release.md
@@ -26,8 +26,8 @@ Note, the assumption is a minor branch release already exists from the latest mi
       2. the release notes
 - [ ] Open, get approvals and merge on the already existing release branch a separate pull-request for bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/master/lib/consts/consts.go#L11-L12). Note, `master` should be already on a next major/minor version.
 - [ ] Pull locally the previously merged changes.
-- [ ] Create and push a new tag of the form `vX.Y.Z` using git: `git tag v0.5x.0 -m "v0.5x.0"`.
-- [ ] If the defect affects DefinitelyTyped's definitions, open a pull request in the `DefinitelyTyped/DefinitelyTyped` repository by creating a branch on the `grafana/k6-DefinitelyTyped` fork, to update the k6 type definitions for the new release.
+- [ ] Create and push a new tag of the form `vX.Y.Z` using git. For instance, if the current release is v0.52, the command could look like `git tag v0.52.1 -m "v0.52.1"` if this is the first hotfix.
+- [ ] If the defect affects DefinitelyTyped's definitions, open a pull request in the `DefinitelyTyped/DefinitelyTyped` repository by creating a branch on the `grafana/k6-DefinitelyTyped` fork, to update the k6 type definitions.
 
 #### In k6 repository, if the defect affects the latest release but not the `master` branch
 

--- a/.github/ISSUE_TEMPLATE/hotfix-release.md
+++ b/.github/ISSUE_TEMPLATE/hotfix-release.md
@@ -33,6 +33,10 @@ Note, the assumption is a minor branch release already exists from the latest mi
 
 The steps are the same as the previous, with the unique exception that the patch pull request has to be directly merged against the release branch instead of being cherry-picked.
 
+#### In k6 repository, if the defect affects the latest release and the `master` branch but they are not anymore the same compatible code.
+
+The union of the previous steps have to be executed, where the changes have to be applied independently to both branches without cherry-picking. Each version get a dedicated patch.
+
 #### Announcements
 
 - [ ] Publish a link to the new GitHub release in the #k6-changelog channel.

--- a/.github/ISSUE_TEMPLATE/hotfix-release.md
+++ b/.github/ISSUE_TEMPLATE/hotfix-release.md
@@ -1,0 +1,44 @@
+---
+name: k6 Hotfix release
+about: Bugs or security issues have been identified and they requires a patch release.
+title: 'k6 hotfix release v<major>.<minor>.<patch>'
+labels: ["release"]
+---
+
+**Release Date**:
+
+25th May 2024 <<  TODO: WRITE HERE THE UPDATED RELEASE DATE
+
+## Release Activities
+
+Note, the assumption is a minor branch release already exists from generated from the latest minor release. It has the name in the form `release-v<major>.<minor>.x`.
+
+#### Documentation
+
+- [ ] If required, open and merge pull-request from `main` applying the changes to the affected version.
+
+#### In k6 repository, if the defect affects the latest release and the `master` branch
+
+- [ ] Open, get approvals and merge on `master` the patch for the defect.
+- [ ] Open, get approvals and merge on `master` the release notes. Ensure that all merged pull-requests are referenced.
+- [ ] Switch on the release branch and cherry-pick the following changes:
+      1. the patch for the defect
+      2. the release notes
+- [ ] Open, get approvals and merge on the already existing release branch a separate pull-request for bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/master/lib/consts/consts.go#L11-L12). Note, `master` should be already on a next major/minor version.
+- [ ] Pull locally the previously merged changes.
+- [ ] Create and push a new tag of the form `vX.Y.Z` using git: `git tag v0.5x.0 -m "v0.5x.0"`.
+- [ ] If the defect affects DefinitelyTyped's definitions, open a pull request in the `DefinitelyTyped/DefinitelyTyped` repository by creating a branch on the `grafana/k6-DefinitelyTyped` fork, to update the k6 type definitions for the new release.
+
+#### In k6 repository, if the defect affects the latest release but not the `master` branch
+
+The steps are the same as the previous, with the unique exception that the patch pull request has to be directly merged against the release branch instead of being cherry-picked.
+
+#### Announcements
+
+- [ ] Publish a link to the new GitHub release in the #k6-changelog channel.
+- [ ] Notify the larger team in the #k6 channel, letting them know that the release is published.
+
+## Wrapping Release
+
+- [ ] Ensure the `DefinitelyTyped/DefinitelyTyped` PR(s) are merged.
+- [ ] Update the k6 repository's `.github/ISSUE_TEMPLATE/hotfix-release.md` in the event steps from this checklist were incorrect or missing.

--- a/.github/ISSUE_TEMPLATE/hotfix-release.md
+++ b/.github/ISSUE_TEMPLATE/hotfix-release.md
@@ -11,7 +11,7 @@ labels: ["release"]
 
 ## Release Activities
 
-Note, the assumption is a minor branch release already exists from generated from the latest minor release. It has the name in the form `release-v<major>.<minor>.x`.
+Note, the assumption is a minor branch release already exists from the latest minor release. This branch is named in the format `release-v<major>.<minor>.x`.
 
 #### Documentation
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -14,7 +14,6 @@ labels: ["release"]
 ### At the beginning of the cycle
 
 - [ ] Obtain the Release coordinator's contact from the `@k6-browser` team and co-assign the issue to them.
-- [ ] Open and merge a pull-request for bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/master/lib/consts/consts.go#L11-L12).
 - [ ] Create a new `release-notes-v<major>.<minor>.<patch>` (e.g. `release-notes-v0.51.0`) long-lived branch and add a new release notes file using the available [template](https://github.com/grafana/k6/blob/master/release%20notes/template.md) to the [repository's `release notes` folder](https://github.com/grafana/k6/blob/master/release%20notes).
 - [ ] Go through the potential [dependencies updates](https://github.com/grafana/k6/blob/master/Dependencies.md) and create a dedicated pull-request if any of them is relevant to this release.
 - [ ] Create a new `release-v<major>.<minor>.<patch>` (e.g. `release-v0.51.0`) long-lived branch on the [grafana/k6-DefinitelyTyped](https://github.com/grafana/k6-DefinitelyTyped) fork repository.
@@ -26,6 +25,7 @@ labels: ["release"]
 
 - [ ] Ensure that all pull-requests from a release milestone are merged.
 - [ ] Ensure that browser and other experimental modules (if needed) have been updated to their latest version.
+- [ ] Open and merge a pull-request for bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/master/lib/consts/consts.go#L11-L12).
 - [ ] Open a new release branch with the format `release-v0.<minor>.x` (e.g. `release-v0.51.x`). Note, if during the next two weeks, any patch relevant for the release is merged on `master` then remember to cherry-pick it on the release branch.
 
 #### ~ 1 week before the release date

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -16,7 +16,7 @@ labels: ["release"]
 - [ ] Obtain the Release coordinator's contact from the `@k6-browser` team and co-assign the issue to them.
 - [ ] Open and merge a pull-request for bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/master/lib/consts/consts.go#L11-L12).
 - [ ] Create a new `release-notes-v<major>.<minor>.<patch>` (e.g. `release-notes-v0.51.0`) long-lived branch and add a new release notes file using the available [template](https://github.com/grafana/k6/blob/master/release%20notes/template.md) to the [repository's `release notes` folder](https://github.com/grafana/k6/blob/master/release%20notes).
-- [ ] Go through the potential [dependencies updates](https://github.com/grafana/k6/blob/master/Dependencies.md) and create a dedicated PR if any of them is relevant to this release.
+- [ ] Go through the potential [dependencies updates](https://github.com/grafana/k6/blob/master/Dependencies.md) and create a dedicated pull-request if any of them is relevant to this release.
 - [ ] Create a new `release-v<major>.<minor>.<patch>` (e.g. `release-v0.51.0`) long-lived branch on the [grafana/k6-DefinitelyTyped](https://github.com/grafana/k6-DefinitelyTyped) fork repository.
     - [ ] Bump the version in [types/k6/package.json](https://github.com/grafana/k6-DefinitelyTyped/blob/master/types/k6/package.json#L4) to the next one.
 
@@ -26,19 +26,18 @@ labels: ["release"]
 
 - [ ] Ensure that all pull-requests from a release milestone are merged.
 - [ ] Ensure that browser and other experimental modules (if needed) have been updated to their latest version.
-- [ ] Open a new release branch with the format `release-v0.<minor>.x` (e.g. `release-v0.51.x`)
-- [ ] During the next two weeks, if any patch relevant for the release has been merged on `master` then
+- [ ] Open a new release branch with the format `release-v0.<minor>.x` (e.g. `release-v0.51.x`). Note, if during the next two weeks, any patch relevant for the release is merged on `master` then remember to cherry-pick it on the release branch.
 
 #### ~ 1 week before the release date
 
 - [ ] Ensure that all merged pull-requests referenced in the release notes are linked to the release milestone.
 - [ ] Ensure all pull-requests in the `k6-docs` repository, related to new or modified functionalities introduced by the new version have been created.
-- [ ] Ensure all PRs in the k6 repository, part of the current [milestone](https://github.com/grafana/k6/milestones), have been merged.
-- [ ] Open a PR with the release notes for the new version
+- [ ] Ensure all pull-requests in the k6 repository, part of the current [milestone](https://github.com/grafana/k6/milestones), have been merged.
+- [ ] Open a pull-request with the release notes for the new version
   - [ ] Ask teams who might have contributed to the release (k6-browser, k6-ecosystem, k6-docs, k6-devrel teams, etc.) to contribute their notes and review the existing ones.
   - [ ] Remember to mention and thank [external contributors](https://github.com/search?q=user%3Agrafana+repo%3Ak6+milestone%3A%22v0.51.0%22+-author%3Amstoykov+-author%3Aoleiade+-author%3Ana--+-author%3Acodebien+-author%3Aolegbespalov+-author%3Aandrewslotin+-author%3Ajoanlopez+-author%3Aankur22+-author%3Ainancgumus+-author%3Aszkiba+-author%3Adependabot%5Bbot%5D&type=pullrequests). <-- Update the query with the correct milestone version.
-- [ ] Share the release notes PR with the k6 open-source teams. Request contributions from all affected teams (k6-browser, k6-chaos, k6-docs, k6-devrel, etc.) and any other stakeholders involved in the new release.
-- [ ] Open a PR in the `DefinitelyTyped/DefinitelyTyped` repository, using the release branch created in the grafana/k6-DefinitelyTyped fork, to update the k6 type definitions for the new release.
+- [ ] Share the release notes pull-request with the k6 open-source teams. Request contributions from all affected teams (k6-browser, k6-chaos, k6-docs, k6-devrel, etc.) and any other stakeholders involved in the new release.
+- [ ] Open a pull-request in the `DefinitelyTyped/DefinitelyTyped` repository, using the release branch created in the grafana/k6-DefinitelyTyped fork, to update the k6 type definitions for the new release.
 
 #### ~ 1 day before the release date
 
@@ -49,12 +48,12 @@ labels: ["release"]
 #### Documentation
 
 - [ ] Open and merge a pull-request from `main` in the `k6-docs` repository, copying the current k6's `next` to a folder named with the k6 version (e.g. `v0.48.x`).
-- [ ] Ensure the k6 repository release notes PR contains the correct links to the docs.
+- [ ] Ensure the k6 repository release notes pull-request contains the correct links to the docs.
 
 #### In k6 repository
 
 - [ ] Make sure all the patches have been cherry-picked on the release branch.
-- [ ] Merge the release notes PR.
+- [ ] Merge the release notes pull-request.
 - [ ] Pull locally the previously merged changes.
 - [ ] Switch on the release branch then cherry-pick the release notes changes.
 - [ ] Directly from the release branch, create and push a new tag of the form `v<major>.<minor>.<patch>` using git: `git tag v0.5x.0 -m "v0.5x.0"`.
@@ -68,5 +67,5 @@ labels: ["release"]
 
 ## Wrapping Release
 
-- [ ] Ensure the `DefinitelyTyped/DefinitelyTyped` PR(s) are merged.
+- [ ] Ensure the `DefinitelyTyped/DefinitelyTyped` pull-request(s) are merged.
 - [ ] Update the k6 repository's `.github/ISSUE_TEMPLATE/release.md` in the event steps from this checklist were incorrect or missing.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -57,8 +57,8 @@ labels: ["release"]
 - [ ] Merge the release notes PR.
 - [ ] Pull locally the previously merged changes.
 - [ ] Switch on the release branch then cherry-pick the release notes changes.
-- [ ] Directly from the relaese branch, create and push a new tag of the form `v<major>.<minor>.<patch>` using git: `git tag v0.5x.0 -m "v0.5x.0"`.
-- [ ] Delete the previous minor's relaese branch. Note, in a major version only the latest minor is actively maintained.
+- [ ] Directly from the release branch, create and push a new tag of the form `v<major>.<minor>.<patch>` using git: `git tag v0.5x.0 -m "v0.5x.0"`.
+- [ ] Delete the previous minor's release branch. Note, in a major version only the latest minor is actively maintained.
 
 #### Announcements
 

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -52,7 +52,7 @@ labels: ["release"]
 
 #### In k6 repository
 
-- [ ] Ensure that all the patches have been cherry-picked to other branches where necessary.
+- [ ] Ensure that all the patches have been cherry-picked to other branches where necessary. Or, if they are dedicated for the release branch that they have been merged. 
 - [ ] Merge the release notes pull-request.
 - [ ] Pull locally the previously merged changes.
 - [ ] Switch on the release branch then cherry-pick the release notes changes.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -52,7 +52,7 @@ labels: ["release"]
 
 #### In k6 repository
 
-- [ ] Make sure all the patches have been cherry-picked on the release branch.
+- [ ] Ensure that all the patches have been cherry-picked to other branches where necessary.
 - [ ] Merge the release notes pull-request.
 - [ ] Pull locally the previously merged changes.
 - [ ] Switch on the release branch then cherry-pick the release notes changes.

--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -14,9 +14,10 @@ labels: ["release"]
 ### At the beginning of the cycle
 
 - [ ] Obtain the Release coordinator's contact from the `@k6-browser` team and co-assign the issue to them.
-- [ ] Create a new `release-v0.5x.0` long-lived branch and add a new release notes file using the available [template](https://github.com/grafana/k6/blob/master/release%20notes/template.md) to the [repository's `release notes` folder](https://github.com/grafana/k6/blob/master/release%20notes).
+- [ ] Open and merge a pull-request for bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/master/lib/consts/consts.go#L11-L12).
+- [ ] Create a new `release-notes-v<major>.<minor>.<patch>` (e.g. `release-notes-v0.51.0`) long-lived branch and add a new release notes file using the available [template](https://github.com/grafana/k6/blob/master/release%20notes/template.md) to the [repository's `release notes` folder](https://github.com/grafana/k6/blob/master/release%20notes).
 - [ ] Go through the potential [dependencies updates](https://github.com/grafana/k6/blob/master/Dependencies.md) and create a dedicated PR if any of them is relevant to this release.
-- [ ] Create a new `release-v0.5x.0` long-lived branch on the [grafana/k6-DefinitelyTyped](https://github.com/grafana/k6-DefinitelyTyped) fork repository.
+- [ ] Create a new `release-v<major>.<minor>.<patch>` (e.g. `release-v0.51.0`) long-lived branch on the [grafana/k6-DefinitelyTyped](https://github.com/grafana/k6-DefinitelyTyped) fork repository.
     - [ ] Bump the version in [types/k6/package.json](https://github.com/grafana/k6-DefinitelyTyped/blob/master/types/k6/package.json#L4) to the next one.
 
 ### Release Preparation
@@ -25,6 +26,8 @@ labels: ["release"]
 
 - [ ] Ensure that all pull-requests from a release milestone are merged.
 - [ ] Ensure that browser and other experimental modules (if needed) have been updated to their latest version.
+- [ ] Open a new release branch with the format `release-v0.<minor>.x` (e.g. `release-v0.51.x`)
+- [ ] During the next two weeks, if any patch relevant for the release has been merged on `master` then
 
 #### ~ 1 week before the release date
 
@@ -35,7 +38,6 @@ labels: ["release"]
   - [ ] Ask teams who might have contributed to the release (k6-browser, k6-ecosystem, k6-docs, k6-devrel teams, etc.) to contribute their notes and review the existing ones.
   - [ ] Remember to mention and thank [external contributors](https://github.com/search?q=user%3Agrafana+repo%3Ak6+milestone%3A%22v0.51.0%22+-author%3Amstoykov+-author%3Aoleiade+-author%3Ana--+-author%3Acodebien+-author%3Aolegbespalov+-author%3Aandrewslotin+-author%3Ajoanlopez+-author%3Aankur22+-author%3Ainancgumus+-author%3Aszkiba+-author%3Adependabot%5Bbot%5D&type=pullrequests). <-- Update the query with the correct milestone version.
 - [ ] Share the release notes PR with the k6 open-source teams. Request contributions from all affected teams (k6-browser, k6-chaos, k6-docs, k6-devrel, etc.) and any other stakeholders involved in the new release.
-- [ ] Open a separate pull-request for bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/master/lib/consts/consts.go#L11-L12).
 - [ ] Open a PR in the `DefinitelyTyped/DefinitelyTyped` repository, using the release branch created in the grafana/k6-DefinitelyTyped fork, to update the k6 type definitions for the new release.
 
 #### ~ 1 day before the release date
@@ -51,10 +53,12 @@ labels: ["release"]
 
 #### In k6 repository
 
-- [ ] Merge the PR bumping [the k6 Go project's version](https://github.com/grafana/k6/blob/master/lib/consts/consts.go#L11-L12).
+- [ ] Make sure all the patches have been cherry-picked on the release branch.
 - [ ] Merge the release notes PR.
 - [ ] Pull locally the previously merged changes.
-- [ ] Create and push a new tag of the form `vX.Y.Z` using git: `git tag v0.5x.0 -m "v0.5x.0"`.
+- [ ] Switch on the release branch then cherry-pick the release notes changes.
+- [ ] Directly from the relaese branch, create and push a new tag of the form `v<major>.<minor>.<patch>` using git: `git tag v0.5x.0 -m "v0.5x.0"`.
+- [ ] Delete the previous minor's relaese branch. Note, in a major version only the latest minor is actively maintained.
 
 #### Announcements
 


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

* It updates the release process introducing the release branches.
* It creates a dedicated template to release patch versions.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

* It doesn't freeze the master branch when the k6 repo is on feature freeze.
* Patches and minor releases have the same process by tagging from a release branch. (Instead, now we tag from master for minor releases and from a hotfix branch for patches).

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
