### PR TITLE
Update issues auto-assigner maintainers

### DIFF
--- a/.github/workflows/issue-auto-assign.yml
+++ b/.github/workflows/issue-auto-assign.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/github-script@v7
         with:
           script: |
-            const assignees = ['mstoykov', 'olegbespalov', 'oleiade', 'joanlopez'];
+            const assignees = ['mstoykov', 'olegbespalov', 'oleiade', 'joanlopez', 'ankur22', 'inancgumus'];
             const assigneeCount = 1;
 
             // Do not automatically assign users if someone was already assigned or it was opened by a maintainer


### PR DESCRIPTION
## What?

Adding @ankur22 and @inancgumus to the issue auto-assigner. 

That way, you folks will be in rotation for the GitHub issues in main k6 (or extensions that we maintain) repository.

## Why?

Knowledge sharing

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
