### PR TITLE
browser: reduce races in evaluate*

### DIFF
--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -87,21 +87,24 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			if sobekEmptyString(pageFunc) {
 				return nil, fmt.Errorf("evaluate requires a page function")
 			}
+			funcString := pageFunc.String()
+			gopts := exportArgs(gargs)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return p.Evaluate(pageFunc.String(), exportArgs(gargs)...)
+				return p.Evaluate(funcString, gopts...)
 			}), nil
 		},
 		"evaluateHandle": func(pageFunc sobek.Value, gargs ...sobek.Value) (*sobek.Promise, error) {
 			if sobekEmptyString(pageFunc) {
 				return nil, fmt.Errorf("evaluateHandle requires a page function")
 			}
+			funcString := pageFunc.String()
+			gopts := exportArgs(gargs)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				jsh, err := p.EvaluateHandle(pageFunc.String(), exportArgs(gargs)...)
+				jsh, err := p.EvaluateHandle(funcString, gopts...)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
+				// TODO(@mstoykov): don't use sobek Values in a separate goroutine - this uses the runtime in a lot of the cases
 				return mapJSHandle(vu, jsh), nil
 			}), nil
 		},


### PR DESCRIPTION
## What?

Reduce the number of sobek.Runtime used in page.evaluate that are off the event loop
## Why?
This is racy and very likely the underlying cause of #4085 - although without a runnable example, it is impossible to check.

Unfortunately some of the usage for `evalueateHandle` will require even more changes. In order to provide some fixes I opted to not try to fix everything in one go.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Possibly fixing #4085
