### PR TITLE
Introduces --json flag for k6 version sub-command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,6 @@ import (
 	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/errext"
 	"go.k6.io/k6/errext/exitcodes"
-	"go.k6.io/k6/lib/consts"
 	"go.k6.io/k6/log"
 )
 
@@ -79,7 +78,7 @@ func (c *rootCommand) persistentPreRunE(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	c.globalState.Logger.Debugf("k6 version: v%s", consts.FullVersion())
+	c.globalState.Logger.Debugf("k6 version: v%s", fullVersion())
 	return nil
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -154,13 +154,11 @@ func (c *versionCmd) run(cmd *cobra.Command, _ []string) error {
 		details["extensions"] = list
 	}
 
-	jsonDetails, err := json.Marshal(details)
-	if err != nil {
-		return fmt.Errorf("failed produce a JSON version details: %w", err)
+	if err := json.NewEncoder(c.gs.Stdout).Encode(details); err != nil {
+		return fmt.Errorf("failed to encode/output version details: %w", err)
 	}
 
-	_, err = fmt.Fprintln(c.gs.Stdout, string(jsonDetails))
-	return err
+	return nil
 }
 
 func getCmdVersion(gs *state.GlobalState) *cobra.Command {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -131,13 +131,15 @@ func (c *versionCmd) run(cmd *cobra.Command, _ []string) error {
 
 		ext := make(map[string]extInfo)
 		for _, e := range exts {
-			if v, ok := ext[e.Path]; ok {
+			key := e.Path + "@" + e.Version
+
+			if v, ok := ext[key]; ok {
 				v.Imports = append(v.Imports, e.Name)
-				ext[e.Path] = v
+				ext[key] = v
 				continue
 			}
 
-			ext[e.Path] = extInfo{
+			ext[key] = extInfo{
 				Module:  e.Path,
 				Version: e.Version,
 				Imports: []string{e.Name},

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"encoding/json"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.k6.io/k6/cmd/tests"
+	"go.k6.io/k6/lib/consts"
+)
+
+func TestVersionFlag(t *testing.T) {
+	t.Parallel()
+
+	ts := tests.NewGlobalTestState(t)
+	ts.ExpectedExitCode = 0
+	ts.CmdArgs = []string{"k6", "--version"}
+
+	ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.NotEmpty(t, stdout)
+
+	// Check that the version/format string is correct
+	assert.Contains(t, stdout, "k6 v")
+	assert.Contains(t, stdout, consts.Version)
+	assert.Contains(t, stdout, runtime.Version())
+	assert.Contains(t, stdout, runtime.GOOS)
+	assert.Contains(t, stdout, runtime.GOARCH)
+}
+
+func TestVersionSubCommand(t *testing.T) {
+	t.Parallel()
+
+	ts := tests.NewGlobalTestState(t)
+	ts.ExpectedExitCode = 0
+	ts.CmdArgs = []string{"k6", "version"}
+
+	ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.NotEmpty(t, stdout)
+
+	// Check that the version/format string is correct
+	assert.Contains(t, stdout, "k6 v")
+	assert.Contains(t, stdout, consts.Version)
+	assert.Contains(t, stdout, runtime.Version())
+	assert.Contains(t, stdout, runtime.GOOS)
+	assert.Contains(t, stdout, runtime.GOARCH)
+}
+
+func TestVersionJSONSubCommand(t *testing.T) {
+	t.Parallel()
+
+	ts := tests.NewGlobalTestState(t)
+	ts.ExpectedExitCode = 0
+	ts.CmdArgs = []string{"k6", "version", "--json"}
+
+	ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.NotEmpty(t, stdout)
+
+	// try to unmarshal the JSON output
+	var details map[string]interface{}
+	err := json.Unmarshal([]byte(stdout), &details)
+	assert.NoError(t, err)
+
+	// Check that details are correct
+	assert.Contains(t, details, "version")
+	assert.Contains(t, details, "go_version")
+	assert.Contains(t, details, "go_os")
+	assert.Contains(t, details, "go_arch")
+	assert.Equal(t, "v"+consts.Version, details["version"])
+	assert.Equal(t, runtime.Version(), details["go_version"])
+	assert.Equal(t, runtime.GOOS, details["go_os"])
+	assert.Equal(t, runtime.GOARCH, details["go_arch"])
+}

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -11,14 +11,53 @@ import (
 // Version contains the current semantic version of k6.
 const Version = "0.55.0"
 
+const (
+	commitKey      = "commit"
+	commitDirtyKey = "commit_dirty"
+)
+
 // FullVersion returns the maximally full version and build information for
 // the currently running k6 executable.
 func FullVersion() string {
-	goVersionArch := fmt.Sprintf("%s, %s/%s", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	details := VersionDetails()
+
+	goVersionArch := fmt.Sprintf("%s, %s/%s", details["go_version"], details["go_os"], details["go_arch"])
+
+	k6version := fmt.Sprintf("%s", details["version"])
+	// for the fallback case when the version is not in the expected format
+	// cobra adds a "v" prefix to the version
+	k6version = strings.TrimLeft(k6version, "v")
+
+	commit, ok := details[commitKey].(string)
+	if !ok || commit == "" {
+		return fmt.Sprintf("%s (%s)", k6version, goVersionArch)
+	}
+
+	isDirty, ok := details[commitDirtyKey].(bool)
+	if ok && isDirty {
+		commit += "-dirty"
+	}
+
+	return fmt.Sprintf("%s (commit/%s, %s)", k6version, commit, goVersionArch)
+}
+
+// VersionDetails returns the structured details about version
+func VersionDetails() map[string]interface{} {
+	v := Version
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+
+	details := map[string]interface{}{
+		"version":    v,
+		"go_version": runtime.Version(),
+		"go_os":      runtime.GOOS,
+		"go_arch":    runtime.GOARCH,
+	}
 
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
-		return fmt.Sprintf("%s (%s)", Version, goVersionArch)
+		return details
 	}
 
 	var (
@@ -42,14 +81,15 @@ func FullVersion() string {
 	}
 
 	if commit == "" {
-		return fmt.Sprintf("%s (%s)", Version, goVersionArch)
+		return details
 	}
 
+	details[commitKey] = commit
 	if dirty {
-		commit += "-dirty"
+		details[commitDirtyKey] = true
 	}
 
-	return fmt.Sprintf("%s (commit/%s, %s)", Version, commit, goVersionArch)
+	return details
 }
 
 // Banner returns the ASCII-art banner with the k6 logo

--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -2,95 +2,11 @@
 package consts
 
 import (
-	"fmt"
-	"runtime"
-	"runtime/debug"
 	"strings"
 )
 
 // Version contains the current semantic version of k6.
 const Version = "0.55.0"
-
-const (
-	commitKey      = "commit"
-	commitDirtyKey = "commit_dirty"
-)
-
-// FullVersion returns the maximally full version and build information for
-// the currently running k6 executable.
-func FullVersion() string {
-	details := VersionDetails()
-
-	goVersionArch := fmt.Sprintf("%s, %s/%s", details["go_version"], details["go_os"], details["go_arch"])
-
-	k6version := fmt.Sprintf("%s", details["version"])
-	// for the fallback case when the version is not in the expected format
-	// cobra adds a "v" prefix to the version
-	k6version = strings.TrimLeft(k6version, "v")
-
-	commit, ok := details[commitKey].(string)
-	if !ok || commit == "" {
-		return fmt.Sprintf("%s (%s)", k6version, goVersionArch)
-	}
-
-	isDirty, ok := details[commitDirtyKey].(bool)
-	if ok && isDirty {
-		commit += "-dirty"
-	}
-
-	return fmt.Sprintf("%s (commit/%s, %s)", k6version, commit, goVersionArch)
-}
-
-// VersionDetails returns the structured details about version
-func VersionDetails() map[string]interface{} {
-	v := Version
-	if !strings.HasPrefix(v, "v") {
-		v = "v" + v
-	}
-
-	details := map[string]interface{}{
-		"version":    v,
-		"go_version": runtime.Version(),
-		"go_os":      runtime.GOOS,
-		"go_arch":    runtime.GOARCH,
-	}
-
-	buildInfo, ok := debug.ReadBuildInfo()
-	if !ok {
-		return details
-	}
-
-	var (
-		commit string
-		dirty  bool
-	)
-	for _, s := range buildInfo.Settings {
-		switch s.Key {
-		case "vcs.revision":
-			commitLen := 10
-			if len(s.Value) < commitLen {
-				commitLen = len(s.Value)
-			}
-			commit = s.Value[:commitLen]
-		case "vcs.modified":
-			if s.Value == "true" {
-				dirty = true
-			}
-		default:
-		}
-	}
-
-	if commit == "" {
-		return details
-	}
-
-	details[commitKey] = commit
-	if dirty {
-		details[commitDirtyKey] = true
-	}
-
-	return details
-}
 
 // Banner returns the ASCII-art banner with the k6 logo
 func Banner() string {


### PR DESCRIPTION
## What?

This PR introduces the new `--json` flag for `k6 version` sub-command, which switches the output format to a JSON. 

Here are some examples:

Basic
```bash
./k6 version --json | jq
{
  "commit": "ec1f601e4f",
  "commit_dirty": true,
  "go_arch": "amd64",
  "go_os": "linux",
  "go_version": "go1.23.2",
  "version": "v0.55.0"
}
```
```bash
./k6 version
k6 v0.55.0 (commit/ec1f601e4f-dirty, go1.23.2, linux/amd64)
```
```bash
./k6 --version
k6 v0.55.0 (commit/ec1f601e4f-dirty, go1.23.2, linux/amd64)
```

With extensions:
```bash
./k6 version --json | jq
{
  "extensions": [
    {
      "imports": [
        "k6/x/sql"
      ],
      "module": "github.com/grafana/xk6-sql",
      "version": "v0.0.1"
    }
  ],
  "go_arch": "amd64",
  "go_os": "linux",
  "go_version": "go1.23.2",
  "version": "v0.55.0"
}
```

```bash
./k6 --version
k6 v0.55.0 (go1.23.2, linux/amd64)
Extensions:
  github.com/grafana/xk6-sql v0.0.1, k6/x/sql [js]
```
```bash
./k6 version
k6 v0.55.0 (go1.23.2, linux/amd64)
Extensions:
  github.com/grafana/xk6-sql v0.0.1, k6/x/sql [js]
```




## Why?

Having the ability to produce JSON structured output is essential if k6 used as part of some automation.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
