### PR TITLE
Fix namespaced object export when default is the only one available

### DIFF
--- a/js/module_loading_test.go
+++ b/js/module_loading_test.go
@@ -626,6 +626,9 @@ func TestStarImport(t *testing.T) {
 	r1, err := getSimpleRunner(t, "/script.js", `
 		import * as cjs from "./commonjs_file.js"; // commonjs
 		import * as k6 from "k6"; // "new" go module
+		// go module that only exports default object, but we want it to
+		// export as a namespace object.
+		import * as http from "k6/http";
 		// TODO: test with basic go module maybe
 
 		if (cjs.something != 5) {
@@ -633,6 +636,9 @@ func TestStarImport(t *testing.T) {
 		}
 		if (typeof k6.sleep != "function") {
 			throw "k6.sleep has wrong type" + typeof k6.sleep;
+		}
+		if (typeof http.get != "function") {
+			throw "http.get has wrong type" + typeof http.get;
 		}
 		export default () => {}
 	`, fs, lib.RuntimeOptions{CompatibilityMode: null.StringFrom("extended")})

--- a/js/module_loading_test.go
+++ b/js/module_loading_test.go
@@ -629,9 +629,6 @@ func TestStarImport(t *testing.T) {
 		r1, err := getSimpleRunner(t, "/script.js", `
 			import * as cjs from "./commonjs_file.js"; // commonjs
 			import * as k6 from "k6"; // "new" go module
-			// go module that only exports default object, but we want it to
-			// export as a namespace object.
-			import * as http from "k6/http";
 			// TODO: test with basic go module maybe
 	
 			if (cjs.something != 5) {
@@ -639,9 +636,6 @@ func TestStarImport(t *testing.T) {
 			}
 			if (typeof k6.sleep != "function") {
 				throw "k6.sleep has wrong type" + typeof k6.sleep;
-			}
-			if (typeof http.get != "function") {
-				throw "http.get has wrong type" + typeof http.get;
 			}
 			export default () => {}
 		`, fs, lib.RuntimeOptions{CompatibilityMode: null.StringFrom("extended")})

--- a/js/modules/gomodule.go
+++ b/js/modules/gomodule.go
@@ -26,7 +26,7 @@ func (gm *goModule) Instantiate(rt *sobek.Runtime) (sobek.CyclicModuleInstance, 
 		named := mi.Exports().Named
 
 		if named == nil && mi.Exports().Default != nil {
-			// If named length is 0 but default is defined, then try to work with
+			// If named is nil but default is defined, then try to work with
 			// default and extract the names of the object's properties. This
 			// behavior isn't ESM compatible, but we do want to allow defaults to
 			// be imported as namespaced object, which is also how node works.

--- a/js/modules/gomodule.go
+++ b/js/modules/gomodule.go
@@ -35,7 +35,7 @@ func (gm *goModule) Instantiate(rt *sobek.Runtime) (sobek.CyclicModuleInstance, 
 				gm.exportedNames = obj.GetOwnPropertyNames()
 			}
 		default:
-			gm.exportedNames = make([]string, len(named))
+			gm.exportedNames = make([]string, 0, len(named))
 			for name := range named {
 				gm.exportedNames = append(gm.exportedNames, name)
 			}

--- a/js/modules/gomodule.go
+++ b/js/modules/gomodule.go
@@ -26,7 +26,7 @@ func (gm *goModule) Instantiate(rt *sobek.Runtime) (sobek.CyclicModuleInstance, 
 		named := mi.Exports().Named
 
 		switch {
-		case len(named) == 0 && mi.Exports().Default != nil:
+		case named == nil && mi.Exports().Default != nil:
 			// If named length is 0 but default is defined, then try to work with
 			// default and extract the names of the object's properties. This
 			// behavior isn't ESM compatible, but we do want to allow defaults to

--- a/js/modules/gomodule.go
+++ b/js/modules/gomodule.go
@@ -25,15 +25,14 @@ func (gm *goModule) Instantiate(rt *sobek.Runtime) (sobek.CyclicModuleInstance, 
 	if gm.exportedNames == nil {
 		named := mi.Exports().Named
 
-		switch {
-		case named == nil && mi.Exports().Default != nil:
+		if named == nil && mi.Exports().Default != nil {
 			// If named length is 0 but default is defined, then try to work with
 			// default and extract the names of the object's properties. This
 			// behavior isn't ESM compatible, but we do want to allow defaults to
 			// be imported as namespaced object, which is also how node works.
 			obj := rt.ToValue(mi.Exports().Default).ToObject(rt)
 			gm.exportedNames = obj.GetOwnPropertyNames()
-		default:
+		} else {
 			gm.exportedNames = make([]string, 0, len(named))
 			for name := range named {
 				gm.exportedNames = append(gm.exportedNames, name)

--- a/js/modules/gomodule.go
+++ b/js/modules/gomodule.go
@@ -25,10 +25,14 @@ func (gm *goModule) Instantiate(rt *sobek.Runtime) (sobek.CyclicModuleInstance, 
 	if gm.exportedNames == nil {
 		named := mi.Exports().Named
 
-		gm.exportedNames = make([]string, len(named))
-		for name := range named {
-			gm.exportedNames = append(gm.exportedNames, name)
+		switch {
+		default:
+			gm.exportedNames = make([]string, len(named))
+			for name := range named {
+				gm.exportedNames = append(gm.exportedNames, name)
+			}
 		}
+
 		for _, callback := range gm.exportedNamesCallbacks {
 			callback(gm.exportedNames)
 		}

--- a/js/modules/gomodule.go
+++ b/js/modules/gomodule.go
@@ -31,9 +31,8 @@ func (gm *goModule) Instantiate(rt *sobek.Runtime) (sobek.CyclicModuleInstance, 
 			// default and extract the names of the object's properties. This
 			// behavior isn't ESM compatible, but we do want to allow defaults to
 			// be imported as namespaced object, which is also how node works.
-			if obj, ok := mi.Exports().Default.(*sobek.Object); ok {
-				gm.exportedNames = obj.GetOwnPropertyNames()
-			}
+			obj := rt.ToValue(mi.Exports().Default).ToObject(rt)
+			gm.exportedNames = obj.GetOwnPropertyNames()
 		default:
 			gm.exportedNames = make([]string, 0, len(named))
 			for name := range named {

--- a/js/modules/gomodule.go
+++ b/js/modules/gomodule.go
@@ -26,6 +26,14 @@ func (gm *goModule) Instantiate(rt *sobek.Runtime) (sobek.CyclicModuleInstance, 
 		named := mi.Exports().Named
 
 		switch {
+		case len(named) == 0 && mi.Exports().Default != nil:
+			// If named length is 0 but default is defined, then try to work with
+			// default and extract the names of the object's properties. This
+			// behavior isn't ESM compatible, but we do want to allow defaults to
+			// be imported as namespaced object, which is also how node works.
+			if obj, ok := mi.Exports().Default.(*sobek.Object); ok {
+				gm.exportedNames = obj.GetOwnPropertyNames()
+			}
 		default:
 			gm.exportedNames = make([]string, len(named))
 			for name := range named {


### PR DESCRIPTION
## What?

This fixes an issue where a module only expose a default object, but we also want to allow the the module to be imported as a namespaced object. 

## Why?

This is how node works, and this is how we have chosen to work even after the changes to work with ESM from commonJS. It prevents breaking changes with older scripts that were not intended.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
Related: https://github.com/grafana/k6/issues/4050