### PR TITLE
browser: fix possible races

### DIFF
--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -219,10 +219,16 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return nil, f.SetContent(html, opts) //nolint:wrapcheck
 			})
 		},
-		"setInputFiles": func(selector string, files sobek.Value, opts sobek.Value) *sobek.Promise {
+		"setInputFiles": func(selector string, files sobek.Value, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameSetInputFilesOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing setInputFiles options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, f.SetInputFiles(selector, files, opts) //nolint:wrapcheck
-			})
+				// TODO: don't use sobek Values in a separate goroutine, complete files migration
+				return nil, f.SetInputFiles(selector, files, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"tap": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
 			popts := common.NewFrameTapOptions(f.Timeout())

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -193,10 +193,16 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return nil, f.Press(selector, key, opts) //nolint:wrapcheck
 			})
 		},
-		"selectOption": func(selector string, values sobek.Value, opts sobek.Value) *sobek.Promise {
+		"selectOption": func(selector string, values sobek.Value, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameSelectOptionOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing select option options: %w", err)
+			}
+
+			// TODO: don't use sobek Values in a separate goroutine: finish migrating values
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return f.SelectOption(selector, values, opts) //nolint:wrapcheck
-			})
+				return f.SelectOption(selector, values, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"setChecked": func(selector string, checked bool, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -239,9 +239,14 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return nil, f.Tap(selector, popts) //nolint:wrapcheck
 			}), nil
 		},
-		"textContent": func(selector string, opts sobek.Value) *sobek.Promise {
+		"textContent": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameTextContentOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing text content options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				s, ok, err := f.TextContent(selector, opts)
+				s, ok, err := f.TextContent(selector, popts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
@@ -249,7 +254,7 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 					return nil, nil
 				}
 				return s, nil
-			})
+			}), nil
 		},
 		"title": func() *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -251,7 +251,7 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 					return nil, err //nolint:wrapcheck
 				}
 				if !ok {
-					return nil, nil
+					return nil, nil //nolint:nilnil
 				}
 				return s, nil
 			}), nil

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -11,7 +11,7 @@ import (
 
 // mapFrame to the JS module.
 //
-//nolint:funlen,gocognit
+//nolint:funlen,gocognit,cyclop
 func mapFrame(vu moduleVU, f *common.Frame) mapping {
 	maps := mapping{
 		"check": func(selector string, opts sobek.Value) *sobek.Promise {

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -204,10 +204,15 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return f.SelectOption(selector, values, popts) //nolint:wrapcheck
 			}), nil
 		},
-		"setChecked": func(selector string, checked bool, opts sobek.Value) *sobek.Promise {
+		"setChecked": func(selector string, checked bool, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameCheckOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing frame set check options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, f.SetChecked(selector, checked, opts) //nolint:wrapcheck
-			})
+				return nil, f.SetChecked(selector, checked, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"setContent": func(html string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -347,7 +347,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 					return nil, err //nolint:wrapcheck
 				}
 				if !ok {
-					return nil, nil
+					return nil, nil //nolint:nilnil
 				}
 				return s, nil
 			}), nil

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -335,10 +335,14 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return nil, p.Tap(selector, popts) //nolint:wrapcheck
 			}), nil
 		},
-		"textContent": func(selector string, opts sobek.Value) *sobek.Promise {
+		"textContent": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameTextContentOptions(p.MainFrame().Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing text content options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				s, ok, err := p.TextContent(selector, opts)
+				s, ok, err := p.TextContent(selector, popts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
@@ -346,7 +350,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 					return nil, nil
 				}
 				return s, nil
-			})
+			}), nil
 		},
 		"throttleCPU": func(cpuProfile common.CPUProfile) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -310,11 +310,16 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return nil, p.SetExtraHTTPHeaders(headers) //nolint:wrapcheck
 			})
 		},
-		"setInputFiles": func(selector string, files sobek.Value, opts sobek.Value) *sobek.Promise {
+		"setInputFiles": func(selector string, files sobek.Value, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameSetInputFilesOptions(p.MainFrame().Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing setInputFiles options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return nil, p.SetInputFiles(selector, files, opts) //nolint:wrapcheck
-			})
+				// TODO: don't use sobek Values in a separate goroutine, complete files migration
+				return nil, p.SetInputFiles(selector, files, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"setViewportSize": func(viewportSize sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -276,11 +276,16 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return &ab, nil
 			}), nil
 		},
-		"selectOption": func(selector string, values sobek.Value, opts sobek.Value) *sobek.Promise {
+		"selectOption": func(selector string, values sobek.Value, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameSelectOptionOptions(p.MainFrame().Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing select option options: %w", err)
+			}
+
+			// TODO: don't use sobek Values in a separate goroutine: finish migrating values
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return p.SelectOption(selector, values, opts) //nolint:wrapcheck
-			})
+				return p.SelectOption(selector, values, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"setChecked": func(selector string, checked bool, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -287,11 +287,15 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return p.SelectOption(selector, values, popts) //nolint:wrapcheck
 			}), nil
 		},
-		"setChecked": func(selector string, checked bool, opts sobek.Value) *sobek.Promise {
+		"setChecked": func(selector string, checked bool, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameCheckOptions(p.MainFrame().Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing frame set check options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return nil, p.SetChecked(selector, checked, opts) //nolint:wrapcheck
-			})
+				return nil, p.SetChecked(selector, checked, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"setContent": func(html string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1635,13 +1635,9 @@ func (f *Frame) setInputFiles(selector string, files *Files, opts *FrameSetInput
 // TextContent returns the textContent attribute of the first element found
 // that matches the selector. The second return value is true if the returned
 // text content is not null or empty, and false otherwise.
-func (f *Frame) TextContent(selector string, opts sobek.Value) (string, bool, error) {
+func (f *Frame) TextContent(selector string, popts *FrameTextContentOptions) (string, bool, error) {
 	f.log.Debugf("Frame:TextContent", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameTextContentOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return "", false, fmt.Errorf("parsing text content options: %w", err)
-	}
 	v, ok, err := f.textContent(selector, popts)
 	if err != nil {
 		return "", false, fmt.Errorf("getting text content of %q: %w", selector, err)

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1571,13 +1571,8 @@ func (f *Frame) SetContent(html string, opts sobek.Value) error {
 }
 
 // SetInputFiles sets input files for the selected element.
-func (f *Frame) SetInputFiles(selector string, files sobek.Value, opts sobek.Value) error {
+func (f *Frame) SetInputFiles(selector string, files sobek.Value, popts *FrameSetInputFilesOptions) error {
 	f.log.Debugf("Frame:SetInputFiles", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
-
-	popts := NewFrameSetInputFilesOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return fmt.Errorf("parsing setInputFiles options: %w", err)
-	}
 
 	pfiles := &Files{}
 	if err := pfiles.Parse(f.ctx, files); err != nil {

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1488,13 +1488,9 @@ func (f *Frame) press(selector, key string, opts *FramePressOptions) error {
 
 // SelectOption selects the given options and returns the array of
 // option values of the first element found that matches the selector.
-func (f *Frame) SelectOption(selector string, values sobek.Value, opts sobek.Value) ([]string, error) {
+func (f *Frame) SelectOption(selector string, values sobek.Value, popts *FrameSelectOptionOptions) ([]string, error) {
 	f.log.Debugf("Frame:SelectOption", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameSelectOptionOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return nil, fmt.Errorf("parsing select option options: %w", err)
-	}
 	v, err := f.selectOption(selector, values, popts)
 	if err != nil {
 		return nil, fmt.Errorf("selecting option on %q: %w", selector, err)

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -637,13 +637,9 @@ func (f *Frame) setChecked(selector string, checked bool, opts *FrameCheckOption
 }
 
 // SetChecked sets the checked state of the first element found that matches the selector.
-func (f *Frame) SetChecked(selector string, checked bool, opts sobek.Value) error {
+func (f *Frame) SetChecked(selector string, checked bool, popts *FrameCheckOptions) error {
 	f.log.Debugf("Frame:SetChecked", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameCheckOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return fmt.Errorf("parsing frame set check options: %w", err)
-	}
 	if err := f.setChecked(selector, checked, popts); err != nil {
 		return fmt.Errorf("setting checked %q: %w", selector, err)
 	}

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1407,10 +1407,10 @@ func (p *Page) Tap(selector string, opts *FrameTapOptions) error {
 // TextContent returns the textContent attribute of the first element found
 // that matches the selector. The second return value is true if the returned
 // text content is not null or empty, and false otherwise.
-func (p *Page) TextContent(selector string, opts sobek.Value) (string, bool, error) {
+func (p *Page) TextContent(selector string, popts *FrameTextContentOptions) (string, bool, error) {
 	p.logger.Debugf("Page:TextContent", "sid:%v selector:%s", p.sessionID(), selector)
 
-	return p.MainFrame().TextContent(selector, opts)
+	return p.MainFrame().TextContent(selector, popts)
 }
 
 // Timeout will return the default timeout or the one set by the user.

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1340,10 +1340,10 @@ func (p *Page) Screenshot(opts *PageScreenshotOptions, sp ScreenshotPersister) (
 
 // SelectOption selects the given options and returns the array of
 // option values of the first element found that matches the selector.
-func (p *Page) SelectOption(selector string, values sobek.Value, opts sobek.Value) ([]string, error) {
+func (p *Page) SelectOption(selector string, values sobek.Value, popts *FrameSelectOptionOptions) ([]string, error) {
 	p.logger.Debugf("Page:SelectOption", "sid:%v selector:%s", p.sessionID(), selector)
 
-	return p.MainFrame().SelectOption(selector, values, opts)
+	return p.MainFrame().SelectOption(selector, values, popts)
 }
 
 // SetContent replaces the entire HTML document content.

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -813,10 +813,10 @@ func (p *Page) BringToFront() error {
 }
 
 // SetChecked sets the checked state of the element matching the provided selector.
-func (p *Page) SetChecked(selector string, checked bool, opts sobek.Value) error {
+func (p *Page) SetChecked(selector string, checked bool, popts *FrameCheckOptions) error {
 	p.logger.Debugf("Page:SetChecked", "sid:%v selector:%s checked:%t", p.sessionID(), selector, checked)
 
-	return p.MainFrame().SetChecked(selector, checked, opts)
+	return p.MainFrame().SetChecked(selector, checked, popts)
 }
 
 // Check checks an element matching the provided selector.

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1376,7 +1376,7 @@ func (p *Page) SetExtraHTTPHeaders(headers map[string]string) error {
 }
 
 // SetInputFiles sets input files for the selected element.
-func (p *Page) SetInputFiles(selector string, files sobek.Value, opts sobek.Value) error {
+func (p *Page) SetInputFiles(selector string, files sobek.Value, opts *FrameSetInputFilesOptions) error {
 	p.logger.Debugf("Page:SetInputFiles", "sid:%v selector:%s", p.sessionID(), selector)
 
 	return p.MainFrame().SetInputFiles(selector, files, opts)

--- a/internal/js/modules/k6/browser/tests/frame_test.go
+++ b/internal/js/modules/k6/browser/tests/frame_test.go
@@ -226,13 +226,13 @@ func TestFrameSetChecked(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, checked)
 
-	err = p.Frames()[0].SetChecked("#el", true, nil)
+	err = p.Frames()[0].SetChecked("#el", true, common.NewFrameCheckOptions(p.Frames()[0].Timeout()))
 	require.NoError(t, err)
 	checked, err = p.Frames()[0].IsChecked("#el", nil)
 	require.NoError(t, err)
 	assert.True(t, checked)
 
-	err = p.Frames()[0].SetChecked("#el", false, nil)
+	err = p.Frames()[0].SetChecked("#el", false, common.NewFrameCheckOptions(p.Frames()[0].Timeout()))
 	require.NoError(t, err)
 	checked, err = p.Frames()[0].IsChecked("#el", nil)
 	require.NoError(t, err)

--- a/internal/js/modules/k6/browser/tests/frame_test.go
+++ b/internal/js/modules/k6/browser/tests/frame_test.go
@@ -67,7 +67,7 @@ func TestFrameDismissDialogBox(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			result, ok, err := p.TextContent("#textField", nil)
+			result, ok, err := p.TextContent("#textField", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 			require.NoError(t, err)
 			require.True(t, ok)
 			assert.EqualValues(t, tt+" dismissed", result)
@@ -102,7 +102,7 @@ func TestFrameNoPanicWithEmbeddedIFrame(t *testing.T) {
 	_, err := p.Goto(tb.staticURL("embedded_iframe.html"), opts)
 	require.NoError(t, err)
 
-	result, ok, err := p.TextContent("#doneDiv", nil)
+	result, ok, err := p.TextContent("#doneDiv", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.EqualValues(t, "Done!", result)
@@ -156,7 +156,7 @@ func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	result, ok, err := p.TextContent("#doneDiv", nil)
+	result, ok, err := p.TextContent("#doneDiv", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 	require.NoError(t, err)
 	require.True(t, ok)
 	assert.EqualValues(t, "Sign In Page", result)

--- a/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
+++ b/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
@@ -149,7 +149,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				_, err := p.SelectOption("select", tb.toSobekValue("foo"), nil)
+				_, err := p.SelectOption("select", tb.toSobekValue("foo"), common.NewFrameSelectOptionOptions(p.MainFrame().Timeout()))
 				require.NoError(t, err)
 			})
 		})
@@ -281,7 +281,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f *common.Frame) {
-				_, err := f.SelectOption("select", tb.toSobekValue("foo"), nil)
+				_, err := f.SelectOption("select", tb.toSobekValue("foo"), common.NewFrameSelectOptionOptions(f.Timeout()))
 				require.NoError(t, err)
 			})
 		})

--- a/internal/js/modules/k6/browser/tests/lifecycle_wait_test.go
+++ b/internal/js/modules/k6/browser/tests/lifecycle_wait_test.go
@@ -128,7 +128,7 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 			pingJSSlow:   false,
 			waitUntil:    common.LifecycleEventNetworkIdle,
 			assertFunc: func(tb *testBrowser, p *common.Page) error {
-				result, _, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
@@ -166,13 +166,13 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 			}
 
 			assertHome(t, tb, p, tt.waitUntil, func() error {
-				result, _, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
 				tt.pingRequestTextAssert(result, 10)
 
-				result, _, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
@@ -195,11 +195,11 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 
 				return tb.run(ctx, waitForNav, click)
 			}, func() {
-				result, _, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				require.NoError(t, err)
 				tt.pingRequestTextAssert(result, 20)
 
-				result, _, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				require.NoError(t, err)
 				tt.pingJSTextAssert(result)
 			}, "")
@@ -284,11 +284,11 @@ func TestLifecycleWaitForLoadState(t *testing.T) {
 				err := p.WaitForLoadState(common.LifecycleEventNetworkIdle.String(), nil)
 				require.NoError(t, err)
 
-				result, _, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				require.NoError(t, err)
 				assert.EqualValues(t, "Waiting... pong 10 - for loop complete", result)
 
-				result, _, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				require.NoError(t, err)
 				assert.EqualValues(t, "ping.js loaded from server", result)
 			},
@@ -316,11 +316,11 @@ func TestLifecycleWaitForLoadState(t *testing.T) {
 			}
 
 			assertHome(t, tb, p, tt.waitUntil, func() error {
-				result, _, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				require.NoError(t, err)
 				tt.pingRequestTextAssert(result)
 
-				result, _, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				require.NoError(t, err)
 				tt.pingJSTextAssert(result)
 
@@ -403,13 +403,13 @@ func TestLifecycleReload(t *testing.T) {
 			withPingJSHandler(t, tb, tt.pingJSSlow, nil, false)
 
 			assertHome(t, tb, p, tt.waitUntil, func() error {
-				result, _, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
 				tt.pingRequestTextAssert(result, 10)
 
-				result, _, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
@@ -422,13 +422,13 @@ func TestLifecycleReload(t *testing.T) {
 				_, err = p.Reload(opts)
 				require.NoError(t, err)
 
-				result, _, err = p.TextContent("#pingRequestText", nil)
+				result, _, err = p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
 				tt.pingRequestTextAssert(result, 20)
 
-				result, _, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
@@ -513,13 +513,13 @@ func TestLifecycleGotoWithSubFrame(t *testing.T) {
 			withPingJSHandler(t, tb, tt.pingJSSlow, nil, true)
 
 			assertHome(t, tb, p, tt.waitUntil, func() error {
-				result, _, err := p.TextContent("#subFramePingRequestText", nil)
+				result, _, err := p.TextContent("#subFramePingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
 				tt.pingRequestTextAssert(result)
 
-				result, _, err = p.TextContent("#subFramePingJSText", nil)
+				result, _, err = p.TextContent("#subFramePingJSText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
@@ -590,13 +590,13 @@ func TestLifecycleGoto(t *testing.T) {
 			withPingJSHandler(t, tb, tt.pingJSSlow, nil, false)
 
 			assertHome(t, tb, p, tt.waitUntil, func() error {
-				result, _, err := p.TextContent("#pingRequestText", nil)
+				result, _, err := p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
 				tt.pingRequestTextAssert(result)
 
-				result, _, err = p.TextContent("#pingJSText", nil)
+				result, _, err = p.TextContent("#pingJSText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				if err != nil {
 					return err
 				}
@@ -632,7 +632,7 @@ func TestLifecycleGotoNetworkIdle(t *testing.T) {
 		withPingJSHandler(t, tb, false, nil, false)
 
 		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() error {
-			result, _, err := p.TextContent("#pingJSText", nil)
+			result, _, err := p.TextContent("#pingJSText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 			if err != nil {
 				return err
 			}
@@ -654,13 +654,13 @@ func TestLifecycleGotoNetworkIdle(t *testing.T) {
 		withPingJSHandler(t, tb, false, ch, false)
 
 		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() error {
-			result, _, err := p.TextContent("#pingRequestText", nil)
+			result, _, err := p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 			if err != nil {
 				return err
 			}
 			assert.EqualValues(t, "Waiting... pong 4 - for loop complete", result)
 
-			result, _, err = p.TextContent("#pingJSText", nil)
+			result, _, err = p.TextContent("#pingJSText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 			if err != nil {
 				return err
 			}
@@ -680,7 +680,7 @@ func TestLifecycleGotoNetworkIdle(t *testing.T) {
 		withPingHandler(t, tb, 50*time.Millisecond, nil)
 
 		assertHome(t, tb, p, common.LifecycleEventNetworkIdle, func() error {
-			result, _, err := p.TextContent("#pingRequestText", nil)
+			result, _, err := p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 			if err != nil {
 				return err
 			}

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -148,7 +148,7 @@ func TestLocator(t *testing.T) {
 				const value = "fill me up"
 				lo := p.Locator("#firstParagraph", nil)
 				require.NoError(t, lo.Fill(value, nil))
-				textContent, ok, err := p.TextContent("#firstParagraph", nil)
+				textContent, ok, err := p.TextContent("#firstParagraph", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 				require.NoError(t, err)
 				require.True(t, ok)
 				require.Equal(t, value, textContent)

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -468,7 +468,7 @@ func TestPageTextContent(t *testing.T) {
 		p := newTestBrowser(t).NewPage(nil)
 		err := p.SetContent(sampleHTML, nil)
 		require.NoError(t, err)
-		textContent, ok, err := p.TextContent("div", nil)
+		textContent, ok, err := p.TextContent("div", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 		require.NoError(t, err)
 		require.True(t, ok)
 		assert.Equal(t, "TestOne", textContent)
@@ -479,7 +479,7 @@ func TestPageTextContent(t *testing.T) {
 
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
-		_, _, err := p.TextContent("", nil)
+		_, _, err := p.TextContent("", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
 		require.ErrorContains(t, err, "The provided selector is empty")
 	})
 
@@ -490,9 +490,7 @@ func TestPageTextContent(t *testing.T) {
 		p := tb.NewPage(nil)
 		err := p.SetContent(sampleHTML, nil)
 		require.NoError(t, err)
-		_, _, err = p.TextContent("p", tb.toSobekValue(jsFrameBaseOpts{
-			Timeout: "100",
-		}))
+		_, _, err = p.TextContent("p", common.NewFrameTextContentOptions(100))
 		require.Error(t, err)
 	})
 
@@ -503,9 +501,7 @@ func TestPageTextContent(t *testing.T) {
 		p := tb.NewPage(nil)
 		err := p.SetContent(sampleHTML, nil)
 		require.NoError(t, err)
-		_, _, err = p.TextContent("p", tb.toSobekValue(jsFrameBaseOpts{
-			Timeout: "100",
-		}))
+		_, _, err = p.TextContent("p", common.NewFrameTextContentOptions(100))
 		require.Error(t, err)
 	})
 }

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -636,13 +636,13 @@ func TestPageSetChecked(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, checked)
 
-	err = p.SetChecked("#el", true, nil)
+	err = p.SetChecked("#el", true, common.NewFrameCheckOptions(p.MainFrame().Timeout()))
 	require.NoError(t, err)
 	checked, err = p.IsChecked("#el", nil)
 	require.NoError(t, err)
 	assert.True(t, checked)
 
-	err = p.SetChecked("#el", false, nil)
+	err = p.SetChecked("#el", false, common.NewFrameCheckOptions(p.MainFrame().Timeout()))
 	require.NoError(t, err)
 	checked, err = p.IsChecked("#el", nil)
 	require.NoError(t, err)

--- a/internal/js/modules/k6/browser/tests/setinputfiles_test.go
+++ b/internal/js/modules/k6/browser/tests/setinputfiles_test.go
@@ -36,7 +36,7 @@ func TestSetInputFiles(t *testing.T) {
 	`
 
 	defaultTestPage := func(tb *testBrowser, page *common.Page, files sobek.Value) error {
-		return page.SetInputFiles("#upload", files, tb.toSobekValue(nil))
+		return page.SetInputFiles("#upload", files, common.NewFrameSetInputFilesOptions(page.MainFrame().Timeout()))
 	}
 	defaultTestElementHandle := func(tb *testBrowser, page *common.Page, files sobek.Value) error {
 		handle, err := page.WaitForSelector("#upload", tb.toSobekValue(nil))
@@ -124,7 +124,7 @@ func TestSetInputFiles(t *testing.T) {
 			},
 			tests: []testFn{
 				func(tb *testBrowser, page *common.Page, files sobek.Value) error {
-					return page.SetInputFiles("#button1", files, tb.toSobekValue(nil))
+					return page.SetInputFiles("#button1", files, common.NewFrameSetInputFilesOptions(page.MainFrame().Timeout()))
 				},
 				func(tb *testBrowser, page *common.Page, files sobek.Value) error {
 					handle, err := page.WaitForSelector("#button1", tb.toSobekValue(nil))
@@ -147,7 +147,7 @@ func TestSetInputFiles(t *testing.T) {
 			},
 			tests: []testFn{
 				func(tb *testBrowser, page *common.Page, files sobek.Value) error {
-					return page.SetInputFiles("#textinput", files, tb.toSobekValue(nil))
+					return page.SetInputFiles("#textinput", files, common.NewFrameSetInputFilesOptions(page.MainFrame().Timeout()))
 				},
 				func(tb *testBrowser, page *common.Page, files sobek.Value) error {
 					handle, err := page.WaitForSelector("#textinput", tb.toSobekValue(nil))


### PR DESCRIPTION
## What?

Same as https://github.com/grafana/k6/pull/4522 this PR fixes usages of `sobek.Value` inside go routines which could lead to the race.

It fixes this for following APIs:
* SelectOption
* SetChecked
* SetInputFiles
* TextContent

Note that `SelectOption` and `SetInputFiles` still not fully migrated, since some usages of the `sobek.Value` requires a bigger refactoring there.

## Why?

https://github.com/grafana/k6/issues/4085

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
