### PR TITLE
Support file scheme in open and experimental fs

### DIFF
--- a/internal/js/bundle_test.go
+++ b/internal/js/bundle_test.go
@@ -755,6 +755,7 @@ func TestOpen(t *testing.T) {
 
 				t.Run(tCase.name, testFunc)
 				if isWindows {
+					tCase := tCase // copy test case before making modifications
 					// windowsify the testcase
 					tCase.openPath = strings.ReplaceAll(tCase.openPath, `/`, `\`)
 					tCase.pwd = strings.ReplaceAll(tCase.pwd, `/`, `\`)

--- a/internal/js/initcontext.go
+++ b/internal/js/initcontext.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/grafana/sobek"
 	"github.com/sirupsen/logrus"
@@ -19,6 +20,8 @@ const cantBeUsedOutsideInitContextMsg = `the "%s" function is only available in 
 // contents of a file. If the second argument is "b" it returns an ArrayBuffer
 // instance, otherwise a string representation.
 func openImpl(rt *sobek.Runtime, fs fsext.Fs, basePWD *url.URL, filename string, args ...string) (sobek.Value, error) {
+	// Strip file scheme if available as we should support only this scheme
+	filename = strings.TrimPrefix(filename, "file://")
 	data, err := readFile(fs, fsext.Abs(basePWD.Path, filename))
 	if err != nil {
 		return nil, err

--- a/internal/js/modules/k6/experimental/fs/module.go
+++ b/internal/js/modules/k6/experimental/fs/module.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"strings"
 
 	"go.k6.io/k6/lib/fsext"
 
@@ -102,6 +103,8 @@ func (mi *ModuleInstance) Open(path sobek.Value) *sobek.Promise {
 
 func (mi *ModuleInstance) openImpl(path string) (*File, error) {
 	initEnv := mi.vu.InitEnv()
+	// Strip file scheme if available as we should support only this scheme
+	path = strings.TrimPrefix(path, "file://")
 
 	// We resolve the path relative to the entrypoint script, as opposed to
 	// the current working directory (the k6 command is called from).

--- a/internal/js/modules/k6/experimental/fs/module_test.go
+++ b/internal/js/modules/k6/experimental/fs/module_test.go
@@ -34,6 +34,11 @@ func TestOpen(t *testing.T) {
 				wantPath: fsext.FilePathSeparator + testFileName,
 			},
 			{
+				name:     "open file absolute path",
+				openPath: "file://" + fsext.FilePathSeparator + testFileName,
+				wantPath: fsext.FilePathSeparator + testFileName,
+			},
+			{
 				name:     "open relative path",
 				openPath: filepath.Join(".", fsext.FilePathSeparator, testFileName),
 				wantPath: fsext.FilePathSeparator + testFileName,

--- a/internal/js/modules/k6/grpc/client.go
+++ b/internal/js/modules/k6/grpc/client.go
@@ -54,6 +54,11 @@ func (c *Client) Load(importPaths []string, filenames ...string) ([]MethodInfo, 
 		importPaths = append(importPaths, initEnv.CWD.Path)
 	}
 
+	for i, s := range importPaths {
+		// Clean file scheme as it is the only supported scheme and the following APIs do not support them
+		importPaths[i] = strings.TrimPrefix(s, "file://")
+	}
+
 	parser := protoparse.Parser{
 		ImportPaths:      importPaths,
 		InferImportPaths: false,

--- a/internal/js/modules/k6/grpc/teststate_test.go
+++ b/internal/js/modules/k6/grpc/teststate_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sync"
 	"testing"
@@ -108,7 +109,7 @@ func newTestState(t *testing.T) testState {
 	if isWindows {
 		fs = fsext.NewTrimFilePathSeparatorFs(fs)
 	}
-	testRuntime.VU.InitEnvField.CWD = &url.URL{Path: cwd}
+	testRuntime.VU.InitEnvField.CWD = &url.URL{Scheme: "file", Path: filepath.ToSlash(cwd)}
 	testRuntime.VU.InitEnvField.FileSystems = map[string]fsext.Fs{"file": fs}
 
 	logger := logrus.New()


### PR DESCRIPTION
## What?

Fix `open` and experimental `fs.open` and `grpc.Client#Load` to work with file scheme paths

Fixes #4512

## Why?

This apparently has never been supported which is likely due to nothing really returning absolute paths.

After adding import.meta.resolve though this is changed. And there is really no reason why it shouldn't be supported.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
