### PR TITLE
Add additional usages

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -285,6 +285,7 @@ func (bi *BundleInstance) manipulateOptions(options lib.Options) error {
 
 func (b *Bundle) newCompiler(logger logrus.FieldLogger) *compiler.Compiler {
 	c := compiler.New(logger)
+	c.WithUsage(b.preInitState.Usage)
 	c.Options = compiler.Options{
 		CompatibilityMode: b.CompatibilityMode,
 		SourceMapLoader:   generateSourceMapLoader(logger, b.filesystems),

--- a/js/modules/require_impl.go
+++ b/js/modules/require_impl.go
@@ -12,6 +12,10 @@ import (
 
 // Require is the actual call that implements require
 func (ms *ModuleSystem) Require(specifier string) (*sobek.Object, error) {
+	if err := ms.resolver.usage.Uint64("usage/require", 1); err != nil {
+		ms.resolver.logger.WithError(err).Warn("couldn't report usage")
+	}
+
 	if specifier == "" {
 		return nil, errors.New("require() can't be used with an empty specifier")
 	}


### PR DESCRIPTION
## What?

Add reporting some additional usages to better figure how k6 is used.

## Why?

We do need to make decisions on what to work on or break or keep working if it is problematic.

We usually make a lot of those based on anecdotal data or only on data we have access through direct communication with customers. This is not terrible but definitely leaves us with blind spots.

The newly added usage counters have descriptions in each of the commits and are used for different areas where we might decide to cleanup k6 or work more on a give feature.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
