### PR TITLE
don't fail fast on xk6

### DIFF
--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -14,6 +14,7 @@ defaults:
 jobs:
   test-xk6:
     strategy:
+      fail-fast: false
       matrix:
         go: [stable, tip]
         platform: [ubuntu-latest, windows-latest, macos-latest]


### PR DESCRIPTION
## What?

Do not fail all of the xk6 tests if one fails

## Why?

There now have been a couple of cases where this fail. It will be nice to know if all of them fail or just one. So failing fast isn't a particularly good idea in this case.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
