### PR TITLE
browser: Fix ElemenHandle.SelectOption sobek

### DIFF
--- a/internal/js/modules/k6/browser/browser/element_handle_mapping.go
+++ b/internal/js/modules/k6/browser/browser/element_handle_mapping.go
@@ -194,8 +194,12 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 			if err != nil {
 				return nil, fmt.Errorf("parsing select options values: %w", err)
 			}
+			popts := common.NewElementHandleBaseOptions(eh.DefaultTimeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing selectOption options: %w", err)
+			}
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return eh.SelectOption(convValues, opts) //nolint:wrapcheck
+				return eh.SelectOption(convValues, popts) //nolint:wrapcheck
 			}), nil
 		},
 		"selectText": func(opts sobek.Value) (*sobek.Promise, error) {

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -1306,19 +1306,14 @@ func (h *ElementHandle) ScrollIntoViewIfNeeded(opts *ElementHandleBaseOptions) e
 }
 
 // SelectOption selects the options matching the given values.
-func (h *ElementHandle) SelectOption(values []any, opts sobek.Value) ([]string, error) {
-	aopts := NewElementHandleBaseOptions(h.DefaultTimeout())
-	if err := aopts.Parse(h.ctx, opts); err != nil {
-		return nil, fmt.Errorf("parsing selectOption options: %w", err)
-	}
-
+func (h *ElementHandle) SelectOption(values []any, opts *ElementHandleBaseOptions) ([]string, error) {
 	selectOption := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.selectOption(apiCtx, values)
 	}
 	selectOptionAction := h.newAction(
-		[]string{}, selectOption, aopts.Force, aopts.NoWaitAfter, aopts.Timeout,
+		[]string{}, selectOption, opts.Force, opts.NoWaitAfter, opts.Timeout,
 	)
-	selectedOptions, err := call(h.ctx, selectOptionAction, aopts.Timeout)
+	selectedOptions, err := call(h.ctx, selectOptionAction, opts.Timeout)
 	if err != nil {
 		return nil, fmt.Errorf("selecting options: %w", err)
 	}


### PR DESCRIPTION
## What?

Fixes one more Sobek value usage for `ElementHandle`: `SelectOption`.

## Why?

Fixing potential race conditions.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] ~I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER~
- [ ] ~I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER~
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- #4567