### PR TITLE
Remove BaseEventEmitter from components

### DIFF
--- a/js/modules/k6/browser/common/event_emitter.go
+++ b/js/modules/k6/browser/common/event_emitter.go
@@ -22,34 +22,6 @@ const (
 
 	EventFrameNavigation   string = "navigation"
 	EventFrameAddLifecycle string = "addlifecycle"
-
-	// Page
-
-	EventPageClose           string = "close"
-	EventPageConsole         string = "console"
-	EventPageCrash           string = "crash"
-	EventPageDialog          string = "dialog"
-	EventPageDownload        string = "download"
-	EventPageFilechooser     string = "filechooser"
-	EventPageFrameAttached   string = "frameattached"
-	EventPageFrameDetached   string = "framedetached"
-	EventPageFrameNavigated  string = "framenavigated"
-	EventPageError           string = "pageerror"
-	EventPagePopup           string = "popup"
-	EventPageRequest         string = "request"
-	EventPageRequestFailed   string = "requestfailed"
-	EventPageRequestFinished string = "requestfinished"
-	EventPageResponse        string = "response"
-	EventPageWebSocket       string = "websocket"
-	EventPageWorker          string = "worker"
-
-	// Session
-
-	EventSessionClosed string = "close"
-
-	// Worker
-
-	EventWorkerClose string = "close"
 )
 
 // Event as emitted by an EventEmiter.

--- a/js/modules/k6/browser/common/frame.go
+++ b/js/modules/k6/browser/common/frame.go
@@ -314,7 +314,6 @@ func (f *Frame) navigated(name string, url string, loaderID string) {
 	f.name = name
 	f.url = url
 	f.loaderID = loaderID
-	f.page.emit(EventPageFrameNavigated, f)
 }
 
 func (f *Frame) nullContext(execCtxID runtime.ExecutionContextID) {

--- a/js/modules/k6/browser/common/frame_manager.go
+++ b/js/modules/k6/browser/common/frame_manager.go
@@ -470,12 +470,6 @@ func (m *FrameManager) removeFramesRecursively(frame *Frame) error {
 	delete(m.frames, cdp.FrameID(frame.ID()))
 	m.framesMu.Unlock()
 
-	if !m.page.IsClosed() {
-		m.logger.Debugf("FrameManager:removeFramesRecursively:emit:EventPageFrameDetached",
-			"fmid:%d fid:%v fname:%s furl:%s",
-			m.ID(), frame.ID(), frame.Name(), frame.URL())
-	}
-
 	return nil
 }
 

--- a/js/modules/k6/browser/common/frame_manager.go
+++ b/js/modules/k6/browser/common/frame_manager.go
@@ -157,8 +157,6 @@ func (m *FrameManager) frameAttached(frameID cdp.FrameID, parentFrameID cdp.Fram
 
 		m.logger.Debugf("FrameManager:frameAttached:emit:EventPageFrameAttached",
 			"fmid:%d fid:%v pfid:%v", m.ID(), frameID, parentFrameID)
-
-		m.page.emit(EventPageFrameAttached, frame)
 	}
 }
 
@@ -476,8 +474,6 @@ func (m *FrameManager) removeFramesRecursively(frame *Frame) error {
 		m.logger.Debugf("FrameManager:removeFramesRecursively:emit:EventPageFrameDetached",
 			"fmid:%d fid:%v fname:%s furl:%s",
 			m.ID(), frame.ID(), frame.Name(), frame.URL())
-
-		m.page.emit(EventPageFrameDetached, frame)
 	}
 
 	return nil
@@ -485,8 +481,6 @@ func (m *FrameManager) removeFramesRecursively(frame *Frame) error {
 
 func (m *FrameManager) requestFailed(req *Request, canceled bool) {
 	m.logger.Debugf("FrameManager:requestFailed", "fmid:%d rurl:%s", m.ID(), req.URL())
-
-	defer m.page.emit(EventPageRequestFailed, req)
 
 	frame := req.getFrame()
 	if frame == nil {
@@ -517,8 +511,6 @@ func (m *FrameManager) requestFinished(req *Request) {
 	m.logger.Debugf("FrameManager:requestFinished", "fmid:%d rurl:%s",
 		m.ID(), req.URL())
 
-	defer m.page.emit(EventPageRequestFinished, req)
-
 	frame := req.getFrame()
 	if frame == nil {
 		m.logger.Debugf("FrameManager:requestFinished:return",
@@ -537,8 +529,6 @@ func (m *FrameManager) requestFinished(req *Request) {
 
 func (m *FrameManager) requestReceivedResponse(res *Response) {
 	m.logger.Debugf("FrameManager:requestReceivedResponse", "fmid:%d rurl:%s", m.ID(), res.URL())
-
-	m.page.emit(EventPageResponse, res)
 }
 
 func (m *FrameManager) requestStarted(req *Request) {
@@ -546,7 +536,6 @@ func (m *FrameManager) requestStarted(req *Request) {
 
 	m.framesMu.Lock()
 	defer m.framesMu.Unlock()
-	defer m.page.emit(EventPageRequest, req)
 
 	frame := req.getFrame()
 	if frame == nil {

--- a/js/modules/k6/browser/common/frame_manager.go
+++ b/js/modules/k6/browser/common/frame_manager.go
@@ -527,10 +527,6 @@ func (m *FrameManager) requestFinished(req *Request) {
 	*/
 }
 
-func (m *FrameManager) requestReceivedResponse(res *Response) {
-	m.logger.Debugf("FrameManager:requestReceivedResponse", "fmid:%d rurl:%s", m.ID(), res.URL())
-}
-
 func (m *FrameManager) requestStarted(req *Request) {
 	m.logger.Debugf("FrameManager:requestStarted", "fmid:%d rurl:%s", m.ID(), req.URL())
 

--- a/js/modules/k6/browser/common/frame_session.go
+++ b/js/modules/k6/browser/common/frame_session.go
@@ -1049,7 +1049,7 @@ func (fs *FrameSession) onDetachedFromTarget(event *target.EventDetachedFromTarg
 		"sid:%v tid:%v esid:%v",
 		fs.session.ID(), fs.targetID, event.SessionID)
 
-	fs.page.closeWorker(event.SessionID)
+	fs.page.removeWorker(event.SessionID)
 }
 
 func (fs *FrameSession) onTargetCrashed() {

--- a/js/modules/k6/browser/common/frame_session.go
+++ b/js/modules/k6/browser/common/frame_session.go
@@ -661,7 +661,7 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 }
 
 func (fs *FrameSession) onExceptionThrown(event *cdpruntime.EventExceptionThrown) {
-	fs.page.emit(EventPageError, event.ExceptionDetails)
+	// TODO: Test and handle this
 }
 
 func (fs *FrameSession) onExecutionContextCreated(event *cdpruntime.EventExecutionContextCreated) {
@@ -1061,7 +1061,6 @@ func (fs *FrameSession) onTargetCrashed() {
 		k6ext.Panic(fs.ctx, "unexpected type %T", fs.session)
 	}
 	s.markAsCrashed()
-	fs.page.didCrash()
 }
 
 func (fs *FrameSession) updateEmulateMedia() error {

--- a/js/modules/k6/browser/common/frame_session.go
+++ b/js/modules/k6/browser/common/frame_session.go
@@ -660,8 +660,14 @@ func (fs *FrameSession) onConsoleAPICalled(event *cdpruntime.EventConsoleAPICall
 	l.Debug(msg)
 }
 
+// We should consider building an API around this as it could be useful
+// information about the user's website not handling exceptions.
 func (fs *FrameSession) onExceptionThrown(event *cdpruntime.EventExceptionThrown) {
-	// TODO: Test and handle this
+	fs.logger.Debugf("FrameSession:onExceptionThrown",
+		"sid:%v tid:%v url:%s line:%d col:%d text:%s",
+		fs.session.ID(), fs.targetID, event.ExceptionDetails.URL,
+		event.ExceptionDetails.LineNumber, event.ExceptionDetails.ColumnNumber,
+		event.ExceptionDetails.Text)
 }
 
 func (fs *FrameSession) onExecutionContextCreated(event *cdpruntime.EventExecutionContextCreated) {

--- a/js/modules/k6/browser/common/network_manager.go
+++ b/js/modules/k6/browser/common/network_manager.go
@@ -660,7 +660,8 @@ func (m *NetworkManager) onResponseReceived(event *network.EventResponseReceived
 	req.responseMu.Lock()
 	req.response = resp
 	req.responseMu.Unlock()
-	m.frameManager.requestReceivedResponse(resp)
+
+	m.logger.Debugf("FrameManager:onResponseReceived", "rid:%s rurl:%s", event.RequestID, resp.URL())
 }
 
 func (m *NetworkManager) requestFromID(reqID network.RequestID) (*Request, bool) {

--- a/js/modules/k6/browser/common/page.go
+++ b/js/modules/k6/browser/common/page.go
@@ -186,8 +186,6 @@ type PageOnHandler func(PageOnEvent) error
 
 // Page stores Page/tab related context.
 type Page struct {
-	BaseEventEmitter
-
 	Keyboard    *Keyboard
 	Mouse       *Mouse
 	Touchscreen *Touchscreen
@@ -246,7 +244,6 @@ func NewPage(
 	logger *log.Logger,
 ) (*Page, error) {
 	p := Page{
-		BaseEventEmitter: NewBaseEventEmitter(ctx),
 		ctx:              ctx,
 		session:          s,
 		browserCtx:       bctx,
@@ -561,14 +558,6 @@ func (p *Page) didClose() {
 		p.closed = true
 	}
 	p.closedMu.Unlock()
-
-	p.emit(EventPageClose, p)
-}
-
-func (p *Page) didCrash() {
-	p.logger.Debugf("Page:didCrash", "sid:%v", p.sessionID())
-
-	p.emit(EventPageCrash, p)
 }
 
 func (p *Page) evaluateOnNewDocument(source string) error {

--- a/js/modules/k6/browser/common/page.go
+++ b/js/modules/k6/browser/common/page.go
@@ -540,8 +540,8 @@ func (p *Page) consoleMsgFromConsoleEvent(e *runtime.EventConsoleAPICalled) (*Co
 	}, nil
 }
 
-func (p *Page) closeWorker(sessionID target.SessionID) {
-	p.logger.Debugf("Page:closeWorker", "sid:%v", sessionID)
+func (p *Page) removeWorker(sessionID target.SessionID) {
+	p.logger.Debugf("Page:removeWorker", "sid:%v", sessionID)
 
 	delete(p.workers, sessionID)
 }

--- a/js/modules/k6/browser/common/page.go
+++ b/js/modules/k6/browser/common/page.go
@@ -546,10 +546,7 @@ func (p *Page) consoleMsgFromConsoleEvent(e *runtime.EventConsoleAPICalled) (*Co
 func (p *Page) closeWorker(sessionID target.SessionID) {
 	p.logger.Debugf("Page:closeWorker", "sid:%v", sessionID)
 
-	if worker, ok := p.workers[sessionID]; ok {
-		worker.didClose()
-		delete(p.workers, sessionID)
-	}
+	delete(p.workers, sessionID)
 }
 
 func (p *Page) defaultTimeout() time.Duration {

--- a/js/modules/k6/browser/common/session.go
+++ b/js/modules/k6/browser/common/session.go
@@ -68,8 +68,6 @@ func (s *Session) close() {
 	// Stop the read loop
 	close(s.done)
 	s.closed = true
-
-	s.emit(EventSessionClosed, nil)
 }
 
 func (s *Session) markAsCrashed() {

--- a/js/modules/k6/browser/common/touchscreen.go
+++ b/js/modules/k6/browser/common/touchscreen.go
@@ -10,8 +10,6 @@ import (
 
 // Touchscreen represents a touchscreen.
 type Touchscreen struct {
-	BaseEventEmitter
-
 	ctx      context.Context
 	session  session
 	keyboard *Keyboard

--- a/js/modules/k6/browser/common/worker.go
+++ b/js/modules/k6/browser/common/worker.go
@@ -12,8 +12,6 @@ import (
 )
 
 type Worker struct {
-	BaseEventEmitter
-
 	ctx     context.Context
 	session session
 
@@ -24,21 +22,16 @@ type Worker struct {
 // NewWorker creates a new page viewport.
 func NewWorker(ctx context.Context, s session, id target.ID, url string) (*Worker, error) {
 	w := Worker{
-		BaseEventEmitter: NewBaseEventEmitter(ctx),
-		ctx:              ctx,
-		session:          s,
-		targetID:         id,
-		url:              url,
+		ctx:      ctx,
+		session:  s,
+		targetID: id,
+		url:      url,
 	}
 	if err := w.initEvents(); err != nil {
 		return nil, err
 	}
 
 	return &w, nil
-}
-
-func (w *Worker) didClose() {
-	w.emit(EventWorkerClose, w)
 }
 
 func (w *Worker) initEvents() error {


### PR DESCRIPTION
## What?

Removing the BaseEventEmitter from `Touchscreen`, `Page` and `Worker`, as well as the events which are emitted.

## Why?

While debugging another issue i found that these components had instances of their own event emitter, which were emitting events, but nothing was consuming them. It's confusing to see these events being emitted and can cause confusion while debugging issues with the event emitter. This is why they are being removed.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
