### PR TITLE
Bump version to 0.55.2

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.55.1"
+const Version = "0.55.2"
 
 // FullVersion returns the maximally full version and build information for
 // the currently running k6 executable.

--- a/release notes/v0.55.2.md
+++ b/release notes/v0.55.2.md
@@ -1,0 +1,3 @@
+k6 `v0.55.2` is a patch release that fixes packaging issue.
+
+There are no functional changes in k6 compared to v0.55.1.


### PR DESCRIPTION
## What?

Bumping to v0.55.2.

## Why?

Due to a build/release issue, the published version of the .deb file seems to have also failed. For an unknown reason the size of the file doesn't match the expected size: `File has unexpected size (28726870 != 28726866). Mirror sync in progress?`.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
