### PR TITLE
TestStreamLogsToLogger: increase wait time to get less flakiness

### DIFF
--- a/cloudapi/logs_test.go
+++ b/cloudapi/logs_test.go
@@ -248,7 +248,7 @@ func TestStreamLogsToLogger(t *testing.T) {
 			require.NoError(t, err)
 
 			// wait the flush on the network
-			time.Sleep(25 * time.Millisecond)
+			time.Sleep(100 * time.Millisecond)
 			cancel()
 		})
 


### PR DESCRIPTION
## What?

Increase the timeout

## Why?

This fails fairly regularly in CI and it is no problem if the wait is a bit longer.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
