### PR TITLE
Add testutils.MakeMemMapFs test helper

### DIFF
--- a/lib/archive_test.go
+++ b/lib/archive_test.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"testing"
 
+	"go.k6.io/k6/lib/testutils"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
@@ -50,14 +52,6 @@ func TestNormalizeAndAnonymizePath(t *testing.T) {
 			assert.Equal(t, res, NormalizeAndAnonymizePath(res))
 		})
 	}
-}
-
-func makeMemMapFs(t *testing.T, input map[string][]byte) fsext.Fs {
-	fs := fsext.NewMemMapFs()
-	for path, data := range input {
-		require.NoError(t, fsext.WriteFile(fs, path, data, 0o644))
-	}
-	return fs
 }
 
 func getMapKeys(m map[string]fsext.Fs) []string {
@@ -129,13 +123,13 @@ func TestArchiveReadWrite(t *testing.T) {
 			Data:        []byte(`// a contents`),
 			PwdURL:      &url.URL{Scheme: "file", Path: "/path/to"},
 			Filesystems: map[string]fsext.Fs{
-				"file": makeMemMapFs(t, map[string][]byte{
+				"file": testutils.MakeMemMapFs(t, map[string][]byte{
 					"/path/to/a.js":      []byte(`// a contents`),
 					"/path/to/b.js":      []byte(`// b contents`),
 					"/path/to/file1.txt": []byte(`hi!`),
 					"/path/to/file2.txt": []byte(`bye!`),
 				}),
-				"https": makeMemMapFs(t, map[string][]byte{
+				"https": testutils.MakeMemMapFs(t, map[string][]byte{
 					"/cdnjs.com/libraries/Faker":          []byte(`// faker contents`),
 					"/github.com/loadimpact/k6/README.md": []byte(`README`),
 				}),
@@ -181,13 +175,13 @@ func TestArchiveReadWrite(t *testing.T) {
 				Data:        []byte(`// a contents`),
 				PwdURL:      &url.URL{Scheme: "file", Path: entry.Pwd},
 				Filesystems: map[string]fsext.Fs{
-					"file": makeMemMapFs(t, map[string][]byte{
+					"file": testutils.MakeMemMapFs(t, map[string][]byte{
 						fmt.Sprintf("%s/a.js", entry.Pwd):      []byte(`// a contents`),
 						fmt.Sprintf("%s/b.js", entry.Pwd):      []byte(`// b contents`),
 						fmt.Sprintf("%s/file1.txt", entry.Pwd): []byte(`hi!`),
 						fmt.Sprintf("%s/file2.txt", entry.Pwd): []byte(`bye!`),
 					}),
-					"https": makeMemMapFs(t, map[string][]byte{
+					"https": testutils.MakeMemMapFs(t, map[string][]byte{
 						"/cdnjs.com/libraries/Faker":          []byte(`// faker contents`),
 						"/github.com/loadimpact/k6/README.md": []byte(`README`),
 					}),
@@ -205,13 +199,13 @@ func TestArchiveReadWrite(t *testing.T) {
 				PwdURL:      &url.URL{Scheme: "file", Path: entry.PwdNormAnon},
 
 				Filesystems: map[string]fsext.Fs{
-					"file": makeMemMapFs(t, map[string][]byte{
+					"file": testutils.MakeMemMapFs(t, map[string][]byte{
 						fmt.Sprintf("%s/a.js", entry.PwdNormAnon):      []byte(`// a contents`),
 						fmt.Sprintf("%s/b.js", entry.PwdNormAnon):      []byte(`// b contents`),
 						fmt.Sprintf("%s/file1.txt", entry.PwdNormAnon): []byte(`hi!`),
 						fmt.Sprintf("%s/file2.txt", entry.PwdNormAnon): []byte(`bye!`),
 					}),
-					"https": makeMemMapFs(t, map[string][]byte{
+					"https": testutils.MakeMemMapFs(t, map[string][]byte{
 						"/cdnjs.com/libraries/Faker":          []byte(`// faker contents`),
 						"/github.com/loadimpact/k6/README.md": []byte(`README`),
 					}),
@@ -335,7 +329,7 @@ func TestStrangePaths(t *testing.T) {
 			Data:        []byte(`// ` + pathToChange + ` contents`),
 			PwdURL:      &url.URL{Scheme: "file", Path: path.Dir(pathToChange)},
 			Filesystems: map[string]fsext.Fs{
-				"file": makeMemMapFs(t, otherMap),
+				"file": testutils.MakeMemMapFs(t, otherMap),
 			},
 		}
 

--- a/lib/executor/executors_test.go
+++ b/lib/executor/executors_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"go.k6.io/k6/lib/testutils"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
@@ -492,7 +494,7 @@ func TestArchiveRoundTripExecutorConfig(t *testing.T) {
 		Data:        []byte(`// a contents`),
 		PwdURL:      &url.URL{Scheme: "file", Path: "/path/to"},
 		Filesystems: map[string]fsext.Fs{
-			"file": makeMemMapFs(t, map[string][]byte{
+			"file": testutils.MakeMemMapFs(t, map[string][]byte{
 				"/path/to/a.js": []byte(`// a contents`),
 			}),
 		},
@@ -510,13 +512,4 @@ func TestArchiveRoundTripExecutorConfig(t *testing.T) {
 	require.True(t, ok)
 
 	assert.EqualValues(t, execCfg, execCfg2)
-}
-
-// copied from lib/archive_test.go
-func makeMemMapFs(t *testing.T, input map[string][]byte) fsext.Fs {
-	fs := fsext.NewMemMapFs()
-	for path, data := range input {
-		require.NoError(t, fsext.WriteFile(fs, path, data, 0o644))
-	}
-	return fs
 }

--- a/lib/old_archive_test.go
+++ b/lib/old_archive_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"go.k6.io/k6/lib/testutils"
+
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/lib/fsext"
@@ -70,7 +72,7 @@ func TestOldArchive(t *testing.T) {
 		t.Run(filename, func(t *testing.T) {
 			t.Parallel()
 			metadata := `{"filename": "` + filename + `", "options": {}}`
-			fs := makeMemMapFs(t, map[string][]byte{
+			fs := testutils.MakeMemMapFs(t, map[string][]byte{
 				// files
 				"/files/example.com/path/to.js": []byte(`example.com file`),
 				"/files/_/C/something/path":     []byte(`windows file`),
@@ -88,13 +90,13 @@ func TestOldArchive(t *testing.T) {
 			require.NoError(t, err)
 
 			expectedFilesystems := map[string]fsext.Fs{
-				"file": makeMemMapFs(t, map[string][]byte{
+				"file": testutils.MakeMemMapFs(t, map[string][]byte{
 					"/C:/something/path":  []byte(`windows file`),
 					"/absolulte/path":     []byte(`unix file`),
 					"/C:/something/path2": []byte(`windows script`),
 					"/absolulte/path2":    []byte(`unix script`),
 				}),
-				"https": makeMemMapFs(t, map[string][]byte{
+				"https": testutils.MakeMemMapFs(t, map[string][]byte{
 					"/example.com/path/to.js":  []byte(`example.com file`),
 					"/example.com/path/too.js": []byte(`example.com script`),
 				}),
@@ -110,7 +112,7 @@ func TestOldArchive(t *testing.T) {
 
 func TestUnknownPrefix(t *testing.T) {
 	t.Parallel()
-	fs := makeMemMapFs(t, map[string][]byte{
+	fs := testutils.MakeMemMapFs(t, map[string][]byte{
 		"/strange/something": []byte(`github file`),
 	})
 	buf, err := dumpMemMapFsToBuf(fs)
@@ -174,7 +176,7 @@ func TestFilenamePwdResolve(t *testing.T) {
 		"options": {}
 	}`
 
-		buf, err := dumpMemMapFsToBuf(makeMemMapFs(t, map[string][]byte{
+		buf, err := dumpMemMapFsToBuf(testutils.MakeMemMapFs(t, map[string][]byte{
 			"/metadata.json": []byte(metadata),
 		}))
 		require.NoError(t, err)
@@ -241,7 +243,7 @@ func TestDerivedExecutionDiscarding(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		buf, err := dumpMemMapFsToBuf(makeMemMapFs(t, map[string][]byte{
+		buf, err := dumpMemMapFsToBuf(testutils.MakeMemMapFs(t, map[string][]byte{
 			"/metadata.json": []byte(test.metadata),
 		}))
 		require.NoError(t, err)

--- a/lib/testutils/fs.go
+++ b/lib/testutils/fs.go
@@ -1,0 +1,28 @@
+package testutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/lib/fsext"
+)
+
+// MakeMemMapFs creates a new in-memory filesystem with the given files.
+//
+// It is particularly useful for testing code that interacts with the
+// filesystem, as it  allows to create a filesystem with a known state
+// without having to create temporary directories and files on disk.
+//
+// The keys of the withFiles map are the paths of the files to create, and the
+// values are the contents of the files. The files are created with 644 mode.
+//
+// The filesystem is returned as a [fsext.Fs].
+func MakeMemMapFs(t *testing.T, withFiles map[string][]byte) fsext.Fs {
+	fs := fsext.NewMemMapFs()
+
+	for path, data := range withFiles {
+		require.NoError(t, fsext.WriteFile(fs, path, data, 0o644))
+	}
+
+	return fs
+}


### PR DESCRIPTION
## What?

This PR introduces a `MakeMemMapFs` test helper to the testutils package.

This helper function creates a new in-memory filesystem with the given files. It is particularly useful for testing code that interacts with the filesystem, as it allows the creation of a filesystem with a known state without having to create temporary directories and files on disk.

## Why?

While working on another PR, I was looking for a way to initialize a test Fs quickly. I found in the codebase occurences of a `makeMemMapFs` function, which was already duplicated twice in the codebase.

In the spirit of continuous improvement, instead of adding a third copy, I thought I would make a `testutil` function out of it.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
