### PR TITLE
WIP: Add abort event

### DIFF
--- a/api/v1/status_routes.go
+++ b/api/v1/status_routes.go
@@ -54,6 +54,7 @@ func handlePatchStatus(cs *ControlSurface, rw http.ResponseWriter, r *http.Reque
 	if status.Stopped { //nolint:nestif
 		execution.AbortTestRun( //nolint:contextcheck // false-positive cs.RunCtx a right way of passing context there
 			cs.RunCtx,
+			cs.RunState.Events,
 			errext.WithAbortReasonIfNone(
 				errext.WithExitCodeIfNone(fmt.Errorf("test run stopped from REST API"), exitcodes.ScriptStoppedFromRESTAPI),
 				errext.AbortedByUser,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -347,6 +347,14 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 	// Trap Interrupts, SIGINTs and SIGTERMs.
 	// TODO: move upwards, right after runCtx is created
 	gracefulStop := func(sig os.Signal) {
+		// This is a temporary abort signal. It should be removed
+		// once https://github.com/grafana/xk6-browser/issues/1410
+		// is complete.
+		waitAbortDone := emitEvent(&event.Event{
+			Type: event.Abort,
+		})
+		waitAbortDone()
+
 		logger.WithField("sig", sig).Debug("Stopping k6 in response to signal...")
 		// first abort the test run this way, to propagate the error
 		runAbort(errext.WithAbortReasonIfNone(

--- a/cmd/tests/cmd_run_test.go
+++ b/cmd/tests/cmd_run_test.go
@@ -2106,6 +2106,7 @@ func TestEventSystemError(t *testing.T) {
 				"got event TestStart with data '<nil>'",
 				"got event IterStart with data '{Iteration:0 VUID:1 ScenarioName:default Error:<nil>}'",
 				"got event IterEnd with data '{Iteration:0 VUID:1 ScenarioName:default Error:test aborted: oops! at default (file:///-:11:16(5))}'",
+				"got event Abort with data '<nil>'",
 				"got event TestEnd with data '<nil>'",
 				"got event Exit with data '&{Error:test aborted: oops! at default (file:///-:11:16(5))}'",
 				"test aborted: oops! at default (file:///-:11:16(5))",

--- a/event/system.go
+++ b/event/system.go
@@ -103,7 +103,7 @@ func (s *System) Emit(event *Event) (wait func(context.Context) error) {
 	s.logger.WithFields(logrus.Fields{
 		"subscribers": totalSubs,
 		"event":       event.Type,
-	}).Trace("Emitted event")
+	}).Info("Emitted event")
 
 	return func(ctx context.Context) error {
 		var doneCount int

--- a/event/system_test.go
+++ b/event/system_test.go
@@ -84,7 +84,7 @@ func TestEventSystem(t *testing.T) {
 		var (
 			doneMx     sync.RWMutex
 			processed  = make(map[Type]int)
-			emitEvents = []Type{Init, TestStart, IterStart, IterEnd, TestEnd, Exit}
+			emitEvents = []Type{Init, TestStart, IterStart, IterEnd, TestEnd, Exit, Abort}
 			data       int
 		)
 		for _, et := range emitEvents {

--- a/event/type.go
+++ b/event/type.go
@@ -18,12 +18,14 @@ const (
 	IterEnd
 	// Exit is emitted when the k6 process is about to exit.
 	Exit
+	// Abort is a temporary event that will be emitted when a gracefulStop occurs.
+	Abort
 )
 
 //nolint:gochecknoglobals
 var (
 	// GlobalEvents are emitted once per test run.
-	GlobalEvents = []Type{Init, TestStart, TestEnd, Exit}
+	GlobalEvents = []Type{Init, TestStart, TestEnd, Exit, Abort}
 	// VUEvents are emitted multiple times per each VU.
 	VUEvents = []Type{IterStart, IterEnd}
 )

--- a/event/type_gen.go
+++ b/event/type_gen.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 )
 
-const _TypeName = "InitTestStartTestEndIterStartIterEndExit"
+const _TypeName = "InitTestStartTestEndIterStartIterEndExitAbort"
 
-var _TypeIndex = [...]uint8{0, 4, 13, 20, 29, 36, 40}
+var _TypeIndex = [...]uint8{0, 4, 13, 20, 29, 36, 40, 45}
 
 func (i Type) String() string {
 	i -= 1
@@ -18,7 +18,7 @@ func (i Type) String() string {
 	return _TypeName[_TypeIndex[i]:_TypeIndex[i+1]]
 }
 
-var _TypeValues = []Type{1, 2, 3, 4, 5, 6}
+var _TypeValues = []Type{1, 2, 3, 4, 5, 6, 7}
 
 var _TypeNameToValueMap = map[string]Type{
 	_TypeName[0:4]:   1,
@@ -27,6 +27,7 @@ var _TypeNameToValueMap = map[string]Type{
 	_TypeName[20:29]: 4,
 	_TypeName[29:36]: 5,
 	_TypeName[36:40]: 6,
+	_TypeName[40:45]: 7,
 }
 
 // TypeString retrieves an enum value from the enum constants string name.

--- a/execution/abort.go
+++ b/execution/abort.go
@@ -43,6 +43,7 @@ func (tac *testAbortController) abort(ctx context.Context, events EventAbortEmit
 	// 5 seconds, this is good enough in the short term.
 	waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
 	defer waitCancel()
+	tac.logger.Infof("abort event fired due to '%s'", err)
 	if werr := waitDone(waitCtx); werr != nil {
 		tac.logger.WithError(werr).Warn()
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/websocket v1.5.1
-	github.com/grafana/xk6-browser v1.7.1
+	github.com/grafana/xk6-browser v1.7.2-0.20240830125845-1cc2738ebb94
 	github.com/grafana/xk6-dashboard v0.7.5
 	github.com/grafana/xk6-output-opentelemetry v0.1.1
 	github.com/grafana/xk6-output-prometheus-remote v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/grafana/sobek v0.0.0-20240816075701-fd55381ddfc3 h1:mJ1DN6EDA5MlRtcspUjVTsfINUVJMd4Yw70RdFoKN8E=
 github.com/grafana/sobek v0.0.0-20240816075701-fd55381ddfc3/go.mod h1:14YTHWUwjApKs5kzRn+4akwbvPMRsXEmjfozc5OmT0I=
-github.com/grafana/xk6-browser v1.7.1 h1:RKCcoFyKT97iGgbnK76WwxcXnkB23ijlO1LghqjHQ0E=
-github.com/grafana/xk6-browser v1.7.1/go.mod h1:sZO7cT7/XQf2mz+rXkp6poswhOCA0JKA8isj3fQrfaU=
+github.com/grafana/xk6-browser v1.7.2-0.20240830125845-1cc2738ebb94 h1:ACgftcYIgQGYfIRJGNajUDqQIxpt2Irykn/JRYA8kZs=
+github.com/grafana/xk6-browser v1.7.2-0.20240830125845-1cc2738ebb94/go.mod h1:l1vbyRsaAqIeDiq87Ne/bDDbVQ8ukmBuR0zvdUWG+bs=
 github.com/grafana/xk6-dashboard v0.7.5 h1:TcILyffT/Ea/XD7xG1jMA5lwtusOPRbEQsQDHmO30Mk=
 github.com/grafana/xk6-dashboard v0.7.5/go.mod h1:Y75F8xmgCraKT+pBzFH6me9AyH5PkXD+Bxo1dm6Il/M=
 github.com/grafana/xk6-output-opentelemetry v0.1.1 h1:kLfzKkL9olhmMO+Kmr7ObhX3LknSAbUbzFaDG6mQVeg=

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"go.k6.io/k6/errext"
+	"go.k6.io/k6/event"
 	"go.k6.io/k6/execution"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/types"
@@ -86,10 +87,10 @@ func validateStages(stages []Stage) []error {
 
 // handleInterrupt returns true if err is InterruptError and if so it
 // cancels the executor context passed with ctx.
-func handleInterrupt(ctx context.Context, err error) bool {
+func handleInterrupt(ctx context.Context, events *event.System, err error) bool {
 	if err != nil {
 		if errext.IsInterruptError(err) {
-			execution.AbortTestRun(ctx, err)
+			execution.AbortTestRun(ctx, events, err)
 			return true
 		}
 	}
@@ -118,7 +119,7 @@ func getIterationRunner(
 			return false
 		default:
 			if err != nil {
-				if handleInterrupt(ctx, err) {
+				if handleInterrupt(ctx, executionState.Test.Events, err) {
 					executionState.AddInterruptedIterations(1)
 					return false
 				}

--- a/vendor/github.com/grafana/xk6-browser/browser/registry.go
+++ b/vendor/github.com/grafana/xk6-browser/browser/registry.go
@@ -224,6 +224,7 @@ func newBrowserRegistry(
 
 	exitSubID, exitCh := vu.Events().Global.Subscribe(
 		k6event.Exit,
+		k6event.Abort,
 	)
 	iterSubID, eventsCh := vu.Events().Local.Subscribe(
 		k6event.IterStart,

--- a/vendor/github.com/grafana/xk6-browser/browser/sync_page_mapping.go
+++ b/vendor/github.com/grafana/xk6-browser/browser/sync_page_mapping.go
@@ -140,6 +140,10 @@ func syncMapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return nil, err //nolint:wrapcheck
 			}
 
+			if resp == nil {
+				return nil, nil //nolint:nilnil
+			}
+
 			r := syncMapResponse(vu, resp)
 
 			return rt.ToValue(r).ToObject(rt), nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -173,8 +173,8 @@ github.com/grafana/sobek/ftoa/internal/fast
 github.com/grafana/sobek/parser
 github.com/grafana/sobek/token
 github.com/grafana/sobek/unistring
-# github.com/grafana/xk6-browser v1.7.1
-## explicit; go 1.20
+# github.com/grafana/xk6-browser v1.7.2-0.20240830125845-1cc2738ebb94
+## explicit; go 1.21
 github.com/grafana/xk6-browser/browser
 github.com/grafana/xk6-browser/chromium
 github.com/grafana/xk6-browser/common


### PR DESCRIPTION
## What?

Adds a temporary Abort event which would signal to subscribers that k6 has received a termination signal from somewhere (REST, OS, etc).

## Why?

The browser module currently isn't relying on the VU Context to control the iteration lifecycle. There is an [open issue](https://github.com/grafana/xk6-browser/issues/1410) to move it over to working with the VU Context. A quick fix is to add an Abort event which will inform the browser module to close any chromium instances down, which will force any waiting API calls to exit since the connection to chromium has ended.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
Updates: https://github.com/grafana/k6-cloud/issues/2664