### PR TITLE
browser: Fix options races

### DIFF
--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -140,10 +140,14 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return mapResponse(vu, resp), nil
 			}), nil
 		},
-		"hover": func(selector string, opts sobek.Value) *sobek.Promise {
+		"hover": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			hopts := common.NewFrameHoverOptions(f.Timeout())
+			if err := hopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parse hover options of selector %q: %w", selector, err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, f.Hover(selector, opts) //nolint:wrapcheck
-			})
+				return nil, f.Hover(selector, hopts) //nolint:wrapcheck
+			}), nil
 		},
 		"innerHTML": func(selector string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -11,7 +11,7 @@ import (
 
 // mapFrame to the JS module.
 //
-//nolint:funlen,gocognit
+//nolint:funlen,gocognit,cyclop
 func mapFrame(vu moduleVU, f *common.Frame) mapping {
 	maps := mapping{
 		"check": func(selector string, opts sobek.Value) *sobek.Promise {
@@ -107,17 +107,21 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return mapElementHandle(vu, fe), nil
 			})
 		},
-		"getAttribute": func(selector, name string, opts sobek.Value) *sobek.Promise {
+		"getAttribute": func(selector, name string, opts sobek.Value) (*sobek.Promise, error) {
+			gaopts := common.NewFrameBaseOptions(f.Timeout())
+			if err := gaopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing base frame options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				s, ok, err := f.GetAttribute(selector, name, opts)
+				s, ok, err := f.GetAttribute(selector, name, gaopts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
 				if !ok {
-					return nil, nil
+					return nil, nil //nolint:nilnil
 				}
 				return s, nil
-			})
+			}), nil
 		},
 		"goto": func(url string, opts sobek.Value) (*sobek.Promise, error) {
 			gopts := common.NewFrameGotoOptions(

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -149,10 +149,14 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return nil, f.Hover(selector, hopts) //nolint:wrapcheck
 			}), nil
 		},
-		"innerHTML": func(selector string, opts sobek.Value) *sobek.Promise {
+		"innerHTML": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			inopts := common.NewFrameInnerHTMLOptions(f.Timeout())
+			if err := inopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parse innerHTML options of selector %q: %w", selector, err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return f.InnerHTML(selector, opts) //nolint:wrapcheck
-			})
+				return f.InnerHTML(selector, inopts) //nolint:wrapcheck
+			}), nil
 		},
 		"innerText": func(selector string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -158,10 +158,14 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return f.InnerHTML(selector, inopts) //nolint:wrapcheck
 			}), nil
 		},
-		"innerText": func(selector string, opts sobek.Value) *sobek.Promise {
+		"innerText": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			inopts := common.NewFrameInnerTextOptions(f.Timeout())
+			if err := inopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parse innerText options of selector %q: %w", selector, err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return f.InnerText(selector, opts) //nolint:wrapcheck
-			})
+				return f.InnerText(selector, inopts) //nolint:wrapcheck
+			}), nil
 		},
 		"inputValue": func(selector string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -45,18 +45,23 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return f.Content() //nolint:wrapcheck
 			})
 		},
-		"dblclick": func(selector string, opts sobek.Value) *sobek.Promise {
+		"dblclick": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameDblClickOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing double click options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, f.Dblclick(selector, opts) //nolint:wrapcheck
-			})
+				return nil, f.Dblclick(selector, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"dispatchEvent": func(selector, typ string, eventInit, opts sobek.Value) (*sobek.Promise, error) {
 			popts := common.NewFrameDispatchEventOptions(f.Timeout())
 			if err := popts.Parse(vu.Context(), opts); err != nil {
 				return nil, fmt.Errorf("parsing frame dispatch event options: %w", err)
 			}
+			earg := exportArg(eventInit)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, f.DispatchEvent(selector, typ, exportArg(eventInit), popts) //nolint:wrapcheck
+				return nil, f.DispatchEvent(selector, typ, earg, popts) //nolint:wrapcheck
 			}), nil
 		},
 		"evaluate": func(pageFunc sobek.Value, gargs ...sobek.Value) (*sobek.Promise, error) {
@@ -79,10 +84,14 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return mapJSHandle(vu, jsh), nil
 			}), nil
 		},
-		"fill": func(selector, value string, opts sobek.Value) *sobek.Promise {
+		"fill": func(selector, value string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameFillOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing fill options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, f.Fill(selector, value, opts) //nolint:wrapcheck
-			})
+				return nil, f.Fill(selector, value, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"focus": func(selector string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -167,10 +167,14 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return f.InnerText(selector, inopts) //nolint:wrapcheck
 			}), nil
 		},
-		"inputValue": func(selector string, opts sobek.Value) *sobek.Promise {
+		"inputValue": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			inopts := common.NewFrameInputValueOptions(f.Timeout())
+			if err := inopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parse innerText options of selector %q: %w", selector, err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return f.InputValue(selector, opts) //nolint:wrapcheck
-			})
+				return f.InputValue(selector, inopts) //nolint:wrapcheck
+			}), nil
 		},
 		"isChecked": func(selector string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -174,11 +174,14 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return mapResponse(vu, resp), nil
 			}), nil
 		},
-		"hover": func(selector string, opts sobek.Value) *sobek.Promise {
+		"hover": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			hopts := common.NewFrameHoverOptions(p.Timeout())
+			if err := hopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parse hover options of selector %q: %w", selector, err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return nil, p.Hover(selector, opts) //nolint:wrapcheck
-			})
+				return nil, p.Hover(selector, hopts) //nolint:wrapcheck
+			}), nil
 		},
 		"innerHTML": func(selector string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -192,11 +192,14 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return p.InnerHTML(selector, inopts) //nolint:wrapcheck
 			}), nil
 		},
-		"innerText": func(selector string, opts sobek.Value) *sobek.Promise {
+		"innerText": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			inopts := common.NewFrameInnerTextOptions(p.Timeout())
+			if err := inopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parse innerText options of selector %q: %w", selector, err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return p.InnerText(selector, opts) //nolint:wrapcheck
-			})
+				return p.InnerText(selector, inopts) //nolint:wrapcheck
+			}), nil
 		},
 		"inputValue": func(selector string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -141,18 +141,21 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			}
 			return rt.ToValue(mfrs).ToObject(rt)
 		},
-		"getAttribute": func(selector string, name string, opts sobek.Value) *sobek.Promise {
+		"getAttribute": func(selector string, name string, opts sobek.Value) (*sobek.Promise, error) {
+			gaopts := common.NewFrameBaseOptions(p.MainFrame().Timeout())
+			if err := gaopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parse getAttribute options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				s, ok, err := p.GetAttribute(selector, name, opts)
+				s, ok, err := p.GetAttribute(selector, name, gaopts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
 				if !ok {
-					return nil, nil
+					return nil, nil //nolint:nilnil
 				}
 				return s, nil
-			})
+			}), nil
 		},
 		"goto": func(url string, opts sobek.Value) (*sobek.Promise, error) {
 			gopts := common.NewFrameGotoOptions(

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -183,11 +183,14 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return nil, p.Hover(selector, hopts) //nolint:wrapcheck
 			}), nil
 		},
-		"innerHTML": func(selector string, opts sobek.Value) *sobek.Promise {
+		"innerHTML": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			inopts := common.NewFrameInnerHTMLOptions(p.Timeout())
+			if err := inopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parse innerHTML options of selector %q: %w", selector, err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return p.InnerHTML(selector, opts) //nolint:wrapcheck
-			})
+				return p.InnerHTML(selector, inopts) //nolint:wrapcheck
+			}), nil
 		},
 		"innerText": func(selector string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -201,11 +201,14 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return p.InnerText(selector, inopts) //nolint:wrapcheck
 			}), nil
 		},
-		"inputValue": func(selector string, opts sobek.Value) *sobek.Promise {
+		"inputValue": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			inopts := common.NewFrameInputValueOptions(p.Timeout())
+			if err := inopts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parse innerText options of selector %q: %w", selector, err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return p.InputValue(selector, opts) //nolint:wrapcheck
-			})
+				return p.InputValue(selector, inopts) //nolint:wrapcheck
+			}), nil
 		},
 		"isChecked": func(selector string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -87,21 +87,24 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			if sobekEmptyString(pageFunc) {
 				return nil, fmt.Errorf("evaluate requires a page function")
 			}
+			funcString := pageFunc.String()
+			gopts := exportArgs(gargs)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return p.Evaluate(pageFunc.String(), exportArgs(gargs)...)
+				return p.Evaluate(funcString, gopts...)
 			}), nil
 		},
 		"evaluateHandle": func(pageFunc sobek.Value, gargs ...sobek.Value) (*sobek.Promise, error) {
 			if sobekEmptyString(pageFunc) {
 				return nil, fmt.Errorf("evaluateHandle requires a page function")
 			}
+			funcString := pageFunc.String()
+			gopts := exportArgs(gargs)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				jsh, err := p.EvaluateHandle(pageFunc.String(), exportArgs(gargs)...)
+				jsh, err := p.EvaluateHandle(funcString, gopts...)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
+				// TODO(@mstoykov): don't use sobek Values in a separate goroutine - this uses the runtime in a lot of the cases
 				return mapJSHandle(vu, jsh), nil
 			}), nil
 		},

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1082,18 +1082,12 @@ func (f *Frame) innerHTML(selector string, opts *FrameInnerHTMLOptions) (string,
 
 // InnerText returns the inner text of the first element found
 // that matches the selector.
-func (f *Frame) InnerText(selector string, opts sobek.Value) (string, error) {
+func (f *Frame) InnerText(selector string, opts *FrameInnerTextOptions) (string, error) {
 	f.log.Debugf("Frame:InnerText", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
-
-	popts := NewFrameInnerTextOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return "", fmt.Errorf("parsing inner text options: %w", err)
-	}
-	v, err := f.innerText(selector, popts)
+	v, err := f.innerText(selector, opts)
 	if err != nil {
 		return "", fmt.Errorf("getting inner text of %q: %w", selector, err)
 	}
-
 	return v, nil
 }
 

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1049,18 +1049,12 @@ func (f *Frame) hover(selector string, opts *FrameHoverOptions) error {
 
 // InnerHTML returns the innerHTML attribute of the first element found
 // that matches the selector.
-func (f *Frame) InnerHTML(selector string, opts sobek.Value) (string, error) {
+func (f *Frame) InnerHTML(selector string, opts *FrameInnerHTMLOptions) (string, error) {
 	f.log.Debugf("Frame:InnerHTML", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
-
-	popts := NewFrameInnerHTMLOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return "", fmt.Errorf("parsing inner HTML options: %w", err)
-	}
-	v, err := f.innerHTML(selector, popts)
+	v, err := f.innerHTML(selector, opts)
 	if err != nil {
 		return "", fmt.Errorf("getting inner HTML of %q: %w", selector, err)
 	}
-
 	return v, nil
 }
 
@@ -1083,7 +1077,6 @@ func (f *Frame) innerHTML(selector string, opts *FrameInnerHTMLOptions) (string,
 	if !ok {
 		return "", fmt.Errorf("unexpected type %T", v)
 	}
-
 	return gv, nil
 }
 

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -753,13 +753,9 @@ func (f *Frame) Content() (string, error) {
 }
 
 // Dblclick double clicks an element matching provided selector.
-func (f *Frame) Dblclick(selector string, opts sobek.Value) error {
+func (f *Frame) Dblclick(selector string, popts *FrameDblclickOptions) error {
 	f.log.Debugf("Frame:DblClick", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameDblClickOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return fmt.Errorf("parsing double click options: %w", err)
-	}
 	if err := f.dblclick(selector, popts); err != nil {
 		return fmt.Errorf("double clicking on %q: %w", selector, err)
 	}
@@ -892,13 +888,9 @@ func (f *Frame) EvaluateHandle(pageFunc string, args ...any) (handle JSHandleAPI
 }
 
 // Fill fills out the first element found that matches the selector.
-func (f *Frame) Fill(selector, value string, opts sobek.Value) error {
+func (f *Frame) Fill(selector, value string, popts *FrameFillOptions) error {
 	f.log.Debugf("Frame:Fill", "fid:%s furl:%q sel:%q val:%q", f.ID(), f.URL(), selector, value)
 
-	popts := NewFrameFillOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return fmt.Errorf("parsing fill options: %w", err)
-	}
 	if err := f.fill(selector, value, popts); err != nil {
 		return fmt.Errorf("filling %q with %q: %w", selector, value, err)
 	}

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1025,19 +1025,12 @@ func (f *Frame) Goto(url string, opts *FrameGotoOptions) (*Response, error) {
 }
 
 // Hover moves the pointer over the first element that matches the selector.
-func (f *Frame) Hover(selector string, opts sobek.Value) error {
+func (f *Frame) Hover(selector string, opts *FrameHoverOptions) error {
 	f.log.Debugf("Frame:Hover", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
-
-	popts := NewFrameHoverOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return fmt.Errorf("parsing hover options: %w", err)
-	}
-	if err := f.hover(selector, popts); err != nil {
+	if err := f.hover(selector, opts); err != nil {
 		return fmt.Errorf("hovering %q: %w", selector, err)
 	}
-
 	applySlowMo(f.ctx)
-
 	return nil
 }
 
@@ -1051,7 +1044,6 @@ func (f *Frame) hover(selector string, opts *FrameHoverOptions) error {
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err)
 	}
-
 	return nil
 }
 

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -961,18 +961,12 @@ func (f *Frame) FrameElement() (*ElementHandle, error) {
 
 // GetAttribute of the first element found that matches the selector.
 // The second return value is true if the attribute exists, and false otherwise.
-func (f *Frame) GetAttribute(selector, name string, opts sobek.Value) (string, bool, error) {
+func (f *Frame) GetAttribute(selector, name string, opts *FrameBaseOptions) (string, bool, error) {
 	f.log.Debugf("Frame:GetAttribute", "fid:%s furl:%q sel:%q name:%s", f.ID(), f.URL(), selector, name)
-
-	popts := NewFrameBaseOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return "", false, fmt.Errorf("parsing get attribute options: %w", err)
-	}
-	s, ok, err := f.getAttribute(selector, name, popts)
+	s, ok, err := f.getAttribute(selector, name, opts)
 	if err != nil {
 		return "", false, fmt.Errorf("getting attribute %q of %q: %w", name, selector, err)
 	}
-
 	return s, ok, nil
 }
 

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1115,18 +1115,12 @@ func (f *Frame) innerText(selector string, opts *FrameInnerTextOptions) (string,
 }
 
 // InputValue returns the input value of the first element found that matches the selector.
-func (f *Frame) InputValue(selector string, opts sobek.Value) (string, error) {
+func (f *Frame) InputValue(selector string, opts *FrameInputValueOptions) (string, error) {
 	f.log.Debugf("Frame:InputValue", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
-
-	popts := NewFrameInputValueOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return "", fmt.Errorf("parsing input value options: %w", err)
-	}
-	v, err := f.inputValue(selector, popts)
+	v, err := f.inputValue(selector, opts)
 	if err != nil {
 		return "", fmt.Errorf("getting input value of %q: %w", selector, err)
 	}
-
 	return v, nil
 }
 

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1050,7 +1050,7 @@ func (p *Page) Goto(url string, opts *FrameGotoOptions) (*Response, error) {
 }
 
 // Hover hovers over an element matching the provided selector.
-func (p *Page) Hover(selector string, opts sobek.Value) error {
+func (p *Page) Hover(selector string, opts *FrameHoverOptions) error {
 	p.logger.Debugf("Page:Hover", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().Hover(selector, opts)

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1008,10 +1008,9 @@ func (p *Page) Frames() []*Frame {
 
 // GetAttribute returns the attribute value of the element matching the provided selector.
 // The second return value is true if the attribute exists, and false otherwise.
-func (p *Page) GetAttribute(selector string, name string, opts sobek.Value) (string, bool, error) {
+func (p *Page) GetAttribute(selector string, name string, opts *FrameBaseOptions) (string, bool, error) {
 	p.logger.Debugf("Page:GetAttribute", "sid:%v selector:%s name:%s",
 		p.sessionID(), selector, name)
-
 	return p.MainFrame().GetAttribute(selector, name, opts)
 }
 

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -849,7 +849,7 @@ func (p *Page) Click(selector string, opts *FrameClickOptions) error {
 }
 
 // Close closes the page.
-func (p *Page) Close(_ sobek.Value) error {
+func (p *Page) Close() error {
 	p.logger.Debugf("Page:Close", "sid:%v", p.sessionID())
 	_, span := TraceAPICall(p.ctx, p.targetID.String(), "page.close")
 	defer span.End()
@@ -907,10 +907,10 @@ func (p *Page) Context() *BrowserContext {
 }
 
 // Dblclick double clicks an element matching provided selector.
-func (p *Page) Dblclick(selector string, opts sobek.Value) error {
+func (p *Page) Dblclick(selector string, popts *FrameDblclickOptions) error {
 	p.logger.Debugf("Page:Dblclick", "sid:%v selector:%s", p.sessionID(), selector)
 
-	return p.MainFrame().Dblclick(selector, opts)
+	return p.MainFrame().Dblclick(selector, popts)
 }
 
 // DispatchEvent dispatches an event on the page to the element that matches the provided selector.
@@ -921,17 +921,12 @@ func (p *Page) DispatchEvent(selector string, typ string, eventInit any, opts *F
 }
 
 // EmulateMedia emulates the given media type.
-func (p *Page) EmulateMedia(opts sobek.Value) error {
+func (p *Page) EmulateMedia(popts *PageEmulateMediaOptions) error {
 	p.logger.Debugf("Page:EmulateMedia", "sid:%v", p.sessionID())
 
-	parsedOpts := NewPageEmulateMediaOptions(p.mediaType, p.colorScheme, p.reducedMotion)
-	if err := parsedOpts.Parse(p.ctx, opts); err != nil {
-		return fmt.Errorf("parsing emulateMedia options: %w", err)
-	}
-
-	p.mediaType = parsedOpts.Media
-	p.colorScheme = parsedOpts.ColorScheme
-	p.reducedMotion = parsedOpts.ReducedMotion
+	p.mediaType = popts.Media
+	p.colorScheme = popts.ColorScheme
+	p.reducedMotion = popts.ReducedMotion
 
 	p.frameSessionsMu.RLock()
 	for _, fs := range p.frameSessions {
@@ -993,10 +988,10 @@ func (p *Page) EvaluateHandle(pageFunc string, args ...any) (JSHandleAPI, error)
 }
 
 // Fill fills an input element with the provided value.
-func (p *Page) Fill(selector string, value string, opts sobek.Value) error {
+func (p *Page) Fill(selector string, value string, popts *FrameFillOptions) error {
 	p.logger.Debugf("Page:Fill", "sid:%v selector:%s", p.sessionID(), selector)
 
-	return p.MainFrame().Fill(selector, value, opts)
+	return p.MainFrame().Fill(selector, value, popts)
 }
 
 // Focus focuses an element matching the provided selector.

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1064,7 +1064,7 @@ func (p *Page) InnerHTML(selector string, opts *FrameInnerHTMLOptions) (string, 
 }
 
 // InnerText returns the inner text of the element matching the provided selector.
-func (p *Page) InnerText(selector string, opts sobek.Value) (string, error) {
+func (p *Page) InnerText(selector string, opts *FrameInnerTextOptions) (string, error) {
 	p.logger.Debugf("Page:InnerText", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().InnerText(selector, opts)

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1071,7 +1071,7 @@ func (p *Page) InnerText(selector string, opts *FrameInnerTextOptions) (string, 
 }
 
 // InputValue returns the value of the input element matching the provided selector.
-func (p *Page) InputValue(selector string, opts sobek.Value) (string, error) {
+func (p *Page) InputValue(selector string, opts *FrameInputValueOptions) (string, error) {
 	p.logger.Debugf("Page:InputValue", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().InputValue(selector, opts)

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1057,7 +1057,7 @@ func (p *Page) Hover(selector string, opts *FrameHoverOptions) error {
 }
 
 // InnerHTML returns the inner HTML of the element matching the provided selector.
-func (p *Page) InnerHTML(selector string, opts sobek.Value) (string, error) {
+func (p *Page) InnerHTML(selector string, opts *FrameInnerHTMLOptions) (string, error) {
 	p.logger.Debugf("Page:InnerHTML", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().InnerHTML(selector, opts)

--- a/internal/js/modules/k6/browser/common/page_options.go
+++ b/internal/js/modules/k6/browser/common/page_options.go
@@ -32,13 +32,11 @@ type PageScreenshotOptions struct {
 	Quality        int64          `json:"quality"`
 }
 
-func NewPageEmulateMediaOptions(
-	defaultMedia MediaType, defaultColorScheme ColorScheme, defaultReducedMotion ReducedMotion,
-) *PageEmulateMediaOptions {
+func NewPageEmulateMediaOptions(from *Page) *PageEmulateMediaOptions {
 	return &PageEmulateMediaOptions{
-		ColorScheme:   defaultColorScheme,
-		Media:         defaultMedia,
-		ReducedMotion: defaultReducedMotion,
+		ColorScheme:   from.colorScheme,
+		Media:         from.mediaType,
+		ReducedMotion: from.reducedMotion,
 	}
 }
 

--- a/internal/js/modules/k6/browser/tests/browser_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_test.go
@@ -34,7 +34,7 @@ func TestBrowserNewPage(t *testing.T) {
 	_, err := b.Browser.NewPage(nil)
 	assert.EqualError(t, err, "new page: existing browser context must be closed before creating a new one")
 
-	err = p1.Close(nil)
+	err = p1.Close()
 	require.NoError(t, err)
 	c = b.Context()
 	assert.NotNil(t, c)
@@ -91,7 +91,7 @@ func TestTmpDirCleanup(t *testing.T) {
 		withEnvLookup(env.ConstLookup("TMPDIR", tmpDirPath)),
 	)
 	p := b.NewPage(nil)
-	err = p.Close(nil)
+	err = p.Close()
 	require.NoError(t, err)
 
 	matches, err := filepath.Glob(filepath.Join(tmpDirPath, storage.K6BrowserDataDirPattern))
@@ -354,13 +354,13 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 	bctx2, err := b2.NewContext(nil)
 	require.NoError(t, err)
 
-	err = p1.Close(nil)
+	err = p1.Close()
 	require.NoError(t, err, "failed to close page #1")
 	require.NoError(t, bctx1.Close())
 
 	p2, err := bctx2.NewPage()
 	require.NoError(t, err, "failed to create page #2")
-	err = p2.Close(nil)
+	err = p2.Close()
 	require.NoError(t, err, "failed to close page #2")
 }
 

--- a/internal/js/modules/k6/browser/tests/frame_test.go
+++ b/internal/js/modules/k6/browser/tests/frame_test.go
@@ -32,7 +32,7 @@ func TestFramePress(t *testing.T) {
 	require.NoError(t, f.Press("#text1", "KeyB", nil))
 	require.NoError(t, f.Press("#text1", "Shift+KeyC", nil))
 
-	inputValue, err := f.InputValue("#text1", nil)
+	inputValue, err := f.InputValue("#text1", common.NewFrameInputValueOptions(f.Timeout()))
 	require.NoError(t, err)
 	require.Equal(t, "AbC", inputValue)
 }

--- a/internal/js/modules/k6/browser/tests/frame_test.go
+++ b/internal/js/modules/k6/browser/tests/frame_test.go
@@ -184,7 +184,8 @@ func TestFrameGetAttribute(t *testing.T) {
 	err := p.SetContent(`<a id="el" href="null">Something</a>`, nil)
 	require.NoError(t, err)
 
-	got, ok, err := p.Frames()[0].GetAttribute("#el", "href", nil)
+	opts := common.NewFrameBaseOptions(p.MainFrame().Timeout())
+	got, ok, err := p.Frames()[0].GetAttribute("#el", "href", opts)
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "null", got)
@@ -197,7 +198,8 @@ func TestFrameGetAttributeMissing(t *testing.T) {
 	err := p.SetContent(`<a id="el">Something</a>`, nil)
 	require.NoError(t, err)
 
-	got, ok, err := p.Frames()[0].GetAttribute("#el", "missing", nil)
+	opts := common.NewFrameBaseOptions(p.MainFrame().Timeout())
+	got, ok, err := p.Frames()[0].GetAttribute("#el", "missing", opts)
 	require.NoError(t, err)
 	require.False(t, ok)
 	assert.Equal(t, "", got)
@@ -210,7 +212,8 @@ func TestFrameGetAttributeEmpty(t *testing.T) {
 	err := p.SetContent(`<a id="el" empty>Something</a>`, nil)
 	require.NoError(t, err)
 
-	got, ok, err := p.Frames()[0].GetAttribute("#el", "empty", nil)
+	opts := common.NewFrameBaseOptions(p.MainFrame().Timeout())
+	got, ok, err := p.Frames()[0].GetAttribute("#el", "empty", opts)
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "", got)

--- a/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
+++ b/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
@@ -114,7 +114,8 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				err := p.Hover("button", nil)
+				opts := common.NewFrameHoverOptions(p.Timeout())
+				err := p.Hover("button", opts)
 				require.NoError(t, err)
 			})
 		})
@@ -254,7 +255,8 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f *common.Frame) {
-				err := f.Hover("button", nil)
+				opts := common.NewFrameHoverOptions(f.Timeout())
+				err := f.Hover("button", opts)
 				require.NoError(t, err)
 			})
 		})

--- a/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
+++ b/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
@@ -38,7 +38,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				err := p.Dblclick("button", nil)
+				err := p.Dblclick("button", common.NewFrameDblClickOptions(p.Timeout()))
 				require.NoError(t, err)
 			})
 		})
@@ -54,11 +54,13 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				err := p.EmulateMedia(tb.toSobekValue(struct {
+				popts := common.NewPageEmulateMediaOptions(p)
+				require.NoError(t, popts.Parse(tb.context(), tb.toSobekValue(struct {
 					Media string `js:"media"`
 				}{
 					Media: "print",
-				}))
+				})))
+				err := p.EmulateMedia(popts)
 				require.NoError(t, err)
 			})
 		})
@@ -82,7 +84,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				err := p.Fill(".fill", "foo", nil)
+				err := p.Fill(".fill", "foo", common.NewFrameFillOptions(p.MainFrame().Timeout()))
 				require.NoError(t, err)
 			})
 		})
@@ -191,7 +193,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f *common.Frame) {
-				err := f.Dblclick("button", nil)
+				err := f.Dblclick("button", common.NewFrameDblClickOptions(f.Timeout()))
 				require.NoError(t, err)
 			})
 		})
@@ -223,7 +225,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f *common.Frame) {
-				err := f.Fill(".fill", "foo", nil)
+				err := f.Fill(".fill", "foo", common.NewFrameFillOptions(f.Timeout()))
 				require.NoError(t, err)
 			})
 		})

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -77,13 +77,17 @@ func TestLocator(t *testing.T) {
 				l := p.Locator("#inputText", nil)
 
 				require.NoError(t, l.Fill(value, nil))
-				inputValue, err := p.InputValue("#inputText", nil)
+
+				inopts := common.NewFrameInputValueOptions(common.DefaultTimeout)
+				inputValue, err := p.InputValue("#inputText", inopts)
 				require.NoError(t, err)
 				require.Equal(t, value, inputValue)
 
 				err = l.Clear(common.NewFrameFillOptions(l.Timeout()))
 				assert.NoError(t, err)
-				inputValue, err = p.InputValue("#inputText", nil)
+
+				inopts = common.NewFrameInputValueOptions(common.DefaultTimeout)
+				inputValue, err = p.InputValue("#inputText", inopts)
 				require.NoError(t, err)
 				assert.Equal(t, "", inputValue)
 			},
@@ -128,7 +132,8 @@ func TestLocator(t *testing.T) {
 				const value = "fill me up"
 				lo := p.Locator("#inputText", nil)
 				require.NoError(t, lo.Fill(value, nil))
-				inputValue, err := p.InputValue("#inputText", nil)
+				inopts := common.NewFrameInputValueOptions(common.DefaultTimeout)
+				inputValue, err := p.InputValue("#inputText", inopts)
 				require.NoError(t, err)
 				require.Equal(t, value, inputValue)
 			},
@@ -138,7 +143,8 @@ func TestLocator(t *testing.T) {
 				const value = "fill me up"
 				lo := p.Locator("textarea", nil)
 				require.NoError(t, lo.Fill(value, nil))
-				inputValue, err := p.InputValue("textarea", nil)
+				opts := common.NewFrameInputValueOptions(common.DefaultTimeout)
+				inputValue, err := p.InputValue("textarea", opts)
 				require.NoError(t, err)
 				require.Equal(t, value, inputValue)
 			},
@@ -231,7 +237,8 @@ func TestLocator(t *testing.T) {
 			"Press", func(_ *testBrowser, p *common.Page) {
 				lo := p.Locator("#inputText", nil)
 				require.NoError(t, lo.Press("x", nil))
-				inputValue, err := p.InputValue("#inputText", nil)
+				opts := common.NewFrameInputValueOptions(common.DefaultTimeout)
+				inputValue, err := p.InputValue("#inputText", opts)
 				require.NoError(t, err)
 				require.Equal(t, "xsomething", inputValue)
 			},
@@ -271,7 +278,7 @@ func TestLocator(t *testing.T) {
 			"Type", func(_ *testBrowser, p *common.Page) {
 				lo := p.Locator("#inputText", nil)
 				require.NoError(t, lo.Type("real ", nil))
-				inputValue, err := p.InputValue("#inputText", nil)
+				inputValue, err := p.InputValue("#inputText", common.NewFrameInputValueOptions(common.DefaultTimeout))
 				require.NoError(t, err)
 				require.Equal(t, "real something", inputValue)
 			},

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -397,7 +397,7 @@ func TestPageInnerHTML(t *testing.T) {
 		p := newTestBrowser(t).NewPage(nil)
 		err := p.SetContent(sampleHTML, nil)
 		require.NoError(t, err)
-		innerHTML, err := p.InnerHTML("div", nil)
+		innerHTML, err := p.InnerHTML("div", common.NewFrameInnerHTMLOptions(p.Timeout()))
 		require.NoError(t, err)
 		assert.Equal(t, `<b>Test</b><ol><li><i>One</i></li></ol>`, innerHTML)
 	})
@@ -410,7 +410,7 @@ func TestPageInnerHTML(t *testing.T) {
 
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
-		_, err := p.InnerHTML("", nil)
+		_, err := p.InnerHTML("", common.NewFrameInnerHTMLOptions(p.Timeout()))
 		require.ErrorContains(t, err, "The provided selector is empty")
 	})
 
@@ -421,7 +421,7 @@ func TestPageInnerHTML(t *testing.T) {
 		p := tb.NewPage(nil)
 		err := p.SetContent(sampleHTML, nil)
 		require.NoError(t, err)
-		_, err = p.InnerHTML("p", tb.toSobekValue(jsFrameBaseOpts{Timeout: "100"}))
+		_, err = p.InnerHTML("p", common.NewFrameInnerHTMLOptions(p.Timeout()))
 		require.Error(t, err)
 	})
 }
@@ -1863,7 +1863,7 @@ func TestPageTargetBlank(t *testing.T) {
 	assert.Equal(t, 2, len(pp))
 
 	// Make sure the new page contains the correct page.
-	got, err := p2.InnerHTML("h1", nil)
+	got, err := p2.InnerHTML("h1", common.NewFrameInnerHTMLOptions(p2.Timeout()))
 	require.NoError(t, err)
 	assert.Equal(t, "you clicked!", got)
 }

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -524,17 +524,17 @@ func TestPageInputValue(t *testing.T) {
      	`, nil)
 	require.NoError(t, err)
 
-	inputValue, err := p.InputValue("input", nil)
+	inputValue, err := p.InputValue("input", common.NewFrameInputValueOptions(p.Timeout()))
 	require.NoError(t, err)
 	got, want := inputValue, "hello1"
 	assert.Equal(t, got, want)
 
-	inputValue, err = p.InputValue("select", nil)
+	inputValue, err = p.InputValue("select", common.NewFrameInputValueOptions(p.Timeout()))
 	require.NoError(t, err)
 	got, want = inputValue, "hello2"
 	assert.Equal(t, got, want)
 
-	inputValue, err = p.InputValue("textarea", nil)
+	inputValue, err = p.InputValue("textarea", common.NewFrameInputValueOptions(p.Timeout()))
 	require.NoError(t, err)
 	got, want = inputValue, "hello3"
 	assert.Equal(t, got, want)
@@ -597,7 +597,7 @@ func TestPageFill(t *testing.T) {
 		t.Run("happy/"+tt.name, func(t *testing.T) {
 			err := p.Fill(tt.selector, tt.value, common.NewFrameFillOptions(p.MainFrame().Timeout()))
 			require.NoError(t, err)
-			inputValue, err := p.InputValue(tt.selector, nil)
+			inputValue, err := p.InputValue(tt.selector, common.NewFrameInputValueOptions(p.MainFrame().Timeout()))
 			require.NoError(t, err)
 			require.Equal(t, tt.value, inputValue)
 		})
@@ -956,7 +956,7 @@ func TestPagePress(t *testing.T) {
 	require.NoError(t, p.Press("#text1", "KeyB", nil))
 	require.NoError(t, p.Press("#text1", "Shift+KeyC", nil))
 
-	inputValue, err := p.InputValue("#text1", nil)
+	inputValue, err := p.InputValue("#text1", common.NewFrameInputValueOptions(p.Timeout()))
 	require.NoError(t, err)
 	require.Equal(t, "AbC", inputValue)
 }

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -92,11 +92,13 @@ func TestPageEmulateMedia(t *testing.T) {
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
-	err := p.EmulateMedia(tb.toSobekValue(emulateMediaOpts{
+	popts := common.NewPageEmulateMediaOptions(p)
+	require.NoError(t, popts.Parse(tb.context(), tb.toSobekValue(emulateMediaOpts{
 		Media:         "print",
 		ColorScheme:   "dark",
 		ReducedMotion: "reduce",
-	}))
+	})))
+	err := p.EmulateMedia(popts)
 	require.NoError(t, err)
 
 	result, err := p.Evaluate(`() => matchMedia('print').matches`)
@@ -593,7 +595,7 @@ func TestPageFill(t *testing.T) {
 	}
 	for _, tt := range happy {
 		t.Run("happy/"+tt.name, func(t *testing.T) {
-			err := p.Fill(tt.selector, tt.value, nil)
+			err := p.Fill(tt.selector, tt.value, common.NewFrameFillOptions(p.MainFrame().Timeout()))
 			require.NoError(t, err)
 			inputValue, err := p.InputValue(tt.selector, nil)
 			require.NoError(t, err)
@@ -602,7 +604,7 @@ func TestPageFill(t *testing.T) {
 	}
 	for _, tt := range sad {
 		t.Run("sad/"+tt.name, func(t *testing.T) {
-			err := p.Fill(tt.selector, tt.value, nil)
+			err := p.Fill(tt.selector, tt.value, common.NewFrameFillOptions(p.MainFrame().Timeout()))
 			require.Error(t, err)
 		})
 	}
@@ -993,7 +995,7 @@ func TestPageClose(t *testing.T) {
 
 		p := b.NewPage(nil)
 
-		err := p.Close(nil)
+		err := p.Close()
 		assert.NoError(t, err)
 	})
 
@@ -1007,7 +1009,7 @@ func TestPageClose(t *testing.T) {
 		p, err := c.NewPage()
 		require.NoError(t, err)
 
-		err = p.Close(nil)
+		err = p.Close()
 		assert.NoError(t, err)
 	})
 }

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -1875,7 +1875,8 @@ func TestPageGetAttribute(t *testing.T) {
 	err := p.SetContent(`<a id="el" href="null">Something</a>`, nil)
 	require.NoError(t, err)
 
-	got, ok, err := p.GetAttribute("#el", "href", nil)
+	opts := common.NewFrameBaseOptions(p.MainFrame().Timeout())
+	got, ok, err := p.GetAttribute("#el", "href", opts)
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "null", got)
@@ -1888,7 +1889,8 @@ func TestPageGetAttributeMissing(t *testing.T) {
 	err := p.SetContent(`<a id="el">Something</a>`, nil)
 	require.NoError(t, err)
 
-	got, ok, err := p.GetAttribute("#el", "missing", nil)
+	opts := common.NewFrameBaseOptions(p.MainFrame().Timeout())
+	got, ok, err := p.GetAttribute("#el", "missing", opts)
 	require.NoError(t, err)
 	require.False(t, ok)
 	assert.Equal(t, "", got)
@@ -1901,7 +1903,8 @@ func TestPageGetAttributeEmpty(t *testing.T) {
 	err := p.SetContent(`<a id="el" empty>Something</a>`, nil)
 	require.NoError(t, err)
 
-	got, ok, err := p.GetAttribute("#el", "empty", nil)
+	opts := common.NewFrameBaseOptions(p.MainFrame().Timeout())
+	got, ok, err := p.GetAttribute("#el", "empty", opts)
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.Equal(t, "", got)

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -435,7 +435,7 @@ func TestPageInnerText(t *testing.T) {
 		p := newTestBrowser(t).NewPage(nil)
 		err := p.SetContent(sampleHTML, nil)
 		require.NoError(t, err)
-		innerText, err := p.InnerText("div", nil)
+		innerText, err := p.InnerText("div", common.NewFrameInnerTextOptions(p.Timeout()))
 		require.NoError(t, err)
 		assert.Equal(t, "Test\nOne", innerText)
 	})
@@ -445,7 +445,7 @@ func TestPageInnerText(t *testing.T) {
 
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
-		_, err := p.InnerText("", nil)
+		_, err := p.InnerText("", common.NewFrameInnerTextOptions(p.Timeout()))
 		require.ErrorContains(t, err, "The provided selector is empty")
 	})
 
@@ -456,7 +456,7 @@ func TestPageInnerText(t *testing.T) {
 		p := tb.NewPage(nil)
 		err := p.SetContent(sampleHTML, nil)
 		require.NoError(t, err)
-		_, err = p.InnerText("p", tb.toSobekValue(jsFrameBaseOpts{Timeout: "100"}))
+		_, err = p.InnerText("p", common.NewFrameInnerTextOptions(p.Timeout()))
 		require.Error(t, err)
 	})
 }
@@ -1527,7 +1527,7 @@ func TestPageThrottleNetwork(t *testing.T) {
 			_, err = page.WaitForSelector(selector, nil)
 			require.NoError(t, err)
 
-			resp, err := page.InnerText(selector, nil)
+			resp, err := page.InnerText(selector, common.NewFrameInnerTextOptions(page.Timeout()))
 			require.NoError(t, err)
 			ms, err := strconv.ParseInt(resp, 10, 64)
 			require.NoError(t, err)

--- a/internal/js/modules/k6/browser/tests/webvital_test.go
+++ b/internal/js/modules/k6/browser/tests/webvital_test.go
@@ -83,7 +83,7 @@ func TestWebVitalMetric(t *testing.T) {
 	require.NoError(t, err)
 
 	// prevents `err:fetching response body: context canceled` warning.`
-	require.NoError(t, page.Close(nil))
+	require.NoError(t, page.Close())
 	done <- struct{}{}
 
 	for k, v := range expected {
@@ -141,7 +141,7 @@ func TestWebVitalMetricNoInteraction(t *testing.T) {
 	require.NotNil(t, resp)
 
 	// prevents `err:fetching response body: context canceled` warning.`
-	require.NoError(t, page.Close(nil))
+	require.NoError(t, page.Close())
 	done <- struct{}{}
 
 	for k, v := range expected {


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

It expands https://github.com/grafana/k6/pull/4522.

It fixes the following funcs:
- `getAttribute`
- `hover`
- `innerHTML`
- `innerText`
- `inputValue`

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

Updates https://github.com/grafana/k6/issues/4085
