### PR TITLE
examples/browser/throttle.js make it lighter to pass in MacOS CI

### DIFF
--- a/examples/browser/throttle.js
+++ b/examples/browser/throttle.js
@@ -19,6 +19,7 @@ export const options = {
         },
       },
       exec: 'networkThrottled',
+      startTime: "10s",
     },
     cpuThrottled: {
       executor: 'shared-iterations',
@@ -28,6 +29,7 @@ export const options = {
         },
       },
       exec: 'cpuThrottled',
+      startTime: "5s",
     },
   },
   thresholds: {


### PR DESCRIPTION
## What?

Try to make the throttle.js lighter to pass on MacOS CI

## Why?
MacOS github action runners are ... not very performant, and it seems that they do not do well with running 3 browser at the same time.

This PR spreads the three browser executions in time so it hopefully will not fail on the normal (not throttled one) being too slow every once in a while 
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Similar to https://github.com/grafana/k6/pull/4529 