### PR TITLE
refactor: use context.AfterFunc around VU management

### DIFF
--- a/js/runner.go
+++ b/js/runner.go
@@ -368,10 +368,9 @@ func (r *Runner) HandleSummary(ctx context.Context, summary *lib.Summary) (map[s
 		return nil, err
 	}
 
-	go func() {
-		<-summaryCtx.Done()
+	_ = context.AfterFunc(summaryCtx, func() {
 		vu.Runtime.Interrupt(context.Canceled)
-	}()
+	})
 	vu.moduleVUImpl.ctx = summaryCtx
 
 	callbackResult := sobek.Undefined()
@@ -540,10 +539,9 @@ func (r *Runner) runPart(
 		return sobek.Undefined(), nil
 	}
 
-	go func() {
-		<-ctx.Done()
+	_ = context.AfterFunc(ctx, func() {
 		vu.Runtime.Interrupt(context.Canceled)
-	}()
+	})
 	vu.moduleVUImpl.ctx = ctx
 
 	groupPath, err := lib.NewGroupPath(lib.RootGroupPath, name)
@@ -706,9 +704,8 @@ func (u *VU) Activate(params *lib.VUActivationParams) lib.ActiveVU {
 		return avu.scIterGlobal
 	}
 
-	go func() {
-		// Wait for the run context to be over
-		<-ctx.Done()
+	// Wait for the run context to be over
+	context.AfterFunc(ctx, func() {
 		// Interrupt the JS runtime
 		u.Runtime.Interrupt(context.Canceled)
 		// Wait for the VU to stop running, if it was, and prevent it from
@@ -718,7 +715,7 @@ func (u *VU) Activate(params *lib.VUActivationParams) lib.ActiveVU {
 		if params.DeactivateCallback != nil {
 			params.DeactivateCallback(u)
 		}
-	}()
+	})
 
 	return avu
 }

--- a/lib/testutils/minirunner/minirunner.go
+++ b/lib/testutils/minirunner/minirunner.go
@@ -172,9 +172,7 @@ func (vu *VU) Activate(params *lib.VUActivationParams) lib.ActiveVU {
 		return avu.scIterGlobal
 	}
 
-	go func() {
-		<-ctx.Done()
-
+	context.AfterFunc(ctx, func() {
 		// Wait for the VU to stop running, if it was, and prevent it from
 		// running again for this activation
 		avu.busy <- struct{}{}
@@ -182,7 +180,7 @@ func (vu *VU) Activate(params *lib.VUActivationParams) lib.ActiveVU {
 		if params.DeactivateCallback != nil {
 			params.DeactivateCallback(vu)
 		}
-	}()
+	})
 
 	return avu
 }


### PR DESCRIPTION
## What?

Use context.AfterFunc

## Why?

This cuts down on the amount of goroutines needed to be up for each VU.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
