### PR TITLE
Warn on shorthand options overriding scenarios

### DIFF
--- a/cmd/config_consolidation_test.go
+++ b/cmd/config_consolidation_test.go
@@ -293,7 +293,9 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 				env: []string{"K6_ITERATIONS=25"},
 				cli: []string{"--vus", "12"},
 			},
-			exp{},
+			exp{
+				logWarning: true,
+			},
 			verifySharedIters(I(12), I(25)),
 		},
 		{


### PR DESCRIPTION
## What?

Warn on shorthand options(vus, duration, stages, iterations) overriding scenarios from previously defined scenarios. Mostly applicable when using cli flags to override them from within the script.

This is currently implemented only for scenarios as that is the case that is most confusing. Implementing this for duration overriding stages (for example) is possible, but it seems to not be nearly hit enough.

Unfortunately due to too many of things of #883 and the way shorthand options are handled in particular, the code can't be in any Apply function with enough information to have a nice message.


## Why?

This is probably one of the things that confuses the most users as explained in the original #2529 issue.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Fixes #2529
