### PR TITLE
Add `page.on('request')`

### DIFF
--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -585,6 +585,10 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageOnEventName, sobek.C
 				init: prepK6BrowserRegExChecker(rt),
 				wait: true,
 			},
+			common.EventPageRequestCalled: {
+				mapp: mapRequestEvent,
+				wait: false,
+			},
 		}
 		pageOnEvent, ok := pageOnEvents[eventName]
 		if !ok {

--- a/internal/js/modules/k6/browser/browser/request_mapping.go
+++ b/internal/js/modules/k6/browser/browser/request_mapping.go
@@ -7,6 +7,12 @@ import (
 	"go.k6.io/k6/internal/js/modules/k6/browser/k6ext"
 )
 
+func mapRequestEvent(vu moduleVU, event common.PageOnEvent) mapping {
+	r := event.Request
+
+	return mapRequest(vu, r)
+}
+
 // mapRequest to the JS module.
 func mapRequest(vu moduleVU, r *common.Request) mapping {
 	rt := vu.Runtime()

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -361,6 +361,10 @@ type resourceTiming struct {
 
 // Timing returns the request timing information.
 func (r *Request) Timing() *resourceTiming {
+	if r.response == nil {
+		return nil
+	}
+
 	timing := r.response.timing
 
 	return &resourceTiming{

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -45,6 +45,7 @@ func (c Credentials) IsEmpty() bool {
 
 type metricInterceptor interface {
 	urlTagName(urlTag string, method string) (string, bool)
+	onRequest(request *Request)
 }
 
 // NetworkManager manages all frames in HTML document.
@@ -511,6 +512,8 @@ func (m *NetworkManager) onRequest(event *network.EventRequestWillBeSent, interc
 	m.reqsMu.Unlock()
 	m.emitRequestMetrics(req)
 	m.frameManager.requestStarted(req)
+
+	m.mi.onRequest(req)
 }
 
 func (m *NetworkManager) onRequestPaused(event *fetch.EventRequestPaused) {

--- a/internal/js/modules/k6/browser/common/network_manager_test.go
+++ b/internal/js/modules/k6/browser/common/network_manager_test.go
@@ -215,6 +215,8 @@ func (m *MetricInterceptorMock) urlTagName(_ string, _ string) (string, bool) {
 	return "", false
 }
 
+func (m *MetricInterceptorMock) onRequest(request *Request) {}
+
 func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 	t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/network_manager_test.go
+++ b/internal/js/modules/k6/browser/common/network_manager_test.go
@@ -209,13 +209,13 @@ func TestOnRequestPausedBlockedIPs(t *testing.T) {
 	}
 }
 
-type MetricInterceptorMock struct{}
+type EventInterceptorMock struct{}
 
-func (m *MetricInterceptorMock) urlTagName(_ string, _ string) (string, bool) {
+func (m *EventInterceptorMock) urlTagName(_ string, _ string) (string, bool) {
 	return "", false
 }
 
-func (m *MetricInterceptorMock) onRequest(request *Request) {}
+func (m *EventInterceptorMock) onRequest(request *Request) {}
 
 func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 	t.Parallel()
@@ -279,7 +279,7 @@ func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 
 			var (
 				vu = k6test.NewVU(t)
-				nm = &NetworkManager{ctx: vu.Context(), vu: vu, customMetrics: k6m, mi: &MetricInterceptorMock{}}
+				nm = &NetworkManager{ctx: vu.Context(), vu: vu, customMetrics: k6m, eventInterceptor: &EventInterceptorMock{}}
 			)
 			vu.ActivateVU()
 

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -42,6 +42,9 @@ const (
 
 	// EventPageMetricCalled represents the page.on('metric') event.
 	EventPageMetricCalled PageOnEventName = "metric"
+
+	// EventPageRequestCalled represents the page.on('request') event.
+	EventPageRequestCalled PageOnEventName = "request"
 )
 
 // MediaType represents the type of media to emulate.

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1169,6 +1169,10 @@ type PageOnEvent struct {
 
 	// Metric is the metric event event.
 	Metric *MetricEvent
+
+	// Request is the read only request that is about to be sent from the
+	// browser to the WuT.
+	Request *Request
 }
 
 // On subscribes to a page event for which the given handler will be executed

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2230,7 +2230,6 @@ func TestPageOnRequest(t *testing.T) {
 	tb.withHandler("/api", func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		defer require.NoError(t, r.Body.Close())
 
 		var data struct {
 			Name string `json:"name"`

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -8,7 +8,6 @@ import (
 	"image/png"
 	"io"
 	"net/http"
-	"regexp"
 	"runtime"
 	"strconv"
 	"sync/atomic"
@@ -2297,27 +2296,6 @@ func TestPageOnRequest(t *testing.T) {
 	err = json.Unmarshal([]byte(got.Result().String()), &requests)
 	require.NoError(t, err)
 
-	for i := range requests {
-		// Normalize any port numbers in the string values to :8080
-		if requests[i].URL != "" {
-			requests[i].URL = regexp.MustCompile(`:\d+`).ReplaceAllString(requests[i].URL, ":8080")
-		}
-		if requests[i].FrameURL != "" {
-			requests[i].FrameURL = regexp.MustCompile(`:\d+`).ReplaceAllString(requests[i].FrameURL, ":8080")
-		}
-		for k, v := range requests[i].AllHeaders {
-			requests[i].AllHeaders[k] = regexp.MustCompile(`:\d+`).ReplaceAllString(v, ":8080")
-		}
-		for k, v := range requests[i].Headers {
-			requests[i].Headers[k] = regexp.MustCompile(`:\d+`).ReplaceAllString(v, ":8080")
-		}
-		for k, header := range requests[i].HeadersArray {
-			if header["value"] != "" {
-				requests[i].HeadersArray[k]["value"] = regexp.MustCompile(`:\d+`).ReplaceAllString(header["value"], ":8080")
-			}
-		}
-	}
-
 	expected := []request{
 		{
 			AllHeaders: map[string]string{
@@ -2346,25 +2324,25 @@ func TestPageOnRequest(t *testing.T) {
 				"body":    0,
 				"headers": 103,
 			},
-			URL: "http://127.0.0.1:8080/home",
+			URL: tb.url("/home"),
 		},
 		{
 			AllHeaders: map[string]string{
 				"accept-language": "en-US",
-				"referer":         "http://127.0.0.1:8080/home",
+				"referer":         tb.url("/home"),
 				"user-agent":      "some-user-agent",
 			},
-			FrameURL:             "http://127.0.0.1:8080/home",
+			FrameURL:             tb.url("/home"),
 			AcceptLanguageHeader: "en-US",
 			Headers: map[string]string{
 				"Accept-Language": "en-US",
-				"Referer":         "http://127.0.0.1:8080/home",
+				"Referer":         tb.url("/home"),
 				"User-Agent":      "some-user-agent",
 			},
 			HeadersArray: []map[string]string{
 				{"name": "User-Agent", "value": "some-user-agent"},
 				{"name": "Accept-Language", "value": "en-US"},
-				{"name": "Referer", "value": "http://127.0.0.1:8080/home"},
+				{"name": "Referer", "value": tb.url("/home")},
 			},
 			IsNavigationRequest: false,
 			Method:              "GET",
@@ -2375,25 +2353,25 @@ func TestPageOnRequest(t *testing.T) {
 				"body":    0,
 				"headers": 116,
 			},
-			URL: "http://127.0.0.1:8080/style.css",
+			URL: tb.url("/style.css"),
 		},
 		{
 			AllHeaders: map[string]string{
 				"accept-language": "en-US",
 				"content-type":    "application/json",
-				"referer":         "http://127.0.0.1:8080/home",
+				"referer":         tb.url("/home"),
 				"user-agent":      "some-user-agent",
 			},
-			FrameURL:             "http://127.0.0.1:8080/home",
+			FrameURL:             tb.url("/home"),
 			AcceptLanguageHeader: "en-US",
 			Headers: map[string]string{
 				"Accept-Language": "en-US",
 				"Content-Type":    "application/json",
-				"Referer":         "http://127.0.0.1:8080/home",
+				"Referer":         tb.url("/home"),
 				"User-Agent":      "some-user-agent",
 			},
 			HeadersArray: []map[string]string{
-				{"name": "Referer", "value": "http://127.0.0.1:8080/home"},
+				{"name": "Referer", "value": tb.url("/home")},
 				{"name": "User-Agent", "value": "some-user-agent"},
 				{"name": "Accept-Language", "value": "en-US"},
 				{"name": "Content-Type", "value": "application/json"},
@@ -2407,24 +2385,24 @@ func TestPageOnRequest(t *testing.T) {
 				"body":    17,
 				"headers": 143,
 			},
-			URL: "http://127.0.0.1:8080/api",
+			URL: tb.url("/api"),
 		},
 		{
 			AllHeaders: map[string]string{
 				"accept-language": "en-US",
-				"referer":         "http://127.0.0.1:8080/home",
+				"referer":         tb.url("/home"),
 				"user-agent":      "some-user-agent",
 			},
-			FrameURL:             "http://127.0.0.1:8080/home",
+			FrameURL:             tb.url("/home"),
 			AcceptLanguageHeader: "en-US",
 			Headers: map[string]string{
 				"Accept-Language": "en-US",
-				"Referer":         "http://127.0.0.1:8080/home",
+				"Referer":         tb.url("/home"),
 				"User-Agent":      "some-user-agent",
 			},
 			HeadersArray: []map[string]string{
 				{"name": "Accept-Language", "value": "en-US"},
-				{"name": "Referer", "value": "http://127.0.0.1:8080/home"},
+				{"name": "Referer", "value": tb.url("/home")},
 				{"name": "User-Agent", "value": "some-user-agent"},
 			},
 			IsNavigationRequest: false,
@@ -2436,7 +2414,7 @@ func TestPageOnRequest(t *testing.T) {
 				"body":    0,
 				"headers": 118,
 			},
-			URL: "http://127.0.0.1:8080/favicon.ico",
+			URL: tb.url("/favicon.ico"),
 		},
 	}
 

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2422,13 +2422,7 @@ func TestPageOnRequest(t *testing.T) {
 
 	// Compare each request one by one for better test failure visibility
 	for _, req := range requests {
-		i := -1
-		for j, e := range expected {
-			if req.URL == e.URL {
-				i = j
-				break
-			}
-		}
+		i := slices.IndexFunc(expected, func(r request) bool { return req.URL == r.URL })
 		assert.NotEqual(t, -1, i, "failed to find expected request with URL %s", req.URL)
 
 		sortByName := func(m1, m2 map[string]string) int {

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -9,7 +9,9 @@ import (
 	"io"
 	"net/http"
 	"runtime"
+	"slices"
 	"strconv"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2429,30 +2431,12 @@ func TestPageOnRequest(t *testing.T) {
 		}
 		assert.NotEqual(t, -1, i, "failed to find expected request with URL %s", req.URL)
 
-		assert.Equal(t, expected[i].AllHeaders, req.AllHeaders, "AllHeaders mismatch")
-		assert.Equal(t, expected[i].FrameURL, req.FrameURL, "FrameUrl mismatch")
-		assert.Equal(t, expected[i].AcceptLanguageHeader, req.AcceptLanguageHeader, "AcceptLanguageHeader mismatch")
-		assert.Equal(t, expected[i].Headers, req.Headers, "Headers mismatch")
-		assert.Equal(t, expected[i].IsNavigationRequest, req.IsNavigationRequest, "IsNavigationRequest mismatch")
-		assert.Equal(t, expected[i].Method, req.Method, "Method mismatch")
-		assert.Equal(t, expected[i].PostData, req.PostData, "PostData mismatch")
-		assert.Equal(t, expected[i].PostDataBuffer, req.PostDataBuffer, "PostDataBuffer mismatch")
-		assert.Equal(t, expected[i].ResourceType, req.ResourceType, "ResourceType mismatch")
-		assert.Equal(t, expected[i].Size, req.Size, "Size mismatch")
-		assert.Equal(t, expected[i].URL, req.URL, "URL mismatch")
-
-		// Compare HeadersArray elements one by one
-		assert.Equal(t, len(expected[i].HeadersArray), len(req.HeadersArray), "HeadersArray length mismatch")
-		for _, expectedHeader := range expected[i].HeadersArray {
-			found := false
-			for _, actualHeader := range req.HeadersArray {
-				if expectedHeader["name"] == actualHeader["name"] && expectedHeader["value"] == actualHeader["value"] {
-					found = true
-					break
-				}
-			}
-			assert.True(t, found, fmt.Sprintf("Expected header {name: %s, value: %s} not found in actual headers", expectedHeader["name"], expectedHeader["value"]))
+		sortByName := func(m1, m2 map[string]string) int {
+			return strings.Compare(m1["name"], m2["name"])
 		}
+		slices.SortFunc(req.HeadersArray, sortByName)
+		slices.SortFunc(expected[i].HeadersArray, sortByName)
+		assert.Equal(t, expected[i], req)
 	}
 }
 


### PR DESCRIPTION
## What?

This implements the `page.on('request')` API from Playwright. When the handler is created, all subsequent requests will be directed to the handler, where the user can interact with the read only request. The request is intercepted just before it is sent from the browser to the website under test.

An example usage is:

```js
import { browser } from 'k6/browser'

export const options = {
  scenarios: {
    ui: {
      executor: 'shared-iterations',
      options: {
        browser: {
          type: 'chromium',
        },
      },
    },
  },
}

export default async function () {
  const page = await browser.newPage()

  // Logs the url of the request
  page.on('request', async (request) => {
    console.log(request.url());
  })

  await page.goto('https://quickpizza.grafana.com/', { waitUntil: 'networkidle' })

  await page.close();
}
```

## Why?

This can be useful to:

* retrieve data that is to be used later;
* assert certain conditions on an expected request;

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
Updates: https://github.com/grafana/k6/issues/4281