### PR TITLE
Try to make TestConstantArrivalRateRunCorrectRate less flaky

### DIFF
--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -88,8 +88,13 @@ func TestConstantArrivalRateRunCorrectRate(t *testing.T) {
 		// check that we got around the amount of VU iterations as we would expect
 		var totalCount int64
 
-		for i := 0; i < 5; i++ {
-			time.Sleep(time.Second)
+		i := 5
+		ticker := time.NewTicker(time.Second)
+		for range ticker.C {
+			i--
+			if i == 0 {
+				break
+			}
 			currentCount := atomic.SwapInt64(&count, 0)
 			totalCount += currentCount
 			// We have a relatively relaxed constraint here, but we also check


### PR DESCRIPTION
## What?


The test is testing how constant arrival rate is starting iterations over time. But it used time.Sleep of 1 second which means that it doesn't actually check every second it checks and then it waits for 1 second and then again.

This seems to move enough, especially on windows, that it sometimes fails.

This PR uses time.Ticker to make it check every second, making it more likely that it won't drift.

## Why?
Flaky test bad
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
