### PR TITLE
Add `header` option support to the CSV module

### DIFF
--- a/internal/js/modules/k6/data/data.go
+++ b/internal/js/modules/k6/data/data.go
@@ -101,7 +101,7 @@ func (d *Data) sharedArray(call sobek.ConstructorCall) *sobek.Object {
 // The data module RecordReader interface is implemented by types that can read data that can be
 // treated as records, from data sources such as a CSV file, etc.
 type RecordReader interface {
-	Read() ([]string, error)
+	Read() (any, error)
 }
 
 // NewSharedArrayFrom creates a new shared array from the provided data.

--- a/internal/js/modules/k6/experimental/csv/module.go
+++ b/internal/js/modules/k6/experimental/csv/module.go
@@ -192,11 +192,13 @@ func (p *Parser) Next() *sobek.Promise {
 	promise, resolve, reject := promises.New(p.vu)
 
 	go func() {
-		var records []string
+		// var records []string
+		var record any
 		var done bool
 		var err error
 
-		records, err = p.reader.Read()
+		// records, err = p.reader.Read()
+		record, err = p.reader.Read()
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				resolve(parseResult{Done: true, Value: []string{}})
@@ -209,7 +211,8 @@ func (p *Parser) Next() *sobek.Promise {
 
 		p.currentLine.Add(1)
 
-		resolve(parseResult{Done: done, Value: records})
+		// resolve(parseResult{Done: done, Value: records})
+		resolve(parseResult{Done: done, Value: record})
 	}()
 
 	return promise
@@ -222,7 +225,7 @@ type parseResult struct {
 	Done bool `js:"done"`
 
 	// Value holds the line's records value.
-	Value []string `js:"value"`
+	Value any `js:"value"`
 }
 
 // options holds options used to configure CSV parsing when utilizing the module.

--- a/internal/js/modules/k6/experimental/csv/module.go
+++ b/internal/js/modules/k6/experimental/csv/module.go
@@ -99,7 +99,7 @@ func (mi *ModuleInstance) Parse(file sobek.Value, options sobek.Value) *sobek.Pr
 
 	rt := mi.vu.Runtime()
 
-	// 1. Make sure the Sobek object is a fs.File (sobek operation)
+	// 1. Make sure the Sobek object is a fs.File (Sobek operation)
 	var fileObj fs.File
 	if err := mi.vu.Runtime().ExportTo(file, &fileObj); err != nil {
 		reject(fmt.Errorf("first argument expected to be a fs.File instance, got %T instead", file))

--- a/internal/js/modules/k6/experimental/csv/module_test.go
+++ b/internal/js/modules/k6/experimental/csv/module_test.go
@@ -621,6 +621,7 @@ func TestParse(t *testing.T) {
 
 			if (csvRecords.length !== 10) {
 				throw new Error("Expected 10 records, but got " + csvRecords.length);
+			}
 
 			for (const record of csvRecords) {
 				if (typeof record !== 'object' || record === null || Array.isArray(record)) {

--- a/internal/js/modules/k6/experimental/csv/module_test.go
+++ b/internal/js/modules/k6/experimental/csv/module_test.go
@@ -620,8 +620,7 @@ func TestParse(t *testing.T) {
 			const csvRecords = await csv.parse(file, { asObjects: true });
 
 			if (csvRecords.length !== 10) {
-				throw new Error("Expected 11 records, but got " + csvRecords.length);
-			}
+				throw new Error("Expected 10 records, but got " + csvRecords.length);
 
 			for (const record of csvRecords) {
 				if (typeof record !== 'object' || record === null || Array.isArray(record)) {

--- a/internal/js/modules/k6/experimental/csv/module_test.go
+++ b/internal/js/modules/k6/experimental/csv/module_test.go
@@ -79,7 +79,7 @@ func TestParserConstructor(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("constructing a parser with both header and skipFirstLine options should fail", func(t *testing.T) {
+	t.Run("constructing a parser with both asObjects and skipFirstLine options should fail", func(t *testing.T) {
 		t.Parallel()
 
 		r, err := newConfiguredRuntime(t)
@@ -92,13 +92,13 @@ func TestParserConstructor(t *testing.T) {
 
 		_, err = r.RunOnEventLoop(wrapInAsyncLambda(fmt.Sprintf(`
 			  const file = await fs.open(%q);
-			  const parser = new csv.Parser(file, { delimiter: ';', skipFirstLine: true, header: true });
+			  const parser = new csv.Parser(file, { delimiter: ';', skipFirstLine: true, asObjects: true });
 		`, testFilePath)))
 
 		require.Error(t, err)
 	})
 
-	t.Run("constructing a parser with both the header option and fromLine option greater than 0 should fail", func(t *testing.T) {
+	t.Run("constructing a parser with both the asObjects option and fromLine option greater than 0 should fail", func(t *testing.T) {
 		t.Parallel()
 
 		r, err := newConfiguredRuntime(t)
@@ -111,7 +111,7 @@ func TestParserConstructor(t *testing.T) {
 
 		_, err = r.RunOnEventLoop(wrapInAsyncLambda(fmt.Sprintf(`
 			  const file = await fs.open(%q);
-			  const parser = new csv.Parser(file, { delimiter: ';', fromLine: 1, header: true });
+			  const parser = new csv.Parser(file, { delimiter: ';', fromLine: 1, asObjects: true });
 		`, testFilePath)))
 
 		require.Error(t, err)
@@ -405,7 +405,7 @@ func TestParserNext(t *testing.T) {
 
 		_, err = r.RunOnEventLoop(wrapInAsyncLambda(fmt.Sprintf(`
 			const file = await fs.open(%q);
-			const parser = new csv.Parser(file, { header: true });
+			const parser = new csv.Parser(file, { asObjects: true });
 			let gotParsedCount = 0;
 
 			let { done, value } = await parser.next();
@@ -617,7 +617,7 @@ func TestParse(t *testing.T) {
 
 		_, err = r.RunOnEventLoop(wrapInAsyncLambda(fmt.Sprintf(`
 			const file = await fs.open(%q);
-			const csvRecords = await csv.parse(file, { header: true });
+			const csvRecords = await csv.parse(file, { asObjects: true });
 
 			if (csvRecords.length !== 10) {
 				throw new Error("Expected 11 records, but got " + csvRecords.length);

--- a/internal/js/modules/k6/experimental/csv/reader.go
+++ b/internal/js/modules/k6/experimental/csv/reader.go
@@ -21,8 +21,9 @@ type Reader struct {
 	// options holds the reader's options.
 	options options
 
-	// header stores the column names when header option is enabled.
-	header []string
+	// columnNames stores the column names when the asObjects option is enabled
+	// in order to be able to map each row values to their corresponding column.
+	columnNames []string
 }
 
 // NewReaderFrom creates a new CSV reader from the provided io.Reader.
@@ -60,7 +61,7 @@ func NewReaderFrom(r io.Reader, options options) (*Reader, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to read the first line; reason: %w", err)
 		}
-		reader.header = header
+		reader.columnNames = header
 		reader.currentLine.Add(1)
 	}
 
@@ -106,19 +107,19 @@ func (r *Reader) Read() (any, error) {
 
 	r.currentLine.Add(1)
 
-	// If option is enabled, return a map of the record.
+	// If header option is enabled, return a map of the record.
 	if r.options.AsObjects.Valid && r.options.AsObjects.Bool {
-		if r.header == nil {
-			return nil, fmt.Errorf("the '' option is enabled, but no header was found")
+		if r.columnNames == nil {
+			return nil, fmt.Errorf("the 'asObjects' option is enabled, but no header was found")
 		}
 
-		if len(record) != len(r.header) {
-			return nil, fmt.Errorf("record length (%d) doesn't match header length (%d)", len(record), len(r.header))
+		if len(record) != len(r.columnNames) {
+			return nil, fmt.Errorf("record length (%d) doesn't match header length (%d)", len(record), len(r.columnNames))
 		}
 
 		recordMap := make(map[string]string)
 		for i, value := range record {
-			recordMap[r.header[i]] = value
+			recordMap[r.columnNames[i]] = value
 		}
 
 		return recordMap, nil

--- a/internal/js/modules/k6/experimental/csv/reader.go
+++ b/internal/js/modules/k6/experimental/csv/reader.go
@@ -96,7 +96,8 @@ func NewReaderFrom(r io.Reader, options options) (*Reader, error) {
 	return reader, nil
 }
 
-func (r *Reader) Read() ([]string, error) {
+// func (r *Reader) Read() ([]string, error) {
+func (r *Reader) Read() (any, error) {
 	toLineSet := r.options.ToLine.Valid
 
 	// If the `toLine` option was set and we have reached it, we return EOF.
@@ -104,12 +105,12 @@ func (r *Reader) Read() ([]string, error) {
 		return nil, io.EOF
 	}
 
-	records, err := r.csv.Read()
+	record, err := r.csv.Read()
 	if err != nil {
 		return nil, err
 	}
 
 	r.currentLine.Add(1)
 
-	return records, nil
+	return record, nil
 }

--- a/internal/js/modules/k6/experimental/csv/reader.go
+++ b/internal/js/modules/k6/experimental/csv/reader.go
@@ -55,8 +55,8 @@ func NewReaderFrom(r io.Reader, options options) (*Reader, error) {
 		options: options,
 	}
 
-	headerEnabled := options.AsObjects.Valid && options.AsObjects.Bool
-	if headerEnabled {
+	asObjectsEnabled := options.AsObjects.Valid && options.AsObjects.Bool
+	if asObjectsEnabled {
 		header, err := csvParser.Read()
 		if err != nil {
 			return nil, fmt.Errorf("failed to read the first line; reason: %w", err)
@@ -134,14 +134,14 @@ func validateOptions(options options) error {
 		fromLineSet      = options.FromLine.Valid
 		toLineSet        = options.ToLine.Valid
 		skipFirstLineSet = options.SkipFirstLine
-		headerEnabled    = options.AsObjects.Valid && options.AsObjects.Bool
+		asObjectsEnabled = options.AsObjects.Valid && options.AsObjects.Bool
 	)
 
-	if headerEnabled && skipFirstLineSet {
+	if asObjectsEnabled && skipFirstLineSet {
 		return fmt.Errorf("the 'header' option cannot be enabled when 'skipFirstLine' is true")
 	}
 
-	if headerEnabled && fromLineSet && options.FromLine.Int64 > 0 {
+	if asObjectsEnabled && fromLineSet && options.FromLine.Int64 > 0 {
 		return fmt.Errorf("the 'header' option cannot be enabled when 'fromLine' is set to a value greater than 0")
 	}
 

--- a/internal/js/modules/k6/experimental/csv/reader.go
+++ b/internal/js/modules/k6/experimental/csv/reader.go
@@ -54,7 +54,7 @@ func NewReaderFrom(r io.Reader, options options) (*Reader, error) {
 		options: options,
 	}
 
-	headerEnabled := options.Header.Valid && options.Header.Bool
+	headerEnabled := options.AsObjects.Valid && options.AsObjects.Bool
 	if headerEnabled {
 		header, err := csvParser.Read()
 		if err != nil {
@@ -107,7 +107,7 @@ func (r *Reader) Read() (any, error) {
 	r.currentLine.Add(1)
 
 	// If header option is enabled, return a map of the record.
-	if r.options.Header.Valid && r.options.Header.Bool {
+	if r.options.AsObjects.Valid && r.options.AsObjects.Bool {
 		if r.header == nil {
 			return nil, fmt.Errorf("the 'header' option is enabled, but no header was found")
 		}
@@ -133,7 +133,7 @@ func validateOptions(options options) error {
 		fromLineSet      = options.FromLine.Valid
 		toLineSet        = options.ToLine.Valid
 		skipFirstLineSet = options.SkipFirstLine
-		headerEnabled    = options.Header.Valid && options.Header.Bool
+		headerEnabled    = options.AsObjects.Valid && options.AsObjects.Bool
 	)
 
 	if headerEnabled && skipFirstLineSet {

--- a/internal/js/modules/k6/experimental/csv/reader.go
+++ b/internal/js/modules/k6/experimental/csv/reader.go
@@ -106,10 +106,10 @@ func (r *Reader) Read() (any, error) {
 
 	r.currentLine.Add(1)
 
-	// If header option is enabled, return a map of the record.
+	// If option is enabled, return a map of the record.
 	if r.options.AsObjects.Valid && r.options.AsObjects.Bool {
 		if r.header == nil {
-			return nil, fmt.Errorf("the 'header' option is enabled, but no header was found")
+			return nil, fmt.Errorf("the '' option is enabled, but no header was found")
 		}
 
 		if len(record) != len(r.header) {

--- a/internal/js/modules/k6/experimental/csv/reader_test.go
+++ b/internal/js/modules/k6/experimental/csv/reader_test.go
@@ -51,32 +51,32 @@ func TestNewReaderFrom(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("instantiating a new reader with header option enabled and skipFirstLine option enabled should fail", func(t *testing.T) {
+	t.Run("instantiating a new reader with asObjects option enabled and skipFirstLine option enabled should fail", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := NewReaderFrom(
 			strings.NewReader("lastname,firstname,composer,born,died,dates\n"),
-			options{Header: null.NewBool(true, true), SkipFirstLine: true},
+			options{AsObjects: null.NewBool(true, true), SkipFirstLine: true},
 		)
 		require.Error(t, err)
 	})
 
-	t.Run("instantiating a new reader with header option enabled and fromLine option set to a value greater than 0 should fail", func(t *testing.T) {
+	t.Run("instantiating a new reader with asObjects option enabled and fromLine option set to a value greater than 0 should fail", func(t *testing.T) {
 		t.Parallel()
 
 		_, err := NewReaderFrom(
 			strings.NewReader("lastname,firstname,composer,born,died,dates\n"),
-			options{Header: null.NewBool(true, true), FromLine: null.NewInt(1, true)},
+			options{AsObjects: null.NewBool(true, true), FromLine: null.NewInt(1, true)},
 		)
 		require.Error(t, err)
 	})
 
-	t.Run("instantiating a new reader with header option enabled and compatible options should succeed", func(t *testing.T) {
+	t.Run("instantiating a new reader with asObjects option enabled and compatible options should succeed", func(t *testing.T) {
 		t.Parallel()
 
 		r, err := NewReaderFrom(
 			strings.NewReader("lastname,firstname,composer,born,died,dates\n"),
-			options{Header: null.NewBool(true, true)},
+			options{AsObjects: null.NewBool(true, true)},
 		)
 		require.NoError(t, err)
 		assert.NotNil(t, r.header)
@@ -171,7 +171,7 @@ func TestReader_Read(t *testing.T) {
 		require.ErrorIs(t, err, io.EOF)
 	})
 
-	t.Run("header option should lead to lines being returned as maps and succeed", func(t *testing.T) {
+	t.Run("asObjects option should lead to lines being returned as maps and succeed", func(t *testing.T) {
 		t.Parallel()
 
 		const csvTestData = "lastname,firstname,composer,born,died,dates\n" +
@@ -179,11 +179,11 @@ func TestReader_Read(t *testing.T) {
 
 		r, err := NewReaderFrom(
 			strings.NewReader(csvTestData),
-			options{Header: null.NewBool(true, true)},
+			options{AsObjects: null.NewBool(true, true)},
 		)
 		require.NoError(t, err)
 
-		// Header line, if present should be ignored and records should be returned as maps
+		// AsObjects line, if present should be ignored and records should be returned as maps
 		firstRecord, err := r.Read()
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{
@@ -237,17 +237,17 @@ func TestReader_Read(t *testing.T) {
 func TestValidateOptions(t *testing.T) {
 	t.Parallel()
 
-	t.Run("validateOptions with header and skipFirstLine should fail", func(t *testing.T) {
+	t.Run("validateOptions with asObjects and skipFirstLine should fail", func(t *testing.T) {
 		t.Parallel()
 
-		err := validateOptions(options{Header: null.NewBool(true, true), SkipFirstLine: true})
+		err := validateOptions(options{AsObjects: null.NewBool(true, true), SkipFirstLine: true})
 		require.Error(t, err)
 	})
 
-	t.Run("validateOptions with header and fromLine greater than 0 should fail", func(t *testing.T) {
+	t.Run("validateOptions with asObjects and fromLine greater than 0 should fail", func(t *testing.T) {
 		t.Parallel()
 
-		err := validateOptions(options{Header: null.NewBool(true, true), FromLine: null.NewInt(1, true)})
+		err := validateOptions(options{AsObjects: null.NewBool(true, true), FromLine: null.NewInt(1, true)})
 		require.Error(t, err)
 	})
 

--- a/internal/js/modules/k6/experimental/csv/reader_test.go
+++ b/internal/js/modules/k6/experimental/csv/reader_test.go
@@ -79,8 +79,8 @@ func TestNewReaderFrom(t *testing.T) {
 			options{AsObjects: null.NewBool(true, true)},
 		)
 		require.NoError(t, err)
-		assert.NotNil(t, r.header)
-		assert.Equal(t, []string{"lastname", "firstname", "composer", "born", "died", "dates"}, r.header)
+		assert.NotNil(t, r.columnNames)
+		assert.Equal(t, []string{"lastname", "firstname", "composer", "born", "died", "dates"}, r.columnNames)
 		assert.Equal(t, r.currentLine.Load(), int64(1))
 	})
 

--- a/internal/js/modules/k6/experimental/csv/reader_test.go
+++ b/internal/js/modules/k6/experimental/csv/reader_test.go
@@ -51,6 +51,39 @@ func TestNewReaderFrom(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("instantiating a new reader with header option enabled and skipFirstLine option enabled should fail", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewReaderFrom(
+			strings.NewReader("lastname,firstname,composer,born,died,dates\n"),
+			options{Header: null.NewBool(true, true), SkipFirstLine: true},
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("instantiating a new reader with header option enabled and fromLine option set to a value greater than 0 should fail", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := NewReaderFrom(
+			strings.NewReader("lastname,firstname,composer,born,died,dates\n"),
+			options{Header: null.NewBool(true, true), FromLine: null.NewInt(1, true)},
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("instantiating a new reader with header option enabled and compatible options should succeed", func(t *testing.T) {
+		t.Parallel()
+
+		r, err := NewReaderFrom(
+			strings.NewReader("lastname,firstname,composer,born,died,dates\n"),
+			options{Header: null.NewBool(true, true)},
+		)
+		require.NoError(t, err)
+		assert.NotNil(t, r.header)
+		assert.Equal(t, []string{"lastname", "firstname", "composer", "born", "died", "dates"}, r.header)
+		assert.Equal(t, r.currentLine.Load(), int64(1))
+	})
+
 	t.Run("skipFirstLine option skips first line and succeeds", func(t *testing.T) {
 		t.Parallel()
 
@@ -110,7 +143,7 @@ func TestNewReaderFrom(t *testing.T) {
 func TestReader_Read(t *testing.T) {
 	t.Parallel()
 
-	t.Run("default behavior should return all lines and succeed", func(t *testing.T) {
+	t.Run("default behavior should return all lines as slices of strings and succeed", func(t *testing.T) {
 		t.Parallel()
 
 		const csvTestData = "lastname,firstname,composer,born,died,dates\n" +
@@ -131,6 +164,36 @@ func TestReader_Read(t *testing.T) {
 		gotFirstLine, err := r.Read()
 		require.NoError(t, err)
 		assert.Equal(t, []string{"Scarlatti", "Domenico", "Domenico Scarlatti", "1685", "1757", "1685–1757"}, gotFirstLine)
+
+		// As we've reached EOF, we should get EOF
+		_, err = r.Read()
+		require.Error(t, err)
+		require.ErrorIs(t, err, io.EOF)
+	})
+
+	t.Run("header option should lead to lines being returned as maps and succeed", func(t *testing.T) {
+		t.Parallel()
+
+		const csvTestData = "lastname,firstname,composer,born,died,dates\n" +
+			"Scarlatti,Domenico,Domenico Scarlatti,1685,1757,1685–1757\n"
+
+		r, err := NewReaderFrom(
+			strings.NewReader(csvTestData),
+			options{Header: null.NewBool(true, true)},
+		)
+		require.NoError(t, err)
+
+		// Header line, if present should be ignored and records should be returned as maps
+		firstRecord, err := r.Read()
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{
+			"lastname":  "Scarlatti",
+			"firstname": "Domenico",
+			"composer":  "Domenico Scarlatti",
+			"born":      "1685",
+			"died":      "1757",
+			"dates":     "1685–1757",
+		}, firstRecord)
 
 		// As we've reached EOF, we should get EOF
 		_, err = r.Read()
@@ -168,5 +231,51 @@ func TestReader_Read(t *testing.T) {
 		_, err = r.Read()
 		require.Error(t, err)
 		require.ErrorIs(t, err, io.EOF)
+	})
+}
+
+func TestValidateOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("validateOptions with header and skipFirstLine should fail", func(t *testing.T) {
+		t.Parallel()
+
+		err := validateOptions(options{Header: null.NewBool(true, true), SkipFirstLine: true})
+		require.Error(t, err)
+	})
+
+	t.Run("validateOptions with header and fromLine greater than 0 should fail", func(t *testing.T) {
+		t.Parallel()
+
+		err := validateOptions(options{Header: null.NewBool(true, true), FromLine: null.NewInt(1, true)})
+		require.Error(t, err)
+	})
+
+	t.Run("validateOptions with fromLine less than 0 should fail", func(t *testing.T) {
+		t.Parallel()
+
+		err := validateOptions(options{FromLine: null.NewInt(-1, true)})
+		require.Error(t, err)
+	})
+
+	t.Run("validateOptions with toLine less than 0 should fail", func(t *testing.T) {
+		t.Parallel()
+
+		err := validateOptions(options{ToLine: null.NewInt(-1, true)})
+		require.Error(t, err)
+	})
+
+	t.Run("validateOptions with fromLine greater than toLine should fail", func(t *testing.T) {
+		t.Parallel()
+
+		err := validateOptions(options{FromLine: null.NewInt(2, true), ToLine: null.NewInt(1, true)})
+		require.Error(t, err)
+	})
+
+	t.Run("validateOptions with compatible options should succeed", func(t *testing.T) {
+		t.Parallel()
+
+		err := validateOptions(options{})
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## What?

Adds support for a `header` option to the csv module's option. When set to `true`, the `header` option leads the module's `parse` function as well as the `Parser.next` method to return records as objects with the header corresping row name as the property key, and value as the value.

```javascript
const file = await open('data.csv');
const csvRecords = await csv.parse(file, { header: true })

export default async function() {
	console.log(csvRecords[scenario.iterationInTest])
}
```

**Would print:**
```
INFO[0000] {"age":"72","firstname":"fariha","lastname":"ehlenfeldt"}  source=console
INFO[0000] {"age":"50","firstname":"qudratullah","lastname":"gillfillan"}  source=console
INFO[0000] {"age":"41","firstname":"jeleah","lastname":"rodina"}  source=console
INFO[0000] {"age":"99","firstname":"thaisia","lastname":"nowalk"}  source=console
INFO[0000] {"age":"75","firstname":"joey-lynn","lastname":"wilsford"}  source=console
INFO[0000] {"age":"81","firstname":"tudur","lastname":"granville"}  source=console
INFO[0000] {"age":"56","firstname":"aytek","lastname":"umber"}  source=console
INFO[0000] {"age":"30","firstname":"aynoor","lastname":"hisaw"}  source=console
INFO[0000] {"age":"31","firstname":"fiadh-rose","lastname":"iravani"}  source=console
INFO[0000] {"age":"70","firstname":"annely","lastname":"ooley"}  source=console
```

As opposed to, for reference, treating records as array without the header option set:
```
INFO[0000] ["firstname","lastname","age"]                source=console
INFO[0000] ["fariha","ehlenfeldt","72"]                  source=console
INFO[0000] ["qudratullah","gillfillan","50"]             source=console
INFO[0000] ["jeleah","rodina","41"]                      source=console
INFO[0000] ["thaisia","nowalk","99"]                     source=console
INFO[0000] ["joey-lynn","wilsford","75"]                 source=console
INFO[0000] ["tudur","granville","81"]                    source=console
INFO[0000] ["aytek","umber","56"]                        source=console
INFO[0000] ["aynoor","hisaw","30"]                       source=console
INFO[0000] ["fiadh-rose","iravani","31"]                 source=console
```

**Note**: that the same behavior can be observed when using a `Parser`'s `next` method with the `header` option set to `true`.


## Why?

This PR tackles #4284, and directly addresses a request from the team behind k6 studio, and one of the project's issues [k6-studio/#363](https://github.com/grafana/k6-studio/issues/363).

It also nicely complements the feature set of the csv parser in general, and aligns its options-set with [papaparse's](https://www.papaparse.com/docs).

## Checklist

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [X] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

[k6/#4284](https://github.com/grafana/issues/4284)
[k6-studio/#363](https://github.com/grafana/k6-studio/issues/363)