### PR TITLE
browser: Add page on request example

### DIFF
--- a/examples/browser/pageon-request.js
+++ b/examples/browser/pageon-request.js
@@ -1,0 +1,25 @@
+import { browser } from 'k6/browser'
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: 'shared-iterations',
+      options: {
+        browser: {
+          type: 'chromium',
+        },
+      },
+    },
+  },
+}
+
+export default async function () {
+  const page = await browser.newPage()
+
+  // registers a handler that logs all requests made by the page
+  page.on('request', async request => console.log(request.url()))
+
+  await page.goto('https://quickpizza.grafana.com/', { waitUntil: 'networkidle' })
+
+  await page.close();
+}


### PR DESCRIPTION
## What?

Add `page.on('request')` example.

## Why?

To show how to use the feature and also for E2E testing.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] ~I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER~
- [ ] ~I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER~
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- #4281 
- #4290