### PR TITLE
Bump version to v0.56.0

### DIFF
--- a/lib/consts/consts.go
+++ b/lib/consts/consts.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Version contains the current semantic version of k6.
-const Version = "0.55.0"
+const Version = "0.56.0"
 
 // Banner returns the ASCII-art banner with the k6 logo
 func Banner() string {


### PR DESCRIPTION
## What?

This PR bumps the k6 version to v0.56.0.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
- https://github.com/grafana/k6/issues/4064
- https://github.com/grafana/k6/pull/4066