### PR TITLE
Support comma in tag values through cli flag

### DIFF
--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -64,7 +64,7 @@ func optionFlagSet() *pflag.FlagSet {
 		metrics.DefaultSystemTagSet.SetString(),
 	)
 	flags.StringSlice("system-tags", nil, systemTagsCliHelpText)
-	flags.StringSlice("tag", nil, "add a `tag` to be applied to all samples, as `[name]=[value]`")
+	flags.StringArray("tag", nil, "add a `tag` to be applied to all samples, as `[name]=[value]`")
 	flags.String("console-output", "", "redirects the console logging to the provided output file")
 	flags.Bool("discard-response-bodies", false, "Read but don't process or save HTTP response bodies")
 	flags.String("local-ips", "", "Client IP Ranges and/or CIDRs from which each VU will be making requests, "+
@@ -210,7 +210,7 @@ func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 		opts.SummaryTimeUnit = null.StringFrom(summaryTimeUnit)
 	}
 
-	runTags, err := flags.GetStringSlice("tag")
+	runTags, err := flags.GetStringArray("tag")
 	if err != nil {
 		return opts, err
 	}

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -1641,7 +1641,7 @@ func TestRunTags(t *testing.T) {
 
 	ts := getSingleFileTestState(t, script, []string{
 		"-u", "2", "--log-output=stdout", "--out", "json=results.json",
-		"--tag", "foo=bar", "--tag", "test=mest", "--tag", "over=written",
+		"--tag", "foo=bar", "--tag", "test=mest", "--tag", "over=written, something",
 	}, 0)
 	ts.Env["K6_ITERATIONS"] = "3"
 	ts.Env["K6_INSECURE_SKIP_TLS_VERIFY"] = "true"
@@ -1653,7 +1653,7 @@ func TestRunTags(t *testing.T) {
 	jsonResults, err := fsext.ReadFile(ts.FS, "results.json")
 	require.NoError(t, err)
 
-	expTags := map[string]string{"foo": "bar", "test": "mest", "over": "written", "scenario": "default"}
+	expTags := map[string]string{"foo": "bar", "test": "mest", "over": "written, something", "scenario": "default"}
 	assert.Equal(t, float64(3), sum(getSampleValues(t, jsonResults, "iterations", expTags)))
 	assert.Equal(t, 3, len(getSampleValues(t, jsonResults, "iteration_duration", expTags)))
 	assert.Less(t, float64(0), sum(getSampleValues(t, jsonResults, "data_received", expTags)))


### PR DESCRIPTION
## What?

Support setting tags which values contain commas through cli flags

## Why?

It seems very strange that this isn't supported at all on the cli, but you can do it through options. 

This is a breaking change as before you can do `--tag one=value,two=value`  which will produce 2 flags one with key `one`, the other with `two`. 

This will now produce only 1 tag. 

I would argue though that the alternative is to forbid commas in the values. And that seems like a bigger breaking change. 

Given our documentation and help we have never documented that you can put two tags with the same flag, so :shrug: 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have added tests for my changes.
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
