### PR TITLE
Fix E2E browser CI flakiness by reducing example number of browser

### DIFF
--- a/examples/browser/multiple-scenario.js
+++ b/examples/browser/multiple-scenario.js
@@ -5,7 +5,7 @@ export const options = {
     messages: {
       executor: 'constant-vus',
       exec: 'messages',
-      vus: 2,
+      vus: 1,
       duration: '2s',
       options: {
         browser: {
@@ -16,8 +16,8 @@ export const options = {
     news: {
       executor: 'per-vu-iterations',
       exec: 'news',
-      vus: 2,
-      iterations: 4,
+      vus: 1,
+      iterations: 2,
       maxDuration: '5s',
       options: {
         browser: {


### PR DESCRIPTION
## What?

Make multiple scenario example a bit lighter to run. Hopefully reducing CI flakiness on MacOS

## Why?

It seems like on MacOS running 3 browsers is way too much and it regularly fails.

Given that the failure is due to threshold being blown over as the CI just can't load pages fast enough, I see no point for this to keep being flaky.

The example is about multiple scenarios not about multiple browsers in scenarios as well.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
