### PR TITLE
Fix memory leak in queue

### DIFF
--- a/internal/js/modules/k6/browser/common/event_emitter.go
+++ b/internal/js/modules/k6/browser/common/event_emitter.go
@@ -136,6 +136,8 @@ func (e *BaseEventEmitter) emit(event string, data any) {
 		// the read queue until that is again depleted.
 		if len(eh.queue.read) == 0 {
 			eh.queue.writeMutex.Lock()
+			// Clear the read slice before swapping to prevent keeping references
+			eh.queue.read = make([]Event, 0)
 			eh.queue.read, eh.queue.write = eh.queue.write, eh.queue.read
 			eh.queue.writeMutex.Unlock()
 		}


### PR DESCRIPTION
## What?

Overwrite the empty `queue.read` with a new slice.

## Why?

When we read off the `queue.read` slice, it essentially pops the first available element by doing this:

```go
case eh.ch <- eh.queue.read[0]:
        eh.queue.read[0] = Event{}
	eh.queue.read = eh.queue.read[1:]
```
([link to code](https://github.com/grafana/k6/blob/3f1536e258273e0df5ff347ee63e39fbf4a3c798/js/modules/k6/browser/common/event_emitter.go#L146-L148))

So the entry where the event used to exist has been overwritten with a fresh instance of `Event` which will help avoid a memory leak (which was recently [fixed](https://github.com/grafana/xk6-browser/pull/1488)). However the issue is that the underlying slice keeps growing. During a long running test the slice could grow to an unnecessarily length.

To avoid this issue, when `queue.read` is [empty](https://github.com/grafana/k6/blob/3f1536e258273e0df5ff347ee63e39fbf4a3c798/js/modules/k6/browser/common/event_emitter.go#L137) and is swapped with `queue.write`, just before swapping them around the existing `queue.read` is overwritten with a new slice, freeing up the old potentially long slice. This should help avoid further memory leaks.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
