### PR TITLE
UX: better error message for json errors while parsing options

### DIFF
--- a/internal/js/bundle.go
+++ b/internal/js/bundle.go
@@ -217,6 +217,15 @@ func (b *Bundle) populateExports(updateOptions bool, bi *BundleInstance) error {
 				dec.DisallowUnknownFields()
 				if err = dec.Decode(&b.Options); err != nil {
 					if uerr := json.Unmarshal(data, &b.Options); uerr != nil {
+						unmarshalTypError := new(json.UnmarshalTypeError)
+						if errors.As(uerr, &unmarshalTypError) {
+							e := unmarshalTypError
+							previousNewLineIndex := max(bytes.LastIndexByte(data[:e.Offset], '\n'), 0)
+							nextNewLineIndex := max(bytes.IndexByte(data[e.Offset:], '\n'), len(data)-1)
+
+							info := strings.TrimSpace(string(data[previousNewLineIndex:nextNewLineIndex]))
+							uerr = fmt.Errorf("parsing options from script got error while parsing %q: %w", info, e)
+						}
 						err = errext.WithAbortReasonIfNone(
 							errext.WithExitCodeIfNone(uerr, exitcodes.InvalidConfig),
 							errext.AbortedByScriptError,

--- a/internal/js/bundle_test.go
+++ b/internal/js/bundle_test.go
@@ -230,11 +230,24 @@ func TestNewBundle(t *testing.T) {
 			invalidOptions := map[string]struct {
 				Expr, Error string
 			}{
-				"Array":    {`[]`, "json: cannot unmarshal array into Go value of type lib.Options"},
-				"Function": {`function(){}`, "error parsing script options: json: unsupported type: func(sobek.FunctionCall) sobek.Value"},
+				"Array": {
+					`[]`,
+					`parsing options from script got error while parsing "[": ` +
+						`json: cannot unmarshal array into Go value of type lib.Options`,
+				},
+				"Bad value": {
+					`{"tags":["something"]}`,
+					`parsing options from script got error while parsing "{\"tags\":[\"something\"]": ` +
+						`json: cannot unmarshal array into Go struct field Options.tags of type map[string]string`,
+				},
+				"Function": {
+					`function(){}`,
+					"error parsing script options: json: unsupported type: func(sobek.FunctionCall) sobek.Value",
+				},
 			}
 			for name, data := range invalidOptions {
 				t.Run(name, func(t *testing.T) {
+					t.Parallel()
 					_, err := getSimpleBundle(t, "/script.js", fmt.Sprintf(`
 						export let options = %s;
 						export default function() {};


### PR DESCRIPTION


## What?

This predominantly tries to actually list the problematic part of the options.

## Why?

Hopefully help users figure out what the problem is

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER
- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
