### PR TITLE
Update to 1.8.4 of the browser moduler

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/websocket v1.5.1
-	github.com/grafana/xk6-browser v1.8.3
+	github.com/grafana/xk6-browser v1.8.4
 	github.com/grafana/xk6-dashboard v0.7.5
 	github.com/grafana/xk6-output-opentelemetry v0.2.0
 	github.com/grafana/xk6-output-prometheus-remote v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/grafana/sobek v0.0.0-20240829081756-447e8c611945 h1:rxyoc2Ee/iKcm5EYNU/dEO0GcMZDN5vaDGyIo7pt804=
 github.com/grafana/sobek v0.0.0-20240829081756-447e8c611945/go.mod h1:FmcutBFPLiGgroH42I4/HBahv7GxVjODcVWFTw1ISes=
-github.com/grafana/xk6-browser v1.8.3 h1:MmbFs9vVAA3l9GPhhYk8/MhIGnsgswVy+ztjtZD2tME=
-github.com/grafana/xk6-browser v1.8.3/go.mod h1:we1lHAYSVZD5s/4yre2KWtaqY4G0ikNVpn0QE2EO8DA=
+github.com/grafana/xk6-browser v1.8.4 h1:k7ivI6fVIaS8ZTdNXSI+4eVayUNQa6I7We93PjLkW9s=
+github.com/grafana/xk6-browser v1.8.4/go.mod h1:we1lHAYSVZD5s/4yre2KWtaqY4G0ikNVpn0QE2EO8DA=
 github.com/grafana/xk6-dashboard v0.7.5 h1:TcILyffT/Ea/XD7xG1jMA5lwtusOPRbEQsQDHmO30Mk=
 github.com/grafana/xk6-dashboard v0.7.5/go.mod h1:Y75F8xmgCraKT+pBzFH6me9AyH5PkXD+Bxo1dm6Il/M=
 github.com/grafana/xk6-output-opentelemetry v0.2.0 h1:u/ctsfUQsyLh6paBjOmKshqeYr6HUsCJr29eO2QTb/s=

--- a/vendor/github.com/grafana/xk6-browser/common/element_handle.go
+++ b/vendor/github.com/grafana/xk6-browser/common/element_handle.go
@@ -1558,9 +1558,15 @@ func (h *ElementHandle) newAction(
 
 	return func(apiCtx context.Context, resultCh chan any, errCh chan error) {
 		if res, err := actionFn(apiCtx); err != nil {
-			errCh <- err
+			select {
+			case <-apiCtx.Done():
+			case errCh <- err:
+			}
 		} else {
-			resultCh <- res
+			select {
+			case <-apiCtx.Done():
+			case resultCh <- res:
+			}
 		}
 	}
 }
@@ -1646,9 +1652,15 @@ func (h *ElementHandle) newPointerAction(
 
 	return func(apiCtx context.Context, resultCh chan any, errCh chan error) {
 		if res, err := retryPointerAction(apiCtx, pointerFn, opts); err != nil {
-			errCh <- err
+			select {
+			case <-apiCtx.Done():
+			case errCh <- err:
+			}
 		} else {
-			resultCh <- res
+			select {
+			case <-apiCtx.Done():
+			case resultCh <- res:
+			}
 		}
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -173,7 +173,7 @@ github.com/grafana/sobek/ftoa/internal/fast
 github.com/grafana/sobek/parser
 github.com/grafana/sobek/token
 github.com/grafana/sobek/unistring
-# github.com/grafana/xk6-browser v1.8.3
+# github.com/grafana/xk6-browser v1.8.4
 ## explicit; go 1.21
 github.com/grafana/xk6-browser/browser
 github.com/grafana/xk6-browser/chromium


### PR DESCRIPTION
## What?

Contains a fix to prevent a goroutine from hanging around.

## Why?

Avoids having to force abort the test if it seems to hang.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/xk6-browser/issues/1437