### PR TITLE
Update fatih/color and set the logo color to be the correct RGB one

### DIFF
--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -51,7 +51,7 @@ func getColor(noColor bool, attributes ...color.Attribute) *color.Color {
 }
 
 func getBanner(noColor bool) string {
-	c := setColor(noColor, color.RGB(0xFF, 0x67, 0x1d))
+	c := setColor(noColor, color.RGB(0xFF, 0x67, 0x1d).Add(color.Bold))
 	return c.Sprint(consts.Banner())
 }
 

--- a/cmd/ui.go
+++ b/cmd/ui.go
@@ -34,23 +34,24 @@ const (
 	defaultTermWidth = 80
 )
 
+func setColor(noColor bool, c *color.Color) *color.Color {
+	if noColor {
+		c.DisableColor()
+	} else {
+		c.EnableColor()
+	}
+	return c
+}
+
 // getColor returns the requested color, or an uncolored object, depending on
 // the value of noColor. The explicit EnableColor() and DisableColor() are
 // needed because the library checks os.Stdout itself otherwise...
 func getColor(noColor bool, attributes ...color.Attribute) *color.Color {
-	if noColor {
-		c := color.New()
-		c.DisableColor()
-		return c
-	}
-
-	c := color.New(attributes...)
-	c.EnableColor()
-	return c
+	return setColor(noColor, color.New(attributes...))
 }
 
 func getBanner(noColor bool) string {
-	c := getColor(noColor, color.FgYellow)
+	c := setColor(noColor, color.RGB(0xFF, 0x67, 0x1d))
 	return c.Sprint(consts.Banner())
 }
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Soontao/goHttpDigestClient v0.0.0-20170320082612-6d28bb1415c5
 	github.com/andybalholm/brotli v1.1.1
 	github.com/evanw/esbuild v0.21.2
-	github.com/fatih/color v1.17.0
+	github.com/fatih/color v1.18.0
 	github.com/go-sourcemap/sourcemap v2.1.4+incompatible
 	github.com/golang/protobuf v1.5.4
 	github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,8 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanw/esbuild v0.21.2 h1:CLplcGi794CfHLVmUbvVfTMKkykm+nyIHU8SU60KUTA=
 github.com/evanw/esbuild v0.21.2/go.mod h1:D2vIQZqV/vIf/VRHtViaUtViZmG7o+kKmlBfVQuRi48=
-github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
-github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
+github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
+github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/fsnotify/fsnotify v1.5.4 h1:jRbGcIw6P2Meqdwuo0H1p6JVLbL5DHKAKlYndzMwVZI=
 github.com/fsnotify/fsnotify v1.5.4/go.mod h1:OVB6XrOHzAwXMpEM7uPOzcehqUV2UqJxmVXmkdnm1bU=
 github.com/go-kit/log v0.1.0/go.mod h1:zbhenjAZHb184qTLMA9ZjW7ThYL0H2mk7Q6pNt4vbaY=

--- a/vendor/github.com/fatih/color/README.md
+++ b/vendor/github.com/fatih/color/README.md
@@ -9,7 +9,7 @@ suits you.
 
 ## Install
 
-```bash
+```
 go get github.com/fatih/color
 ```
 
@@ -28,6 +28,18 @@ color.Blue("Prints %s in blue.", "text")
 color.Red("We have red")
 color.Magenta("And many others ..")
 
+```
+
+### RGB colors
+
+If your terminal supports 24-bit colors, you can use RGB color codes.
+
+```go
+color.RGB(255, 128, 0).Println("foreground orange")
+color.RGB(230, 42, 42).Println("foreground red")
+
+color.BgRGB(255, 128, 0).Println("background orange")
+color.BgRGB(230, 42, 42).Println("background red")
 ```
 
 ### Mix and reuse colors
@@ -49,6 +61,11 @@ boldRed.Println("This will print text in bold red.")
 
 whiteBackground := red.Add(color.BgWhite)
 whiteBackground.Println("Red text with white background.")
+
+// Mix with RGB color codes
+color.RGB(255, 128, 0).AddBgRGB(0, 0, 0).Println("orange with black background")
+
+color.BgRGB(255, 128, 0).AddRGB(255, 255, 255).Println("orange background with white foreground")
 ```
 
 ### Use your own output (io.Writer)
@@ -161,10 +178,6 @@ c.Println("This prints again cyan...")
 
 To output color in GitHub Actions (or other CI systems that support ANSI colors), make sure to set `color.NoColor = false` so that it bypasses the check for non-tty output streams. 
 
-## Todo
-
-* Save/Return previous values
-* Evaluate fmt.Formatter interface
 
 ## Credits
 

--- a/vendor/github.com/fatih/color/color.go
+++ b/vendor/github.com/fatih/color/color.go
@@ -98,6 +98,9 @@ const (
 	FgMagenta
 	FgCyan
 	FgWhite
+
+	// used internally for 256 and 24-bit coloring
+	foreground
 )
 
 // Foreground Hi-Intensity text colors
@@ -122,6 +125,9 @@ const (
 	BgMagenta
 	BgCyan
 	BgWhite
+
+	// used internally for 256 and 24-bit coloring
+	background
 )
 
 // Background Hi-Intensity text colors
@@ -147,6 +153,30 @@ func New(value ...Attribute) *Color {
 	}
 
 	c.Add(value...)
+	return c
+}
+
+// RGB returns a new foreground color in 24-bit RGB.
+func RGB(r, g, b int) *Color {
+	return New(foreground, 2, Attribute(r), Attribute(g), Attribute(b))
+}
+
+// BgRGB returns a new background color in 24-bit RGB.
+func BgRGB(r, g, b int) *Color {
+	return New(background, 2, Attribute(r), Attribute(g), Attribute(b))
+}
+
+// AddRGB is used to chain foreground RGB SGR parameters. Use as many as parameters to combine
+// and create custom color objects. Example: .Add(34, 0, 12).Add(255, 128, 0).
+func (c *Color) AddRGB(r, g, b int) *Color {
+	c.params = append(c.params, foreground, 2, Attribute(r), Attribute(g), Attribute(b))
+	return c
+}
+
+// AddRGB is used to chain background RGB SGR parameters. Use as many as parameters to combine
+// and create custom color objects. Example: .Add(34, 0, 12).Add(255, 128, 0).
+func (c *Color) AddBgRGB(r, g, b int) *Color {
+	c.params = append(c.params, background, 2, Attribute(r), Attribute(g), Attribute(b))
 	return c
 }
 
@@ -401,7 +431,7 @@ func (c *Color) format() string {
 
 func (c *Color) unformat() string {
 	//return fmt.Sprintf("%s[%dm", escape, Reset)
-	//for each element in sequence let's use the speficic reset escape, ou the generic one if not found
+	//for each element in sequence let's use the specific reset escape, or the generic one if not found
 	format := make([]string, len(c.params))
 	for i, v := range c.params {
 		format[i] = strconv.Itoa(int(Reset))

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -137,7 +137,7 @@ github.com/evanw/esbuild/internal/runtime
 github.com/evanw/esbuild/internal/sourcemap
 github.com/evanw/esbuild/internal/xxhash
 github.com/evanw/esbuild/pkg/api
-# github.com/fatih/color v1.17.0
+# github.com/fatih/color v1.18.0
 ## explicit; go 1.17
 github.com/fatih/color
 # github.com/fsnotify/fsnotify v1.5.4


### PR DESCRIPTION
## What?

Update fatih/color and use the RGB functionality to match the banner logo to the official k6 color.

## Why?

RGB :sparkles: 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
