### PR TITLE
Explicitly check if we actually timed out

### DIFF
--- a/js/modules/k6/browser/common/browser.go
+++ b/js/modules/k6/browser/common/browser.go
@@ -493,12 +493,22 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 		page = b.pages[tid]
 		b.pagesMu.RUnlock()
 	case <-ctx.Done():
+		b.logger.Debugf("Browser:newPageInContext:<-ctx.Done", "tid:%v bctxid:%v err:%v", tid, id, ctx.Err())
+	}
+
+	if err = ctx.Err(); err != nil {
 		err = &k6ext.UserFriendlyError{
 			Err:     ctx.Err(),
 			Timeout: b.browserOpts.Timeout,
 		}
-		b.logger.Debugf("Browser:newPageInContext:<-ctx.Done", "tid:%v bctxid:%v err:%v", tid, id, err)
 	}
+
+	if err == nil && page == nil {
+		err = &k6ext.UserFriendlyError{
+			Err: errors.New("can't fetch the page for unknown reason"),
+		}
+	}
+
 	return page, err
 }
 

--- a/js/modules/k6/browser/common/browser_context.go
+++ b/js/modules/k6/browser/common/browser_context.go
@@ -269,9 +269,7 @@ func (b *BrowserContext) NewPage() (*Page, error) {
 	if b != nil {
 		bctxid = b.id
 	}
-	if p != nil {
-		ptid = p.targetID
-	}
+
 	b.logger.Debugf("BrowserContext:NewPage:return", "bctxid:%v ptid:%s", bctxid, ptid)
 
 	return p, nil

--- a/js/modules/k6/browser/common/browser_context.go
+++ b/js/modules/k6/browser/common/browser_context.go
@@ -262,16 +262,7 @@ func (b *BrowserContext) NewPage() (*Page, error) {
 		return nil, err
 	}
 
-	var (
-		bctxid cdp.BrowserContextID
-		ptid   target.ID
-	)
-	if b != nil {
-		bctxid = b.id
-	}
-
-	b.logger.Debugf("BrowserContext:NewPage:return", "bctxid:%v ptid:%s", bctxid, ptid)
-
+	b.logger.Debugf("BrowserContext:NewPage:return", "bctxid:%v ptid:%s", b.id, p.targetID)
 	return p, nil
 }
 


### PR DESCRIPTION
## What?

It's an attempt to address a nil pointer from #4128 

Unfortunately, we don't have a script/steps to reproduce the #4128, but after analyzing the stack trace and code it seems like one of the possible scenarios what happens is that we reached the [default (30s) context timeout](https://github.com/grafana/k6/blob/d3c7fc51bdd3135492ddb8bd615ad0965357e259/js/modules/k6/browser/common/browser.go#L457-L458) which causing context deadline, [somewhere down the `createWaitForEventHandler`](https://github.com/grafana/k6/blob/d3c7fc51bdd3135492ddb8bd615ad0965357e259/js/modules/k6/browser/common/helpers.go#L129-L176) it exits the releases the channel and as result [we didn't fill the page](https://github.com/grafana/k6/blob/d3c7fc51bdd3135492ddb8bd615ad0965357e259/js/modules/k6/browser/common/browser.go#L490-L494).

So we will always check the context error to check if it was timed out and also explicitly check if we were able to fetch non-nil page (the main purpose of the method)

## Why?

Fix the panic and error explicit.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Fixes #4128

<!-- Thanks for your contribution! 🙏🏼 -->
