### PR TITLE
Run WPT tests with `-race` and fix race in ReadableStream.cancel

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -24,10 +24,10 @@ jobs:
           set -x
           cd internal/js/modules/k6/experimental/streams/tests
           sh checkout.sh
-          go test ../... -tags=wpt
+          go test -race ../... -tags=wpt
       - name: Run Webcrypto Tests
         run: |
           set -x
           cd internal/js/modules/k6/webcrypto/tests
           sh checkout.sh
-          go test ./... -tags=wpt
+          go test -race ./... -tags=wpt


### PR DESCRIPTION
## What?

Run wpt tests with -race and fix race in ReadableStream.cancel

## Why?

So we catch race conditions 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
