### PR TITLE
Rename browser data directory

### DIFF
--- a/internal/js/modules/k6/browser/storage/storage.go
+++ b/internal/js/modules/k6/browser/storage/storage.go
@@ -10,7 +10,9 @@ import (
 	"sync"
 )
 
-const k6BrowserDataDirPattern = "xk6-browser-data-*"
+// K6BrowserDataDirPattern is the pattern used to create the
+// temporary directory for the browser data.
+const K6BrowserDataDirPattern = "k6browser-data-*"
 
 // Dir manages data storage for the extension and user specific data
 // on the local filesystem.
@@ -42,10 +44,10 @@ func (d *Dir) Make(tmpDir string, dir any) error {
 		d.fsMkdirTemp = os.MkdirTemp //nolint:forbidigo
 	}
 	var err error
-	if d.Dir, err = d.fsMkdirTemp(tmpDir, k6BrowserDataDirPattern); err != nil {
+	if d.Dir, err = d.fsMkdirTemp(tmpDir, K6BrowserDataDirPattern); err != nil {
 		var (
 			pe   *fs.PathError
-			path = filepath.Join(tmpDir, k6BrowserDataDirPattern)
+			path = filepath.Join(tmpDir, K6BrowserDataDirPattern)
 		)
 		if errors.As(err, &pe) {
 			path = pe.Path

--- a/internal/js/modules/k6/browser/tests/browser_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_test.go
@@ -20,6 +20,7 @@ import (
 	"go.k6.io/k6/internal/js/modules/k6/browser/env"
 	"go.k6.io/k6/internal/js/modules/k6/browser/k6ext"
 	"go.k6.io/k6/internal/js/modules/k6/browser/k6ext/k6test"
+	"go.k6.io/k6/internal/js/modules/k6/browser/storage"
 )
 
 func TestBrowserNewPage(t *testing.T) {
@@ -93,9 +94,9 @@ func TestTmpDirCleanup(t *testing.T) {
 	err = p.Close(nil)
 	require.NoError(t, err)
 
-	matches, err := filepath.Glob(tmpDirPath + "/xk6-browser-data-*")
+	matches, err := filepath.Glob(filepath.Join(tmpDirPath, storage.K6BrowserDataDirPattern))
 	assert.NoError(t, err)
-	assert.NotEmpty(t, matches, "a dir should exist that matches the pattern `xk6-browser-data-*`")
+	assert.NotEmptyf(t, matches, "a dir should exist that matches the pattern %q", storage.K6BrowserDataDirPattern)
 
 	b.Close()
 
@@ -104,7 +105,7 @@ func TestTmpDirCleanup(t *testing.T) {
 	// To try to mitigate the issue, we're adding a retry which waits half a
 	// second if the dir still exits.
 	for i := 0; i < 5; i++ {
-		matches, err = filepath.Glob(tmpDirPath + "/xk6-browser-data-*")
+		matches, err = filepath.Glob(filepath.Join(tmpDirPath, storage.K6BrowserDataDirPattern))
 		assert.NoError(t, err)
 		if len(matches) == 0 {
 			break
@@ -112,7 +113,7 @@ func TestTmpDirCleanup(t *testing.T) {
 		time.Sleep(time.Millisecond * 500)
 	}
 
-	assert.Empty(t, matches, "a dir shouldn't exist which matches the pattern `xk6-browser-data-*`")
+	assert.Empty(t, matches, "a dir shouldn't exist which matches the pattern %q", storage.K6BrowserDataDirPattern)
 }
 
 func TestTmpDirCleanupOnContextClose(t *testing.T) {
@@ -133,18 +134,18 @@ func TestTmpDirCleanupOnContextClose(t *testing.T) {
 		withEnvLookup(env.ConstLookup("TMPDIR", tmpDirPath)),
 	)
 
-	matches, err := filepath.Glob(tmpDirPath + "/xk6-browser-data-*")
+	matches, err := filepath.Glob(filepath.Join(tmpDirPath, storage.K6BrowserDataDirPattern))
 	assert.NoError(t, err)
-	assert.NotEmpty(t, matches, "a dir should exist that matches the pattern `xk6-browser-data-*`")
+	assert.NotEmpty(t, matches, "a dir should exist that matches the pattern %q", storage.K6BrowserDataDirPattern)
 
 	b.cancelContext()
 	<-b.ctx.Done()
 
 	require.NotPanicsf(t, b.Close, "first call to browser.close should not panic")
 
-	matches, err = filepath.Glob(tmpDirPath + "/xk6-browser-data-*")
+	matches, err = filepath.Glob(filepath.Join(tmpDirPath, storage.K6BrowserDataDirPattern))
 	assert.NoError(t, err)
-	assert.Empty(t, matches, "a dir shouldn't exist which matches the pattern `xk6-browser-data-*`")
+	assert.Empty(t, matches, "a dir shouldn't exist which matches the pattern %q", storage.K6BrowserDataDirPattern)
 }
 
 func TestBrowserOn(t *testing.T) {


### PR DESCRIPTION
## What?

Renames `xk6-browser-data-*` to `k6browser-data-*`.

## Why?

* To be consistent with the artifact directory: `k6browser-artifacts-*`
* Removing the deprecated `xk6-browser` name.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- #4288