### PR TITLE
Use the new usage-stats endpoint

### DIFF
--- a/cmd/report.go
+++ b/cmd/report.go
@@ -37,14 +37,18 @@ func reportUsage(ctx context.Context, execScheduler *execution.Scheduler, test *
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://reports.k6.io", bytes.NewBuffer(body))
+
+	const usageStatsURL = "https://stats.grafana.org/k6-usage-report"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, usageStatsURL, bytes.NewBuffer(body))
 	if err != nil {
 		return err
 	}
+
 	req.Header.Set("Content-Type", "application/json")
 	res, err := http.DefaultClient.Do(req)
 	if err == nil {
 		_ = res.Body.Close()
 	}
+
 	return err
 }


### PR DESCRIPTION
## What?

It updates the endpoint used to send [usage stats](https://grafana.com/docs/k6/latest/set-up/usage-collection/), to the service used by the rest of the projects of the organization.

## Why?

Because that's the one used by the rest of the projects of the organization, and the legacy (current) one will be deprecated soon. See some examples:

- Loki: https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go#L27
- Grafana: https://github.com/grafana/grafana/blob/main/pkg/infra/usagestats/service/usage_stats.go#L29

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes #3878 