### PR TITLE
Update xk6-websockets to fix readyState bug

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grafana/xk6-output-prometheus-remote v0.4.0
 	github.com/grafana/xk6-redis v0.3.0
 	github.com/grafana/xk6-webcrypto v0.4.0
-	github.com/grafana/xk6-websockets v0.7.0
+	github.com/grafana/xk6-websockets v0.7.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/influxdata/influxdb1-client v0.0.0-20190402204710-8ff2fc3824fc
 	github.com/jhump/protoreflect v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -103,8 +103,8 @@ github.com/grafana/xk6-redis v0.3.0 h1:eV1YO0miPqGFilN8sL/3OdO6Mm+hZH2nsvJm5dkE0
 github.com/grafana/xk6-redis v0.3.0/go.mod h1:3e/U9i1Nm3WEaMy4nZSGMjVf8ZsFau+aXurYJhJ7MfQ=
 github.com/grafana/xk6-webcrypto v0.4.0 h1:CXRGkvVg8snYEyGCq3d5XGzDPxTPJ1m5CS68jPdtZZk=
 github.com/grafana/xk6-webcrypto v0.4.0/go.mod h1:+THllImZ8OWlsFc8llWqvzzjottlGdXq/7rIQ16zmFs=
-github.com/grafana/xk6-websockets v0.7.0 h1:oTdfQNISs3bEuALfPv9VvQgb3xOxbu3C/DBySf5DnOI=
-github.com/grafana/xk6-websockets v0.7.0/go.mod h1:D76ALTjp3bMugqx7ulseJ9TZrmSvDogieWxWXr8S0+A=
+github.com/grafana/xk6-websockets v0.7.1 h1:ONiw2xWvLzWjM1VtQlkMMFJGjVjn0LbigsC+wVw6ZxM=
+github.com/grafana/xk6-websockets v0.7.1/go.mod h1:D76ALTjp3bMugqx7ulseJ9TZrmSvDogieWxWXr8S0+A=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.22.0 h1:asbCHRVmodnJTuQ3qamDwqVOIjwqUPTYmYuemVOx+Ys=

--- a/vendor/github.com/grafana/xk6-websockets/websockets/websockets.go
+++ b/vendor/github.com/grafana/xk6-websockets/websockets/websockets.go
@@ -187,8 +187,8 @@ func defineWebsocket(rt *sobek.Runtime, w *webSocket) {
 	must(rt, w.obj.DefineDataProperty(
 		"url", rt.ToValue(w.url.String()), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
 	must(rt, w.obj.DefineAccessorProperty( // this needs to be with an accessor as we change the value
-		"readyState", rt.ToValue(func() ReadyState {
-			return w.readyState
+		"readyState", rt.ToValue(func() sobek.Value {
+			return rt.ToValue((uint)(w.readyState))
 		}), nil, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
 	must(rt, w.obj.DefineAccessorProperty(
 		"bufferedAmount", rt.ToValue(func() sobek.Value { return rt.ToValue(w.bufferedAmount) }), nil,

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -203,7 +203,7 @@ github.com/grafana/xk6-redis/redis
 # github.com/grafana/xk6-webcrypto v0.4.0
 ## explicit; go 1.20
 github.com/grafana/xk6-webcrypto/webcrypto
-# github.com/grafana/xk6-websockets v0.7.0
+# github.com/grafana/xk6-websockets v0.7.1
 ## explicit; go 1.20
 github.com/grafana/xk6-websockets/websockets
 github.com/grafana/xk6-websockets/websockets/events


### PR DESCRIPTION
## What?

Update xk6-websockets

## Why?

Fix `readyState` in `k6/experimental/websockets` to actually be a number.  

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
