### PR TITLE
test: split error message check to fix it for go 1.24

### DIFF
--- a/js/compiler/compiler_test.go
+++ b/js/compiler/compiler_test.go
@@ -130,7 +130,9 @@ func TestCorruptSourceMap(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Contains(t, msg, `Couldn't load source map for somefile`)
-	require.Contains(t, msg, `json: cannot unmarshal number into Go struct field v3.mappings of type string`)
+	// @mstoykov: this is split as message changed in go1.24
+	require.Contains(t, msg, `json: cannot unmarshal number into Go struct field`)
+	require.Contains(t, msg, `mappings of type string`)
 }
 
 func TestMinimalSourceMap(t *testing.T) {


### PR DESCRIPTION
## What?

Fix a test in gotip/go1.24

## Why?

as part of https://github.com/golang/go/commit/0fe6347732bdb9918e3af4e0c4b52f7f0c162894 now messages around encoding/json better specify the fields when embedding fields.

This does break a check on the message and the message will now be different between go versions.

With this commit the check is made to work between go versions.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
