### PR TITLE
Bump version to v0.55.0

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.54.0"
+const Version = "0.55.0"
 
 // FullVersion returns the maximally full version and build information for
 // the currently running k6 executable.


### PR DESCRIPTION
## What?

This PR bumps the k6 version to v0.55.0.

## Why?

As per the release process.

## Related PR(s)/Issue(s)

#3979
#4033 

