### PR TITLE
metrics: use `regexp.MatchString` for metric name check

### DIFF
--- a/metrics/registry.go
+++ b/metrics/registry.go
@@ -35,7 +35,7 @@ const (
 var compileNameRegex = regexp.MustCompile(nameRegexString)
 
 func checkName(name string) bool {
-	return compileNameRegex.Match([]byte(name))
+	return compileNameRegex.MatchString(name)
 }
 
 // NewMetric returns new metric registered to this registry


### PR DESCRIPTION
## What?

`(*Regexp).Match` have a string-based equivalent `(*Regexp).MatchString`. We should use the string version to avoid unnecessary `[]byte` conversions. 

## Why?


It's a one-line change that provides a free performance gain.

Benchmark:

```go
func BenchmarkMatch(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := compileNameRegex.Match([]byte("my_metric_name1")); !match {
			b.Fail()
		}
	}
}

func BenchmarkMatchString(b *testing.B) {
	for i := 0; i < b.N; i++ {
		if match := compileNameRegex.MatchString("my_metric_name1"); !match {
			b.Fail()
		}
	}
}
```

Result:

```
goos: linux
goarch: amd64
pkg: go.k6.io/k6/metrics
cpu: AMD Ryzen 7 PRO 4750U with Radeon Graphics
BenchmarkMatch-16          	 1457095	       820.7 ns/op	      16 B/op	       1 allocs/op
BenchmarkMatchString-16    	 1664458	       726.6 ns/op	       0 B/op	       0 allocs/op
PASS
coverage: 0.2% of statements
ok  	go.k6.io/k6/metrics	3.983s
```


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
