### PR TITLE
Add copyloopvar as a linter and auto fix

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -78,6 +78,7 @@ linters:
     - canonicalheader
     - contextcheck
     - cyclop
+    - copyloopvar
     - dogsled
     - dupl
     - durationcheck

--- a/api/v1/group_routes_test.go
+++ b/api/v1/group_routes_test.go
@@ -155,7 +155,6 @@ func TestGetGroups(t *testing.T) {
 		})
 	})
 	for _, gp := range []*lib.Group{g0, g1, g2} {
-		gp := gp
 		t.Run(gp.Name, func(t *testing.T) {
 			t.Parallel()
 			rw := httptest.NewRecorder()

--- a/api/v1/setup_teardown_routes_test.go
+++ b/api/v1/setup_teardown_routes_test.go
@@ -206,7 +206,6 @@ func TestSetupData(t *testing.T) {
 	}
 
 	for id := range testCases {
-		id := id
 		t.Run(fmt.Sprintf("testcase_%d", id), func(t *testing.T) {
 			t.Parallel()
 			runTestCase(t, id)

--- a/cloudapi/logs_test.go
+++ b/cloudapi/logs_test.go
@@ -150,7 +150,6 @@ func TestRetry(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 				var sleepRequests []time.Duration

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -23,11 +23,9 @@ func testHTTPHandler(rw http.ResponseWriter, _ *http.Request) {
 func TestLogger(t *testing.T) {
 	t.Parallel()
 	for _, method := range []string{"GET", "POST", "PUT", "PATCH"} {
-		method := method
 		t.Run("method="+method, func(t *testing.T) {
 			t.Parallel()
 			for _, path := range []string{"/", "/test", "/test/path"} {
-				path := path
 				t.Run("path="+path, func(t *testing.T) {
 					t.Parallel()
 					rw := httptest.NewRecorder()

--- a/internal/cmd/archive_test.go
+++ b/internal/cmd/archive_test.go
@@ -69,7 +69,6 @@ func TestArchiveThresholds(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -60,11 +60,9 @@ func TestConfigCmd(t *testing.T) {
 	}
 
 	for _, data := range testdata {
-		data := data
 		t.Run(data.Name, func(t *testing.T) {
 			t.Parallel()
 			for _, test := range data.Tests {
-				test := test
 				t.Run(`"`+test.Name+`"`, func(t *testing.T) {
 					t.Parallel()
 					fs := configFlagSet()
@@ -193,7 +191,6 @@ func TestDeriveAndValidateConfig(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := deriveAndValidateConfig(tc.conf,
@@ -499,7 +496,6 @@ func TestLoadConfig(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			l, hook := testutils.NewLoggerWithHook(t)

--- a/internal/cmd/new_test.go
+++ b/internal/cmd/new_test.go
@@ -38,7 +38,6 @@ func TestNewScriptCmd(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/options_test.go
+++ b/internal/cmd/options_test.go
@@ -53,7 +53,6 @@ func TestParseTagKeyValue(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		data := data
 		t.Run(data.input, func(t *testing.T) {
 			t.Parallel()
 			name, value, err := parseTagNameValue(data.input)

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -73,8 +73,6 @@ func TestRootCommandHelpDisplayCommands(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -329,7 +329,6 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 		var wg sync.WaitGroup
 		wg.Add(len(ww))
 		for _, w := range ww {
-			w := w
 			go func() {
 				w()
 				wg.Done()

--- a/internal/cmd/run_test.go
+++ b/internal/cmd/run_test.go
@@ -225,7 +225,7 @@ func TestRunScriptErrorsAndAbort(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
+
 		name := tc.testFilename
 		if tc.name != "" {
 			name = fmt.Sprintf("%s (%s)", tc.testFilename, tc.name)
@@ -293,8 +293,6 @@ func TestInvalidOptionsThresholdErrExitCode(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -343,8 +341,6 @@ func TestThresholdsRuntimeBehavior(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/runtime_options_test.go
+++ b/internal/cmd/runtime_options_test.go
@@ -411,7 +411,6 @@ func TestRuntimeOptions(t *testing.T) {
 		},
 	}
 	for name, tc := range runtimeOptionsTestCases {
-		tc := tc
 		t.Run(fmt.Sprintf("RuntimeOptions test '%s'", name), func(t *testing.T) {
 			t.Parallel()
 			testRuntimeOptionsCase(t, tc)

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -54,8 +54,6 @@ func TestCloudRunCommandIncompatibleFlags(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/tests/cmd_run_grpc_test.go
+++ b/internal/cmd/tests/cmd_run_grpc_test.go
@@ -94,9 +94,6 @@ func TestGRPCInputOutput(t *testing.T) {
 	require.NoError(t, err)
 
 	for name, test := range tc {
-		name := name
-		test := test
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -1884,8 +1884,6 @@ func TestUIRenderOutput(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.expRender, func(t *testing.T) {
 			t.Parallel()
 
@@ -1919,8 +1917,6 @@ func TestUIRenderWebDashboard(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run(tc.expRender, func(t *testing.T) {
 			t.Parallel()
 
@@ -1963,8 +1959,6 @@ func TestRunStaticArchives(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
-
 		t.Run("Using "+tc.archive, func(t *testing.T) {
 			t.Parallel()
 
@@ -1997,8 +1991,6 @@ func TestBadLogOutput(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		name := name
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ts := NewGlobalTestState(t)
@@ -2141,7 +2133,6 @@ func TestEventSystemError(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ts := NewGlobalTestState(t)
@@ -2287,7 +2278,6 @@ func TestBrowserPermissions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			script := fmt.Sprintf(`

--- a/internal/cmd/ui_test.go
+++ b/internal/cmd/ui_test.go
@@ -65,7 +65,6 @@ left 2   [   0% ] right 2  000
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			pbs := createTestProgressBars(3, tc.padding, 1)

--- a/internal/event/system_test.go
+++ b/internal/event/system_test.go
@@ -88,7 +88,7 @@ func TestEventSystem(t *testing.T) {
 			data       int
 		)
 		for _, et := range emitEvents {
-			et := et
+
 			evt := &Event{Type: et, Data: data, Done: func() {
 				doneMx.Lock()
 				processed[et]++

--- a/internal/execution/scheduler_ext_exec_test.go
+++ b/internal/execution/scheduler_ext_exec_test.go
@@ -392,7 +392,6 @@ func TestExecutionInfoAll(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/execution/scheduler_ext_test.go
+++ b/internal/execution/scheduler_ext_test.go
@@ -132,7 +132,6 @@ func TestSchedulerRunNonDefault(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			piState := getTestPreInitState(t)
@@ -247,7 +246,6 @@ func TestSchedulerRunEnv(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			piState := getTestPreInitState(t)
@@ -462,7 +460,6 @@ func TestSchedulerRunCustomTags(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			piState := getTestPreInitState(t)
@@ -843,7 +840,6 @@ func TestSchedulerStages(t *testing.T) {
 	}
 
 	for name, data := range testdata {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			runner := &minirunner.MiniRunner{
@@ -1099,7 +1095,6 @@ func TestDNSResolverCache(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			logger := logrus.New()

--- a/internal/js/bundle_test.go
+++ b/internal/js/bundle_test.go
@@ -195,7 +195,6 @@ func TestNewBundle(t *testing.T) {
 			}
 
 			for _, tc := range testCases {
-				tc := tc
 				t.Run(tc.name, func(t *testing.T) {
 					t.Parallel()
 					rtOpts := lib.RuntimeOptions{CompatibilityMode: null.StringFrom(tc.compatMode)}
@@ -710,7 +709,6 @@ func TestOpen(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			for _, tCase := range testCases {
-				tCase := tCase
 
 				testFunc := func(t *testing.T) {
 					t.Parallel()
@@ -742,7 +740,6 @@ func TestOpen(t *testing.T) {
 					require.NoError(t, err)
 
 					for source, b := range map[string]*Bundle{"source": sourceBundle, "archive": arcBundle} {
-						b := b
 						t.Run(source, func(t *testing.T) {
 							bi, err := b.Instantiate(context.Background(), 0)
 							require.NoError(t, err)
@@ -841,7 +838,6 @@ func TestBundleEnv(t *testing.T) {
 
 	bundles := map[string]*Bundle{"Source": b1, "Archive": b2}
 	for name, b := range bundles {
-		b := b
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, "1", b.preInitState.RuntimeOptions.Env["TEST_A"])
@@ -879,7 +875,6 @@ func TestBundleNotSharable(t *testing.T) {
 	bundles := map[string]*Bundle{"Source": b1, "Archive": b2}
 	var vus, iters uint64 = 10, 1000
 	for name, b := range bundles {
-		b := b
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			for i := uint64(0); i < vus; i++ {
@@ -921,7 +916,6 @@ func TestBundleMakeArchive(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.cm.String(), func(t *testing.T) {
 			t.Parallel()
 			fs := fsext.NewMemMapFs()
@@ -982,7 +976,6 @@ func TestGlobalTimers(t *testing.T) {
 
 	bundles := map[string]*Bundle{"Source": b1, "Archive": b2}
 	for name, b := range bundles {
-		b := b
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			_, err := b.Instantiate(context.Background(), 1)

--- a/internal/js/console_test.go
+++ b/internal/js/console_test.go
@@ -192,8 +192,6 @@ func TestConsoleLogObjectsWithGoTypes(t *testing.T) {
 
 	expFields := logrus.Fields{"source": "console"}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -242,7 +240,6 @@ func TestConsoleLog(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		tt := tt
 		t.Run(fmt.Sprintf("case%d", i), func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/initcontext_test.go
+++ b/internal/js/initcontext_test.go
@@ -243,7 +243,6 @@ func TestInitContextOpen(t *testing.T) {
 		// {[]byte{00, 36, 32, 127}, "utf-16", 2},   // $€
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.file, func(t *testing.T) {
 			t.Parallel()
 			bi, err := createAndReadFile(t, tc.file, tc.content, tc.length, "")
@@ -266,7 +265,6 @@ func TestInitContextOpen(t *testing.T) {
 	}
 
 	for name, loadPath := range testdata {
-		loadPath := loadPath
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			_, err := createAndReadFile(t, loadPath, []byte("content"), 7, "")

--- a/internal/js/module_loading_test.go
+++ b/internal/js/module_loading_test.go
@@ -93,7 +93,6 @@ func TestLoadOnceGlobalVars(t *testing.T) {
 
 			runners := map[string]*Runner{"Source": r1, "Archive": r2}
 			for name, r := range runners {
-				r := r
 				t.Run(name, func(t *testing.T) {
 					t.Parallel()
 					ch := newDevNullSampleChannel()
@@ -144,7 +143,6 @@ func TestLoadExportsIsntUsableInModule(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ch := newDevNullSampleChannel()
@@ -191,7 +189,6 @@ func TestLoadDoesntBreakHTTPGet(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ch := newDevNullSampleChannel()
@@ -236,7 +233,6 @@ func TestLoadGlobalVarsAreNotSharedBetweenVUs(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ch := newDevNullSampleChannel()
@@ -298,7 +294,6 @@ func TestLoadCycle(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ch := newDevNullSampleChannel()
@@ -360,7 +355,6 @@ func TestLoadCycleBinding(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ch := newDevNullSampleChannel()
@@ -424,7 +418,6 @@ func TestBrowserified(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ch := make(chan metrics.SampleContainer, 100)
@@ -467,7 +460,6 @@ func TestLoadingUnexistingModuleDoesntPanic(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ch := newDevNullSampleChannel()
@@ -503,7 +495,6 @@ func TestLoadingSourceMapsDoesntErrorOut(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ch := newDevNullSampleChannel()
@@ -556,7 +547,6 @@ func TestOptionsAreGloballyReadable(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ch := newDevNullSampleChannel()

--- a/internal/js/modules/k6/browser/browser/file_persister_test.go
+++ b/internal/js/modules/k6/browser/browser/file_persister_test.go
@@ -49,8 +49,6 @@ func Test_newScreenshotPersister(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -156,8 +154,6 @@ func Test_parsePresignedURLEnvVar(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -222,7 +222,6 @@ func TestMappings(t *testing.T) {
 			},
 		},
 	} {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			testMapping(t, tt)

--- a/internal/js/modules/k6/browser/browser/registry_test.go
+++ b/internal/js/modules/k6/browser/browser/registry_test.go
@@ -137,7 +137,6 @@ func TestIsRemoteBrowser(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -388,7 +387,6 @@ func TestParseTracesMetadata(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			lookup := func(key string) (string, bool) {

--- a/internal/js/modules/k6/browser/chromium/browser_type_test.go
+++ b/internal/js/modules/k6/browser/chromium/browser_type_test.go
@@ -123,7 +123,6 @@ func TestBrowserTypePrepareFlags(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.flag, func(t *testing.T) {
 			t.Parallel()
 
@@ -235,7 +234,6 @@ func TestExecutablePath(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -317,7 +315,6 @@ func TestParseArgs(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/browser_context_test.go
+++ b/internal/js/modules/k6/browser/common/browser_context_test.go
@@ -312,7 +312,6 @@ func TestFilterCookies(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/browser_options_test.go
+++ b/internal/js/modules/k6/browser/common/browser_options_test.go
@@ -223,7 +223,6 @@ func TestBrowserOptionsParse(t *testing.T) {
 			err:          "browser type option must be set",
 		},
 	} {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var (

--- a/internal/js/modules/k6/browser/common/browser_process_test.go
+++ b/internal/js/modules/k6/browser/common/browser_process_test.go
@@ -147,7 +147,6 @@ func TestParseDevToolsURL(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/http_test.go
+++ b/internal/js/modules/k6/browser/common/http_test.go
@@ -158,7 +158,6 @@ func TestValidateResourceType(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/keyboard_test.go
+++ b/internal/js/modules/k6/browser/common/keyboard_test.go
@@ -65,7 +65,6 @@ func TestSplit(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -189,7 +188,6 @@ func TestKeyDefinitionCode(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(string(tt.key), func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/layout_test.go
+++ b/internal/js/modules/k6/browser/common/layout_test.go
@@ -35,7 +35,6 @@ func TestViewportCalculateInset(t *testing.T) {
 	// should add a different inset to viewport than the default one
 	// if a recognized os is given.
 	for _, os := range []string{"windows", "linux", "darwin"} {
-		os := os
 		t.Run(os, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/network_manager_test.go
+++ b/internal/js/modules/k6/browser/common/network_manager_test.go
@@ -117,7 +117,6 @@ func TestOnRequestPausedBlockedHostnames(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -181,7 +180,6 @@ func TestOnRequestPausedBlockedIPs(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -272,7 +270,6 @@ func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -372,7 +369,6 @@ func TestRequestForOnLoadingFinished(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/remote_object_test.go
+++ b/internal/js/modules/k6/browser/common/remote_object_test.go
@@ -254,7 +254,6 @@ func TestParseRemoteObject(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			remoteObject := &runtime.RemoteObject{

--- a/internal/js/modules/k6/browser/storage/file_persister_test.go
+++ b/internal/js/modules/k6/browser/storage/file_persister_test.go
@@ -46,7 +46,6 @@ func TestLocalFilePersister(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -222,7 +221,6 @@ func TestRemoteFilePersister(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/browser_context_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_context_test.go
@@ -192,7 +192,6 @@ func TestBrowserContextAddCookies(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -538,7 +537,6 @@ func TestBrowserContextCookies(t *testing.T) {
 		},
 	}
 	for name, tt := range tests {
-		tt := tt
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -646,7 +644,6 @@ func TestK6Object(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -723,7 +720,6 @@ func TestBrowserContextTimeout(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -802,7 +798,6 @@ func TestBrowserContextWaitForEvent(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -892,7 +887,6 @@ func TestBrowserContextGrantPermissions(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/frame_manager_test.go
+++ b/internal/js/modules/k6/browser/tests/frame_manager_test.go
@@ -29,7 +29,6 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/frame_test.go
+++ b/internal/js/modules/k6/browser/tests/frame_test.go
@@ -47,7 +47,6 @@ func TestFrameDismissDialogBox(t *testing.T) {
 		"prompt",
 		"beforeunload",
 	} {
-		tt := tt
 		t.Run(tt, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/js_handle_test.go
+++ b/internal/js/modules/k6/browser/tests/js_handle_test.go
@@ -33,8 +33,6 @@ func TestJSHandleEvaluate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -82,8 +80,6 @@ func TestJSHandleEvaluateHandle(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/lifecycle_wait_test.go
+++ b/internal/js/modules/k6/browser/tests/lifecycle_wait_test.go
@@ -147,7 +147,6 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -296,7 +295,6 @@ func TestLifecycleWaitForLoadState(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -391,7 +389,6 @@ func TestLifecycleReload(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -500,7 +497,6 @@ func TestLifecycleGotoWithSubFrame(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -578,7 +574,6 @@ func TestLifecycleGoto(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -315,7 +315,6 @@ func TestLocator(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -452,7 +451,6 @@ func TestLocator(t *testing.T) {
 		},
 	}
 	for _, tt := range sanityTests {
-		tt := tt
 		t.Run("timeout/"+tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -465,7 +463,6 @@ func TestLocator(t *testing.T) {
 	}
 
 	for _, tt := range sanityTests {
-		tt := tt
 		t.Run("strict/"+tt.name, func(t *testing.T) {
 			t.Parallel()
 			tb := newTestBrowser(t, withFileServer())
@@ -535,7 +532,6 @@ func TestLocatorElementState(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.state, func(t *testing.T) {
 			t.Parallel()
 
@@ -597,7 +593,6 @@ func TestLocatorElementState(t *testing.T) {
 		},
 	}
 	for _, tt := range sanityTests {
-		tt := tt
 		t.Run("timeout/"+tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -610,7 +605,6 @@ func TestLocatorElementState(t *testing.T) {
 	}
 
 	for _, tt := range sanityTests {
-		tt := tt
 		t.Run("strict/"+tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -179,7 +179,6 @@ func TestPageEvaluate(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -228,7 +227,6 @@ func TestPageEvaluateMapping(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -279,7 +277,6 @@ func TestPageEvaluateMappingError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1268,7 +1265,6 @@ func TestPageOn(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1348,7 +1344,6 @@ func TestPageTimeout(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1423,7 +1418,6 @@ func TestPageWaitForSelector(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1509,7 +1503,6 @@ func TestPageThrottleNetwork(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1669,7 +1662,6 @@ func TestPageIsVisible(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1742,7 +1734,6 @@ func TestPageIsHidden(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1806,7 +1797,6 @@ func TestShadowDOMAndDocumentFragment(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2117,7 +2107,6 @@ func TestPageOnMetric(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/remote_obj_test.go
+++ b/internal/js/modules/k6/browser/tests/remote_obj_test.go
@@ -72,7 +72,6 @@ func TestConsoleLogParse(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -173,7 +172,6 @@ func TestEvalRemoteObjectParse(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/test_browser.go
+++ b/internal/js/modules/k6/browser/tests/test_browser.go
@@ -306,7 +306,6 @@ func (b *testBrowser) run(ctx context.Context, fs ...func() error) error {
 
 	g, ctx := errgroup.WithContext(ctx)
 	for _, f := range fs {
-		f := f
 		g.Go(func() error {
 			errc := make(chan error, 1)
 			go func() { errc <- f() }()

--- a/internal/js/modules/k6/crypto/crypto_test.go
+++ b/internal/js/modules/k6/crypto/crypto_test.go
@@ -392,8 +392,6 @@ func TestHMac(t *testing.T) {
 		"ripemd160":  "00bb4ce0d6afd4c7424c9d01b8a6caa3e749b08b",
 	}
 	for algorithm, value := range testData {
-		algorithm := algorithm
-		value := value
 
 		t.Run(algorithm+" hasher: valid", func(t *testing.T) {
 			t.Parallel()
@@ -457,8 +455,6 @@ func TestHMac(t *testing.T) {
 		"sha348": "d331e169e2dcfc742e80a3bf4dcc76d0e6425ab3777a3ac217ac6b2552aad5529ed4d40135b06e53a495ac7425d1e462",
 	}
 	for algorithm, value := range invalidData {
-		algorithm := algorithm
-		value := value
 
 		t.Run(algorithm+" hasher: invalid", func(t *testing.T) {
 			t.Parallel()
@@ -508,7 +504,6 @@ func TestHexEncode(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			tc := tc
 			t.Run(fmt.Sprintf("%T", tc), func(t *testing.T) {
 				c := Crypto{}
 				out, err := c.hexEncode(tc)

--- a/internal/js/modules/k6/data/share_test.go
+++ b/internal/js/modules/k6/data/share_test.go
@@ -232,7 +232,7 @@ func TestSharedArrayRaceInInitialization(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		for _, rt := range runtimes {
-			rt := rt
+
 			wg.Add(1)
 			go func() {
 				defer wg.Done()

--- a/internal/js/modules/k6/execution/execution_test.go
+++ b/internal/js/modules/k6/execution/execution_test.go
@@ -110,7 +110,6 @@ func TestVUTagMetadatasSetSuccessAcceptedTypes(t *testing.T) {
 		"float":  {v: 3.14, exp: "3.14"},
 	}
 	for prop := range tagsAndMetricsPropertyNames {
-		prop := prop
 		t.Run(prop, func(t *testing.T) {
 			t.Parallel()
 			tenv := setupTagsExecEnv(t)

--- a/internal/js/modules/k6/experimental/fs/file_test.go
+++ b/internal/js/modules/k6/experimental/fs/file_test.go
@@ -99,8 +99,6 @@ func TestFileImpl(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			tc := tc
-
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -226,8 +224,6 @@ func TestFileImpl(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
-
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/internal/js/modules/k6/experimental/fs/module_test.go
+++ b/internal/js/modules/k6/experimental/fs/module_test.go
@@ -51,8 +51,6 @@ func TestOpen(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
-
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/internal/js/modules/k6/experimental/websockets/blob_test.go
+++ b/internal/js/modules/k6/experimental/websockets/blob_test.go
@@ -75,7 +75,6 @@ func TestBlob(t *testing.T) {
 	}
 
 	for name, tc := range tcs {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ts := newTestState(t)
@@ -193,7 +192,6 @@ func TestBlob_slice(t *testing.T) {
 	}
 
 	for name, tc := range tcs {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ts := newTestState(t)

--- a/internal/js/modules/k6/experimental/websockets/websockets_test.go
+++ b/internal/js/modules/k6/experimental/websockets/websockets_test.go
@@ -512,7 +512,6 @@ func TestExceptionDontPanic(t *testing.T) {
 		},
 	}
 	for name, testcase := range cases {
-		testcase := testcase
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ts := newTestState(t)
@@ -1113,7 +1112,6 @@ func TestSystemTags(t *testing.T) {
 
 	testedSystemTags := []string{"status", "subproto", "url", "ip"}
 	for _, expectedTagStr := range testedSystemTags {
-		expectedTagStr := expectedTagStr
 		t.Run("only "+expectedTagStr, func(t *testing.T) {
 			t.Parallel()
 			expectedTag, err := metrics.SystemTagString(expectedTagStr)
@@ -1311,7 +1309,6 @@ func TestCompressionParams(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.compression, func(t *testing.T) {
 			t.Parallel()
 			ts := newTestState(t)
@@ -1493,7 +1490,6 @@ func TestArrayBufferViewSupport(t *testing.T) {
 		// "BigInt64Array", "BigUint64Arrays",
 		/*"Float16Array", */ "Float32Array", "Float64Array",
 	} {
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/grpc/client_test.go
+++ b/internal/js/modules/k6/grpc/client_test.go
@@ -1128,7 +1128,6 @@ func TestClient(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1274,7 +1273,6 @@ func TestClient_TlsParameters(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1355,7 +1353,6 @@ func TestDebugStat(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var b bytes.Buffer

--- a/internal/js/modules/k6/grpc/params_test.go
+++ b/internal/js/modules/k6/grpc/params_test.go
@@ -48,8 +48,6 @@ func TestCallParamsInvalidInput(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -83,8 +81,6 @@ func TestCallParamsMetadata(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -124,8 +120,6 @@ func TestCallParamsTimeOutParse(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
@@ -165,8 +159,6 @@ func TestCallParamsDiscardResponseMessageParse(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/js/modules/k6/webcrypto/cmd_run_test.go
+++ b/internal/js/modules/k6/webcrypto/cmd_run_test.go
@@ -73,7 +73,6 @@ func TestExamplesInputOutput(t *testing.T) {
 
 		for _, file := range list {
 			name := filepath.Base(file)
-			file := file
 
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()

--- a/internal/js/modules/k6/ws/ws_test.go
+++ b/internal/js/modules/k6/ws/ws_test.go
@@ -394,7 +394,6 @@ func TestSessionClose(t *testing.T) {
 	}
 
 	for _, tc := range serverCloseTests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			tb := httpmultibin.NewHTTPMultiBin(t)
@@ -617,7 +616,7 @@ func TestSocketSendBinary(t *testing.T) { //nolint:tparallel
 	}
 
 	for _, tc := range errTestCases { //nolint:paralleltest
-		tc := tc
+
 		t.Run(fmt.Sprintf("err_%s", tc.expErrType), func(t *testing.T) {
 			_, err := test.VU.Runtime().RunString(fmt.Sprintf(sr(`
 			var res = ws.connect('WSBIN_URL/ws-echo', function(socket){
@@ -726,7 +725,6 @@ func TestSystemTags(t *testing.T) {
 	t.Parallel()
 	testedSystemTags := []string{"status", "subproto", "url", "ip"}
 	for _, expectedTagStr := range testedSystemTags {
-		expectedTagStr := expectedTagStr
 		t.Run("only "+expectedTagStr, func(t *testing.T) {
 			t.Parallel()
 			test := newTestState(t)
@@ -820,7 +818,6 @@ func TestReadPump(t *testing.T) {
 
 	// Ensure readPump returns the response close code sent by the server
 	for _, code := range closeCodes {
-		code := code
 		t.Run(strconv.Itoa(code), func(t *testing.T) {
 			t.Parallel()
 			closeCode := code
@@ -1005,7 +1002,6 @@ func TestCompression(t *testing.T) {
 		}
 
 		for _, testCase := range testCases {
-			testCase := testCase
 			t.Run(testCase.compression, func(t *testing.T) {
 				t.Parallel()
 				ts := newTestState(t)

--- a/internal/js/runner_test.go
+++ b/internal/js/runner_test.go
@@ -147,8 +147,6 @@ func TestRunnerRPSLimit(t *testing.T) {
 	}
 
 	for _, variant := range variants {
-		variant := variant
-
 		t.Run(variant.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -170,7 +168,6 @@ func TestOptionsSettingToScript(t *testing.T) {
 	}
 
 	for i, variant := range optionVariants {
-		variant := variant
 		t.Run(fmt.Sprintf("Variant#%d", i), func(t *testing.T) {
 			t.Parallel()
 			data := variant + `
@@ -237,7 +234,6 @@ func TestOptionsPropagationToScript(t *testing.T) {
 
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range testdata {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			samples := make(chan metrics.SampleContainer, 100)
@@ -404,7 +400,6 @@ func testSetupDataHelper(t *testing.T, data string) {
 
 	testdata := map[string]*Runner{"Source": r1}
 	for name, r := range testdata {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -469,7 +464,6 @@ func TestConsoleInInitContext(t *testing.T) {
 
 	testdata := map[string]*Runner{"Source": r1}
 	for name, r := range testdata {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			samples := make(chan metrics.SampleContainer, 100)
@@ -533,7 +527,6 @@ func TestRunnerIntegrationImports(t *testing.T) {
 		}
 		rtOpts := lib.RuntimeOptions{CompatibilityMode: null.StringFrom("extended")}
 		for _, mod := range modules {
-			mod := mod
 			t.Run(mod, func(t *testing.T) {
 				t.Run("Source", func(t *testing.T) {
 					_, err := getSimpleRunner(t, "/script.js",
@@ -573,7 +566,6 @@ func TestRunnerIntegrationImports(t *testing.T) {
 
 				testdata := map[string]*Runner{"Source": r1, "Archive": r2}
 				for name, r := range testdata {
-					r := r
 					t.Run(name, func(t *testing.T) {
 						ctx, cancel := context.WithCancel(context.Background())
 						defer cancel()
@@ -603,7 +595,6 @@ func TestVURunContext(t *testing.T) {
 
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range testdata {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -677,7 +668,6 @@ func TestVURunInterruptDoesntPanic(t *testing.T) {
 	require.NoError(t, err)
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range testdata {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -730,7 +720,6 @@ func TestVUIntegrationMetrics(t *testing.T) {
 	}
 
 	for name, r := range testdata {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			samples := make(chan metrics.SampleContainer, 100)
@@ -919,7 +908,6 @@ func TestVUIntegrationInsecureRequests(t *testing.T) {
 		},
 	}
 	for name, data := range testdata {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			r1, err := getSimpleRunner(t, "/script.js", `
@@ -937,7 +925,6 @@ func TestVUIntegrationInsecureRequests(t *testing.T) {
 			require.NoError(t, err)
 			runners := map[string]*Runner{"Source": r1, "Archive": r2}
 			for name, r := range runners {
-				r := r
 				t.Run(name, func(t *testing.T) {
 					t.Parallel()
 					r.preInitState.Logger, _ = logtest.NewNullLogger()
@@ -981,7 +968,6 @@ func TestVUIntegrationBlacklistOption(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -1016,7 +1002,6 @@ func TestVUIntegrationBlacklistScript(t *testing.T) {
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -1051,7 +1036,6 @@ func TestVUIntegrationBlockHostnamesOption(t *testing.T) {
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -1088,7 +1072,6 @@ func TestVUIntegrationBlockHostnamesScript(t *testing.T) {
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -1139,7 +1122,6 @@ func TestVUIntegrationHosts(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -1211,7 +1193,6 @@ func TestVUIntegrationTLSConfig(t *testing.T) {
 	cert, err := x509.ParseCertificate(s.TLS.Certificates[0].Certificate[0])
 	require.NoError(t, err)
 	for name, data := range testdata {
-		data := data
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			r1, err := getSimpleRunner(t, "/script.js", `
@@ -1232,7 +1213,6 @@ func TestVUIntegrationTLSConfig(t *testing.T) {
 
 			runners := map[string]*Runner{"Source": r1, "Archive": r2}
 			for name, r := range runners {
-				r := r
 				t.Run(name, func(t *testing.T) {
 					t.Parallel()
 					r.preInitState.Logger, _ = logtest.NewNullLogger()
@@ -1508,7 +1488,6 @@ func TestVUIntegrationCookiesReset(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -1561,7 +1540,6 @@ func TestVUIntegrationCookiesNoReset(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -1595,7 +1573,6 @@ func TestVUIntegrationVUID(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())
@@ -1666,8 +1643,6 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 	go func() { _ = srv.Serve(listener) }()
 	t.Cleanup(func() { _ = listener.Close() })
 	for name, data := range testdata {
-		data := data
-
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1708,7 +1683,6 @@ func TestVUIntegrationClientCerts(t *testing.T) {
 
 			runners := map[string]*Runner{"Source": r1, "Archive": r2}
 			for name, r := range runners {
-				r := r
 				t.Run(name, func(t *testing.T) {
 					t.Parallel()
 					r.preInitState.Logger, _ = logtest.NewNullLogger()
@@ -1822,7 +1796,6 @@ func TestInitContextForbidden(t *testing.T) {
 	tb := httpmultibin.NewHTTPMultiBin(t)
 
 	for _, test := range table {
-		test := test
 		t.Run(test[0], func(t *testing.T) {
 			t.Parallel()
 			_, err := getSimpleRunner(t, "/script.js", tb.Replacer.Replace(test[1]))
@@ -1866,7 +1839,6 @@ func TestArchiveRunningIntegrity(t *testing.T) {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			var err error
@@ -2363,7 +2335,6 @@ func TestForceHTTP1Feature(t *testing.T) {
 
 			runners := map[string]*Runner{"Source": r1, "Archive": r2}
 			for name, r := range runners {
-				r := r
 				t.Run(name, func(t *testing.T) {
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
@@ -2435,7 +2406,6 @@ func TestExecutionInfo(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			r, err := getSimpleRunner(t, "/script.js", tc.script)
@@ -2508,7 +2478,6 @@ exports.default = () => {
 
 	runners := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range runners {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())

--- a/internal/js/share_test.go
+++ b/internal/js/share_test.go
@@ -71,7 +71,6 @@ exports.default = function() {
 
 	testdata := map[string]*Runner{"Source": r1, "Archive": r2}
 	for name, r := range testdata {
-		r := r
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ctx, cancel := context.WithCancel(context.Background())

--- a/internal/lib/netext/grpcext/conn_test.go
+++ b/internal/lib/netext/grpcext/conn_test.go
@@ -153,7 +153,6 @@ func TestConnInvokeInvalid(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/lib/strvals/parser_test.go
+++ b/internal/lib/strvals/parser_test.go
@@ -57,7 +57,6 @@ func TestParserInvalid(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/lib/trace/otel_test.go
+++ b/internal/lib/trace/otel_test.go
@@ -84,7 +84,6 @@ func TestTracerProviderParamsFromConfigLine(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/loader/loader_test.go
+++ b/internal/loader/loader_test.go
@@ -128,7 +128,6 @@ func TestLoad(t *testing.T) {
 		}
 
 		for name, data := range testdata {
-			data := data
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 				pwdURL, err := url.Parse("file://" + data.pwd)

--- a/internal/log/file_test.go
+++ b/internal/log/file_test.go
@@ -86,7 +86,6 @@ func TestFileHookFromConfigLine(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.line, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/log/levels_test.go
+++ b/internal/log/levels_test.go
@@ -43,7 +43,6 @@ func Test_getLevels(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.level, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/log/loki_test.go
+++ b/internal/log/loki_test.go
@@ -73,7 +73,6 @@ func TestSyslogFromConfigLine(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.line, func(t *testing.T) {
 			t.Parallel()
 			// no parallel because this is way too fast and parallel will only slow it down
@@ -140,7 +139,6 @@ func TestFilterLabels(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		c := c
 		t.Run(fmt.Sprint(i), func(t *testing.T) {
 			t.Parallel()
 			h := &lokiHook{}

--- a/internal/metrics/engine/engine_test.go
+++ b/internal/metrics/engine/engine_test.go
@@ -54,7 +54,6 @@ func TestMetricsEngineGetThresholdMetricOrSubmetricError(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run("", func(t *testing.T) {
 			t.Parallel()
 
@@ -102,7 +101,6 @@ func TestMetricsEngineEvaluateThresholdNoAbort(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.threshold, func(t *testing.T) {
 			t.Parallel()
 			me := newTestMetricsEngine(t)

--- a/internal/output/cloud/output_test.go
+++ b/internal/output/cloud/output_test.go
@@ -57,8 +57,6 @@ func TestNewOutputNameResolution(t *testing.T) {
 	}
 
 	for _, testCase := range cases {
-		testCase := testCase
-
 		t.Run(testCase.url.String(), func(t *testing.T) {
 			t.Parallel()
 			out, err := newOutput(output.Params{

--- a/internal/output/json/json.go
+++ b/internal/output/json/json.go
@@ -130,7 +130,7 @@ func (o *Output) flushMetrics() {
 		samples := sc.GetSamples()
 		count += len(samples)
 		for _, sample := range samples {
-			sample := sample
+
 			o.handleMetric(sample.Metric, jw)
 			wrapSample(sample).MarshalEasyJSON(jw)
 			jw.RawByte('\n')

--- a/internal/output/opentelemetry/config_test.go
+++ b/internal/output/opentelemetry/config_test.go
@@ -188,7 +188,6 @@ func TestConfig(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		testCase := testCase
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			config, err := GetConsolidatedConfig(testCase.jsonRaw, testCase.env)

--- a/internal/output/opentelemetry/output_test.go
+++ b/internal/output/opentelemetry/output_test.go
@@ -193,11 +193,9 @@ func TestOutput(t *testing.T) {
 	}
 
 	for _, proto := range testProtocols {
-		proto := proto
 		t.Run(fmt.Sprintf("%s collector", proto), func(t *testing.T) {
 			t.Parallel()
 			for _, tc := range testCases {
-				tc := tc
 				t.Run(tc.name, func(t *testing.T) {
 					t.Parallel()
 

--- a/internal/output/prometheusrw/remotewrite/config_test.go
+++ b/internal/output/prometheusrw/remotewrite/config_test.go
@@ -192,7 +192,6 @@ func TestGetConsolidatedConfig(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		testCase := testCase
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(testCase.jsonRaw, testCase.env, testCase.arg)
@@ -253,7 +252,6 @@ func TestOptionServerURL(t *testing.T) {
 		StaleMarkers:          null.BoolFrom(false),
 	}
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(
@@ -300,7 +298,6 @@ func TestOptionHeaders(t *testing.T) {
 		StaleMarkers: null.BoolFrom(false),
 	}
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(
@@ -334,7 +331,6 @@ func TestOptionInsecureSkipTLSVerify(t *testing.T) {
 		StaleMarkers:          null.BoolFrom(false),
 	}
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(
@@ -371,7 +367,6 @@ func TestOptionBasicAuth(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(
@@ -405,7 +400,6 @@ func TestOptionBearerToken(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(
@@ -440,7 +434,6 @@ func TestOptionClientCertificate(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(
@@ -478,7 +471,6 @@ func TestOptionTrendAsNativeHistogram(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(
@@ -513,7 +505,6 @@ func TestOptionPushInterval(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(
@@ -549,7 +540,6 @@ func TestConfigTrendStats(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(
@@ -582,7 +572,6 @@ func TestOptionStaleMarker(t *testing.T) {
 	}
 
 	for name, tc := range cases {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			c, err := GetConsolidatedConfig(

--- a/internal/output/prometheusrw/remotewrite/remotewrite_test.go
+++ b/internal/output/prometheusrw/remotewrite/remotewrite_test.go
@@ -168,7 +168,6 @@ func TestOutputConvertToPbSeries_WithPreviousState(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			pbseries := o.convertToPbSeries([]metrics.SampleContainer{
 				metrics.Sample{

--- a/internal/ui/pb/helpers_test.go
+++ b/internal/ui/pb/helpers_test.go
@@ -43,7 +43,6 @@ func TestGetFixedLengthInt(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.expRes, func(t *testing.T) {
 			t.Parallel()
 			fmtFormat := GetFixedLengthIntFormat(tc.maxVal)
@@ -90,7 +89,6 @@ func TestGetFixedLengthFloat(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("tc%d_exp_%s", i, tc.expRes), func(t *testing.T) {
 			t.Parallel()
 			fmtFormat := GetFixedLengthFloatFormat(tc.maxVal, tc.precision)
@@ -139,7 +137,6 @@ func TestGetFixedLengthDuration(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("tc%d_exp_%s", i, tc.expRes), func(t *testing.T) {
 			t.Parallel()
 			res := GetFixedLengthDuration(tc.val, tc.maxVal)

--- a/internal/ui/pb/progressbar_test.go
+++ b/internal/ui/pb/progressbar_test.go
@@ -70,7 +70,6 @@ func TestProgressBarRender(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.expected, func(t *testing.T) {
 			t.Parallel()
 			pbar := New(tc.options...)
@@ -94,7 +93,6 @@ func TestProgressBarRenderPaddingMaxLeft(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.left, func(t *testing.T) {
 			t.Parallel()
 			pbar := New(WithLeft(func() string { return tc.left }))
@@ -116,7 +114,6 @@ func TestProgressBarLeft(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.expected, func(t *testing.T) {
 			t.Parallel()
 			pbar := New(WithLeft(tc.left))

--- a/js/common/bridge_test.go
+++ b/js/common/bridge_test.go
@@ -68,7 +68,7 @@ func TestFieldNameMapper(t *testing.T) {
 		}},
 	}
 	for _, data := range testdata {
-		data := data
+
 		for field, name := range data.Fields {
 			field, name := field, name
 			t.Run(field, func(t *testing.T) {

--- a/js/common/util_test.go
+++ b/js/common/util_test.go
@@ -40,7 +40,6 @@ func TestToBytes(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%T", tc.in), func(t *testing.T) {
 			t.Parallel()
 			out, err := ToBytes(tc.in)
@@ -68,7 +67,6 @@ func TestToString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%T", tc.in), func(t *testing.T) {
 			t.Parallel()
 			out, err := ToString(tc.in)

--- a/js/modules/k6/http/batch_test.go
+++ b/js/modules/k6/http/batch_test.go
@@ -69,7 +69,6 @@ func TestBatchError(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ts := newTestCase(t)
@@ -130,7 +129,6 @@ func TestBatchErrorNoPanic(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			ts := newTestCase(t)

--- a/js/modules/k6/http/file_test.go
+++ b/js/modules/k6/http/file_test.go
@@ -43,7 +43,6 @@ func TestHTTPFile(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			t.Parallel()
 			runtime, mi := getTestModuleInstance(t)

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1329,7 +1329,6 @@ func TestRequestArrayBufferBody(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.arr, func(t *testing.T) {
 			_, err := rt.RunString(sr(fmt.Sprintf(`
 			var arr = new %[1]s([104, 101, 108, 108, 111]); // "hello"
@@ -1456,7 +1455,6 @@ func TestRequestCompression(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.compression, func(t *testing.T) {
 			algos := strings.Split(testCase.compression, ",")
 			for i, algo := range algos {
@@ -1774,7 +1772,7 @@ func TestErrorCodes(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
+
 		// clear the Samples
 		metrics.GetBufferedSamples(samples)
 		t.Run(testCase.name, func(t *testing.T) {
@@ -2094,7 +2092,6 @@ func TestRequestAndBatchTLS(t *testing.T) {
 		{Name: "tls12", URL: "tlsv12.localhost", Version: "http.TLS_1_2"},
 	}
 	for _, versionTest := range tlsVersionTests {
-		versionTest := versionTest
 		t.Run(versionTest.Name, func(t *testing.T) {
 			t.Parallel()
 			ts := newTestCase(t)
@@ -2152,7 +2149,6 @@ func TestRequestAndBatchTLS(t *testing.T) {
 		{Name: "cipher_suite_ecc384", URL: "ecc384.localhost", CipherSuite: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256", suite: tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256},
 	}
 	for _, cipherSuiteTest := range tlsCipherSuiteTests {
-		cipherSuiteTest := cipherSuiteTest
 		t.Run(cipherSuiteTest.Name, func(t *testing.T) {
 			t.Parallel()
 			ts := newTestCase(t)

--- a/js/modules/k6/http/response_callback_test.go
+++ b/js/modules/k6/http/response_callback_test.go
@@ -258,7 +258,6 @@ func TestResponseCallbackInAction(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		testCase := testCase
 
 		runCode := func(code string) {
 			t.Helper()
@@ -379,7 +378,6 @@ func TestResponseCallbackBatch(t *testing.T) {
 		},
 	}
 	for name, testCase := range testCases {
-		testCase := testCase
 		t.Run(name, func(t *testing.T) {
 			ts.instance.defaultClient.responseCallback = defaultExpectedStatuses.match
 

--- a/js/modules/k6/k6_test.go
+++ b/js/modules/k6/k6_test.go
@@ -30,7 +30,6 @@ func TestSleep(t *testing.T) {
 		"0.5": 500 * time.Millisecond,
 	}
 	for name, d := range testdata {
-		d := d
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			tc := testCaseRuntime(t)

--- a/lib/execution_segment_test.go
+++ b/lib/execution_segment_test.go
@@ -87,7 +87,6 @@ func TestExecutionSegmentUnmarshalText(t *testing.T) {
 		// TODO add more strange or not so strange cases
 	}
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.input, func(t *testing.T) {
 			t.Parallel()
 			es := new(ExecutionSegment)
@@ -313,7 +312,6 @@ func TestExecutionSegmentSubSegment(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 			require.Equal(t, testCase.result, testCase.base.SubSegment(testCase.sub))
@@ -356,7 +354,6 @@ func TestSegmentExecutionFloatLength(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(testCase.es.String(), func(t *testing.T) {
 			t.Parallel()
 			require.InEpsilon(t, testCase.expected, testCase.es.FloatLength(), 0.001)
@@ -400,7 +397,6 @@ func TestExecutionSegmentStringSequences(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.seq, func(t *testing.T) {
 			t.Parallel()
 			result, err := NewExecutionSegmentSequenceFromString(tc.seq)
@@ -574,7 +570,6 @@ func TestGetStripedOffsets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("seq:%s;segment:%s", tc.seq, tc.seg), func(t *testing.T) {
 			t.Parallel()
 			ess, err := NewExecutionSegmentSequenceFromString(tc.seq)
@@ -611,7 +606,6 @@ func TestSequenceLCD(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("seq:%s", tc.seq), func(t *testing.T) {
 			t.Parallel()
 			ess, err := NewExecutionSegmentSequenceFromString(tc.seq)
@@ -627,7 +621,6 @@ func BenchmarkGetStripedOffsets(b *testing.B) {
 	r := rand.New(rand.NewSource(seed)) //nolint:gosec
 
 	for _, length := range lengths {
-		length := length
 		b.Run(fmt.Sprintf("length%d,seed%d", length, seed), func(b *testing.B) {
 			sequence := generateRandomSequence(b, length, 100, r)
 			b.ResetTimer()
@@ -663,7 +656,6 @@ func BenchmarkGetStripedOffsetsEven(b *testing.B) {
 	}
 
 	for _, length := range lengths {
-		length := length
 		b.Run(fmt.Sprintf("length%d", length), func(b *testing.B) {
 			sequence := generateSequence(length)
 			b.ResetTimer()
@@ -691,7 +683,6 @@ func TestGetNewExecutionTupleBesedOnValue(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("seq:%s;segment:%s", tc.seq, tc.seg), func(t *testing.T) {
 			t.Parallel()
 			ess, err := NewExecutionSegmentSequenceFromString(tc.seq)
@@ -848,7 +839,6 @@ func TestNewExecutionTuple(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
 		t.Run(fmt.Sprintf("seg:'%s',seq:'%s'", testCase.seg, testCase.seq), func(t *testing.T) {
 			t.Parallel()
 			et, err := NewExecutionTuple(testCase.seg, testCase.seq)
@@ -888,7 +878,6 @@ func BenchmarkExecutionSegmentScale(b *testing.B) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		b.Run(fmt.Sprintf("seq:%s;segment:%s", tc.seq, tc.seg), func(b *testing.B) {
 			ess, err := NewExecutionSegmentSequenceFromString(tc.seq)
 			require.NoError(b, err)
@@ -900,7 +889,7 @@ func BenchmarkExecutionSegmentScale(b *testing.B) {
 			et, err := NewExecutionTuple(segment, &ess)
 			require.NoError(b, err)
 			for _, value := range []int64{5, 5523, 5000000, 67280421310721} {
-				value := value
+
 				b.Run(fmt.Sprintf("segment.Scale(%d)", value), func(b *testing.B) {
 					for i := 0; i < b.N; i++ {
 						segment.Scale(value)

--- a/lib/executor/constant_arrival_rate_test.go
+++ b/lib/executor/constant_arrival_rate_test.go
@@ -170,8 +170,6 @@ func TestConstantArrivalRateRunCorrectTiming(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		test := test
-
 		t.Run(fmt.Sprintf("segment %s sequence %s", test.segment, test.sequence), func(t *testing.T) {
 			var count int64
 			startTime := time.Now()
@@ -240,7 +238,6 @@ func TestArrivalRateCancel(t *testing.T) {
 		"ramping":  getTestRampingArrivalRateConfig(),
 	}
 	for name, config := range testCases {
-		config := config
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			ch := make(chan struct{})
@@ -338,7 +335,6 @@ func TestConstantArrivalRateGlobalIters(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s_%s", tc.seq, tc.seg), func(t *testing.T) {
 			t.Parallel()
 

--- a/lib/executor/execution_test.go
+++ b/lib/executor/execution_test.go
@@ -30,7 +30,6 @@ func TestExecutionStateVUIDs(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("seq:%s;segment:%s", tc.seq, tc.seg), func(t *testing.T) {
 			t.Parallel()
 			ess, err := lib.NewExecutionSegmentSequenceFromString(tc.seq)

--- a/lib/executor/executors_test.go
+++ b/lib/executor/executors_test.go
@@ -428,7 +428,6 @@ var configMapTestCases = []configMapTestCase{
 func TestConfigMapParsingAndValidation(t *testing.T) {
 	t.Parallel()
 	for i, tc := range configMapTestCases {
-		tc := tc
 		t.Run(fmt.Sprintf("TestCase#%d", i), func(t *testing.T) {
 			t.Parallel()
 			t.Log(tc.rawJSON)

--- a/lib/executor/ramping_arrival_rate_test.go
+++ b/lib/executor/ramping_arrival_rate_test.go
@@ -433,7 +433,6 @@ func BenchmarkCal(b *testing.B) {
 	for _, t := range []time.Duration{
 		time.Second, time.Minute,
 	} {
-		t := t
 		b.Run(t.String(), func(b *testing.B) {
 			config := RampingArrivalRateConfig{
 				TimeUnit:  types.NullDurationFrom(time.Second),
@@ -469,7 +468,6 @@ func BenchmarkCalRat(b *testing.B) {
 	for _, t := range []time.Duration{
 		time.Second, time.Minute,
 	} {
-		t := t
 		b.Run(t.String(), func(b *testing.B) {
 			config := RampingArrivalRateConfig{
 				TimeUnit:  types.NullDurationFrom(time.Second),
@@ -691,7 +689,6 @@ func TestRampingArrivalRateGlobalIters(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s_%s", tc.seq, tc.seg), func(t *testing.T) {
 			t.Parallel()
 
@@ -796,7 +793,6 @@ func TestRampingArrivalRateActiveVUs_GetExecutionRequirements(t *testing.T) {
 	}
 
 	for name, tc := range tcs {
-		tc := tc
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/lib/executor/ramping_vus_test.go
+++ b/lib/executor/ramping_vus_test.go
@@ -1005,7 +1005,7 @@ func TestRampingVUsGetRawExecutionStepsCornerCases(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		testCase := testCase
+
 		conf := NewRampingVUsConfig("test")
 		conf.StartVUs = null.IntFrom(testCase.start)
 		conf.Stages = testCase.stages
@@ -1059,7 +1059,6 @@ func BenchmarkRampingVUsGetRawExecutionSteps(b *testing.B) {
 		},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		b.Run(fmt.Sprintf("seq:%s;segment:%s", tc.seq, tc.seg), func(b *testing.B) {
 			ess, err := lib.NewExecutionSegmentSequenceFromString(tc.seq)
 			require.NoError(b, err)

--- a/lib/executor/shared_iterations_test.go
+++ b/lib/executor/shared_iterations_test.go
@@ -131,7 +131,6 @@ func TestSharedIterationsGlobalIters(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("%s_%s", tc.seq, tc.seg), func(t *testing.T) {
 			t.Parallel()
 

--- a/lib/fsext/filepath_unix_test.go
+++ b/lib/fsext/filepath_unix_test.go
@@ -63,8 +63,6 @@ func TestJoinFilePath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -119,8 +117,6 @@ func TestAbs(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/lib/helpers_test.go
+++ b/lib/helpers_test.go
@@ -32,7 +32,6 @@ func TestStrictJSONUnmarshal(t *testing.T) {
 		{`{"data": 123, "props": {"test": "mest"}}asdg`, true, &someElement{}, nil},
 	}
 	for i, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("TestCase#%d", i), func(t *testing.T) {
 			t.Parallel()
 			err := StrictJSONUnmarshal([]byte(tc.data), &tc.destination)

--- a/lib/limiter_test.go
+++ b/lib/limiter_test.go
@@ -45,7 +45,6 @@ func TestSlotLimiters(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("limit=%d,launches=%d", tc.limit, tc.launches), func(t *testing.T) {
 			t.Parallel()
 			l := NewSlotLimiter(tc.limit)

--- a/lib/netext/dialer_test.go
+++ b/lib/netext/dialer_test.go
@@ -58,8 +58,6 @@ func TestDialerAddr(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.address, func(t *testing.T) {
 			t.Parallel()
 			addr, err := dialer.getDialAddr(tc.address)
@@ -97,8 +95,6 @@ func TestDialerAddrBlockHostnamesStar(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.address, func(t *testing.T) {
 			t.Parallel()
 			addr, err := dialer.getDialAddr(tc.address)

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -158,7 +158,6 @@ func TestResponseStatus(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			tc := tc
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -218,7 +217,6 @@ func TestURL(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			tc := tc
 			t.Run(tc.url, func(t *testing.T) {
 				t.Parallel()
 				u, err := url.Parse(tc.url)

--- a/lib/netext/resolver_test.go
+++ b/lib/netext/resolver_test.go
@@ -63,7 +63,6 @@ func TestResolver(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			tc := tc
 			t.Run(fmt.Sprintf("%s_%s_%s", tc.ttl, tc.sel, tc.pol), func(t *testing.T) {
 				t.Parallel()
 				r := NewResolver(mr.LookupIPAll, tc.ttl, tc.sel, tc.pol)

--- a/lib/options_test.go
+++ b/lib/options_test.go
@@ -712,7 +712,6 @@ func TestCIDRUnmarshal(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		data := data
 		t.Run(data.input, func(t *testing.T) {
 			t.Parallel()
 			actualIPNet := &IPNet{}
@@ -774,7 +773,6 @@ func TestHost(t *testing.T) {
 	}
 
 	for _, data := range testData {
-		data := data
 		t.Run(data.input, func(t *testing.T) {
 			t.Parallel()
 			actualHost := &types.Host{}
@@ -814,7 +812,6 @@ func TestValidate(t *testing.T) {
 			},
 		}
 		for _, data := range testData {
-			data := data
 			t.Run(data.input, func(t *testing.T) {
 				t.Parallel()
 				sec, _ := time.ParseDuration(data.input)

--- a/lib/types/hosts_test.go
+++ b/lib/types/hosts_test.go
@@ -177,7 +177,6 @@ func TestHosts(t *testing.T) {
 // runTcs is utility function for testing HostTestCase slice
 func runTcs(t *testing.T, at *Hosts, tcs []HostTestCase) {
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.desc+"-"+tc.hostname, func(t *testing.T) {
 			t.Parallel()
 			addr := at.Match(tc.hostname)
@@ -223,7 +222,6 @@ func TestHostsJSON(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range tcs {
-			tc := tc
 			t.Run(tc.marshal, func(t *testing.T) {
 				t.Parallel()
 				m, err := json.Marshal(tc.t)
@@ -237,8 +235,6 @@ func TestHostsJSON(t *testing.T) {
 		t.Parallel()
 
 		for _, tc := range tcs {
-			tc := tc
-
 			t.Run(tc.marshal, func(t *testing.T) {
 				t.Parallel()
 				var trie NullHosts

--- a/lib/types/trie_test.go
+++ b/lib/types/trie_test.go
@@ -52,7 +52,6 @@ func TestTrieContains(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
 		t.Run(tc.query, func(t *testing.T) {
 			t.Parallel()
 
@@ -74,8 +73,6 @@ func TestReverseString(t *testing.T) {
 	}
 
 	for _, tc := range tcs {
-		tc := tc
-
 		t.Run(tc.str, func(t *testing.T) {
 			t.Parallel()
 			val := reverseString(tc.str)

--- a/lib/types/types_test.go
+++ b/lib/types/types_test.go
@@ -47,7 +47,6 @@ func TestParseExtendedDuration(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(fmt.Sprintf("tc_%s_exp", tc.durStr), func(t *testing.T) {
 			t.Parallel()
 			result, err := ParseExtendedDuration(tc.durStr)

--- a/metrics/metric_test.go
+++ b/metrics/metric_test.go
@@ -169,8 +169,6 @@ func TestParseMetricName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/metrics/sample_test.go
+++ b/metrics/sample_test.go
@@ -58,7 +58,6 @@ func TestGetResolversForTrendColumnsValidation(t *testing.T) {
 	}
 
 	for _, tc := range validateTests {
-		tc := tc
 		t.Run(fmt.Sprintf("%v", tc.stats), func(t *testing.T) {
 			t.Parallel()
 			_, err := GetResolversForTrendColumns(tc.stats)
@@ -86,7 +85,6 @@ func TestGetResolversForTrendColumnsCalculation(t *testing.T) {
 	}
 
 	for _, tc := range customResolversTests {
-		tc := tc
 		t.Run(fmt.Sprintf("%v", tc.stats), func(t *testing.T) {
 			t.Parallel()
 			sink := createTestTrendSink(100)

--- a/metrics/thresholds_parser_test.go
+++ b/metrics/thresholds_parser_test.go
@@ -42,8 +42,6 @@ func TestParseThresholdExpression(t *testing.T) {
 		},
 	}
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -173,8 +171,6 @@ func TestParseThresholdAggregationMethod(t *testing.T) {
 		},
 	}
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -300,8 +296,6 @@ func TestScanThresholdExpression(t *testing.T) {
 		},
 	}
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/metrics/thresholds_test.go
+++ b/metrics/thresholds_test.go
@@ -133,8 +133,6 @@ func TestThreshold_runNoTaint(t *testing.T) {
 	}
 
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -487,8 +485,6 @@ func TestThresholdsValidate(t *testing.T) {
 		}
 
 		for _, testCase := range tests {
-			testCase := testCase
-
 			t.Run(testCase.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -733,8 +729,6 @@ func TestThresholdsRun(t *testing.T) {
 		},
 	}
 	for _, testCase := range tests {
-		testCase := testCase
-
 		t.Run(testCase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -825,8 +819,6 @@ func TestThresholdsJSON(t *testing.T) {
 	}
 
 	for _, data := range testdata {
-		data := data
-
 		t.Run(data.JSON, func(t *testing.T) {
 			t.Parallel()
 

--- a/output/cloud/expv2/hdr_test.go
+++ b/output/cloud/expv2/hdr_test.go
@@ -126,7 +126,6 @@ func TestHistogramAddWithSimpleValues(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			h := newHistogram()
@@ -482,7 +481,6 @@ func TestHistogramAsProto(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -180,7 +180,6 @@ func TestOutputHandleFlushError(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/output/csv/config_test.go
+++ b/output/csv/config_test.go
@@ -105,9 +105,6 @@ func TestParseArg(t *testing.T) {
 	}
 
 	for arg, testCase := range cases {
-		arg := arg
-		testCase := testCase
-
 		t.Run(arg, func(t *testing.T) {
 			t.Parallel()
 

--- a/output/csv/output.go
+++ b/output/csv/output.go
@@ -193,7 +193,7 @@ func (o *Output) flushMetrics() {
 		defer o.csvLock.Unlock()
 		for _, sc := range samples {
 			for _, sample := range sc.GetSamples() {
-				sample := sample
+
 				row := SampleToRow(&sample, o.resTags, o.ignoredTags, o.row, o.timeFormat)
 				err := o.csvWriter.Write(row)
 				if err != nil {

--- a/output/csv/output_test.go
+++ b/output/csv/output_test.go
@@ -481,7 +481,7 @@ func TestRun(t *testing.T) {
 
 	for i, data := range testData {
 		name := fmt.Sprint(i)
-		data := data
+
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			mem := fsext.NewMemMapFs()


### PR DESCRIPTION
## What?

Add copyloopvar as a linter and autofix its issues

## Why?

This removes pre 1.22 copying of values in a lot of tests with table tests and make them more modern and slightly shorter. 
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER
- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
