### PR TITLE
Enable type stripping by default

### DIFF
--- a/internal/cmd/runtime_options.go
+++ b/internal/cmd/runtime_options.go
@@ -23,10 +23,9 @@ func runtimeOptionFlagSet(includeSysEnv bool) *pflag.FlagSet {
 	flags.SortFlags = false
 	flags.Bool("include-system-env-vars", includeSysEnv, "pass the real system environment variables to the runtime")
 	flags.String("compatibility-mode", "extended",
-		`JavaScript compiler compatibility mode, "extended" or "base" or "experimental_enhanced"
+		`JavaScript compiler compatibility mode, "extended" or "base"
 base: pure Sobek - Golang JS VM supporting ES6+
 extended: base + sets "global" as alias for "globalThis"
-experimental_enhanced: esbuild-based transpiling for TypeScript and ES6+ support
 `)
 	flags.StringP("type", "t", "", "override test type, \"js\" or \"archive\"")
 	flags.StringArrayP("env", "e", nil, "add/override environment variable with `VAR=value`")

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -67,6 +67,12 @@ func loadLocalTest(gs *state.GlobalState, cmd *cobra.Command, args []string) (*l
 		return nil, err
 	}
 
+	if runtimeOptions.CompatibilityMode.String == lib.CompatibilityModeExperimentalEnhanced.String() {
+		gs.Logger.Warnf("ComaptibilityMode %[1]q is deprecated. Types are stripped by default for `.ts` files. "+
+			"Please move to using %[2]q instead as %[1]q will be removed in the future",
+			lib.CompatibilityModeExperimentalEnhanced.String(), lib.CompatibilityModeBase.String())
+	}
+
 	registry := metrics.NewRegistry()
 	state := &lib.TestPreInitState{
 		Logger:         gs.Logger,

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -2394,7 +2394,7 @@ func TestTypeScriptSupport(t *testing.T) {
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.ts"), []byte(mainScript), 0o644))
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "bar.ts"), []byte(depScript), 0o644))
 
-	ts.CmdArgs = []string{"k6", "run", "--compatibility-mode", "experimental_enhanced", "--quiet", "test.ts"}
+	ts.CmdArgs = []string{"k6", "run", "--quiet", "test.ts"}
 
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 

--- a/internal/js/compiler/compiler.go
+++ b/internal/js/compiler/compiler.go
@@ -119,7 +119,7 @@ func (ps *parsingState) parseImpl(src, filename string, commonJSWrap bool) (*ast
 		return prg, code, nil
 	}
 
-	if ps.compatibilityMode == lib.CompatibilityModeExperimentalEnhanced && strings.HasSuffix(filename, ".ts") {
+	if strings.HasSuffix(filename, ".ts") {
 		if err := ps.compiler.usage.Uint64(usageParsedTSFilesKey, 1); err != nil {
 			ps.compiler.logger.WithError(err).Warn("couldn't report usage for " + usageParsedTSFilesKey)
 		}

--- a/internal/js/compiler/enhanced_test.go
+++ b/internal/js/compiler/enhanced_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/internal/lib/testutils"
-	"go.k6.io/k6/lib"
 )
 
 func Test_esbuildTransform_js(t *testing.T) {
@@ -41,7 +40,6 @@ func TestCompile_experimental_enhanced(t *testing.T) {
 		t.Parallel()
 		c := New(testutils.NewLogger(t))
 		src := `1+(function() { return 2; )()`
-		c.Options.CompatibilityMode = lib.CompatibilityModeExperimentalEnhanced
 		_, _, err := c.Parse(src, "script.ts", false, false)
 		assert.IsType(t, &parser.Error{}, err)
 		assert.Contains(t, err.Error(), `script.ts: Line 1:26 Unexpected ")"`)
@@ -49,7 +47,6 @@ func TestCompile_experimental_enhanced(t *testing.T) {
 	t.Run("experimental_enhanced", func(t *testing.T) {
 		t.Parallel()
 		c := New(testutils.NewLogger(t))
-		c.Options.CompatibilityMode = lib.CompatibilityModeExperimentalEnhanced
 		prg, code, err := c.Parse(`let t :string = "something"; require(t);`, "script.ts", false, false)
 		require.NoError(t, err)
 		assert.Equal(t, `let t = "something";
@@ -70,7 +67,6 @@ require(t);
 	t.Run("experimental_enhanced sourcemap", func(t *testing.T) {
 		t.Parallel()
 		c := New(testutils.NewLogger(t))
-		c.Options.CompatibilityMode = lib.CompatibilityModeExperimentalEnhanced
 		c.Options.SourceMapLoader = func(_ string) ([]byte, error) { return nil, nil }
 		_, code, err := c.Parse(`let t :string = "something"; require(t);`, "script.ts", false, false)
 		require.NoError(t, err)


### PR DESCRIPTION
## What?

Enable type stripping by default

## Why?

Closes #4194 

This does currently skip doing any cleaning in part because most of it will be intrusive but also because it will be somewhat breaking changes. Also might be completely different with #3864 and some other refactoring issues in mind, I feel like not trying to remove stuff now is better. 

Additionally, `experimental_enhanced` is currently just a synonym for `base`. Again touching on #3864 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
