### PR TITLE
Clone Bundle's URLs into lib.Archive

### DIFF
--- a/internal/js/bundle.go
+++ b/internal/js/bundle.go
@@ -164,13 +164,16 @@ func NewBundleFromArchive(piState *lib.TestPreInitState, arc *lib.Archive) (*Bun
 }
 
 func (b *Bundle) makeArchive() *lib.Archive {
+	clonedSourceDataURL, _ := url.Parse(b.sourceData.URL.String())
+	clonedPwdURL, _ := url.Parse(b.pwd.String())
+
 	arc := &lib.Archive{
 		Type:              "js",
 		Filesystems:       b.filesystems,
 		Options:           b.Options,
-		FilenameURL:       b.sourceData.URL,
+		FilenameURL:       clonedSourceDataURL,
 		Data:              b.sourceData.Data,
-		PwdURL:            b.pwd,
+		PwdURL:            clonedPwdURL,
 		Env:               make(map[string]string, len(b.preInitState.RuntimeOptions.Env)),
 		CompatibilityMode: b.CompatibilityMode.String(),
 		K6Version:         consts.Version,


### PR DESCRIPTION
## What?

It modifies the `Bundle.makeArchive` function so `Bundle`'s URLs (pointers) aren't directly reused by the `lib.Archive` it constructs, but cloned ("deep copy") and set.

## Why?

Because the `Archive.Write` method normalizes and anonymizes these URLs to prevent certain details (like OS's user, HOME dir, etc) to be leaked to the GCk6, but we not always want these modifications to be propagated to the `Bundle`'s URLs - e.g. when running the test script locally: `k6 cloud ... --local-execution`.

## Review notes

A better explanation of why this (#4168) happens is because the process goes as follows:
1. The test is loaded and configured, which includes the initialization of the first runner, and thus the cache of the module resolutions.
2. The process of creating the test remotely also involves the creation of the archive, which modifies the URLs, as described above.
3. Later, when the test is executed, the module resolution fails because it points to a different, non-cached, import path, due to the step 2.

Note this started to fail since we introduced this change because the old way of doing the same was `k6 run -o cloud`, and in that case we were not sending any archive at all. Now, the archive is an opt-out "feature", enabled by default.

Also, note that another approach to fix this issue (#4168) could consist on something like "reinstantiating" the first runner, so the "new paths" are cached again, and/or to somehow make it all work with the normalized and anonymized URLs.

However, that sounded a bit counterintuitive to me, plus I suspected that may cause other issue later (like k6 errors/warning not pointing to the correct paths locally, etc). 

While doing a "deep copy" of these URLs to "isolate" changes on `Archive`s sounded good to me, because I could not  think of any scenario where that could be a problem, and logically it kinda makes sense to make the `Archive` "standalone".

### Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Fixes https://github.com/grafana/k6/issues/4168