### PR TITLE
dependabot: update configuration with fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 50
+    groups:
+      golangx:
+        patterns:
+          - "golang.org/x/*"
+      googles:
+        patterns:
+          -  "google.golang.org/*"
     allow:
       # Keep the experimental modules up-to-date
       - dependency-name: "github.com/grafana/xk6-*"
@@ -23,5 +31,3 @@ updates:
       - dependency-name: "github.com/jhump/protoreflect"
       - dependency-name: "github.com/klauspost/compress"
       - dependency-name: "github.com/tidwall/gjson"
-    reviewers:
-      - "grafana/k6-core"


### PR DESCRIPTION
## What?

- try to group golang/x and google dependancies for nicer PRs
- don't assign specific reviewers - we already do this with another integration
- increase the amount of PRs that it can open so we do not get blocked on a few PRs.


## Why?

Fiddle with the configuration to make updating dependancies more seemless
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
