### PR TITLE
streams: just use modulestest to get setTimeout and co.

### DIFF
--- a/js/modules/k6/experimental/streams/readable_streams_test.go
+++ b/js/modules/k6/experimental/streams/readable_streams_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"go.k6.io/k6/js/modules"
-	"go.k6.io/k6/js/modules/k6/timers"
 	"go.k6.io/k6/js/modulestest"
 
 	"github.com/stretchr/testify/assert"
@@ -45,14 +44,11 @@ func TestReadableStream(t *testing.T) {
 func newConfiguredRuntime(t testing.TB) *modulestest.Runtime {
 	rt := modulestest.NewRuntime(t)
 
+	require.NoError(t, rt.SetupModuleSystem(nil, nil, nil))
+
 	// We want to make the [self] available for Web Platform Tests, as it is used in test harness.
 	_, err := rt.VU.Runtime().RunString("var self = this;")
 	require.NoError(t, err)
-
-	// We also want to make [timers.Timers] available for Web Platform Tests.
-	for k, v := range timers.New().NewModuleInstance(rt.VU).Exports().Named {
-		require.NoError(t, rt.VU.RuntimeField.Set(k, v))
-	}
 
 	// We also want the streams module exports to be globally available.
 	m := new(RootModule).NewModuleInstance(rt.VU)


### PR DESCRIPTION
## What?

Use modulesTest insead of k6/timers module

## Why?

This breaks in some cases and more importantly isn't really necessary 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
