### PR TITLE
Grpc get localhost certificate programically

### DIFF
--- a/js/modules/k6/grpc/client_test.go
+++ b/js/modules/k6/grpc/client_test.go
@@ -1206,11 +1206,6 @@ func TestClient_TlsParameters(t *testing.T) {
 			},
 		},
 		{
-			// After https://github.com/golang/go/commit/6783377295e0878aa3ad821eefe3d7879064df6d
-			// and more accurately the test certificate upgrade, this test do not match any certificate
-			// apparently because the signature doesn't match
-			// https://github.com/grafana/k6/issues/3549 likely needs to be implemented to fix  them
-			skip: true,
 			name: "ConnectTls",
 			setup: func(tb *httpmultibin.HTTPMultiBin) {
 				clientCAPool := x509.NewCertPool()
@@ -1222,7 +1217,6 @@ func TestClient_TlsParameters(t *testing.T) {
 			vuString:   codeBlock{code: fmt.Sprintf(`client.connect("GRPCBIN_ADDR", { tls: { cacerts: ["%s"], cert: "%s", key: "%s" }});`, localHostCert, clientAuth, clientAuthKey)},
 		},
 		{
-			skip: true, // see comment on ConnectTls
 			name: "ConnectTlsEncryptedKey",
 			setup: func(tb *httpmultibin.HTTPMultiBin) {
 				clientCAPool := x509.NewCertPool()
@@ -1246,7 +1240,6 @@ func TestClient_TlsParameters(t *testing.T) {
 			},
 		},
 		{
-			skip: true, // see comment on ConnectTls
 			name: "ConnectTlsInvokeSuccess",
 			setup: func(tb *httpmultibin.HTTPMultiBin) {
 				clientCAPool := x509.NewCertPool()
@@ -1278,9 +1271,6 @@ func TestClient_TlsParameters(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if tt.skip {
-				t.Skip()
-			}
 
 			ts := newTestState(t)
 

--- a/js/modules/k6/grpc/teststate_test.go
+++ b/js/modules/k6/grpc/teststate_test.go
@@ -38,7 +38,6 @@ type testcase struct {
 	setup      func(*httpmultibin.HTTPMultiBin)
 	initString codeBlock // runs in the init context
 	vuString   codeBlock // runs in the vu context
-	skip       bool
 }
 
 // callRecorder a helper type that records all calls


### PR DESCRIPTION
## What?

Get the localhost certificate programatically instead of having a hard copy of it from within stdlib

## Why?
This localhost certificate was update in https://github.com/golang/go/commit/6783377295e0878aa3ad821eefe3d7879064df6d and this broke this tests in a none obvious way. 


Big part of the problem is that the `httptest` stdlib package always use the in stdlib certificate. 

But this test had a copy of this, but it is not obvious that the problem was this Certificate instead of something else.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
