### PR TITLE
Add release browser 1408 1422

### DIFF
--- a/release notes/v0.54.0.md
+++ b/release notes/v0.54.0.md
@@ -122,6 +122,7 @@ _what, why, and what this means for the user_
 - [browser#1406](https://github.com/grafana/xk6-browser/pull/1406) fixes panic on iframe attach when iframe didn't contain any UI elements.
 - [browser#1420](https://github.com/grafana/xk6-browser/pull/1420) uses the vu context to control the iterations lifecycle which helps k6 shutdown in a timely manner when a test is aborted.
 - [browser#1421](https://github.com/grafana/xk6-browser/pull/1421) fixes the navigation span by starting when the page starts to load so that it's a better representation of how long the test was on a page.
+- [browser#1408](https://github.com/grafana/xk6-browser/pull/1408), [#1422](https://github.com/grafana/xk6-browser/pull/1422) fixes the `page.reload` API so handles `null` responses without exceptions.
 
 ## Maintenance and internal improvements
 


### PR DESCRIPTION
## What?

Add:
- https://github.com/grafana/xk6-browser/pull/1408
- https://github.com/grafana/xk6-browser/pull/1422

## Why?

To keep users up to date with latest fixes in browser.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
