### PR TITLE
Simple fix for 4240

### DIFF
--- a/internal/js/modules/k6/browser/browser/registry.go
+++ b/internal/js/modules/k6/browser/browser/registry.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 
 	"github.com/mstoykov/k6-taskqueue-lib/taskqueue"
 	"go.opentelemetry.io/otel/attribute"
@@ -181,8 +180,6 @@ type browserRegistry struct {
 	m  map[int64]*common.Browser
 
 	buildFn browserBuildFunc
-
-	stopped atomic.Bool // testing purposes
 }
 
 type browserBuildFunc func(ctx, vuCtx context.Context) (*common.Browser, error)
@@ -410,10 +407,6 @@ func (r *browserRegistry) stopTracesRegistry() {
 	if r.tr != nil {
 		r.tr.stop()
 	}
-}
-
-func (r *browserRegistry) stop() {
-	r.stopped.Store(true)
 }
 
 func isBrowserIter(vu k6modules.VU) bool {

--- a/internal/js/modules/k6/browser/browser/registry_test.go
+++ b/internal/js/modules/k6/browser/browser/registry_test.go
@@ -263,7 +263,7 @@ func TestBrowserRegistry(t *testing.T) {
 		assert.Equal(t, 0, browserRegistry.browserCount())
 	})
 
-	t.Run("unsubscribe_on_non_browser_vu", func(t *testing.T) {
+	t.Run("skip_on_non_browser_vu", func(t *testing.T) {
 		t.Parallel()
 
 		var (
@@ -277,9 +277,10 @@ func TestBrowserRegistry(t *testing.T) {
 		// a browser test VU
 		delete(vu.StateField.Options.Scenarios["default"].GetScenarioOptions().Browser, "type")
 
-		vu.StartIteration(t)
+		vu.StartIteration(t, k6test.WithIteration(0))
 
-		assert.True(t, browserRegistry.stopped.Load())
+		// Verify there are no browsers
+		assert.Equal(t, 0, browserRegistry.browserCount())
 	})
 
 	// This test ensures that the chromium browser's lifecycle is not controlled


### PR DESCRIPTION
## What?

Fix browser test on reused VUs.

This also techinically fixes being able to use browser on reused browser VUs that are not in browser scenarios.

## Why?

While a rare case, reusing VUs is still part of k6. 

The cost currently seems to be around 33% performance for *empty* iterations.

But if I do http.get to not open port it dissapears so I would expect for any real world scripts this is a none issue.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

- #4240