### PR TITLE
Warn on usage of open that will break in the future

### DIFF
--- a/js/bundle.go
+++ b/js/bundle.go
@@ -456,7 +456,7 @@ func (b *Bundle) setInitGlobals(rt *sobek.Runtime, vu *moduleVUImpl, modSys *mod
 					"that in the future open will open relative path relative to the module/file it is written in. "+
 					"You can future proof this by using `import.meta.resolve()` to get relative paths to the file it "+
 					"is written in the current k6 version.", pwd, otherPath)
-				err = b.preInitState.Usage.Uint64("depracations/openRelativity", 1)
+				err = b.preInitState.Usage.Uint64("deprecations/openRelativity", 1)
 				if err != nil {
 					logger.WithError(err).Warn("failed reporting usage of deprecated relativity of open()")
 				}

--- a/js/bundle.go
+++ b/js/bundle.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/grafana/sobek"
 	"github.com/sirupsen/logrus"
@@ -446,6 +447,22 @@ func (b *Bundle) setInitGlobals(rt *sobek.Runtime, vu *moduleVUImpl, modSys *mod
 		if err != nil {
 			return nil, err
 		}
+		if !(strings.HasPrefix(filename, "file://") || filepath.IsAbs(filename)) {
+			otherPath, shouldWarn := modSys.ShouldWarnOnParentDirNotMatchingCurrentModuleParentDir(vu, pwd)
+			logger := b.preInitState.Logger
+			if shouldWarn {
+				logger.Warningf("open() was used and is currently relative to '%s', but in the future "+
+					"it will be aligned with how `require` and imports work and will be relative to '%s'. This means "+
+					"that in the future open will open relative path relative to the module/file it is written in. "+
+					"You can future proof this by using `import.meta.resolve()` to get relative paths to the file it "+
+					"is written in the current k6 version.", pwd, otherPath)
+				err = b.preInitState.Usage.Uint64("depracations/openRelativity", 1)
+				if err != nil {
+					logger.WithError(err).Warn("failed reporting usage of deprecated relativity of open()")
+				}
+			}
+		}
+
 		return openImpl(rt, b.filesystems["file"], pwd, filename, args...)
 	})
 	warnAboutModuleMixing := func(name string) {

--- a/js/modules/require_impl.go
+++ b/js/modules/require_impl.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/grafana/sobek"
+
 	"go.k6.io/k6/loader"
 )
 
@@ -132,6 +133,32 @@ func (ms *ModuleSystem) CurrentlyRequiredModule() (*url.URL, error) {
 			"please report it (https://github.com/grafana/k6/issues)", fileStr)
 	}
 	return loader.Dir(u), nil
+}
+
+// ShouldWarnOnParentDirNotMatchingCurrentModuleParentDir is a helper function to figure out if the provided url
+// is the same folder that an import will be to.
+// It also checks if the modulesystem is locked which means we are past the first init context.
+// If false is returned means that we are not in the init context or the path is matching - so no warning should be done
+// If true, the returned path is the module path that it should be relative to - the one that is checked against.
+func (ms *ModuleSystem) ShouldWarnOnParentDirNotMatchingCurrentModuleParentDir(vu VU, parentModulePwd *url.URL,
+) (string, bool) {
+	if ms.resolver.locked {
+		return "", false
+	}
+	normalizePathToURL := func(path string) string {
+		u, err := url.Parse(path)
+		if err != nil {
+			return path
+		}
+		return loader.Dir(u).String()
+	}
+	parentModuleDir := parentModulePwd.String()
+	parentModuleStr2 := getCurrentModuleScript(vu)
+	parentModuleStr2Dir := normalizePathToURL(parentModuleStr2)
+	if parentModuleDir != parentModuleStr2Dir {
+		return parentModuleStr2, true
+	}
+	return "", false
 }
 
 func toESModuleExports(exp Exports) interface{} {


### PR DESCRIPTION
## What?

Warn on usage of open that will break in the future

TODO: do it for `grpc.Client#load`  and `fs.open()` as well.

This is kind of a draft at this point to get some of the code inline.

## Why?

Align open like functions and align them with how module imports work 

see #3857 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
