### PR TITLE
Fix `tc55/timers.add` flakiness

### DIFF
--- a/internal/js/tc55/timers/timers.go
+++ b/internal/js/tc55/timers/timers.go
@@ -288,7 +288,9 @@ func (tq *timerQueue) add(t *timer) int {
 	if i < 0 {
 		i = len(tq.queue)
 	}
-	tq.queue = slices.Insert(tq.queue, i, t)
+	tq.queue = append(tq.queue, nil)
+	copy(tq.queue[i+1:], tq.queue[i:])
+	tq.queue[i] = t
 	return i
 }
 


### PR DESCRIPTION
## What?

Reverts `tc55/timers.add` to manual insertion.

## Why?

`slices.Insert` is flaky due to its in-place shifting logic. Reverting to the manual method since it's more reliable. TIL.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] ~I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER~
- [ ] ~I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER~
- [ ] ~I have updated the release notes: _link_~

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
