### PR TITLE
Fix some browser Windows tests

### DIFF
--- a/js/modules/k6/browser/tests/page_test.go
+++ b/js/modules/k6/browser/tests/page_test.go
@@ -673,7 +673,7 @@ func TestPageScreenshotFullpage(t *testing.T) {
 		const div = document.createElement('div');
 		div.style.width = '1280px';
 		div.style.height = '800px';
-		div.style.background = 'linear-gradient(red, blue)';
+		div.style.background = 'linear-gradient(to bottom, red, blue)';
 
 		document.body.appendChild(div);
 	}`)
@@ -688,15 +688,16 @@ func TestPageScreenshotFullpage(t *testing.T) {
 	img, err := png.Decode(reader)
 	assert.Nil(t, err)
 
-	assert.Equal(t, 1280, img.Bounds().Max.X, "screenshot width is not 1280px as expected, but %dpx", img.Bounds().Max.X)
-	assert.Equal(t, 800, img.Bounds().Max.Y, "screenshot height is not 800px as expected, but %dpx", img.Bounds().Max.Y)
+	assert.Equal(t, 1280, img.Bounds().Max.X, "want: screenshot width is 1280px, got: %dpx", img.Bounds().Max.X)
+	assert.Equal(t, 800, img.Bounds().Max.Y, "want: screenshot height is 800px, got: %dpx", img.Bounds().Max.Y)
 
+	// Allow tolerance to account for differences in rendering between
+	// different platforms and browsers. The goal is to ensure that the
+	// screenshot is mostly red at the top and mostly blue at the bottom.
 	r, _, b, _ := img.At(0, 0).RGBA()
-	assert.Greater(t, r, uint32(128))
-	assert.Less(t, b, uint32(128))
+	assert.Truef(t, r > b*2, "want: the top pixel to be dominantly red, got R: %d, B: %d", r, b)
 	r, _, b, _ = img.At(0, 799).RGBA()
-	assert.Less(t, r, uint32(128))
-	assert.Greater(t, b, uint32(128))
+	assert.Truef(t, b > r*2, "want: the bottom pixel to be dominantly blue, got R: %d, B: %d", r, b)
 }
 
 func TestPageTitle(t *testing.T) {

--- a/js/modules/k6/browser/tests/test_browser.go
+++ b/js/modules/k6/browser/tests/test_browser.go
@@ -184,7 +184,7 @@ func (b *testBrowser) withFileServer() *testBrowser {
 
 	fs := http.FileServer(http.Dir(testBrowserStaticDir))
 
-	return b.withHandler(path, http.StripPrefix(path, fs).ServeHTTP)
+	return b.withHandler("/"+testBrowserStaticDir+"/", http.StripPrefix(path, fs).ServeHTTP)
 }
 
 // withHandler adds the given handler to the HTTP test server and makes it


### PR DESCRIPTION
## What?

Fixes some tests to work on Windows.

## Why?

These tests stopped working after the updates in #4177 (CI runs: [1](https://github.com/grafana/k6/actions/runs/12772268654/job/35602414728), [2](https://github.com/grafana/k6/actions/runs/12791222587/job/35658838255)).

- Fixes the HTTP handler slash misusage.
- Fixes gradient differences on Windows.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

- #4177
- #4118
