### PR TITLE
 browser: fix possible races p4

### DIFF
--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -261,10 +261,15 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return f.Title()
 			})
 		},
-		"type": func(selector, text string, opts sobek.Value) *sobek.Promise {
+		"type": func(selector, text string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameTypeOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing type options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, f.Type(selector, text, opts) //nolint:wrapcheck
-			})
+				return nil, f.Type(selector, text, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"uncheck": func(selector string, opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -271,10 +271,15 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return nil, f.Type(selector, text, popts) //nolint:wrapcheck
 			}), nil
 		},
-		"uncheck": func(selector string, opts sobek.Value) *sobek.Promise {
+		"uncheck": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameUncheckOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing frame uncheck options %q: %w", selector, err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, f.Uncheck(selector, opts) //nolint:wrapcheck
-			})
+				return nil, f.Uncheck(selector, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"url": f.URL,
 		"waitForFunction": func(pageFunc, opts sobek.Value, args ...sobek.Value) (*sobek.Promise, error) {

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -318,14 +318,19 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return mapResponse(vu, resp), nil
 			}), nil
 		},
-		"waitForSelector": func(selector string, opts sobek.Value) *sobek.Promise {
+		"waitForSelector": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameWaitForSelectorOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing wait for selector %q options: %w", selector, err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				eh, err := f.WaitForSelector(selector, opts)
+				eh, err := f.WaitForSelector(selector, popts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
 				return mapElementHandle(vu, eh), nil
-			})
+			}), nil
 		},
 		"waitForTimeout": func(timeout int64) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -294,10 +294,15 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return f.WaitForFunction(js, popts, pargs...) //nolint:wrapcheck
 			}), nil
 		},
-		"waitForLoadState": func(state string, opts sobek.Value) *sobek.Promise {
+		"waitForLoadState": func(state string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameWaitForLoadStateOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing waitForLoadState %q options: %w", state, err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, f.WaitForLoadState(state, opts) //nolint:wrapcheck
-			})
+				return nil, f.WaitForLoadState(state, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"waitForNavigation": func(opts sobek.Value) (*sobek.Promise, error) {
 			popts := common.NewFrameWaitForNavigationOptions(f.Timeout())

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -371,11 +371,15 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			})
 		},
 		"touchscreen": mapTouchscreen(vu, p.GetTouchscreen()),
-		"type": func(selector string, text string, opts sobek.Value) *sobek.Promise {
-			// TODO(@mstoykov): don't use sobek Values in a separate goroutine
+		"type": func(selector string, text string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameTypeOptions(p.MainFrame().Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing type options: %w", err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, p.Type(selector, text, opts) //nolint:wrapcheck
-			})
+				return nil, p.Type(selector, text, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"uncheck": func(selector string, opts sobek.Value) *sobek.Promise {
 			// TODO(@mstoykov): don't use sobek Values in a separate goroutine

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -430,15 +430,19 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return mapResponse(vu, resp), nil
 			}), nil
 		},
-		"waitForSelector": func(selector string, opts sobek.Value) *sobek.Promise {
+		"waitForSelector": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameWaitForSelectorOptions(p.MainFrame().Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing wait for selector %q options: %w", selector, err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				eh, err := p.WaitForSelector(selector, opts)
+				eh, err := p.WaitForSelector(selector, popts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
 				return mapElementHandle(vu, eh), nil
-			})
+			}), nil
 		},
 		"waitForTimeout": func(timeout int64) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -381,11 +381,15 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return nil, p.Type(selector, text, popts) //nolint:wrapcheck
 			}), nil
 		},
-		"uncheck": func(selector string, opts sobek.Value) *sobek.Promise {
-			// TODO(@mstoykov): don't use sobek Values in a separate goroutine
+		"uncheck": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameUncheckOptions(p.MainFrame().Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing frame uncheck options %q: %w", selector, err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, p.Uncheck(selector, opts) //nolint:wrapcheck
-			})
+				return nil, p.Uncheck(selector, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"url":          p.URL,
 		"viewportSize": p.ViewportSize,

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -405,11 +405,15 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return p.WaitForFunction(js, popts, pargs...) //nolint:wrapcheck
 			}), nil
 		},
-		"waitForLoadState": func(state string, opts sobek.Value) *sobek.Promise {
+		"waitForLoadState": func(state string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameWaitForLoadStateOptions(p.MainFrame().Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing waitForLoadState %q options: %w", state, err)
+			}
+
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return nil, p.WaitForLoadState(state, opts) //nolint:wrapcheck
-			})
+				return nil, p.WaitForLoadState(state, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"waitForNavigation": func(opts sobek.Value) (*sobek.Promise, error) {
 			popts := common.NewFrameWaitForNavigationOptions(p.Timeout())

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1693,13 +1693,9 @@ func (f *Frame) Title() (string, error) {
 }
 
 // Type text on the first element found matches the selector.
-func (f *Frame) Type(selector, text string, opts sobek.Value) error {
+func (f *Frame) Type(selector, text string, popts *FrameTypeOptions) error {
 	f.log.Debugf("Frame:Type", "fid:%s furl:%q sel:%q text:%q", f.ID(), f.URL(), selector, text)
 
-	popts := NewFrameTypeOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return fmt.Errorf("parsing type options: %w", err)
-	}
 	if err := f.typ(selector, text, popts); err != nil {
 		return fmt.Errorf("typing %q in %q: %w", text, selector, err)
 	}

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1944,12 +1944,8 @@ func (f *Frame) WaitForNavigation(opts *FrameWaitForNavigationOptions) (*Respons
 }
 
 // WaitForSelector waits for the given selector to match the waiting criteria.
-func (f *Frame) WaitForSelector(selector string, opts sobek.Value) (*ElementHandle, error) {
-	parsedOpts := NewFrameWaitForSelectorOptions(f.defaultTimeout())
-	if err := parsedOpts.Parse(f.ctx, opts); err != nil {
-		return nil, fmt.Errorf("parsing wait for selector %q options: %w", selector, err)
-	}
-	handle, err := f.waitForSelectorRetry(selector, parsedOpts, maxRetry)
+func (f *Frame) WaitForSelector(selector string, popts *FrameWaitForSelectorOptions) (*ElementHandle, error) {
+	handle, err := f.waitForSelectorRetry(selector, popts, maxRetry)
 	if err != nil {
 		return nil, fmt.Errorf("waiting for selector %q: %w", selector, err)
 	}

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -650,13 +650,9 @@ func (f *Frame) SetChecked(selector string, checked bool, popts *FrameCheckOptio
 }
 
 // Uncheck the first found element that matches the selector.
-func (f *Frame) Uncheck(selector string, opts sobek.Value) error {
+func (f *Frame) Uncheck(selector string, popts *FrameUncheckOptions) error {
 	f.log.Debugf("Frame:Uncheck", "fid:%s furl:%q sel:%q", f.ID(), f.URL(), selector)
 
-	popts := NewFrameUncheckOptions(f.defaultTimeout())
-	if err := popts.Parse(f.ctx, opts); err != nil {
-		return fmt.Errorf("parsing frame uncheck options %q: %w", selector, err)
-	}
 	if err := f.uncheck(selector, popts); err != nil {
 		return fmt.Errorf("unchecking %q: %w", selector, err)
 	}

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1818,16 +1818,11 @@ func (f *Frame) waitForFunction(
 
 // WaitForLoadState waits for the given load state to be reached.
 // This will unblock if that lifecycle event has already been received.
-func (f *Frame) WaitForLoadState(state string, opts sobek.Value) error {
+func (f *Frame) WaitForLoadState(state string, popts *FrameWaitForLoadStateOptions) error {
 	f.log.Debugf("Frame:WaitForLoadState", "fid:%s furl:%q state:%s", f.ID(), f.URL(), state)
 	defer f.log.Debugf("Frame:WaitForLoadState:return", "fid:%s furl:%q state:%s", f.ID(), f.URL(), state)
 
-	waitForLoadStateOpts := NewFrameWaitForLoadStateOptions(f.defaultTimeout())
-	if err := waitForLoadStateOpts.Parse(f.ctx, opts); err != nil {
-		return fmt.Errorf("parsing waitForLoadState %q options: %w", state, err)
-	}
-
-	timeoutCtx, timeoutCancel := context.WithTimeout(f.ctx, waitForLoadStateOpts.Timeout)
+	timeoutCtx, timeoutCancel := context.WithTimeout(f.ctx, popts.Timeout)
 	defer timeoutCancel()
 
 	waitUntil := LifecycleEventLoad

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -827,10 +827,10 @@ func (p *Page) Check(selector string, opts sobek.Value) error {
 }
 
 // Uncheck unchecks an element matching the provided selector.
-func (p *Page) Uncheck(selector string, opts sobek.Value) error {
+func (p *Page) Uncheck(selector string, popts *FrameUncheckOptions) error {
 	p.logger.Debugf("Page:Uncheck", "sid:%v selector:%s", p.sessionID(), selector)
 
-	return p.MainFrame().Uncheck(selector, opts)
+	return p.MainFrame().Uncheck(selector, popts)
 }
 
 // IsChecked returns true if the first element that matches the selector

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1512,10 +1512,10 @@ func (p *Page) WaitForFunction(js string, opts *FrameWaitForFunctionOptions, jsA
 }
 
 // WaitForLoadState waits for the specified page life cycle event.
-func (p *Page) WaitForLoadState(state string, opts sobek.Value) error {
+func (p *Page) WaitForLoadState(state string, popts *FrameWaitForLoadStateOptions) error {
 	p.logger.Debugf("Page:WaitForLoadState", "sid:%v state:%q", p.sessionID(), state)
 
-	return p.frameManager.MainFrame().WaitForLoadState(state, opts)
+	return p.frameManager.MainFrame().WaitForLoadState(state, popts)
 }
 
 // WaitForNavigation waits for the given navigation lifecycle event to happen.

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1471,10 +1471,10 @@ func (p *Page) ThrottleNetwork(networkProfile NetworkProfile) error {
 }
 
 // Type text on the first element found matches the selector.
-func (p *Page) Type(selector string, text string, opts sobek.Value) error {
+func (p *Page) Type(selector string, text string, popts *FrameTypeOptions) error {
 	p.logger.Debugf("Page:Type", "sid:%v selector:%s text:%s", p.sessionID(), selector, text)
 
-	return p.MainFrame().Type(selector, text, opts)
+	return p.MainFrame().Type(selector, text, popts)
 }
 
 // URL returns the location of the page.

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1534,12 +1534,12 @@ func (p *Page) WaitForNavigation(opts *FrameWaitForNavigationOptions) (*Response
 }
 
 // WaitForSelector waits for the given selector to match the waiting criteria.
-func (p *Page) WaitForSelector(selector string, opts sobek.Value) (*ElementHandle, error) {
+func (p *Page) WaitForSelector(selector string, popts *FrameWaitForSelectorOptions) (*ElementHandle, error) {
 	p.logger.Debugf("Page:WaitForSelector",
 		"sid:%v stid:%v ptid:%v selector:%s",
 		p.sessionID(), p.session.TargetID(), p.targetID, selector)
 
-	return p.frameManager.MainFrame().WaitForSelector(selector, opts)
+	return p.frameManager.MainFrame().WaitForSelector(selector, popts)
 }
 
 // WaitForTimeout waits the specified number of milliseconds.

--- a/internal/js/modules/k6/browser/tests/keyboard_test.go
+++ b/internal/js/modules/k6/browser/tests/keyboard_test.go
@@ -144,7 +144,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, err)
 
 		// Wait for the new tab to complete loading.
-		assert.NoError(t, newTab.WaitForLoadState("load", nil))
+		assert.NoError(t, newTab.WaitForLoadState("load", common.NewFrameWaitForLoadStateOptions(p.MainFrame().Timeout())))
 
 		// Make sure the newTab has a different h1 heading.
 		text, err = newTab.Locator("h1", nil).InnerText(nil)

--- a/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
+++ b/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
@@ -157,7 +157,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				err := p.Type(".fill", "a", nil)
+				err := p.Type(".fill", "a", common.NewFrameTypeOptions(p.Timeout()))
 				require.NoError(t, err)
 			})
 		})
@@ -289,7 +289,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f *common.Frame) {
-				err := f.Type(".fill", "a", nil)
+				err := f.Type(".fill", "a", common.NewFrameTypeOptions(f.Timeout()))
 				require.NoError(t, err)
 			})
 		})

--- a/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
+++ b/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
@@ -165,7 +165,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
-				assert.NoError(t, p.Uncheck(".uncheck", nil))
+				assert.NoError(t, p.Uncheck(".uncheck", common.NewFrameUncheckOptions(p.Timeout())))
 			})
 		})
 	})
@@ -297,7 +297,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
 			testFrameSlowMoImpl(t, tb, func(_ *testBrowser, f *common.Frame) {
-				assert.NoError(t, f.Uncheck(".uncheck", nil))
+				assert.NoError(t, f.Uncheck(".uncheck", common.NewFrameUncheckOptions(f.Timeout())))
 			})
 		})
 	})

--- a/internal/js/modules/k6/browser/tests/lifecycle_wait_test.go
+++ b/internal/js/modules/k6/browser/tests/lifecycle_wait_test.go
@@ -281,7 +281,7 @@ func TestLifecycleWaitForLoadState(t *testing.T) {
 			pingJSSlow:   false,
 			waitUntil:    common.LifecycleEventDOMContentLoad,
 			assertFunc: func(p *common.Page) {
-				err := p.WaitForLoadState(common.LifecycleEventNetworkIdle.String(), nil)
+				err := p.WaitForLoadState(common.LifecycleEventNetworkIdle.String(), common.NewFrameWaitForLoadStateOptions(p.MainFrame().Timeout()))
 				require.NoError(t, err)
 
 				result, _, err := p.TextContent("#pingRequestText", common.NewFrameTextContentOptions(p.MainFrame().Timeout()))
@@ -325,7 +325,7 @@ func TestLifecycleWaitForLoadState(t *testing.T) {
 				tt.pingJSTextAssert(result)
 
 				// This shouldn't block and return after calling hasLifecycleEventFired.
-				return p.WaitForLoadState(tt.waitUntil.String(), nil)
+				return p.WaitForLoadState(tt.waitUntil.String(), common.NewFrameWaitForLoadStateOptions(p.MainFrame().Timeout()))
 			}, nil, "")
 		})
 	}

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -917,7 +917,7 @@ func TestPageWaitForLoadState(t *testing.T) {
 
 		tb := newTestBrowser(t)
 		p := tb.NewPage(nil)
-		err := p.WaitForLoadState("none", nil)
+		err := p.WaitForLoadState("none", common.NewFrameWaitForLoadStateOptions(p.MainFrame().Timeout()))
 		require.ErrorContains(t, err, `invalid lifecycle event: "none"; must be one of: load, domcontentloaded, networkidle`)
 	})
 }
@@ -1849,7 +1849,7 @@ func TestPageTargetBlank(t *testing.T) {
 	p2, ok := obj.(*common.Page)
 	require.True(t, ok, "return from WaitForEvent is not a Page")
 
-	err = p2.WaitForLoadState(common.LifecycleEventLoad.String(), nil)
+	err = p2.WaitForLoadState(common.LifecycleEventLoad.String(), common.NewFrameWaitForLoadStateOptions(p.MainFrame().Timeout()))
 	require.NoError(t, err)
 
 	// Now there should be 2 pages.

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -57,7 +57,7 @@ func TestNestedFrames(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	frame1Handle, err := page.WaitForSelector("iframe[id='iframe1']", nil)
+	frame1Handle, err := page.WaitForSelector("iframe[id='iframe1']", common.NewFrameWaitForSelectorOptions(page.MainFrame().Timeout()))
 	assert.Nil(t, err)
 	assert.NotNil(t, frame1Handle)
 
@@ -65,7 +65,7 @@ func TestNestedFrames(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, frame1)
 
-	frame2Handle, err := frame1.WaitForSelector("iframe[id='iframe2']", nil)
+	frame2Handle, err := frame1.WaitForSelector("iframe[id='iframe2']", common.NewFrameWaitForSelectorOptions(frame1.Timeout()))
 	assert.Nil(t, err)
 	assert.NotNil(t, frame2Handle)
 
@@ -73,7 +73,7 @@ func TestNestedFrames(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, frame2)
 
-	button1Handle, err := frame2.WaitForSelector("button[id='button1']", nil)
+	button1Handle, err := frame2.WaitForSelector("button[id='button1']", common.NewFrameWaitForSelectorOptions(frame2.Timeout()))
 	assert.Nil(t, err)
 	assert.NotNil(t, button1Handle)
 
@@ -1369,11 +1369,12 @@ func TestPageWaitForSelector(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		url       string
-		opts      map[string]any
-		selector  string
-		errAssert func(*testing.T, error)
+		name          string
+		url           string
+		opts          map[string]any
+		customTimeout time.Duration
+		selector      string
+		errAssert     func(*testing.T, error)
 	}{
 		{
 			name:     "should wait for selector",
@@ -1387,12 +1388,10 @@ func TestPageWaitForSelector(t *testing.T) {
 		{
 			name: "should TO waiting for selector",
 			url:  "wait_for.html",
-			opts: map[string]any{
-				// set a timeout smaller than the time
-				// it takes the element to show up
-				"timeout": "1",
-			},
-			selector: "#my-div",
+			// set a timeout smaller than the time
+			// it takes the element to show up
+			customTimeout: time.Millisecond,
+			selector:      "#my-div",
 			errAssert: func(t *testing.T, e error) {
 				t.Helper()
 				assert.ErrorContains(t, e, "timed out after")
@@ -1417,7 +1416,12 @@ func TestPageWaitForSelector(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			_, err = page.WaitForSelector(tc.selector, tb.toSobekValue(tc.opts))
+			timeout := page.MainFrame().Timeout()
+			if tc.customTimeout != 0 {
+				timeout = tc.customTimeout
+			}
+
+			_, err = page.WaitForSelector(tc.selector, common.NewFrameWaitForSelectorOptions(timeout))
 			tc.errAssert(t, err)
 		})
 	}
@@ -1518,7 +1522,7 @@ func TestPageThrottleNetwork(t *testing.T) {
 
 			// result selector only appears once the page gets a response
 			// from the async ping request.
-			_, err = page.WaitForSelector(selector, nil)
+			_, err = page.WaitForSelector(selector, common.NewFrameWaitForSelectorOptions(page.MainFrame().Timeout()))
 			require.NoError(t, err)
 
 			resp, err := page.InnerText(selector, nil)
@@ -1589,7 +1593,7 @@ func performPingTest(t *testing.T, tb *testBrowser, page *common.Page, iteration
 
 		// result selector only appears once the page gets a response
 		// from the async ping request.
-		_, err = page.WaitForSelector(selector, nil)
+		_, err = page.WaitForSelector(selector, common.NewFrameWaitForSelectorOptions(page.MainFrame().Timeout()))
 		require.NoError(t, err)
 
 		ms += time.Since(start).Abs().Milliseconds()

--- a/internal/js/modules/k6/browser/tests/setinputfiles_test.go
+++ b/internal/js/modules/k6/browser/tests/setinputfiles_test.go
@@ -39,7 +39,7 @@ func TestSetInputFiles(t *testing.T) {
 		return page.SetInputFiles("#upload", files, common.NewFrameSetInputFilesOptions(page.MainFrame().Timeout()))
 	}
 	defaultTestElementHandle := func(tb *testBrowser, page *common.Page, files sobek.Value) error {
-		handle, err := page.WaitForSelector("#upload", tb.toSobekValue(nil))
+		handle, err := page.WaitForSelector("#upload", common.NewFrameWaitForSelectorOptions(page.MainFrame().Timeout()))
 		assert.NoError(t, err)
 		return handle.SetInputFiles(files, tb.toSobekValue(nil))
 	}
@@ -127,7 +127,7 @@ func TestSetInputFiles(t *testing.T) {
 					return page.SetInputFiles("#button1", files, common.NewFrameSetInputFilesOptions(page.MainFrame().Timeout()))
 				},
 				func(tb *testBrowser, page *common.Page, files sobek.Value) error {
-					handle, err := page.WaitForSelector("#button1", tb.toSobekValue(nil))
+					handle, err := page.WaitForSelector("#button1", common.NewFrameWaitForSelectorOptions(page.MainFrame().Timeout()))
 					assert.NoError(t, err)
 					return handle.SetInputFiles(files, tb.toSobekValue(nil))
 				},
@@ -150,7 +150,7 @@ func TestSetInputFiles(t *testing.T) {
 					return page.SetInputFiles("#textinput", files, common.NewFrameSetInputFilesOptions(page.MainFrame().Timeout()))
 				},
 				func(tb *testBrowser, page *common.Page, files sobek.Value) error {
-					handle, err := page.WaitForSelector("#textinput", tb.toSobekValue(nil))
+					handle, err := page.WaitForSelector("#textinput", common.NewFrameWaitForSelectorOptions(page.MainFrame().Timeout()))
 					assert.NoError(t, err)
 					return handle.SetInputFiles(files, tb.toSobekValue(nil))
 				},


### PR DESCRIPTION
## What?

Same as https://github.com/grafana/k6/pull/4522 this PR fixes usages of sobek.Value inside go routines which could lead to the race.

It fixes this for the following APIs:
* Type
* Uncheck
* WaitForLoadState
* WaitForSelector

## Why?

https://github.com/grafana/k6/issues/4085

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
