### PR TITLE
Report usages of the deprecated 'ext.loadimpact' option

### DIFF
--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -273,7 +273,7 @@ func (lct *loadedAndConfiguredTest) buildTestRunState(
 	// Here, where we get the consolidated options, is where we check if any
 	// of the deprecated options is being used, and we report it.
 	if _, isPresent := configToReinject.External["loadimpact"]; isPresent {
-		if err := lct.preInitState.Usage.Strings("deprecated_options", "ext.loadimpact"); err != nil {
+		if err := lct.preInitState.Usage.Uint64("deprecations/options.ext.loadimpact", 1); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/test_load.go
+++ b/cmd/test_load.go
@@ -265,9 +265,17 @@ func loadSystemCertPool(logger logrus.FieldLogger) {
 func (lct *loadedAndConfiguredTest) buildTestRunState(
 	configToReinject lib.Options,
 ) (*lib.TestRunState, error) {
-	// This might be the full derived or just the consodlidated options
+	// This might be the full derived or just the consolidated options
 	if err := lct.initRunner.SetOptions(configToReinject); err != nil {
 		return nil, err
+	}
+
+	// Here, where we get the consolidated options, is where we check if any
+	// of the deprecated options is being used, and we report it.
+	if _, isPresent := configToReinject.External["loadimpact"]; isPresent {
+		if err := lct.preInitState.Usage.Strings("deprecated_options", "ext.loadimpact"); err != nil {
+			return nil, err
+		}
 	}
 
 	// it pre-loads system certificates to avoid doing it on the first TLS request.


### PR DESCRIPTION
## What?

It adds a new `deprecated_options` field into the usage reports, and accounts if `ext.loadimpact` is still being used, and how often.

## Why?

Because we likely will remove that option parameter before v1, so we need to make some plans.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Related with https://github.com/grafana/k6-cloud/issues/2210

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
