### PR TITLE
Update to browser v.1.8.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/websocket v1.5.1
-	github.com/grafana/xk6-browser v1.8.4
+	github.com/grafana/xk6-browser v1.8.5
 	github.com/grafana/xk6-dashboard v0.7.5
 	github.com/grafana/xk6-output-opentelemetry v0.2.0
 	github.com/grafana/xk6-output-prometheus-remote v0.4.0

--- a/go.sum
+++ b/go.sum
@@ -91,8 +91,8 @@ github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
 github.com/grafana/sobek v0.0.0-20240829081756-447e8c611945 h1:rxyoc2Ee/iKcm5EYNU/dEO0GcMZDN5vaDGyIo7pt804=
 github.com/grafana/sobek v0.0.0-20240829081756-447e8c611945/go.mod h1:FmcutBFPLiGgroH42I4/HBahv7GxVjODcVWFTw1ISes=
-github.com/grafana/xk6-browser v1.8.4 h1:k7ivI6fVIaS8ZTdNXSI+4eVayUNQa6I7We93PjLkW9s=
-github.com/grafana/xk6-browser v1.8.4/go.mod h1:we1lHAYSVZD5s/4yre2KWtaqY4G0ikNVpn0QE2EO8DA=
+github.com/grafana/xk6-browser v1.8.5 h1:dNAG8dhcaEx/HOELEnGzAw8ShCvkpukfyTGUhebZsj0=
+github.com/grafana/xk6-browser v1.8.5/go.mod h1:yCtZ4G8U/imVBikBO4HJoMyNoejmECcJk4CK5XGSxis=
 github.com/grafana/xk6-dashboard v0.7.5 h1:TcILyffT/Ea/XD7xG1jMA5lwtusOPRbEQsQDHmO30Mk=
 github.com/grafana/xk6-dashboard v0.7.5/go.mod h1:Y75F8xmgCraKT+pBzFH6me9AyH5PkXD+Bxo1dm6Il/M=
 github.com/grafana/xk6-output-opentelemetry v0.2.0 h1:u/ctsfUQsyLh6paBjOmKshqeYr6HUsCJr29eO2QTb/s=

--- a/vendor/github.com/grafana/xk6-browser/chromium/browser_type.go
+++ b/vendor/github.com/grafana/xk6-browser/chromium/browser_type.go
@@ -124,7 +124,7 @@ func (b *BrowserType) Connect(ctx, vuCtx context.Context, wsEndpoint string) (*c
 func (b *BrowserType) connect(
 	ctx, vuCtx context.Context, wsURL string, opts *common.BrowserOptions, logger *log.Logger,
 ) (*common.Browser, error) {
-	browserProc, err := b.link(wsURL, logger)
+	browserProc, err := b.link(ctx, wsURL, logger)
 	if browserProc == nil {
 		return nil, fmt.Errorf("connecting to browser: %w", err)
 	}
@@ -144,9 +144,10 @@ func (b *BrowserType) connect(
 }
 
 func (b *BrowserType) link(
+	ctx context.Context,
 	wsURL string, logger *log.Logger,
 ) (*common.BrowserProcess, error) {
-	bProcCtx, bProcCtxCancel := context.WithCancel(context.Background())
+	bProcCtx, bProcCtxCancel := context.WithCancel(ctx)
 	p, err := common.NewRemoteBrowserProcess(bProcCtx, wsURL, bProcCtxCancel, logger)
 	if err != nil {
 		bProcCtxCancel()
@@ -205,7 +206,7 @@ func (b *BrowserType) launch(
 		return nil, 0, fmt.Errorf("finding browser executable: %w", err)
 	}
 
-	browserProc, err := b.allocate(path, flags, dataDir, logger)
+	browserProc, err := b.allocate(ctx, path, flags, dataDir, logger)
 	if browserProc == nil {
 		return nil, 0, fmt.Errorf("launching browser: %w", err)
 	}
@@ -238,11 +239,12 @@ func (b *BrowserType) Name() string {
 
 // allocate starts a new Chromium browser process and returns it.
 func (b *BrowserType) allocate(
+	ctx context.Context,
 	path string,
 	flags map[string]any, dataDir *storage.Dir,
 	logger *log.Logger,
 ) (_ *common.BrowserProcess, rerr error) {
-	bProcCtx, bProcCtxCancel := context.WithCancel(context.Background())
+	bProcCtx, bProcCtxCancel := context.WithCancel(ctx)
 	defer func() {
 		if rerr != nil {
 			bProcCtxCancel()

--- a/vendor/github.com/grafana/xk6-browser/common/connection.go
+++ b/vendor/github.com/grafana/xk6-browser/common/connection.go
@@ -623,7 +623,8 @@ func (c *Connection) Execute(ctx context.Context, method string, params easyjson
 		Method: cdproto.MethodType(method),
 		Params: buf,
 	}
-	return c.send(c.ctx, msg, ch, res)
+
+	return c.send(evCancelCtx, msg, ch, res)
 }
 
 // IgnoreIOErrors signals that the connection will soon be closed, so that any

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -173,7 +173,7 @@ github.com/grafana/sobek/ftoa/internal/fast
 github.com/grafana/sobek/parser
 github.com/grafana/sobek/token
 github.com/grafana/sobek/unistring
-# github.com/grafana/xk6-browser v1.8.4
+# github.com/grafana/xk6-browser v1.8.5
 ## explicit; go 1.21
 github.com/grafana/xk6-browser/browser
 github.com/grafana/xk6-browser/chromium


### PR DESCRIPTION
## What?

Updates to browser v1.8.5.

## Why?

Fixes a situation where the browser might hang if the browserProc exits before the connection closes.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
Related: https://github.com/grafana/xk6-browser/issues/1440