### PR TITLE
Fix sobek values for mouse and keyboard

### DIFF
--- a/internal/js/modules/k6/browser/browser/keyboard_mapping.go
+++ b/internal/js/modules/k6/browser/browser/keyboard_mapping.go
@@ -21,25 +21,23 @@ func mapKeyboard(vu moduleVU, kb *common.Keyboard) mapping {
 				return nil, kb.Up(key) //nolint:wrapcheck
 			})
 		},
-		"press": func(key string, opts sobek.Value) *sobek.Promise {
+		"press": func(key string, opts sobek.Value) (*sobek.Promise, error) {
+			kbopts, err := exportTo[common.KeyboardOptions](vu.Runtime(), opts)
+			if err != nil {
+				return nil, fmt.Errorf("parsing keyboard options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				kbopts, err := exportTo[common.KeyboardOptions](vu.Runtime(), opts)
-				if err != nil {
-					return nil, fmt.Errorf("parsing keyboard options: %w", err)
-				}
 				return nil, kb.Press(key, kbopts)
-			})
+			}), nil
 		},
-		"type": func(text string, opts sobek.Value) *sobek.Promise {
+		"type": func(text string, opts sobek.Value) (*sobek.Promise, error) {
+			kbopts, err := exportTo[common.KeyboardOptions](vu.Runtime(), opts)
+			if err != nil {
+				return nil, fmt.Errorf("parsing keyboard options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				kbopts, err := exportTo[common.KeyboardOptions](vu.Runtime(), opts)
-				if err != nil {
-					return nil, fmt.Errorf("parsing keyboard options: %w", err)
-				}
 				return nil, kb.Type(text, kbopts)
-			})
+			}), nil
 		},
 		"insertText": func(text string) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/mouse_mapping.go
+++ b/internal/js/modules/k6/browser/browser/mouse_mapping.go
@@ -1,6 +1,8 @@
 package browser
 
 import (
+	"fmt"
+
 	"github.com/grafana/sobek"
 
 	"go.k6.io/k6/internal/js/modules/k6/browser/common"
@@ -9,35 +11,50 @@ import (
 
 func mapMouse(vu moduleVU, m *common.Mouse) mapping {
 	return mapping{
-		"click": func(x float64, y float64, opts sobek.Value) *sobek.Promise {
+		"click": func(x float64, y float64, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewMouseClickOptions()
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing mouse click options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return nil, m.Click(x, y, opts) //nolint:wrapcheck
-			})
+				return nil, m.Click(x, y, popts) //nolint:wrapcheck
+			}), nil
 		},
-		"dblClick": func(x float64, y float64, opts sobek.Value) *sobek.Promise {
+		"dblClick": func(x float64, y float64, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewMouseDblClickOptions()
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing double click options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return nil, m.DblClick(x, y, opts) //nolint:wrapcheck
-			})
+				return nil, m.DblClick(x, y, popts) //nolint:wrapcheck
+			}), nil
 		},
-		"down": func(opts sobek.Value) *sobek.Promise {
+		"down": func(opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewMouseDownUpOptions()
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing mouse down options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return nil, m.Down(opts) //nolint:wrapcheck
-			})
+				return nil, m.Down(popts) //nolint:wrapcheck
+			}), nil
 		},
-		"up": func(opts sobek.Value) *sobek.Promise {
+		"up": func(opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewMouseDownUpOptions()
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing mouse down options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return nil, m.Up(opts) //nolint:wrapcheck
-			})
+				return nil, m.Up(popts) //nolint:wrapcheck
+			}), nil
 		},
-		"move": func(x float64, y float64, opts sobek.Value) *sobek.Promise {
+		"move": func(x float64, y float64, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewMouseMoveOptions()
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing mouse move options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				// TODO(@mstoykov): don't use sobek Values in a separate goroutine
-				return nil, m.Move(x, y, opts) //nolint:wrapcheck
-			})
+				return nil, m.Move(x, y, popts) //nolint:wrapcheck
+			}), nil
 		},
 	}
 }

--- a/internal/js/modules/k6/browser/browser/mouse_mapping.go
+++ b/internal/js/modules/k6/browser/browser/mouse_mapping.go
@@ -41,7 +41,7 @@ func mapMouse(vu moduleVU, m *common.Mouse) mapping {
 		"up": func(opts sobek.Value) (*sobek.Promise, error) {
 			popts := common.NewMouseDownUpOptions()
 			if err := popts.Parse(vu.Context(), opts); err != nil {
-				return nil, fmt.Errorf("parsing mouse down options: %w", err)
+				return nil, fmt.Errorf("parsing mouse up options: %w", err)
 			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				return nil, m.Up(popts) //nolint:wrapcheck

--- a/internal/js/modules/k6/browser/common/mouse.go
+++ b/internal/js/modules/k6/browser/common/mouse.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/input"
-	"github.com/grafana/sobek"
 )
 
 // Mouse represents a mouse input device.
@@ -35,12 +34,8 @@ func NewMouse(ctx context.Context, s session, f *Frame, ts *TimeoutSettings, k *
 }
 
 // Click will trigger a series of MouseMove, MouseDown and MouseUp events in the browser.
-func (m *Mouse) Click(x float64, y float64, opts sobek.Value) error {
-	mouseOpts := NewMouseClickOptions()
-	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
-		return fmt.Errorf("parsing mouse click options: %w", err)
-	}
-	if err := m.click(x, y, mouseOpts); err != nil {
+func (m *Mouse) Click(x float64, y float64, opts *MouseClickOptions) error {
+	if err := m.click(x, y, opts); err != nil {
 		return fmt.Errorf("clicking on x:%f y:%f: %w", x, y, err)
 	}
 	return nil
@@ -72,24 +67,16 @@ func (m *Mouse) click(x float64, y float64, opts *MouseClickOptions) error {
 }
 
 // DblClick will trigger Click twice in quick succession.
-func (m *Mouse) DblClick(x float64, y float64, opts sobek.Value) error {
-	mouseOpts := NewMouseDblClickOptions()
-	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
-		return fmt.Errorf("parsing double click options: %w", err)
-	}
-	if err := m.click(x, y, mouseOpts.ToMouseClickOptions()); err != nil {
+func (m *Mouse) DblClick(x float64, y float64, opts *MouseDblClickOptions) error {
+	if err := m.click(x, y, opts.ToMouseClickOptions()); err != nil {
 		return fmt.Errorf("double clicking on x:%f y:%f: %w", x, y, err)
 	}
 	return nil
 }
 
 // Down will trigger a MouseDown event in the browser.
-func (m *Mouse) Down(opts sobek.Value) error {
-	mouseOpts := NewMouseDownUpOptions()
-	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
-		return fmt.Errorf("parsing mouse down options: %w", err)
-	}
-	if err := m.down(mouseOpts); err != nil {
+func (m *Mouse) Down(opts *MouseDownUpOptions) error {
+	if err := m.down(opts); err != nil {
 		return fmt.Errorf("pressing the mouse button on x:%f y:%f: %w", m.x, m.y, err)
 	}
 	return nil
@@ -108,12 +95,8 @@ func (m *Mouse) down(opts *MouseDownUpOptions) error {
 }
 
 // Up will trigger a MouseUp event in the browser.
-func (m *Mouse) Up(opts sobek.Value) error {
-	mouseOpts := NewMouseDownUpOptions()
-	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
-		return fmt.Errorf("parsing mouse up options: %w", err)
-	}
-	if err := m.up(mouseOpts); err != nil {
+func (m *Mouse) Up(opts *MouseDownUpOptions) error {
+	if err := m.up(opts); err != nil {
 		return fmt.Errorf("releasing the mouse button on x:%f y:%f: %w", m.x, m.y, err)
 	}
 	return nil
@@ -133,12 +116,8 @@ func (m *Mouse) up(opts *MouseDownUpOptions) error {
 }
 
 // Move will trigger a MouseMoved event in the browser.
-func (m *Mouse) Move(x float64, y float64, opts sobek.Value) error {
-	mouseOpts := NewMouseMoveOptions()
-	if err := mouseOpts.Parse(m.ctx, opts); err != nil {
-		return fmt.Errorf("parsing mouse move options: %w", err)
-	}
-	if err := m.move(x, y, mouseOpts); err != nil {
+func (m *Mouse) Move(x float64, y float64, opts *MouseMoveOptions) error {
+	if err := m.move(x, y, opts); err != nil {
 		return fmt.Errorf("moving the mouse pointer to x:%f y:%f: %w", x, y, err)
 	}
 	return nil

--- a/internal/js/modules/k6/browser/tests/mouse_test.go
+++ b/internal/js/modules/k6/browser/tests/mouse_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/internal/js/modules/k6/browser/common"
 )
 
 func TestMouseActions(t *testing.T) {
@@ -28,7 +29,7 @@ func TestMouseActions(t *testing.T) {
 
 		// Simulate a click at the button coordinates
 		box := button.BoundingBox()
-		require.NoError(t, m.Click(box.X, box.Y, nil))
+		require.NoError(t, m.Click(box.X, box.Y, common.NewMouseClickOptions()))
 
 		// Verify the button's text changed
 		text, ok, err := button.TextContent()
@@ -61,7 +62,7 @@ func TestMouseActions(t *testing.T) {
 		box := button.BoundingBox()
 
 		// Simulate a double click at the button coordinates
-		require.NoError(t, m.DblClick(box.X, box.Y, nil))
+		require.NoError(t, m.DblClick(box.X, box.Y, common.NewMouseDblClickOptions()))
 
 		// Verify the button's text changed
 		text, ok, err := button.TextContent()
@@ -99,7 +100,7 @@ func TestMouseActions(t *testing.T) {
 
 		// Simulate mouse move within the div
 		box := area.BoundingBox()
-		require.NoError(t, m.Move(box.X+50, box.Y+50, nil)) // Move to the center of the div
+		require.NoError(t, m.Move(box.X+50, box.Y+50, common.NewMouseMoveOptions())) // Move to the center of the div
 		text, ok, err := area.TextContent()
 		require.NoError(t, err)
 		require.True(t, ok)
@@ -126,13 +127,13 @@ func TestMouseActions(t *testing.T) {
 		require.NoError(t, err)
 
 		box := button.BoundingBox()
-		require.NoError(t, m.Move(box.X, box.Y, nil))
-		require.NoError(t, m.Down(nil))
+		require.NoError(t, m.Move(box.X, box.Y, common.NewMouseMoveOptions()))
+		require.NoError(t, m.Down(common.NewMouseDownUpOptions()))
 		text, ok, err := button.TextContent()
 		require.NoError(t, err)
 		require.True(t, ok)
 		assert.Equal(t, "Mouse Down", text)
-		require.NoError(t, m.Up(nil))
+		require.NoError(t, m.Up(common.NewMouseDownUpOptions()))
 		text, ok, err = button.TextContent()
 		require.NoError(t, err)
 		require.True(t, ok)


### PR DESCRIPTION
## What?

Fixes Sobek value usage for `Mouse` and `Keyboard`.

## Why?

Fixing potential race conditions.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make tests`) and all tests pass.
- [x] I have commented on my code, particularly in hard-to-understand areas.

## Related PR(s)/Issue(s)

- #4521
- #4219
- #4565