### PR TITLE
Fix an NPD when handle is overwritten with nil

### DIFF
--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -500,12 +500,12 @@ func (f *Frame) waitForSelector(selector string, opts *FrameWaitForSelectorOptio
 	// an element should belong to the current execution context.
 	// otherwise, we should adopt it to this execution context.
 	if ec != handle.execCtx {
-		defer func() {
+		defer func(handle *ElementHandle) {
 			if err := handle.Dispose(); err != nil {
 				err = fmt.Errorf("disposing element handle: %w", err)
 				rerr = errors.Join(err, rerr)
 			}
-		}()
+		}(handle)
 		if handle, err = ec.adoptElementHandle(handle); err != nil {
 			return nil, fmt.Errorf("waiting for selector %q: adopting element handle: %w", selector, err)
 		}


### PR DESCRIPTION
## What?

Call the defer function with the non nil handle, and allow the handle to be overwritten later. Now the handle in the defer will still be non-nil.

## Why?

Fixes an NPD.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
Linked to: https://github.com/grafana/k6/issues/4279