### PR TITLE
Implement support to collect Usage dynamically

### DIFF
--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -17,6 +17,7 @@ import (
 	"go.k6.io/k6/lib/testutils/minirunner"
 	"go.k6.io/k6/metrics"
 	"go.k6.io/k6/metrics/engine"
+	"go.k6.io/k6/usage"
 )
 
 func getTestPreInitState(tb testing.TB) *lib.TestPreInitState {
@@ -27,6 +28,7 @@ func getTestPreInitState(tb testing.TB) *lib.TestPreInitState {
 		RuntimeOptions: lib.RuntimeOptions{},
 		Registry:       reg,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(reg),
+		Usage:          usage.New(),
 	}
 }
 

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -118,6 +118,7 @@ func createOutputs(
 		ScriptOptions:  test.derivedConfig.Options,
 		RuntimeOptions: test.preInitState.RuntimeOptions,
 		ExecutionPlan:  executionPlan,
+		Usage:          test.usage,
 	}
 
 	outputs := test.derivedConfig.Out

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -137,6 +137,12 @@ func createOutputs(
 				outputType, getPossibleIDList(outputConstructors),
 			)
 		}
+		if _, builtinErr := builtinOutputString(outputType); builtinErr == nil {
+			err := test.usage.Strings("outputs", outputType)
+			if err != nil {
+				gs.Logger.WithError(err).Warnf("Couldn't report usage for output %q", outputType)
+			}
+		}
 
 		params := baseParams
 		params.OutputType = outputType

--- a/cmd/outputs.go
+++ b/cmd/outputs.go
@@ -118,7 +118,7 @@ func createOutputs(
 		ScriptOptions:  test.derivedConfig.Options,
 		RuntimeOptions: test.preInitState.RuntimeOptions,
 		ExecutionPlan:  executionPlan,
-		Usage:          test.usage,
+		Usage:          test.preInitState.Usage,
 	}
 
 	outputs := test.derivedConfig.Out
@@ -138,7 +138,7 @@ func createOutputs(
 			)
 		}
 		if _, builtinErr := builtinOutputString(outputType); builtinErr == nil {
-			err := test.usage.Strings("outputs", outputType)
+			err := test.preInitState.Usage.Strings("outputs", outputType)
 			if err != nil {
 				gs.Logger.WithError(err).Warnf("Couldn't report usage for output %q", outputType)
 			}

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -67,8 +67,6 @@ func createReport(
 		m["duration"] = execState.GetCurrentTestRunDuration().String()
 		m["goos"] = runtime.GOOS
 		m["goarch"] = runtime.GOARCH
-		m["goarch"] = runtime.GOARCH
-		m["goarch"] = runtime.GOARCH
 		m["vus_max"] = uint64(execState.GetInitializedVUsCount())
 		m["iterations"] = execState.GetFullIterationCount()
 	}

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -56,15 +56,17 @@ func createReport(
 		}
 		u.Strings("outputs", o)
 	}
-
-	u.String("k6_version", consts.Version)
 	execState := execScheduler.GetState()
 	u.Uint64("vus_max", uint64(execState.GetInitializedVUsCount()))
 	u.Uint64("iterations", execState.GetFullIterationCount())
-	u.String("duration", execState.GetCurrentTestRunDuration().String())
-	u.String("goos", runtime.GOOS)
-	u.String("goarch", runtime.GOARCH)
-	return u.Map()
+	m := u.Map()
+
+	m["k6_version"] = consts.Version
+	m["duration"] = execState.GetCurrentTestRunDuration().String()
+	m["goos"] = runtime.GOOS
+	m["goarch"] = runtime.GOARCH
+
+	return m
 }
 
 func reportUsage(ctx context.Context, execScheduler *execution.Scheduler, test *loadedAndConfiguredTest) error {

--- a/cmd/report.go
+++ b/cmd/report.go
@@ -17,7 +17,7 @@ func createReport(
 	u *usage.Usage, execScheduler *execution.Scheduler, importedModules []string, outputs []string,
 ) map[string]any {
 	for _, ec := range execScheduler.GetExecutorConfigs() {
-		u.Count("executors/"+ec.GetType(), 1)
+		u.Uint64("executors/"+ec.GetType(), 1)
 	}
 
 	// collect the report only with k6 public modules
@@ -59,8 +59,8 @@ func createReport(
 
 	u.String("k6_version", consts.Version)
 	execState := execScheduler.GetState()
-	u.Count("vus_max", execState.GetInitializedVUsCount())
-	u.Count("iterations", int64(execState.GetFullIterationCount()))
+	u.Uint64("vus_max", uint64(execState.GetInitializedVUsCount()))
+	u.Uint64("iterations", execState.GetFullIterationCount())
 	u.String("duration", execState.GetCurrentTestRunDuration().String())
 	u.String("goos", runtime.GOOS)
 	u.String("goarch", runtime.GOARCH)

--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -12,6 +12,7 @@ import (
 	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/lib/executor"
 	"go.k6.io/k6/lib/testutils"
+	"go.k6.io/k6/usage"
 	"gopkg.in/guregu/null.v3"
 )
 
@@ -51,12 +52,13 @@ func TestCreateReport(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	s.GetState().MarkEnded()
 
-	r := createReport(s, importedModules, outputs)
-	assert.Equal(t, consts.Version, r.Version)
-	assert.Equal(t, map[string]int{"shared-iterations": 1}, r.Executors)
-	assert.Equal(t, 6, int(r.VUsMax))
-	assert.Equal(t, 170, int(r.Iterations))
-	assert.NotEqual(t, "0s", r.Duration)
-	assert.ElementsMatch(t, []string{"k6", "k6/http", "k6/experimental/webcrypto"}, r.Modules)
-	assert.ElementsMatch(t, []string{"json"}, r.Outputs)
+	m := createReport(usage.New(), s, importedModules, outputs)
+
+	assert.Equal(t, consts.Version, m["k6_version"])
+	assert.Equal(t, map[string]interface{}{"shared-iterations": int64(1)}, m["executors"])
+	assert.EqualValues(t, 6, m["vus_max"])
+	assert.EqualValues(t, 170, m["iterations"])
+	assert.NotEqual(t, "0s", m["duration"])
+	assert.ElementsMatch(t, []string{"k6", "k6/http", "k6/experimental/webcrypto"}, m["modules"])
+	assert.ElementsMatch(t, []string{"json"}, m["outputs"])
 }

--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -52,7 +52,8 @@ func TestCreateReport(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	s.GetState().MarkEnded()
 
-	m := createReport(usage.New(), s, importedModules, outputs)
+	m, err := createReport(usage.New(), s, importedModules, outputs)
+	require.NoError(t, err)
 
 	assert.Equal(t, consts.Version, m["k6_version"])
 	assert.Equal(t, map[string]interface{}{"shared-iterations": uint64(1)}, m["executors"])

--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -18,15 +18,6 @@ import (
 
 func TestCreateReport(t *testing.T) {
 	t.Parallel()
-	importedModules := []string{
-		"k6/http",
-		"my-custom-module",
-		"k6/experimental/webcrypto",
-		"file:custom-from-file-system",
-		"k6",
-		"k6/x/custom-extension",
-	}
-
 	logger := testutils.NewLogger(t)
 	opts, err := executor.DeriveScenariosFromShortcuts(lib.Options{
 		VUs:        null.IntFrom(10),
@@ -47,13 +38,12 @@ func TestCreateReport(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	s.GetState().MarkEnded()
 
-	m, err := createReport(usage.New(), s, importedModules)
+	m, err := createReport(usage.New(), s)
 	require.NoError(t, err)
 
 	assert.Equal(t, consts.Version, m["k6_version"])
-	assert.Equal(t, map[string]interface{}{"shared-iterations": uint64(1)}, m["executors"])
+	assert.EqualValues(t, map[string]int{"shared-iterations": 1}, m["executors"])
 	assert.EqualValues(t, 6, m["vus_max"])
 	assert.EqualValues(t, 170, m["iterations"])
 	assert.NotEqual(t, "0s", m["duration"])
-	assert.ElementsMatch(t, []string{"k6", "k6/http", "k6/experimental/webcrypto"}, m["modules"])
 }

--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -55,7 +55,7 @@ func TestCreateReport(t *testing.T) {
 	m := createReport(usage.New(), s, importedModules, outputs)
 
 	assert.Equal(t, consts.Version, m["k6_version"])
-	assert.Equal(t, map[string]interface{}{"shared-iterations": int64(1)}, m["executors"])
+	assert.Equal(t, map[string]interface{}{"shared-iterations": uint64(1)}, m["executors"])
 	assert.EqualValues(t, 6, m["vus_max"])
 	assert.EqualValues(t, 170, m["iterations"])
 	assert.NotEqual(t, "0s", m["duration"])

--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -38,7 +38,7 @@ func TestCreateReport(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	s.GetState().MarkEnded()
 
-	m, err := createReport(usage.New(), s)
+	m := createReport(usage.New(), s)
 	require.NoError(t, err)
 
 	assert.Equal(t, consts.Version, m["k6_version"])

--- a/cmd/report_test.go
+++ b/cmd/report_test.go
@@ -27,11 +27,6 @@ func TestCreateReport(t *testing.T) {
 		"k6/x/custom-extension",
 	}
 
-	outputs := []string{
-		"json",
-		"xk6-output-custom-example",
-	}
-
 	logger := testutils.NewLogger(t)
 	opts, err := executor.DeriveScenariosFromShortcuts(lib.Options{
 		VUs:        null.IntFrom(10),
@@ -52,7 +47,7 @@ func TestCreateReport(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	s.GetState().MarkEnded()
 
-	m, err := createReport(usage.New(), s, importedModules, outputs)
+	m, err := createReport(usage.New(), s, importedModules)
 	require.NoError(t, err)
 
 	assert.Equal(t, consts.Version, m["k6_version"])
@@ -61,5 +56,4 @@ func TestCreateReport(t *testing.T) {
 	assert.EqualValues(t, 170, m["iterations"])
 	assert.NotEqual(t, "0s", m["duration"])
 	assert.ElementsMatch(t, []string{"k6", "k6/http", "k6/experimental/webcrypto"}, m["modules"])
-	assert.ElementsMatch(t, []string{"json"}, m["outputs"])
 }

--- a/cmd/runtime_options_test.go
+++ b/cmd/runtime_options_test.go
@@ -15,6 +15,7 @@ import (
 	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 type runtimeOptionsTestCase struct {
@@ -70,6 +71,7 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 			RuntimeOptions: rtOpts,
 			Registry:       registry,
 			BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+			Usage:          usage.New(),
 		},
 	}
 
@@ -89,6 +91,7 @@ func testRuntimeOptionsCase(t *testing.T, tc runtimeOptionsTestCase) {
 				RuntimeOptions: rtOpts,
 				Registry:       registry,
 				BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+				Usage:          usage.New(),
 			},
 		}
 	}

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -22,6 +22,7 @@ import (
 	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 const (
@@ -41,6 +42,7 @@ type loadedTest struct {
 	initRunner     lib.Runner // TODO: rename to something more appropriate
 	keyLogger      io.Closer
 	moduleResolver *modules.ModuleResolver
+	usage          *usage.Usage
 }
 
 func loadLocalTest(gs *state.GlobalState, cmd *cobra.Command, args []string) (*loadedTest, error) {
@@ -86,6 +88,7 @@ func loadLocalTest(gs *state.GlobalState, cmd *cobra.Command, args []string) (*l
 		fs:             gs.FS,
 		fileSystems:    fileSystems,
 		preInitState:   state,
+		usage:          usage.New(),
 	}
 
 	gs.Logger.Debugf("Initializing k6 runner for '%s' (%s)...", sourceRootPath, resolvedPath)

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -42,7 +42,6 @@ type loadedTest struct {
 	initRunner     lib.Runner // TODO: rename to something more appropriate
 	keyLogger      io.Closer
 	moduleResolver *modules.ModuleResolver
-	usage          *usage.Usage
 }
 
 func loadLocalTest(gs *state.GlobalState, cmd *cobra.Command, args []string) (*loadedTest, error) {
@@ -79,6 +78,7 @@ func loadLocalTest(gs *state.GlobalState, cmd *cobra.Command, args []string) (*l
 			val, ok := gs.Env[key]
 			return val, ok
 		},
+		Usage: usage.New(),
 	}
 
 	test := &loadedTest{
@@ -88,7 +88,6 @@ func loadLocalTest(gs *state.GlobalState, cmd *cobra.Command, args []string) (*l
 		fs:             gs.FS,
 		fileSystems:    fileSystems,
 		preInitState:   state,
-		usage:          usage.New(),
 	}
 
 	gs.Logger.Debugf("Initializing k6 runner for '%s' (%s)...", sourceRootPath, resolvedPath)

--- a/execution/scheduler_ext_exec_test.go
+++ b/execution/scheduler_ext_exec_test.go
@@ -16,6 +16,7 @@ import (
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 // TODO: rewrite and/or move these as integration tests to reduce boilerplate
@@ -74,6 +75,7 @@ func TestExecutionInfoVUSharing(t *testing.T) {
 			Logger:         logger,
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
+			Usage:          usage.New(),
 		},
 		&loader.SourceData{
 			URL:  &url.URL{Path: "/script.js"},
@@ -187,6 +189,7 @@ func TestExecutionInfoScenarioIter(t *testing.T) {
 			Logger:         logger,
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
+			Usage:          usage.New(),
 		},
 		&loader.SourceData{
 			URL:  &url.URL{Path: "/script.js"},
@@ -269,6 +272,7 @@ func TestSharedIterationsStable(t *testing.T) {
 			Logger:         logger,
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
+			Usage:          usage.New(),
 		},
 		&loader.SourceData{
 			URL:  &url.URL{Path: "/script.js"},
@@ -404,6 +408,7 @@ func TestExecutionInfoAll(t *testing.T) {
 					Logger:         logger,
 					BuiltinMetrics: builtinMetrics,
 					Registry:       registry,
+					Usage:          usage.New(),
 				},
 				&loader.SourceData{
 					URL:  &url.URL{Path: "/script.js"},

--- a/execution/scheduler_ext_test.go
+++ b/execution/scheduler_ext_test.go
@@ -32,6 +32,7 @@ import (
 	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 func getTestPreInitState(tb testing.TB) *lib.TestPreInitState {
@@ -41,6 +42,7 @@ func getTestPreInitState(tb testing.TB) *lib.TestPreInitState {
 		RuntimeOptions: lib.RuntimeOptions{},
 		Registry:       reg,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(reg),
+		Usage:          usage.New(),
 	}
 }
 
@@ -1112,6 +1114,7 @@ func TestDNSResolverCache(t *testing.T) {
 					Logger:         logger,
 					BuiltinMetrics: builtinMetrics,
 					Registry:       registry,
+					Usage:          usage.New(),
 				},
 				&loader.SourceData{
 					URL: &url.URL{Path: "/script.js"}, Data: []byte(script),
@@ -1399,6 +1402,7 @@ func TestNewSchedulerHasWork(t *testing.T) {
 		Logger:         logger,
 		Registry:       registry,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+		Usage:          usage.New(),
 	}
 	runner, err := js.New(piState, &loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: script}, nil)
 	require.NoError(t, err)

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -106,7 +106,8 @@ func newBundle(
 	}
 
 	c := bundle.newCompiler(piState.Logger)
-	bundle.ModuleResolver = modules.NewModuleResolver(getJSModules(), generateFileLoad(bundle), c, bundle.pwd)
+	bundle.ModuleResolver = modules.NewModuleResolver(
+		getJSModules(), generateFileLoad(bundle), c, bundle.pwd, piState.Usage, piState.Logger)
 
 	// Instantiate the bundle into a new VM using a bound init context. This uses a context with a
 	// runtime, but no state, to allow module-provided types to function within the init context.

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -26,6 +26,7 @@ import (
 	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 const isWindows = runtime.GOOS == "windows"
@@ -43,6 +44,7 @@ func getTestPreInitState(tb testing.TB, logger logrus.FieldLogger, rtOpts *lib.R
 		RuntimeOptions: *rtOpts,
 		Registry:       reg,
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(reg),
+		Usage:          usage.New(),
 	}
 }
 

--- a/js/console_test.go
+++ b/js/console_test.go
@@ -21,6 +21,7 @@ import (
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 func TestConsoleContext(t *testing.T) {
@@ -73,6 +74,7 @@ func getSimpleRunner(tb testing.TB, filename, data string, opts ...interface{}) 
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
 			LookupEnv:      func(_ string) (val string, ok bool) { return "", false },
+			Usage:          usage.New(),
 		},
 		&loader.SourceData{
 			URL:  &url.URL{Path: filename, Scheme: "file"},
@@ -110,6 +112,7 @@ func getSimpleArchiveRunner(tb testing.TB, arc *lib.Archive, opts ...interface{}
 			RuntimeOptions: rtOpts,
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
+			Usage:          usage.New(),
 		}, arc)
 }
 

--- a/js/init_and_modules_test.go
+++ b/js/init_and_modules_test.go
@@ -19,6 +19,7 @@ import (
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 type CheckModule struct {
@@ -64,6 +65,7 @@ func TestNewJSRunnerWithCustomModule(t *testing.T) {
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
 			RuntimeOptions: rtOptions,
+			Usage:          usage.New(),
 		},
 		&loader.SourceData{
 			URL:  &url.URL{Path: "blah", Scheme: "file"},
@@ -101,6 +103,7 @@ func TestNewJSRunnerWithCustomModule(t *testing.T) {
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
 			RuntimeOptions: rtOptions,
+			Usage:          usage.New(),
 		}, arc)
 	require.NoError(t, err)
 	assert.Equal(t, checkModule.initCtxCalled, 3) // changes because we need to get the exported functions

--- a/js/modules/k6/marshalling_test.go
+++ b/js/modules/k6/marshalling_test.go
@@ -16,6 +16,7 @@ import (
 	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/loader"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 func TestSetupDataMarshalling(t *testing.T) {
@@ -103,6 +104,7 @@ func TestSetupDataMarshalling(t *testing.T) {
 			Logger:         testutils.NewLogger(t),
 			BuiltinMetrics: builtinMetrics,
 			Registry:       registry,
+			Usage:          usage.New(),
 		},
 
 		&loader.SourceData{URL: &url.URL{Path: "/script.js"}, Data: script},

--- a/js/modulestest/runtime.go
+++ b/js/modulestest/runtime.go
@@ -15,6 +15,7 @@ import (
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 // Runtime is a helper struct that contains what is needed to run a (simple) module test
@@ -40,6 +41,7 @@ func NewRuntime(t testing.TB) *Runtime {
 		TestPreInitState: &lib.TestPreInitState{
 			Logger:   testutils.NewLogger(t),
 			Registry: metrics.NewRegistry(),
+			Usage:    usage.New(),
 		},
 		CWD: new(url.URL),
 	}
@@ -74,7 +76,8 @@ func (r *Runtime) SetupModuleSystem(goModules map[string]any, loader modules.Fil
 		goModules["k6/timers"] = timers.New()
 	}
 
-	r.mr = modules.NewModuleResolver(goModules, loader, c, r.VU.InitEnvField.CWD)
+	r.mr = modules.NewModuleResolver(
+		goModules, loader, c, r.VU.InitEnvField.CWD, r.VU.InitEnvField.Usage, r.VU.InitEnvField.Logger)
 	return r.innerSetupModuleSystem()
 }
 

--- a/js/runner.go
+++ b/js/runner.go
@@ -242,6 +242,7 @@ func (r *Runner) newVU(
 		Tags:           lib.NewVUStateTags(vu.Runner.RunTags),
 		BuiltinMetrics: r.preInitState.BuiltinMetrics,
 		TracerProvider: r.preInitState.TracerProvider,
+		Usage:          r.preInitState.Usage,
 	}
 	vu.moduleVUImpl.state = vu.state
 	_ = vu.Runtime.Set("console", vu.Console)

--- a/js/tc39/tc39_test.go
+++ b/js/tc39/tc39_test.go
@@ -30,6 +30,7 @@ import (
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/loader"
+	"go.k6.io/k6/usage"
 	"gopkg.in/yaml.v3"
 )
 
@@ -714,7 +715,7 @@ func (ctx *tc39TestCtx) runTC39Module(name, src string, includes []string, vm *s
 		func(specifier *url.URL, _ string) ([]byte, error) {
 			return fs.ReadFile(os.DirFS("."), specifier.Path[1:])
 		},
-		ctx.compiler(), base)
+		ctx.compiler(), base, usage.New(), testutils.NewLogger(ctx.t))
 
 	ms := modules.NewModuleSystem(mr, moduleRuntime.VU)
 	moduleRuntime.VU.InitEnvField.CWD = base

--- a/lib/test_state.go
+++ b/lib/test_state.go
@@ -9,6 +9,7 @@ import (
 	"go.k6.io/k6/event"
 	"go.k6.io/k6/lib/trace"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 // TestPreInitState contains all of the state that can be gathered and built
@@ -22,6 +23,7 @@ type TestPreInitState struct {
 	LookupEnv      func(key string) (val string, ok bool)
 	Logger         logrus.FieldLogger
 	TracerProvider *trace.TracerProvider
+	Usage          *usage.Usage
 }
 
 // TestRunState contains the pre-init state as well as all of the state and

--- a/lib/vu_state.go
+++ b/lib/vu_state.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 // DialContexter is an interface that can dial with a context
@@ -81,6 +82,9 @@ type State struct {
 
 	// Tracing instrumentation.
 	TracerProvider TracerProvider
+
+	// Usage is a way to report usage statistics
+	Usage *usage.Usage
 }
 
 // VUStateTags wraps the current VU's tags and ensures a thread-safe way to

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -16,6 +16,7 @@ import (
 	"go.k6.io/k6/metrics"
 	"go.k6.io/k6/output"
 	cloudv2 "go.k6.io/k6/output/cloud/expv2"
+	"go.k6.io/k6/usage"
 	"gopkg.in/guregu/null.v3"
 )
 
@@ -61,6 +62,8 @@ type Output struct {
 
 	client       *cloudapi.Client
 	testStopFunc func(error)
+
+	usage *usage.Usage
 }
 
 // Verify that Output implements the wanted interfaces
@@ -135,6 +138,7 @@ func newOutput(params output.Params) (*Output, error) {
 		executionPlan: params.ExecutionPlan,
 		duration:      int64(duration / time.Second),
 		logger:        logger,
+		usage:         params.Usage,
 	}, nil
 }
 
@@ -340,6 +344,8 @@ func (out *Output) startVersionedOutput() error {
 		return errors.New("TestRunID is required")
 	}
 	var err error
+
+	out.usage.String("output.cloud.test_run_id", out.testRunID)
 
 	// TODO: move here the creation of a new cloudapi.Client
 	// so in the case the config has been overwritten the client uses the correct

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -345,7 +345,10 @@ func (out *Output) startVersionedOutput() error {
 	}
 	var err error
 
-	out.usage.Strings("cloud/test_run_id", out.testRunID)
+	usageErr := out.usage.Strings("cloud/test_run_id", out.testRunID)
+	if usageErr != nil {
+		out.logger.Warning("Couldn't report test run id to usage as part of writing to k6 cloud")
+	}
 
 	// TODO: move here the creation of a new cloudapi.Client
 	// so in the case the config has been overwritten the client uses the correct

--- a/output/cloud/output.go
+++ b/output/cloud/output.go
@@ -345,7 +345,7 @@ func (out *Output) startVersionedOutput() error {
 	}
 	var err error
 
-	out.usage.String("output.cloud.test_run_id", out.testRunID)
+	out.usage.Strings("cloud/test_run_id", out.testRunID)
 
 	// TODO: move here the creation of a new cloudapi.Client
 	// so in the case the config has been overwritten the client uses the correct

--- a/output/cloud/output_test.go
+++ b/output/cloud/output_test.go
@@ -20,6 +20,7 @@ import (
 	"go.k6.io/k6/metrics"
 	"go.k6.io/k6/output"
 	cloudv2 "go.k6.io/k6/output/cloud/expv2"
+	"go.k6.io/k6/usage"
 	"gopkg.in/guregu/null.v3"
 )
 
@@ -121,6 +122,7 @@ func TestOutputCreateTestWithConfigOverwrite(t *testing.T) {
 			SystemTags: &metrics.DefaultSystemTagSet,
 		},
 		ScriptPath: &url.URL{Path: "/script.js"},
+		Usage:      usage.New(),
 	})
 	require.NoError(t, err)
 	require.NoError(t, out.Start())
@@ -147,6 +149,7 @@ func TestOutputStartVersionError(t *testing.T) {
 			"K6_CLOUD_API_VERSION": "99",
 		},
 		ScriptPath: &url.URL{Path: "/script.js"},
+		Usage:      usage.New(),
 	})
 	require.NoError(t, err)
 
@@ -170,6 +173,7 @@ func TestOutputStartVersionedOutputV2(t *testing.T) {
 			AggregationPeriod:  types.NullDurationFrom(1 * time.Hour),
 			MetricPushInterval: types.NullDurationFrom(1 * time.Hour),
 		},
+		usage: usage.New(),
 	}
 
 	o.client = cloudapi.NewClient(
@@ -190,6 +194,7 @@ func TestOutputStartVersionedOutputV1Error(t *testing.T) {
 		config: cloudapi.Config{
 			APIVersion: null.IntFrom(1),
 		},
+		usage: usage.New(),
 	}
 
 	err := o.startVersionedOutput()
@@ -217,6 +222,7 @@ func TestOutputStartWithTestRunID(t *testing.T) {
 			SystemTags: &metrics.DefaultSystemTagSet,
 		},
 		ScriptPath: &url.URL{Path: "/script.js"},
+		Usage:      usage.New(),
 	})
 	require.NoError(t, err)
 	require.NoError(t, out.Start())

--- a/output/types.go
+++ b/output/types.go
@@ -13,6 +13,7 @@ import (
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/usage"
 )
 
 // Params contains all possible constructor parameters an output may need.
@@ -30,6 +31,7 @@ type Params struct {
 	ScriptOptions  lib.Options
 	RuntimeOptions lib.RuntimeOptions
 	ExecutionPlan  []lib.ExecutionStep
+	Usage          *usage.Usage
 }
 
 // TODO: make v2 with buffered channels?

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -1,0 +1,136 @@
+// Package usage implements usage tracking for k6 in order to figure what is being used within a given execution
+package usage
+
+import (
+	"strings"
+	"sync"
+)
+
+// Usage is a way to collect usage data for within k6
+type Usage struct {
+	l *sync.Mutex
+	m map[string]any
+}
+
+// New returns a new empty Usage ready to be used
+func New() *Usage {
+	return &Usage{
+		l: new(sync.Mutex),
+		m: make(map[string]any),
+	}
+}
+
+// String appends the provided value to a slice of strings that is the value.
+// If called only a single time, the value will be just a string not a slice
+func (u *Usage) String(k, v string) {
+	u.l.Lock()
+	defer u.l.Unlock()
+	oldV, ok := u.m[k]
+	if !ok {
+		u.m[k] = v
+		return
+	}
+	switch oldV := oldV.(type) {
+	case string:
+		u.m[k] = []string{oldV, v}
+	case []string:
+		u.m[k] = append(oldV, v)
+	default:
+		// TODO: error, panic?, nothing, log?
+	}
+}
+
+// Strings appends the provided value to a slice of strings that is the value.
+// Unlike String it
+func (u *Usage) Strings(k, v string) {
+	u.l.Lock()
+	defer u.l.Unlock()
+	oldV, ok := u.m[k]
+	if !ok {
+		u.m[k] = []string{v}
+		return
+	}
+	switch oldV := oldV.(type) {
+	case string:
+		u.m[k] = []string{oldV, v}
+	case []string:
+		u.m[k] = append(oldV, v)
+	default:
+		// TODO: error, panic?, nothing, log?
+	}
+}
+
+// Count adds the provided value to a given key. Creating the key if needed
+func (u *Usage) Count(k string, v int64) {
+	u.l.Lock()
+	defer u.l.Unlock()
+	oldV, ok := u.m[k]
+	if !ok {
+		u.m[k] = v
+		return
+	}
+	switch oldV := oldV.(type) {
+	case int64:
+		u.m[k] = oldV + v
+	default:
+		// TODO: error, panic?, nothing, log?
+	}
+}
+
+// Map returns a copy of the internal map plus making subusages from keys that have a slash in them
+// only a single level is being respected
+func (u *Usage) Map() map[string]any {
+	u.l.Lock()
+	defer u.l.Unlock()
+
+	result := make(map[string]any, len(u.m))
+	for k, v := range u.m {
+		prefix, post, found := strings.Cut(k, "/")
+		if !found {
+			result[k] = v
+			continue
+		}
+
+		topLevel, ok := result[prefix]
+		if !ok {
+			topLevel = make(map[string]any)
+			result[prefix] = topLevel
+		}
+		topLevelMap, ok := topLevel.(map[string]any)
+		if !ok {
+			continue // TODO panic?, error?
+		}
+		keyLevel, ok := topLevelMap[post]
+		switch value := v.(type) {
+		case int64:
+			switch i := keyLevel.(type) {
+			case int64:
+				keyLevel = i + value
+			default:
+				// TODO:panic? error?
+			}
+		case string:
+			switch i := keyLevel.(type) {
+			case string:
+				keyLevel = append([]string(nil), i, value)
+			case []string:
+				keyLevel = append(i, value) //nolint:gocritic // we assign to the final value
+			default:
+				// TODO:panic? error?
+			}
+		case []string:
+			switch i := keyLevel.(type) {
+			case []string:
+				keyLevel = append(i, value...) //nolint:gocritic // we assign to the final value
+			default:
+				// TODO:panic? error?
+			}
+		}
+		if !ok {
+			keyLevel = v
+		}
+		topLevelMap[post] = keyLevel
+	}
+
+	return result
+}

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -20,28 +20,8 @@ func New() *Usage {
 	}
 }
 
-// String appends the provided value to a slice of strings that is the value.
-// If called only a single time, the value will be just a string not a slice
-func (u *Usage) String(k, v string) {
-	u.l.Lock()
-	defer u.l.Unlock()
-	oldV, ok := u.m[k]
-	if !ok {
-		u.m[k] = v
-		return
-	}
-	switch oldV := oldV.(type) {
-	case string:
-		u.m[k] = []string{oldV, v}
-	case []string:
-		u.m[k] = append(oldV, v)
-	default:
-		// TODO: error, panic?, nothing, log?
-	}
-}
-
 // Strings appends the provided value to a slice of strings that is the value.
-// Unlike String it
+// Appending to the slice if the key is already there.
 func (u *Usage) Strings(k, v string) {
 	u.l.Lock()
 	defer u.l.Unlock()
@@ -106,15 +86,6 @@ func (u *Usage) Map() map[string]any {
 			switch i := keyLevel.(type) {
 			case uint64:
 				keyLevel = i + value
-			default:
-				// TODO:panic? error?
-			}
-		case string:
-			switch i := keyLevel.(type) {
-			case string:
-				keyLevel = append([]string(nil), i, value)
-			case []string:
-				keyLevel = append(i, value) //nolint:gocritic // we assign to the final value
 			default:
 				// TODO:panic? error?
 			}

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -55,7 +55,7 @@ func (u *Usage) Uint64(k string, v uint64) error {
 	case uint64:
 		u.m[k] = oldVUint64 + v
 	default:
-		return fmt.Errorf("!value of key %s is not uint64 as expected but %T", k, oldV)
+		return fmt.Errorf("value of key %s is not uint64 as expected but %T", k, oldV)
 		// TODO: error, panic?, nothing, log?
 	}
 	return nil

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -60,8 +60,8 @@ func (u *Usage) Strings(k, v string) {
 	}
 }
 
-// Count adds the provided value to a given key. Creating the key if needed
-func (u *Usage) Count(k string, v int64) {
+// Uint64 adds the provided value to a given key. Creating the key if needed
+func (u *Usage) Uint64(k string, v uint64) {
 	u.l.Lock()
 	defer u.l.Unlock()
 	oldV, ok := u.m[k]
@@ -70,7 +70,7 @@ func (u *Usage) Count(k string, v int64) {
 		return
 	}
 	switch oldV := oldV.(type) {
-	case int64:
+	case uint64:
 		u.m[k] = oldV + v
 	default:
 		// TODO: error, panic?, nothing, log?
@@ -102,9 +102,9 @@ func (u *Usage) Map() map[string]any {
 		}
 		keyLevel, ok := topLevelMap[post]
 		switch value := v.(type) {
-		case int64:
+		case uint64:
 			switch i := keyLevel.(type) {
-			case int64:
+			case uint64:
 				keyLevel = i + value
 			default:
 				// TODO:panic? error?

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -95,7 +95,7 @@ func (u *Usage) Map() (map[string]any, error) {
 	return result, errors.Join(errs...)
 }
 
-// replace with map.Keys from go 1.23 after that is the minimal version
+// TODO: replace with map.Keys from go 1.23 after that is the minimal version
 func mapKeys(m map[string]any) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {

--- a/usage/usage_test.go
+++ b/usage/usage_test.go
@@ -1,0 +1,40 @@
+package usage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+	u := New()
+	require.NoError(t, u.Uint64("test/one", 1))
+	require.NoError(t, u.Uint64("test/two", 1))
+	require.NoError(t, u.Uint64("test/two", 1))
+	require.NoError(t, u.Strings("test/three", "three"))
+	require.NoError(t, u.Strings("test2/one", "one"))
+
+	require.ErrorContains(t, u.Strings("test/one", "one"),
+		"test/one is not []string as expected but uint64")
+	require.ErrorContains(t, u.Uint64("test2/one", 1),
+		"test2/one is not uint64 as expected but []string")
+
+	require.NoError(t, u.Strings("test3", "some"))
+	require.NoError(t, u.Strings("test3/one", "one"))
+
+	m, err := u.Map()
+	require.ErrorContains(t, err,
+		"key test3 was expected to be a map[string]any but was []string")
+	require.EqualValues(t, map[string]any{
+		"test": map[string]any{
+			"one":   uint64(1),
+			"two":   uint64(2),
+			"three": []string{"three"},
+		},
+		"test2": map[string]any{
+			"one": []string{"one"},
+		},
+		"test3": []string{"some"},
+	}, m)
+}

--- a/usage/usage_test.go
+++ b/usage/usage_test.go
@@ -21,11 +21,10 @@ func TestErrors(t *testing.T) {
 		"test2/one is not uint64 as expected but []string")
 
 	require.NoError(t, u.Strings("test3", "some"))
-	require.NoError(t, u.Strings("test3/one", "one"))
+	require.ErrorContains(t, u.Strings("test3/one", "one"),
+		`new level "test3" for key "test3/one" as the key was already used for []string`)
 
-	m, err := u.Map()
-	require.ErrorContains(t, err,
-		"key test3 was expected to be a map[string]any but was []string")
+	m := u.Map()
 	require.EqualValues(t, map[string]any{
 		"test": map[string]any{
 			"one":   uint64(1),


### PR DESCRIPTION
## What?

Implement support to collect Usage dynamically

## Why?

Previously Usage collection happened in one place in a pull way. The usage report needed to get access to the given data and then pull the info from it and put it in.

This reverses the pattern and adds (if available) the cloud test run id to the usage report.

Future work can pull a bunch of the other parts of it out. For example:
1. used modules can now be reported from the modules
2. outputs can also report their usage
3. same for executors

Currently all the above are still done in the usage report code, but that is not necessary.

This also will allow additional usage reporting without the need to propagate this data through getters to the usage report, and instead just push it from the place it is used.

Allowing potentially reporting usages that we are interested to remove in a more generic and easy way.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
