### PR TITLE
Chore: Homogenize pkg docs comment block format

### DIFF
--- a/internal/js/doc.go
+++ b/internal/js/doc.go
@@ -1,5 +1,3 @@
-/*
-Package js is the JavaScript implementation of the lib.Runner and relative concepts for
-executing concurrent-safe JavaScript code.
-*/
+// Package js is the JavaScript implementation of the lib.Runner and relative concepts for
+// executing concurrent-safe JavaScript code.
 package js

--- a/output/csv/doc.go
+++ b/output/csv/doc.go
@@ -1,4 +1,2 @@
-/*
-Package csv implements an output writing metrics in csv format
-*/
+// Package csv implements an output writing metrics in csv format
 package csv


### PR DESCRIPTION
## What?

Use line code comments (instead of blocks) for existing package docs (`*/doc.go`).

## Why?

As discussed 👉🏻 https://github.com/grafana/k6/pull/4089#discussion_r1963551641