### PR TITLE
Raise TestStreamLogsToLogger log sending delay

### DIFF
--- a/cloudapi/logs_test.go
+++ b/cloudapi/logs_test.go
@@ -248,7 +248,7 @@ func TestStreamLogsToLogger(t *testing.T) {
 			require.NoError(t, err)
 
 			// wait the flush on the network
-			time.Sleep(5 * time.Millisecond)
+			time.Sleep(25 * time.Millisecond)
 			cancel()
 		})
 


### PR DESCRIPTION
## What?

This PR raises the time given to the log emitter to wait for a "flush on the network" in the `cloudapi.TestStreamLogsToLogger` test. Instead of 5 milliseconds, we now wait 25 milliseconds.

## Why?

During the development of #3931, we discovered that the `cloud API.TestStreamLogsToLogger` test was very flaky on Windows. We weren't able to reproduce locally, but through experimentation, we were able to isolate and confirm that `			time.Sleep(5 * time.Millisecond)` was likely the culprit.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#3931 

<!-- Thanks for your contribution! 🙏🏼 -->
