### PR TITLE
Fix sobek values for `ElementHandle`

### DIFF
--- a/internal/js/modules/k6/browser/browser/element_handle_mapping.go
+++ b/internal/js/modules/k6/browser/browser/element_handle_mapping.go
@@ -10,7 +10,7 @@ import (
 )
 
 // mapElementHandle to the JS module.
-func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:gocognit,funlen
+func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:gocognit,funlen,cyclop
 	rt := vu.Runtime()
 	maps := mapping{
 		"boundingBox": func() *sobek.Promise {
@@ -18,10 +18,14 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 				return eh.BoundingBox(), nil
 			})
 		},
-		"check": func(opts sobek.Value) *sobek.Promise {
+		"check": func(opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleSetCheckedOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing check options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.Check(opts) //nolint:wrapcheck
-			})
+				return nil, eh.Check(popts) //nolint:wrapcheck
+			}), nil
 		},
 		"click": func(opts sobek.Value) (*sobek.Promise, error) {
 			popts := common.NewElementHandleClickOptions(eh.Timeout())
@@ -43,20 +47,28 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 				return mapFrame(vu, f), nil
 			})
 		},
-		"dblclick": func(opts sobek.Value) *sobek.Promise {
+		"dblclick": func(opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleDblclickOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing element double click options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.Dblclick(opts) //nolint:wrapcheck
-			})
+				return nil, eh.Dblclick(popts) //nolint:wrapcheck
+			}), nil
 		},
 		"dispatchEvent": func(typ string, eventInit sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				return nil, eh.DispatchEvent(typ, exportArg(eventInit)) //nolint:wrapcheck
 			})
 		},
-		"fill": func(value string, opts sobek.Value) *sobek.Promise {
+		"fill": func(value string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleBaseOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing element fill options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.Fill(value, opts) //nolint:wrapcheck
-			})
+				return nil, eh.Fill(value, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"focus": func() *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
@@ -75,10 +87,14 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 				return s, nil
 			})
 		},
-		"hover": func(opts sobek.Value) *sobek.Promise {
+		"hover": func(opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleHoverOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing element hover options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.Hover(opts) //nolint:wrapcheck
-			})
+				return nil, eh.Hover(popts) //nolint:wrapcheck
+			}), nil
 		},
 		"innerHTML": func() *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
@@ -90,10 +106,14 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 				return eh.InnerText() //nolint:wrapcheck
 			})
 		},
-		"inputValue": func(opts sobek.Value) *sobek.Promise {
+		"inputValue": func(opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleBaseOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing element input value options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return eh.InputValue(opts) //nolint:wrapcheck
-			})
+				return eh.InputValue(popts) //nolint:wrapcheck
+			}), nil
 		},
 		"isChecked": func() *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
@@ -134,10 +154,14 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 				return mapFrame(vu, f), nil
 			})
 		},
-		"press": func(key string, opts sobek.Value) *sobek.Promise {
+		"press": func(key string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandlePressOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing press %q options: %w", key, err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.Press(key, opts) //nolint:wrapcheck
-			})
+				return nil, eh.Press(key, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"screenshot": func(opts sobek.Value) (*sobek.Promise, error) {
 			popts := common.NewElementHandleScreenshotOptions(eh.Timeout())
@@ -156,10 +180,14 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 				return &ab, nil
 			}), nil
 		},
-		"scrollIntoViewIfNeeded": func(opts sobek.Value) *sobek.Promise {
+		"scrollIntoViewIfNeeded": func(opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleBaseOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing scrollIntoViewIfNeeded options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.ScrollIntoViewIfNeeded(opts) //nolint:wrapcheck
-			})
+				return nil, eh.ScrollIntoViewIfNeeded(popts) //nolint:wrapcheck
+			}), nil
 		},
 		"selectOption": func(values sobek.Value, opts sobek.Value) (*sobek.Promise, error) {
 			convValues, err := common.ConvertSelectOptionValues(vu.Runtime(), values)
@@ -170,20 +198,36 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 				return eh.SelectOption(convValues, opts) //nolint:wrapcheck
 			}), nil
 		},
-		"selectText": func(opts sobek.Value) *sobek.Promise {
+		"selectText": func(opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleBaseOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing selectText options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.SelectText(opts) //nolint:wrapcheck
-			})
+				return nil, eh.SelectText(popts) //nolint:wrapcheck
+			}), nil
 		},
-		"setChecked": func(checked bool, opts sobek.Value) *sobek.Promise {
+		"setChecked": func(checked bool, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleSetCheckedOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing setChecked options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.SetChecked(checked, opts) //nolint:wrapcheck
-			})
+				return nil, eh.SetChecked(checked, popts) //nolint:wrapcheck
+			}), nil
 		},
-		"setInputFiles": func(files sobek.Value, opts sobek.Value) *sobek.Promise {
+		"setInputFiles": func(files sobek.Value, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleSetInputFilesOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing setInputFiles options: %w", err)
+			}
+			var pfiles common.Files
+			if err := pfiles.Parse(vu.Context(), files); err != nil {
+				return nil, fmt.Errorf("parsing setInputFiles parameter: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.SetInputFiles(files, opts) //nolint:wrapcheck
-			})
+				return nil, eh.SetInputFiles(&pfiles, popts) //nolint:wrapcheck
+			}), nil
 		},
 		"tap": func(opts sobek.Value) (*sobek.Promise, error) {
 			popts := common.NewElementHandleTapOptions(eh.Timeout())
@@ -206,29 +250,45 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 				return s, nil
 			})
 		},
-		"type": func(text string, opts sobek.Value) *sobek.Promise {
+		"type": func(text string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleTypeOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing type options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.Type(text, opts) //nolint:wrapcheck
-			})
+				return nil, eh.Type(text, popts) //nolint:wrapcheck
+			}), nil
 		},
-		"uncheck": func(opts sobek.Value) *sobek.Promise {
+		"uncheck": func(opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleSetCheckedOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing uncheck options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.Uncheck(opts) //nolint:wrapcheck
-			})
+				return nil, eh.Uncheck(popts) //nolint:wrapcheck
+			}), nil
 		},
-		"waitForElementState": func(state string, opts sobek.Value) *sobek.Promise {
+		"waitForElementState": func(state string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewElementHandleWaitForElementStateOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing waitForElementState options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return nil, eh.WaitForElementState(state, opts) //nolint:wrapcheck
-			})
+				return nil, eh.WaitForElementState(state, popts) //nolint:wrapcheck
+			}), nil
 		},
-		"waitForSelector": func(selector string, opts sobek.Value) *sobek.Promise {
+		"waitForSelector": func(selector string, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameWaitForSelectorOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing waitForSelector %q options: %w", selector, err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				eh, err := eh.WaitForSelector(selector, opts)
+				eh, err := eh.WaitForSelector(selector, popts)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}
 				return mapElementHandle(vu, eh), nil
-			})
+			}), nil
 		},
 	}
 	maps["$"] = func(selector string) *sobek.Promise {

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -237,7 +237,8 @@ func (h *ElementHandle) dblclick(p *Position, opts *MouseClickOptions) error {
 	return h.frame.page.Mouse.click(p.X, p.Y, opts)
 }
 
-func (h *ElementHandle) defaultTimeout() time.Duration {
+// DefaultTimeout returns the default timeout for this element handle.
+func (h *ElementHandle) DefaultTimeout() time.Duration {
 	return h.frame.manager.timeoutSettings.timeout()
 }
 
@@ -803,7 +804,7 @@ func (h *ElementHandle) ContentFrame() (*Frame, error) {
 
 // Dblclick scrolls element into view and double clicks on the element.
 func (h *ElementHandle) Dblclick(opts sobek.Value) error {
-	popts := NewElementHandleDblclickOptions(h.defaultTimeout())
+	popts := NewElementHandleDblclickOptions(h.DefaultTimeout())
 	if err := popts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing element double click options: %w", err)
 	}
@@ -826,7 +827,7 @@ func (h *ElementHandle) DispatchEvent(typ string, eventInit any) error {
 	dispatchEvent := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.dispatchEvent(apiCtx, typ, eventInit)
 	}
-	opts := NewElementHandleBaseOptions(h.defaultTimeout())
+	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	dispatchEventAction := h.newAction(
 		[]string{}, dispatchEvent, opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
@@ -841,7 +842,7 @@ func (h *ElementHandle) DispatchEvent(typ string, eventInit any) error {
 
 // Fill types the given value into the element.
 func (h *ElementHandle) Fill(value string, opts sobek.Value) error {
-	popts := NewElementHandleBaseOptions(h.defaultTimeout())
+	popts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	if err := popts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing element fill options: %w", err)
 	}
@@ -867,7 +868,7 @@ func (h *ElementHandle) Focus() error {
 	focus := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return nil, handle.focus(apiCtx, false)
 	}
-	opts := NewElementHandleBaseOptions(h.defaultTimeout())
+	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	focusAction := h.newAction(
 		[]string{}, focus, opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
@@ -886,7 +887,7 @@ func (h *ElementHandle) GetAttribute(name string) (string, bool, error) {
 	getAttribute := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.getAttribute(apiCtx, name)
 	}
-	opts := NewElementHandleBaseOptions(h.defaultTimeout())
+	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	getAttributeAction := h.newAction(
 		[]string{}, getAttribute, opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
@@ -911,7 +912,7 @@ func (h *ElementHandle) GetAttribute(name string) (string, bool, error) {
 
 // Hover scrolls element into view and hovers over its center point.
 func (h *ElementHandle) Hover(opts sobek.Value) error {
-	aopts := NewElementHandleHoverOptions(h.defaultTimeout())
+	aopts := NewElementHandleHoverOptions(h.DefaultTimeout())
 	if err := aopts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing element hover options: %w", err)
 	}
@@ -934,7 +935,7 @@ func (h *ElementHandle) InnerHTML() (string, error) {
 	innerHTML := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.innerHTML(apiCtx)
 	}
-	opts := NewElementHandleBaseOptions(h.defaultTimeout())
+	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	innerHTMLAction := h.newAction(
 		[]string{}, innerHTML, opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
@@ -958,7 +959,7 @@ func (h *ElementHandle) InnerText() (string, error) {
 	innerText := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.innerText(apiCtx)
 	}
-	opts := NewElementHandleBaseOptions(h.defaultTimeout())
+	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	innerTextAction := h.newAction(
 		[]string{}, innerText, opts.Force, opts.NoWaitAfter, opts.Timeout.Abs(),
 	)
@@ -979,7 +980,7 @@ func (h *ElementHandle) InnerText() (string, error) {
 
 // InputValue returns the value of the input element.
 func (h *ElementHandle) InputValue(opts sobek.Value) (string, error) {
-	aopts := NewElementHandleBaseOptions(h.defaultTimeout())
+	aopts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	if err := aopts.Parse(h.ctx, opts); err != nil {
 		return "", fmt.Errorf("parsing element input value options: %w", err)
 	}
@@ -1120,7 +1121,7 @@ func (h *ElementHandle) OwnerFrame() (_ *Frame, rerr error) {
 
 // Press scrolls element into view and presses the given keys.
 func (h *ElementHandle) Press(key string, opts sobek.Value) error {
-	popts := NewElementHandlePressOptions(h.defaultTimeout())
+	popts := NewElementHandlePressOptions(h.DefaultTimeout())
 	if err := popts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing press %q options: %w", key, err)
 	}
@@ -1242,7 +1243,7 @@ func (h *ElementHandle) queryAll(selector string, eval evalFunc) (_ []*ElementHa
 
 // SetChecked checks or unchecks an element.
 func (h *ElementHandle) SetChecked(checked bool, opts sobek.Value) error {
-	popts := NewElementHandleSetCheckedOptions(h.defaultTimeout())
+	popts := NewElementHandleSetCheckedOptions(h.DefaultTimeout())
 	if err := popts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing setChecked options: %w", err)
 	}
@@ -1324,7 +1325,7 @@ func (h *ElementHandle) Screenshot(
 
 // ScrollIntoViewIfNeeded scrolls element into view if needed.
 func (h *ElementHandle) ScrollIntoViewIfNeeded(opts sobek.Value) error {
-	aopts := NewElementHandleBaseOptions(h.defaultTimeout())
+	aopts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	if err := aopts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing scrollIntoViewIfNeeded options: %w", err)
 	}
@@ -1341,7 +1342,7 @@ func (h *ElementHandle) ScrollIntoViewIfNeeded(opts sobek.Value) error {
 
 // SelectOption selects the options matching the given values.
 func (h *ElementHandle) SelectOption(values []any, opts sobek.Value) ([]string, error) {
-	aopts := NewElementHandleBaseOptions(h.defaultTimeout())
+	aopts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	if err := aopts.Parse(h.ctx, opts); err != nil {
 		return nil, fmt.Errorf("parsing selectOption options: %w", err)
 	}
@@ -1368,7 +1369,7 @@ func (h *ElementHandle) SelectOption(values []any, opts sobek.Value) ([]string, 
 
 // SelectText selects the text of the element.
 func (h *ElementHandle) SelectText(opts sobek.Value) error {
-	aopts := NewElementHandleBaseOptions(h.defaultTimeout())
+	aopts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	if err := aopts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing selectText options: %w", err)
 	}
@@ -1389,7 +1390,7 @@ func (h *ElementHandle) SelectText(opts sobek.Value) error {
 
 // SetInputFiles sets the given files into the input file element.
 func (h *ElementHandle) SetInputFiles(files sobek.Value, opts sobek.Value) error {
-	aopts := NewElementHandleSetInputFilesOptions(h.defaultTimeout())
+	aopts := NewElementHandleSetInputFilesOptions(h.DefaultTimeout())
 	if err := aopts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing setInputFiles options: %w", err)
 	}
@@ -1462,7 +1463,7 @@ func (h *ElementHandle) TextContent() (string, bool, error) {
 	textContent := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.textContent(apiCtx)
 	}
-	opts := NewElementHandleBaseOptions(h.defaultTimeout())
+	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	textContentAction := h.newAction(
 		[]string{}, textContent, opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
@@ -1487,12 +1488,12 @@ func (h *ElementHandle) TextContent() (string, bool, error) {
 // Timeout will return the default timeout or the one set by the user.
 // It's an internal method not to be exposed as a JS API.
 func (h *ElementHandle) Timeout() time.Duration {
-	return h.defaultTimeout()
+	return h.DefaultTimeout()
 }
 
 // Type scrolls element into view, focuses element and types text.
 func (h *ElementHandle) Type(text string, opts sobek.Value) error {
-	popts := NewElementHandleTypeOptions(h.defaultTimeout())
+	popts := NewElementHandleTypeOptions(h.DefaultTimeout())
 	if err := popts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing type options: %w", err)
 	}
@@ -1514,7 +1515,7 @@ func (h *ElementHandle) Type(text string, opts sobek.Value) error {
 
 // WaitForElementState waits for the element to reach the given state.
 func (h *ElementHandle) WaitForElementState(state string, opts sobek.Value) error {
-	popts := NewElementHandleWaitForElementStateOptions(h.defaultTimeout())
+	popts := NewElementHandleWaitForElementStateOptions(h.DefaultTimeout())
 	if err := popts.Parse(h.ctx, opts); err != nil {
 		return fmt.Errorf("parsing waitForElementState options: %w", err)
 	}
@@ -1528,7 +1529,7 @@ func (h *ElementHandle) WaitForElementState(state string, opts sobek.Value) erro
 
 // WaitForSelector waits for the selector to appear in the DOM.
 func (h *ElementHandle) WaitForSelector(selector string, opts sobek.Value) (*ElementHandle, error) {
-	parsedOpts := NewFrameWaitForSelectorOptions(h.defaultTimeout())
+	parsedOpts := NewFrameWaitForSelectorOptions(h.DefaultTimeout())
 	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
 		return nil, fmt.Errorf("parsing waitForSelector %q options: %w", selector, err)
 	}

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -803,17 +803,12 @@ func (h *ElementHandle) ContentFrame() (*Frame, error) {
 }
 
 // Dblclick scrolls element into view and double clicks on the element.
-func (h *ElementHandle) Dblclick(opts sobek.Value) error {
-	popts := NewElementHandleDblclickOptions(h.DefaultTimeout())
-	if err := popts.Parse(h.ctx, opts); err != nil {
-		return fmt.Errorf("parsing element double click options: %w", err)
-	}
-
+func (h *ElementHandle) Dblclick(opts *ElementHandleDblclickOptions) error {
 	dblclick := func(_ context.Context, handle *ElementHandle, p *Position) (any, error) {
-		return nil, handle.dblclick(p, popts.ToMouseClickOptions())
+		return nil, handle.dblclick(p, opts.ToMouseClickOptions())
 	}
-	dblclickAction := h.newPointerAction(dblclick, &popts.ElementHandleBasePointerOptions)
-	if _, err := call(h.ctx, dblclickAction, popts.Timeout); err != nil {
+	dblclickAction := h.newPointerAction(dblclick, &opts.ElementHandleBasePointerOptions)
+	if _, err := call(h.ctx, dblclickAction, opts.Timeout); err != nil {
 		return fmt.Errorf("double clicking on element: %w", err)
 	}
 
@@ -841,20 +836,15 @@ func (h *ElementHandle) DispatchEvent(typ string, eventInit any) error {
 }
 
 // Fill types the given value into the element.
-func (h *ElementHandle) Fill(value string, opts sobek.Value) error {
-	popts := NewElementHandleBaseOptions(h.DefaultTimeout())
-	if err := popts.Parse(h.ctx, opts); err != nil {
-		return fmt.Errorf("parsing element fill options: %w", err)
-	}
-
+func (h *ElementHandle) Fill(value string, opts *ElementHandleBaseOptions) error {
 	fill := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return nil, handle.fill(apiCtx, value)
 	}
 	fillAction := h.newAction(
 		[]string{"visible", "enabled", "editable"},
-		fill, popts.Force, popts.NoWaitAfter, popts.Timeout,
+		fill, opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
-	if _, err := call(h.ctx, fillAction, popts.Timeout); err != nil {
+	if _, err := call(h.ctx, fillAction, opts.Timeout); err != nil {
 		return fmt.Errorf("filling element: %w", err)
 	}
 
@@ -911,17 +901,12 @@ func (h *ElementHandle) GetAttribute(name string) (string, bool, error) {
 }
 
 // Hover scrolls element into view and hovers over its center point.
-func (h *ElementHandle) Hover(opts sobek.Value) error {
-	aopts := NewElementHandleHoverOptions(h.DefaultTimeout())
-	if err := aopts.Parse(h.ctx, opts); err != nil {
-		return fmt.Errorf("parsing element hover options: %w", err)
-	}
-
+func (h *ElementHandle) Hover(opts *ElementHandleHoverOptions) error {
 	hover := func(apiCtx context.Context, handle *ElementHandle, p *Position) (any, error) {
 		return nil, handle.hover(apiCtx, p)
 	}
-	hoverAction := h.newPointerAction(hover, &aopts.ElementHandleBasePointerOptions)
-	if _, err := call(h.ctx, hoverAction, aopts.Timeout); err != nil {
+	hoverAction := h.newPointerAction(hover, &opts.ElementHandleBasePointerOptions)
+	if _, err := call(h.ctx, hoverAction, opts.Timeout); err != nil {
 		return fmt.Errorf("hovering on element: %w", err)
 	}
 
@@ -979,17 +964,12 @@ func (h *ElementHandle) InnerText() (string, error) {
 }
 
 // InputValue returns the value of the input element.
-func (h *ElementHandle) InputValue(opts sobek.Value) (string, error) {
-	aopts := NewElementHandleBaseOptions(h.DefaultTimeout())
-	if err := aopts.Parse(h.ctx, opts); err != nil {
-		return "", fmt.Errorf("parsing element input value options: %w", err)
-	}
-
+func (h *ElementHandle) InputValue(opts *ElementHandleBaseOptions) (string, error) {
 	inputValue := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.inputValue(apiCtx)
 	}
-	inputValueAction := h.newAction([]string{}, inputValue, aopts.Force, aopts.NoWaitAfter, aopts.Timeout)
-	v, err := call(h.ctx, inputValueAction, aopts.Timeout)
+	inputValueAction := h.newAction([]string{}, inputValue, opts.Force, opts.NoWaitAfter, opts.Timeout)
+	v, err := call(h.ctx, inputValueAction, opts.Timeout)
 	if err != nil {
 		return "", fmt.Errorf("getting element's input value: %w", err)
 	}
@@ -1120,19 +1100,14 @@ func (h *ElementHandle) OwnerFrame() (_ *Frame, rerr error) {
 }
 
 // Press scrolls element into view and presses the given keys.
-func (h *ElementHandle) Press(key string, opts sobek.Value) error {
-	popts := NewElementHandlePressOptions(h.DefaultTimeout())
-	if err := popts.Parse(h.ctx, opts); err != nil {
-		return fmt.Errorf("parsing press %q options: %w", key, err)
-	}
-
+func (h *ElementHandle) Press(key string, opts *ElementHandlePressOptions) error {
 	press := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return nil, handle.press(apiCtx, key, KeyboardOptions{})
 	}
 	pressAction := h.newAction(
-		[]string{}, press, false, popts.NoWaitAfter, popts.Timeout,
+		[]string{}, press, false, opts.NoWaitAfter, opts.Timeout,
 	)
-	if _, err := call(h.ctx, pressAction, popts.Timeout); err != nil {
+	if _, err := call(h.ctx, pressAction, opts.Timeout); err != nil {
 		return fmt.Errorf("pressing %q on element: %w", key, err)
 	}
 
@@ -1242,17 +1217,12 @@ func (h *ElementHandle) queryAll(selector string, eval evalFunc) (_ []*ElementHa
 }
 
 // SetChecked checks or unchecks an element.
-func (h *ElementHandle) SetChecked(checked bool, opts sobek.Value) error {
-	popts := NewElementHandleSetCheckedOptions(h.DefaultTimeout())
-	if err := popts.Parse(h.ctx, opts); err != nil {
-		return fmt.Errorf("parsing setChecked options: %w", err)
-	}
-
+func (h *ElementHandle) SetChecked(checked bool, opts *ElementHandleSetCheckedOptions) error {
 	setChecked := func(apiCtx context.Context, handle *ElementHandle, p *Position) (any, error) {
 		return nil, handle.setChecked(apiCtx, checked, p)
 	}
-	setCheckedAction := h.newPointerAction(setChecked, &popts.ElementHandleBasePointerOptions)
-	if _, err := call(h.ctx, setCheckedAction, popts.Timeout); err != nil {
+	setCheckedAction := h.newPointerAction(setChecked, &opts.ElementHandleBasePointerOptions)
+	if _, err := call(h.ctx, setCheckedAction, opts.Timeout); err != nil {
 		return fmt.Errorf("checking element: %w", err)
 	}
 
@@ -1263,13 +1233,13 @@ func (h *ElementHandle) SetChecked(checked bool, opts sobek.Value) error {
 
 // Uncheck scrolls element into view, and if it's an input element of type
 // checkbox that is already checked, clicks on it to mark it as unchecked.
-func (h *ElementHandle) Uncheck(opts sobek.Value) error {
+func (h *ElementHandle) Uncheck(opts *ElementHandleSetCheckedOptions) error {
 	return h.SetChecked(false, opts)
 }
 
 // Check scrolls element into view, and if it's an input element of type
 // checkbox that is unchecked, clicks on it to mark it as checked.
-func (h *ElementHandle) Check(opts sobek.Value) error {
+func (h *ElementHandle) Check(opts *ElementHandleSetCheckedOptions) error {
 	return h.SetChecked(true, opts)
 }
 
@@ -1324,13 +1294,8 @@ func (h *ElementHandle) Screenshot(
 }
 
 // ScrollIntoViewIfNeeded scrolls element into view if needed.
-func (h *ElementHandle) ScrollIntoViewIfNeeded(opts sobek.Value) error {
-	aopts := NewElementHandleBaseOptions(h.DefaultTimeout())
-	if err := aopts.Parse(h.ctx, opts); err != nil {
-		return fmt.Errorf("parsing scrollIntoViewIfNeeded options: %w", err)
-	}
-
-	err := h.waitAndScrollIntoViewIfNeeded(h.ctx, aopts.Force, aopts.NoWaitAfter, aopts.Timeout)
+func (h *ElementHandle) ScrollIntoViewIfNeeded(opts *ElementHandleBaseOptions) error {
+	err := h.waitAndScrollIntoViewIfNeeded(h.ctx, opts.Force, opts.NoWaitAfter, opts.Timeout)
 	if err != nil {
 		return fmt.Errorf("scrolling element into view: %w", err)
 	}
@@ -1368,18 +1333,14 @@ func (h *ElementHandle) SelectOption(values []any, opts sobek.Value) ([]string, 
 }
 
 // SelectText selects the text of the element.
-func (h *ElementHandle) SelectText(opts sobek.Value) error {
-	aopts := NewElementHandleBaseOptions(h.DefaultTimeout())
-	if err := aopts.Parse(h.ctx, opts); err != nil {
-		return fmt.Errorf("parsing selectText options: %w", err)
-	}
+func (h *ElementHandle) SelectText(opts *ElementHandleBaseOptions) error {
 	selectText := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return nil, handle.selectText(apiCtx)
 	}
 	selectTextAction := h.newAction(
-		[]string{}, selectText, aopts.Force, aopts.NoWaitAfter, aopts.Timeout,
+		[]string{}, selectText, opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
-	if _, err := call(h.ctx, selectTextAction, aopts.Timeout); err != nil {
+	if _, err := call(h.ctx, selectTextAction, opts.Timeout); err != nil {
 		return fmt.Errorf("selecting text: %w", err)
 	}
 
@@ -1389,30 +1350,24 @@ func (h *ElementHandle) SelectText(opts sobek.Value) error {
 }
 
 // SetInputFiles sets the given files into the input file element.
-func (h *ElementHandle) SetInputFiles(files sobek.Value, opts sobek.Value) error {
-	aopts := NewElementHandleSetInputFilesOptions(h.DefaultTimeout())
-	if err := aopts.Parse(h.ctx, opts); err != nil {
-		return fmt.Errorf("parsing setInputFiles options: %w", err)
-	}
-
-	actionParam := &Files{}
-
-	if err := actionParam.Parse(h.ctx, files); err != nil {
-		return fmt.Errorf("parsing setInputFiles parameter: %w", err)
-	}
-
+func (h *ElementHandle) SetInputFiles(files *Files, opts *ElementHandleSetInputFilesOptions) error {
 	setInputFiles := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
-		return nil, handle.setInputFiles(apiCtx, actionParam.Payload)
+		return nil, handle.setInputFiles(apiCtx, files)
 	}
-	setInputFilesAction := h.newAction([]string{}, setInputFiles, aopts.Force, aopts.NoWaitAfter, aopts.Timeout)
-	if _, err := call(h.ctx, setInputFilesAction, aopts.Timeout); err != nil {
+	setInputFilesAction := h.newAction([]string{}, setInputFiles, opts.Force, opts.NoWaitAfter, opts.Timeout)
+	if _, err := call(h.ctx, setInputFilesAction, opts.Timeout); err != nil {
 		return fmt.Errorf("setting input files: %w", err)
 	}
 
 	return nil
 }
 
-func (h *ElementHandle) setInputFiles(apiCtx context.Context, payload []*File) error {
+func (h *ElementHandle) setInputFiles(apiCtx context.Context, files *Files) error {
+	// allow clearing the input by passing an empty array
+	var payload []*File
+	if files != nil {
+		payload = files.Payload
+	}
 	fn := `
 		(node, injected, payload) => {
 			return injected.setInputFiles(node, payload);
@@ -1492,19 +1447,14 @@ func (h *ElementHandle) Timeout() time.Duration {
 }
 
 // Type scrolls element into view, focuses element and types text.
-func (h *ElementHandle) Type(text string, opts sobek.Value) error {
-	popts := NewElementHandleTypeOptions(h.DefaultTimeout())
-	if err := popts.Parse(h.ctx, opts); err != nil {
-		return fmt.Errorf("parsing type options: %w", err)
-	}
-
+func (h *ElementHandle) Type(text string, opts *ElementHandleTypeOptions) error {
 	typ := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return nil, handle.typ(apiCtx, text, KeyboardOptions{})
 	}
 	typeAction := h.newAction(
-		[]string{}, typ, false, popts.NoWaitAfter, popts.Timeout,
+		[]string{}, typ, false, opts.NoWaitAfter, opts.Timeout,
 	)
-	if _, err := call(h.ctx, typeAction, popts.Timeout); err != nil {
+	if _, err := call(h.ctx, typeAction, opts.Timeout); err != nil {
 		return fmt.Errorf("typing text %q: %w", text, err)
 	}
 
@@ -1514,12 +1464,8 @@ func (h *ElementHandle) Type(text string, opts sobek.Value) error {
 }
 
 // WaitForElementState waits for the element to reach the given state.
-func (h *ElementHandle) WaitForElementState(state string, opts sobek.Value) error {
-	popts := NewElementHandleWaitForElementStateOptions(h.DefaultTimeout())
-	if err := popts.Parse(h.ctx, opts); err != nil {
-		return fmt.Errorf("parsing waitForElementState options: %w", err)
-	}
-	_, err := h.waitForElementState(h.ctx, []string{state}, popts.Timeout)
+func (h *ElementHandle) WaitForElementState(state string, opts *ElementHandleWaitForElementStateOptions) error {
+	_, err := h.waitForElementState(h.ctx, []string{state}, opts.Timeout)
 	if err != nil {
 		return fmt.Errorf("waiting for element state %q: %w", state, err)
 	}
@@ -1528,13 +1474,8 @@ func (h *ElementHandle) WaitForElementState(state string, opts sobek.Value) erro
 }
 
 // WaitForSelector waits for the selector to appear in the DOM.
-func (h *ElementHandle) WaitForSelector(selector string, opts sobek.Value) (*ElementHandle, error) {
-	parsedOpts := NewFrameWaitForSelectorOptions(h.DefaultTimeout())
-	if err := parsedOpts.Parse(h.ctx, opts); err != nil {
-		return nil, fmt.Errorf("parsing waitForSelector %q options: %w", selector, err)
-	}
-
-	handle, err := h.waitForSelector(h.ctx, selector, parsedOpts)
+func (h *ElementHandle) WaitForSelector(selector string, opts *FrameWaitForSelectorOptions) (*ElementHandle, error) {
+	handle, err := h.waitForSelector(h.ctx, selector, opts)
 	if err != nil {
 		return nil, fmt.Errorf("waiting for selector %q: %w", selector, err)
 	}

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1540,7 +1540,7 @@ func (f *Frame) tap(selector string, opts *FrameTapOptions) error {
 
 func (f *Frame) setInputFiles(selector string, files *Files, opts *FrameSetInputFilesOptions) error {
 	setInputFiles := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
-		return nil, handle.setInputFiles(apiCtx, files.Payload)
+		return nil, handle.setInputFiles(apiCtx, files)
 	}
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict,

--- a/internal/js/modules/k6/browser/tests/element_handle_test.go
+++ b/internal/js/modules/k6/browser/tests/element_handle_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"runtime"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -310,7 +311,7 @@ func TestElementHandleInputValue(t *testing.T) {
 	element, err := p.Query("input")
 	require.NoError(t, err)
 
-	value, err := element.InputValue(nil)
+	value, err := element.InputValue(common.NewElementHandleBaseOptions(element.Timeout()))
 	require.NoError(t, err)
 	require.NoError(t, element.Dispose())
 	assert.Equal(t, value, "hello1", `expected input value "hello1", got %q`, value)
@@ -318,7 +319,7 @@ func TestElementHandleInputValue(t *testing.T) {
 	element, err = p.Query("select")
 	require.NoError(t, err)
 
-	value, err = element.InputValue(nil)
+	value, err = element.InputValue(common.NewElementHandleBaseOptions(element.Timeout()))
 	require.NoError(t, err)
 	require.NoError(t, element.Dispose())
 	assert.Equal(t, value, "hello2", `expected input value "hello2", got %q`, value)
@@ -326,7 +327,7 @@ func TestElementHandleInputValue(t *testing.T) {
 	element, err = p.Query("textarea")
 	require.NoError(t, err)
 
-	value, err = element.InputValue(nil)
+	value, err = element.InputValue(common.NewElementHandleBaseOptions(element.Timeout()))
 	require.NoError(t, err)
 	require.NoError(t, element.Dispose())
 	assert.Equal(t, value, "hello3", `expected input value "hello3", got %q`, value)
@@ -492,9 +493,8 @@ func TestElementHandleWaitForSelector(t *testing.T) {
 		}
 	`)
 	require.NoError(t, err)
-	element, err := root.WaitForSelector(".element-to-appear", tb.toSobekValue(struct {
-		Timeout int64 `js:"timeout"`
-	}{Timeout: 1000}))
+
+	element, err := root.WaitForSelector(".element-to-appear", common.NewFrameWaitForSelectorOptions(time.Second))
 	require.NoError(t, err)
 	require.NotNil(t, element, "expected element to have been found after wait")
 
@@ -514,11 +514,11 @@ func TestElementHandlePress(t *testing.T) {
 	el, err := p.Query("input")
 	require.NoError(t, err)
 
-	require.NoError(t, el.Press("Shift+KeyA", nil))
-	require.NoError(t, el.Press("KeyB", nil))
-	require.NoError(t, el.Press("Shift+KeyC", nil))
+	require.NoError(t, el.Press("Shift+KeyA", common.NewElementHandlePressOptions(el.Timeout())))
+	require.NoError(t, el.Press("KeyB", common.NewElementHandlePressOptions(el.Timeout())))
+	require.NoError(t, el.Press("Shift+KeyC", common.NewElementHandlePressOptions(el.Timeout())))
 
-	v, err := el.InputValue(nil)
+	v, err := el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 	require.NoError(t, err)
 	require.Equal(t, "AbC", v)
 }
@@ -595,13 +595,13 @@ func TestElementHandleSetChecked(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, checked, "expected checkbox to be unchecked")
 
-	err = element.SetChecked(true, nil)
+	err = element.SetChecked(true, common.NewElementHandleSetCheckedOptions(element.Timeout()))
 	require.NoError(t, err)
 	checked, err = element.IsChecked()
 	require.NoError(t, err)
 	assert.True(t, checked, "expected checkbox to be checked")
 
-	err = element.SetChecked(false, nil)
+	err = element.SetChecked(false, common.NewElementHandleSetCheckedOptions(element.Timeout()))
 	require.NoError(t, err)
 	checked, err = element.IsChecked()
 	require.NoError(t, err)

--- a/internal/js/modules/k6/browser/tests/keyboard_test.go
+++ b/internal/js/modules/k6/browser/tests/keyboard_test.go
@@ -47,12 +47,12 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, p.Focus("input", common.NewFrameBaseOptions(p.MainFrame().Timeout())))
 
 		require.NoError(t, kb.Type("Hello World!", common.KeyboardOptions{}))
-		v, err := el.InputValue(nil)
+		v, err := el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 		require.NoError(t, err)
 		require.Equal(t, "Hello World!", v)
 
 		require.NoError(t, kb.Press("Backspace", common.KeyboardOptions{}))
-		v, err = el.InputValue(nil)
+		v, err = el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 		require.NoError(t, err)
 		assert.Equal(t, "Hello World", v)
 	})
@@ -82,7 +82,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, kb.Press("Control+J", common.KeyboardOptions{}))
 		require.NoError(t, kb.Press("Control+k", common.KeyboardOptions{}))
 
-		v, err := el.InputValue(nil)
+		v, err := el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 		require.NoError(t, err)
 		require.Equal(t, "+=@6AbC", v)
 	})
@@ -173,7 +173,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, kb.Press("Shift+b", common.KeyboardOptions{}))
 		require.NoError(t, kb.Press("Shift+C", common.KeyboardOptions{}))
 
-		v, err := el.InputValue(nil)
+		v, err := el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 		require.NoError(t, err)
 		require.Equal(t, "AbC", v)
 
@@ -183,7 +183,7 @@ func TestKeyboardPress(t *testing.T) {
 		}
 		require.NoError(t, kb.Press(metaKey+"+A", common.KeyboardOptions{}))
 		require.NoError(t, kb.Press("Delete", common.KeyboardOptions{}))
-		v, err = el.InputValue(nil)
+		v, err = el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 		require.NoError(t, err)
 		assert.Equal(t, "", v)
 	})
@@ -202,7 +202,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, p.Focus("textarea", common.NewFrameBaseOptions(p.MainFrame().Timeout())))
 
 		require.NoError(t, kb.Type("L+m+KeyN", common.KeyboardOptions{}))
-		v, err := el.InputValue(nil)
+		v, err := el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 		require.NoError(t, err)
 		assert.Equal(t, "L+m+KeyN", v)
 	})
@@ -233,7 +233,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, kb.Up("KeyH"))
 		require.NoError(t, kb.Up("Shift"))
 
-		v, err := el.InputValue(nil)
+		v, err := el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 		require.NoError(t, err)
 		assert.Equal(t, "CdefGH", v)
 	})
@@ -255,7 +255,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, kb.Type("oPqR", common.KeyboardOptions{}))
 		require.NoError(t, kb.Up("Shift"))
 
-		v, err := el.InputValue(nil)
+		v, err := el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 		require.NoError(t, err)
 		assert.Equal(t, "oPqR", v)
 	})
@@ -277,7 +277,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, kb.Press("Enter", common.KeyboardOptions{}))
 		require.NoError(t, kb.Press("Enter", common.KeyboardOptions{}))
 		require.NoError(t, kb.Type("World!", common.KeyboardOptions{}))
-		v, err := el.InputValue(nil)
+		v, err := el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 		require.NoError(t, err)
 		assert.Equal(t, "Hello\n\nWorld!", v)
 	})
@@ -297,7 +297,7 @@ func TestKeyboardPress(t *testing.T) {
 		require.NoError(t, p.Focus("input", common.NewFrameBaseOptions(p.MainFrame().Timeout())))
 
 		require.NoError(t, kb.Type("Hello World!", common.KeyboardOptions{}))
-		v, err := el.InputValue(nil)
+		v, err := el.InputValue(common.NewElementHandleBaseOptions(el.Timeout()))
 		require.NoError(t, err)
 		require.Equal(t, "Hello World!", v)
 

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -562,10 +562,10 @@ func TestPageInputSpecialCharacters(t *testing.T) {
 		`¯\_(ツ)_/¯`,
 	}
 	for _, want := range wants {
-		require.NoError(t, el.Fill("", nil))
-		require.NoError(t, el.Type(want, nil))
+		require.NoError(t, el.Fill("", common.NewElementHandleBaseOptions(common.DefaultTimeout)))
+		require.NoError(t, el.Type(want, common.NewElementHandleTypeOptions(common.DefaultTimeout)))
 
-		got, err := el.InputValue(nil)
+		got, err := el.InputValue(common.NewElementHandleBaseOptions(common.DefaultTimeout))
 		require.NoError(t, err)
 		assert.Equal(t, want, got)
 	}


### PR DESCRIPTION
## What?

Fixes Sobek value usage for `ElementHandle`.

## Why?

Fixing potential race conditions.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER
- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER
- [ ] I have updated the release notes: _link_

## Related PR(s)/Issue(s)

- #4521
- #4219
- #4565