### PR TITLE
Add doc updates checklist to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,8 +23,8 @@ and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 **Please do not merge this PR until the following items are filled out.**
 
 - [ ] I have added the correct milestone and labels to the PR.
-- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): _link_
-- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): _link_
+- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER
+- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER
 - [ ] I have updated the release notes: _link_
 
 <!-- - [ ] Any other relevant item -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,9 +22,9 @@ and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 
 **Please do not merge this PR until the following items are filled out.**
 
-- [ ] I have added the correct milestone to the PR.
-- [ ] I have updated the k6-documentation: _link_
-- [ ] I have updated the TypeScript definitions: _link_
+- [ ] I have added the correct milestone and labels to the PR.
+- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): _link_
+- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): _link_
 - [ ] I have updated the release notes: _link_
 
 <!-- - [ ] Any other relevant item -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,10 +14,19 @@ and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 -->
 
 - [ ] I have performed a self-review of my code.
-- [ ] I have added tests for my changes.
-- [ ] I have run linter locally (`make lint`) and all checks pass.
-- [ ] I have run tests locally (`make tests`) and all tests pass.
 - [ ] I have commented on my code, particularly in hard-to-understand areas.
+- [ ] I have added tests for my changes.
+- [ ] I have run linter and tests locally (`make check`) and all pass.
+
+## Checklist: Documentation (only for k6 maintainers and if relevant)
+
+**Please do not merge this PR until the following items are filled out.**
+
+- [ ] I have added the correct milestone to the PR.
+- [ ] I have updated the k6-documentation: _link_
+- [ ] I have updated the TypeScript definitions: _link_
+- [ ] I have updated the release notes: _link_
+
 <!-- - [ ] Any other relevant item -->
 
 ## Related PR(s)/Issue(s)


### PR DESCRIPTION
## What?

Adds the documentation updates checklist to the PR template.

## Why?

To streamline the release process and reduce mistakes.

## Notes

* **Ownership:** The PR owner is responsible for making all documentation updates.
* **Mandatory documentation updates:** To prevent documentation from being overlooked, reduce mistakes, and streamline the release process (avoiding bottlenecks).
* **Direct documentation updates:** To reduce mistakes and avoid having to keep a to-do list throughout the cycle.
* **External contributor PRs:** The reviewers are responsible for updating the documentation (bonus: request updates from the contributor if possible).