### PR TITLE
Fix/4123 click panic

### DIFF
--- a/js/modules/k6/browser/common/element_handle.go
+++ b/js/modules/k6/browser/common/element_handle.go
@@ -71,7 +71,7 @@ func (h *ElementHandle) checkHitTargetAt(apiCtx context.Context, point Position)
 		return false, fmt.Errorf("checking hit target at %v: %w", point, err)
 	}
 	if frame != nil && frame.parentFrame != nil {
-		el, err := h.frame.FrameElement()
+		el, err := frame.FrameElement()
 		if err != nil {
 			return false, err
 		}

--- a/js/modules/k6/browser/common/execution_context.go
+++ b/js/modules/k6/browser/common/execution_context.go
@@ -113,6 +113,10 @@ func (e *ExecutionContext) adoptBackendNodeID(backendNodeID cdp.BackendNodeID) (
 		return nil, fmt.Errorf("resolving DOM node: %w", err)
 	}
 
+	if remoteObj == nil {
+		return nil, fmt.Errorf("the page may have navigated away or the element is now missing: %w", err)
+	}
+
 	return NewJSHandle(e.ctx, e.session, e, e.frame, remoteObj, e.logger).AsElement(), nil
 }
 

--- a/js/modules/k6/browser/common/execution_context.go
+++ b/js/modules/k6/browser/common/execution_context.go
@@ -113,6 +113,8 @@ func (e *ExecutionContext) adoptBackendNodeID(backendNodeID cdp.BackendNodeID) (
 		return nil, fmt.Errorf("resolving DOM node: %w", err)
 	}
 
+	// This can occur due to race conditions between trying to click on an element
+	// and chrome moving on (e.g. navigating).
 	if remoteObj == nil {
 		return nil, fmt.Errorf("the page may have navigated away or the element is now missing: %w", err)
 	}

--- a/js/modules/k6/browser/common/execution_context.go
+++ b/js/modules/k6/browser/common/execution_context.go
@@ -118,7 +118,7 @@ func (e *ExecutionContext) adoptBackendNodeID(backendNodeID cdp.BackendNodeID) (
 	if remoteObj == nil {
 		return nil, fmt.Errorf(`the page may have navigated away or the element is
 			now missing. It might happen when k6 and/or Chrome are overloaded. You
-			might need to increase the compute resources: %w`, err)
+			might need to increase the compute resources`)
 	}
 
 	return NewJSHandle(e.ctx, e.session, e, e.frame, remoteObj, e.logger).AsElement(), nil

--- a/js/modules/k6/browser/common/execution_context.go
+++ b/js/modules/k6/browser/common/execution_context.go
@@ -116,7 +116,9 @@ func (e *ExecutionContext) adoptBackendNodeID(backendNodeID cdp.BackendNodeID) (
 	// This can occur due to race conditions between trying to click on an element
 	// and chrome moving on (e.g. navigating).
 	if remoteObj == nil {
-		return nil, fmt.Errorf("the page may have navigated away or the element is now missing: %w", err)
+		return nil, fmt.Errorf(`the page may have navigated away or the element is
+			now missing. It might happen when k6 and/or Chrome are overloaded. You
+			might need to increase the compute resources: %w`, err)
 	}
 
 	return NewJSHandle(e.ctx, e.session, e, e.frame, remoteObj, e.logger).AsElement(), nil

--- a/js/modules/k6/browser/common/frame_manager.go
+++ b/js/modules/k6/browser/common/frame_manager.go
@@ -177,8 +177,8 @@ func (m *FrameManager) frameDetached(frameID cdp.FrameID, reason cdppage.FrameDe
 	// when the type of detach is a swap. After this detach event usually
 	// the iframe navigates, which requires the frames to be present for the
 	// navigate to work.
-	fs := m.page.getFrameSession(frameID)
-	if fs != nil {
+	fs, ok := m.page.getFrameSession(frameID)
+	if ok {
 		m.logger.Debugf("FrameManager:frameDetached:sessionFound",
 			"fmid:%d fid:%v fsID1:%v fsID2:%v found session for frame",
 			m.ID(), frameID, fs.session.ID(), m.session.ID())
@@ -657,8 +657,8 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *Frame
 		})
 	defer lifecycleEvtCancel()
 
-	fs := frame.page.getFrameSession(cdp.FrameID(frame.ID()))
-	if fs == nil {
+	fs, ok := frame.page.getFrameSession(cdp.FrameID(frame.ID()))
+	if !ok {
 		m.logger.Debugf("FrameManager:NavigateFrame",
 			"fmid:%d fid:%v furl:%s url:%s fs:nil",
 			fmid, fid, furl, url)

--- a/js/modules/k6/browser/common/frame_session.go
+++ b/js/modules/k6/browser/common/frame_session.go
@@ -1024,7 +1024,10 @@ func (fs *FrameSession) attachIFrameToTarget(ti *target.Info, sid target.Session
 		return fmt.Errorf("attaching iframe target ID %v to session ID %v: %w",
 			ti.TargetID, sid, err)
 	}
-	fs.page.attachFrameSession(cdp.FrameID(ti.TargetID), nfs)
+
+	if err := fs.page.attachFrameSession(cdp.FrameID(ti.TargetID), nfs); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/js/modules/k6/browser/common/page.go
+++ b/js/modules/k6/browser/common/page.go
@@ -682,11 +682,18 @@ func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) (cdp.Fram
 	return frameID, nil
 }
 
-func (p *Page) attachFrameSession(fid cdp.FrameID, fs *FrameSession) {
+func (p *Page) attachFrameSession(fid cdp.FrameID, fs *FrameSession) error {
 	p.logger.Debugf("Page:attachFrameSession", "sid:%v fid=%v", p.session.ID(), fid)
+
+	if fs == nil {
+		return errors.New("internal error: FrameSession is nil")
+	}
+
 	p.frameSessionsMu.Lock()
 	defer p.frameSessionsMu.Unlock()
 	fs.page.frameSessions[fid] = fs
+
+	return nil
 }
 
 func (p *Page) getFrameSession(frameID cdp.FrameID) (*FrameSession, bool) {

--- a/js/modules/k6/browser/common/page.go
+++ b/js/modules/k6/browser/common/page.go
@@ -603,7 +603,11 @@ func (p *Page) getFrameElement(f *Frame) (handle *ElementHandle, _ error) {
 	for ; rootFrame.parentFrame != nil; rootFrame = rootFrame.parentFrame {
 	}
 
-	parentSession := p.getFrameSession(cdp.FrameID(rootFrame.ID()))
+	parentSession, ok := p.getFrameSession(cdp.FrameID(rootFrame.ID()))
+	if !ok {
+		return nil, errors.New("parent frame has been detached")
+	}
+
 	action := dom.GetFrameOwner(cdp.FrameID(f.ID()))
 	backendNodeID, _, err := action.Do(cdp.WithExecutor(p.ctx, parentSession.session))
 	if err != nil {
@@ -685,11 +689,14 @@ func (p *Page) attachFrameSession(fid cdp.FrameID, fs *FrameSession) {
 	fs.page.frameSessions[fid] = fs
 }
 
-func (p *Page) getFrameSession(frameID cdp.FrameID) *FrameSession {
+func (p *Page) getFrameSession(frameID cdp.FrameID) (*FrameSession, bool) {
 	p.logger.Debugf("Page:getFrameSession", "sid:%v fid:%v", p.sessionID(), frameID)
 	p.frameSessionsMu.RLock()
 	defer p.frameSessionsMu.RUnlock()
-	return p.frameSessions[frameID]
+
+	v, ok := p.frameSessions[frameID]
+
+	return v, ok
 }
 
 func (p *Page) hasRoutes() bool {


### PR DESCRIPTION
## What?

This makes changes to the codebase so that we alert the user of an error that they could work with to try and fix their environment.

## Why?

When either the load generator and/or chrome are under heavy load (CPU is nearly maxed out), a user might sometimes see an NPD error. This isn't useful and the user cannot do anything with that information. We protect against an NPD by returning an error which should give the user some idea of what steps to take to get their test to work (increase compute resources).

More details can be found in https://github.com/grafana/k6/issues/4124#issuecomment-2577675900.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/issues/4124