### PR TITLE
dependabot: add a bunch more dependencies to it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,20 @@ updates:
       # Keep the experimental modules up-to-date
       - dependency-name: "github.com/grafana/xk6-*"
         dependency-type: "all"
-    commit-message:
-      prefix: "Upgrade experimental module "
-      include: "scope"
+      # golang/x
+      - dependency-name: "golang.org/x/*"
+        dependency-type: "all"
+      # google's grpc and protobuf
+      - dependency-name: "google.golang.org/*"
+        dependency-type: "all"
+      # miscellaneous
+      - dependency-name: "github.com/PuerkitoBio/goquery"
+      - dependency-name: "github.com/andybalholm/brotli"
+      - dependency-name: "github.com/evanw/esbuild"
+      - dependency-name: "github.com/gorilla/websocket"
+      - dependency-name: "github.com/grafana/sobek"
+      - dependency-name: "github.com/jhump/protoreflect"
+      - dependency-name: "github.com/klauspost/compress"
+      - dependency-name: "github.com/tidwall/gjson"
     reviewers:
       - "grafana/k6-core"


### PR DESCRIPTION
## What?

Add more dependancies to be checked by dependabot

## Why?

While k6 still doesn't update all its dependencies, we do update quite a lot of them.

Currently there is a manual step of not only updating them and making a PR but also trying to gather what has changed.

While having a PR for every small change is likely going to be a lot noisier and we will have to ignore some of them. It seems like a better idea than having someone go through 20 repositories trying to figure out what commits have changed, given that dependabot does this automatically.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
