### PR TITLE
Add true color detection for k6 banner

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -43,7 +43,7 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 	rootCmd := &cobra.Command{
 		Use:               gs.BinaryName,
 		Short:             "a next-generation load generator",
-		Long:              "\n" + getBanner(gs.Flags.NoColor || !gs.Stdout.IsTTY),
+		Long:              "\n" + getBanner(gs.Flags.NoColor || !gs.Stdout.IsTTY, isTrueColor(gs.Env)),
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 		PersistentPreRunE: c.persistentPreRunE,


### PR DESCRIPTION
## What?

Only color the k6 logo with `RGB(0xFF, 0x67, 0x1d)` if the terminal supports TrueColor. Otherwise, it picks k6 v0.54.0's yellow color. This change should cover most cases, but we can still improve it later. It feels safer to fall back to a 256-color scheme rather than using TrueColor from the get-go.

## Why?

#4542

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- #4542