### PR TITLE
Update golangci-lint to 1.64.6 and update code to conform

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v1.63.4
+# v1.64.6
 # Please don't remove the first line. It uses in CI to determine the golangci version
 run:
   timeout: 5m
@@ -65,6 +65,8 @@ linters-settings:
       # Forbid everything in syscall except the uppercase constants
       - '^syscall\.[^A-Z_]+$(# Using anything except constants from the syscall package is forbidden )?'
       - '^logrus\.Logger$'
+  usetesting:
+    os-setenv: true
 
 linters:
   disable-all: true
@@ -84,7 +86,6 @@ linters:
     - errname
     - errorlint
     - exhaustive
-    - exportloopref
     - fatcontext
     - forbidigo
     - forcetypeassert
@@ -125,13 +126,13 @@ linters:
     - sqlclosecheck
     - staticcheck
     - stylecheck
-    - tenv
     - tparallel
     - typecheck
     - unconvert
     - unparam
     - unused
     - usestdlibvars
+    - usetesting
     - wastedassign
     - whitespace
   fast: false

--- a/internal/js/bundle_test.go
+++ b/internal/js/bundle_test.go
@@ -687,8 +687,7 @@ func TestOpen(t *testing.T) {
 			return fs, "", func() {}
 		},
 		"OsFS": func() (fsext.Fs, string, func()) {
-			prefix, err := os.MkdirTemp("", "k6_open_test") //nolint:forbidigo
-			require.NoError(t, err)
+			prefix := t.TempDir()
 			fs := fsext.NewOsFs()
 			filePath := filepath.Join(prefix, "/path/to/file.txt")
 			require.NoError(t, fs.MkdirAll(filepath.Join(prefix, "/path/to"), 0o755))

--- a/internal/js/console_test.go
+++ b/internal/js/console_test.go
@@ -375,7 +375,7 @@ func TestFileConsole(t *testing.T) {
 						msg, deleteFile := msg, deleteFile
 						t.Run(msg, func(t *testing.T) {
 							t.Parallel()
-							f, err := os.CreateTemp("", "") //nolint:forbidigo // fix with https://github.com/grafana/k6/issues/2565
+							f, err := os.CreateTemp(t.TempDir(), "") //nolint:forbidigo // fix with https://github.com/grafana/k6/issues/2565
 							require.NoError(t, err)
 							logFilename := f.Name()
 							defer os.Remove(logFilename) //nolint:errcheck,forbidigo // fix with https://github.com/grafana/k6/issues/2565

--- a/internal/js/modules/k6/browser/browser/registry_test.go
+++ b/internal/js/modules/k6/browser/browser/registry_test.go
@@ -290,7 +290,7 @@ func TestBrowserRegistry(t *testing.T) {
 
 		vu := k6test.NewVU(t)
 		var cancel context.CancelFunc
-		vu.CtxField, cancel = context.WithCancel(vu.CtxField) //nolint:fatcontext
+		vu.CtxField, cancel = context.WithCancel(vu.CtxField)
 		browserRegistry := newBrowserRegistry(context.Background(), vu, remoteRegistry, &pidRegistry{}, nil)
 
 		vu.ActivateVU()

--- a/internal/js/modules/k6/browser/common/browser_test.go
+++ b/internal/js/modules/k6/browser/common/browser_test.go
@@ -171,7 +171,7 @@ func TestBrowserNewPageInContext(t *testing.T) {
 		}
 
 		var cancel func()
-		tc.b.vuCtx, cancel = context.WithCancel(tc.b.vuCtx) //nolint:fatcontext
+		tc.b.vuCtx, cancel = context.WithCancel(tc.b.vuCtx)
 		// let newPageInContext return a context cancelation error by canceling the context before
 		// running the method.
 		cancel()

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -565,7 +565,7 @@ func (h *ElementHandle) selectOption(apiCtx context.Context, values []any) (any,
 		forceCallable: true,
 		returnByValue: false,
 	}
-	result, err := h.evalWithScript(apiCtx, opts, fn, values) //nolint:asasalint
+	result, err := h.evalWithScript(apiCtx, opts, fn, values)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/js/modules/k6/browser/storage/storage_test.go
+++ b/internal/js/modules/k6/browser/storage/storage_test.go
@@ -18,9 +18,7 @@ func TestDirMake(t *testing.T) {
 	t.Run("dir_provided", func(t *testing.T) {
 		t.Parallel()
 
-		dir, err := os.MkdirTemp("", "*") //nolint:forbidigo
-		require.NoError(t, err)
-		t.Cleanup(func() { _ = os.RemoveAll(dir) }) //nolint:forbidigo
+		dir := t.TempDir()
 
 		var s Dir
 		require.NoError(t, s.Make("", dir))

--- a/internal/js/modules/k6/browser/tests/browser_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_test.go
@@ -76,14 +76,7 @@ func TestBrowserNewContext(t *testing.T) {
 func TestTmpDirCleanup(t *testing.T) {
 	t.Parallel()
 
-	tmpDirPath, err := os.MkdirTemp("./", "") //nolint:forbidigo
-	t.Cleanup(
-		func() {
-			err := os.RemoveAll(tmpDirPath) //nolint:forbidigo
-			require.NoError(t, err)
-		},
-	)
-	require.NoError(t, err)
+	tmpDirPath := t.TempDir()
 
 	b := newTestBrowser(
 		t,
@@ -91,8 +84,7 @@ func TestTmpDirCleanup(t *testing.T) {
 		withEnvLookup(env.ConstLookup("TMPDIR", tmpDirPath)),
 	)
 	p := b.NewPage(nil)
-	err = p.Close()
-	require.NoError(t, err)
+	require.NoError(t, p.Close())
 
 	matches, err := filepath.Glob(filepath.Join(tmpDirPath, storage.K6BrowserDataDirPattern))
 	assert.NoError(t, err)
@@ -119,14 +111,7 @@ func TestTmpDirCleanup(t *testing.T) {
 func TestTmpDirCleanupOnContextClose(t *testing.T) {
 	t.Parallel()
 
-	tmpDirPath, err := os.MkdirTemp("./", "") //nolint:forbidigo
-	t.Cleanup(
-		func() {
-			err := os.RemoveAll(tmpDirPath) //nolint:forbidigo
-			require.NoError(t, err)
-		},
-	)
-	require.NoError(t, err)
+	tmpDirPath := t.TempDir()
 
 	b := newTestBrowser(
 		t,

--- a/internal/js/modules/k6/experimental/fs/file.go
+++ b/internal/js/modules/k6/experimental/fs/file.go
@@ -82,7 +82,7 @@ var _ io.Reader = (*file)(nil)
 //
 // When using SeekModeStart, the offset must be positive.
 // Negative offsets are allowed when using `SeekModeCurrent` or `SeekModeEnd`.
-func (f *file) Seek(offset int64, whence SeekMode) (int64, error) {
+func (f *file) Seek(offset int64, whence SeekMode) (int64, error) { //nolint:govet
 	startingOffset := f.offset.Load()
 
 	newOffset := startingOffset

--- a/internal/js/modules/k6/experimental/websockets/blob.go
+++ b/internal/js/modules/k6/experimental/websockets/blob.go
@@ -123,7 +123,7 @@ func (r *WebSocketsAPI) fillData(b *blob, blobParts []interface{}, call sobek.Co
 				obj := call.Arguments[0].ToObject(rt).Get(strconv.FormatInt(int64(n), 10)).ToObject(rt)
 				switch {
 				case isDataView(obj, rt):
-					_, err = b.data.Write(obj.Get("buffer").Export().(sobek.ArrayBuffer).Bytes())
+					_, err = b.data.Write(obj.Get("buffer").Export().(sobek.ArrayBuffer).Bytes()) //nolint:forcetypeassert
 				case isBlob(obj, r.blobConstructor):
 					_, err = b.data.Write(extractBytes(obj, rt))
 				default:

--- a/internal/lib/testutils/httpmultibin/grpc_wrappers_testing/service.go
+++ b/internal/lib/testutils/httpmultibin/grpc_wrappers_testing/service.go
@@ -12,15 +12,16 @@ import (
 //go:generate protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative test.proto
 
 // Register registers a test service that could be used for the testing gRPC wrappers
-func Register(r grpc.ServiceRegistrar) *service { //nolint:revive // this is a test service
-	s := &service{}
+func Register(r grpc.ServiceRegistrar) *Service {
+	s := &Service{}
 
 	RegisterServiceServer(r, s)
 
 	return s
 }
 
-type service struct {
+// Service is the test service for different grpc values and how they are handled
+type Service struct {
 	UnimplementedServiceServer
 
 	TestStringImplementation  func(context.Context, *wrappers.StringValue) (*wrappers.StringValue, error)
@@ -31,7 +32,8 @@ type service struct {
 	TestStreamImplementation  func(Service_TestStreamServer) error
 }
 
-func (s *service) TestString(ctx context.Context, in *wrappers.StringValue) (*wrappers.StringValue, error) {
+// TestString is getting and returning a string value
+func (s *Service) TestString(ctx context.Context, in *wrappers.StringValue) (*wrappers.StringValue, error) {
 	if s.TestStringImplementation != nil {
 		return s.TestStringImplementation(ctx, in)
 	}
@@ -39,7 +41,8 @@ func (s *service) TestString(ctx context.Context, in *wrappers.StringValue) (*wr
 	return s.UnimplementedServiceServer.TestString(ctx, in)
 }
 
-func (s *service) TestInteger(ctx context.Context, in *wrappers.Int64Value) (*wrappers.Int64Value, error) {
+// TestInteger is getting and returning a integer value
+func (s *Service) TestInteger(ctx context.Context, in *wrappers.Int64Value) (*wrappers.Int64Value, error) {
 	if s.TestIntegerImplementation != nil {
 		return s.TestIntegerImplementation(ctx, in)
 	}
@@ -47,7 +50,8 @@ func (s *service) TestInteger(ctx context.Context, in *wrappers.Int64Value) (*wr
 	return s.UnimplementedServiceServer.TestInteger(ctx, in)
 }
 
-func (s *service) TestBoolean(ctx context.Context, in *wrappers.BoolValue) (*wrappers.BoolValue, error) {
+// TestBoolean is getting and returning a boolean value
+func (s *Service) TestBoolean(ctx context.Context, in *wrappers.BoolValue) (*wrappers.BoolValue, error) {
 	if s.TestBooleanImplementation != nil {
 		return s.TestBooleanImplementation(ctx, in)
 	}
@@ -55,7 +59,8 @@ func (s *service) TestBoolean(ctx context.Context, in *wrappers.BoolValue) (*wra
 	return s.UnimplementedServiceServer.TestBoolean(ctx, in)
 }
 
-func (s *service) TestDouble(ctx context.Context, in *wrappers.DoubleValue) (*wrappers.DoubleValue, error) {
+// TestDouble is getting and returning a double value
+func (s *Service) TestDouble(ctx context.Context, in *wrappers.DoubleValue) (*wrappers.DoubleValue, error) {
 	if s.TestDoubleImplementation != nil {
 		return s.TestDoubleImplementation(ctx, in)
 	}
@@ -63,7 +68,8 @@ func (s *service) TestDouble(ctx context.Context, in *wrappers.DoubleValue) (*wr
 	return s.UnimplementedServiceServer.TestDouble(ctx, in)
 }
 
-func (s *service) TestValue(ctx context.Context, in *_struct.Value) (*_struct.Value, error) {
+// TestValue is getting and returning a generic value
+func (s *Service) TestValue(ctx context.Context, in *_struct.Value) (*_struct.Value, error) {
 	if s.TestValueImplementation != nil {
 		return s.TestValueImplementation(ctx, in)
 	}
@@ -71,7 +77,8 @@ func (s *service) TestValue(ctx context.Context, in *_struct.Value) (*_struct.Va
 	return s.UnimplementedServiceServer.TestValue(ctx, in)
 }
 
-func (s *service) TestStream(stream Service_TestStreamServer) error {
+// TestStream is testing a stream of values
+func (s *Service) TestStream(stream Service_TestStreamServer) error {
 	if s.TestStreamImplementation != nil {
 		return s.TestStreamImplementation(stream)
 	}

--- a/metrics/builtin.go
+++ b/metrics/builtin.go
@@ -1,6 +1,5 @@
 package metrics
 
-//nolint:nolintlint // unfortunately it is having a false possitive
 //nolint:revive
 const (
 	VUsName               = "vus"


### PR DESCRIPTION
## What?

Bump golangci-lint to latest version

## Why?

Mostly so it actually works with a version that works with go1.24, but also as to get some bugfixes ... and new stuff.

- usetesting seems okay and we already had tenv - I have done some t.TempDir() fixes around it as well
- exportloopref - is not relevant after using go 1.22
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER
- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
