### PR TITLE
Prevent panic when 'options' value is nil

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -197,7 +197,7 @@ func (b *Bundle) populateExports(updateOptions bool, bi *BundleInstance) error {
 			}
 			switch k {
 			case consts.Options:
-				if !updateOptions {
+				if !updateOptions || v == nil {
 					continue
 				}
 				var data []byte

--- a/js/bundle_test.go
+++ b/js/bundle_test.go
@@ -214,6 +214,16 @@ func TestNewBundle(t *testing.T) {
 			`)
 			require.NoError(t, err)
 		})
+		t.Run("Null", func(t *testing.T) {
+			t.Parallel()
+			fs := fsext.NewMemMapFs()
+			require.NoError(t, fsext.WriteFile(fs, "/options.js", []byte("module.exports={}"), 0o644))
+			_, err := getSimpleBundle(t, "/script.js", `
+				export {options} from "./options.js";
+				export default function() {};
+			`, fs)
+			require.NoError(t, err)
+		})
 		t.Run("Invalid", func(t *testing.T) {
 			t.Parallel()
 			invalidOptions := map[string]struct {


### PR DESCRIPTION
## What?

It early returns when `options` is `nil`, to prevent reaching the point where `json.Marshal(v.Export())` with `v == nil`.

## Why?

To prevent it from panicking.

In v0.52, that code was slightly different: https://github.com/grafana/k6/blob/v0.52.0/js/bundle.go#L176, and so the value received was `goja.valueUndefined`, which is enough for not panicking when calling `json.Marshal(v.Export())`.

Since changes introduced in v0.53, `v` is `nil`, and thus it panics.

## Additional comments

Another approach that I suggested was changing the behavior of [`SourceTextModuleInstance.GetBindingValue` in Sobek](https://github.com/grafana/k6/blob/master/vendor/github.com/grafana/sobek/modules_sourcetext.go#L63-L69), so it returns `sobek.Undefined()` when no _getter_ is found, but @mstoykov had doubts around the general correctness of that approach, so I guess the least intrusive way to prevent such panics here is this.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
