### PR TITLE
UX: fix anchor link in the error message

### DIFF
--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -34,7 +34,7 @@ const (
 		`local directory (-v /local/path/:/inside/docker/path) containing ` +
 		`your script and modules so that they're accessible by k6 from ` +
 		`inside of the container, see ` +
-		`https://grafana.com/docs/k6/latest/using-k6/modules/#using-local-modules-with-docker.`
+		`https://grafana.com/docs/k6/latest/using-k6/modules/#local-modules-2.`
 )
 
 type unresolvableURLError string

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -34,7 +34,7 @@ const (
 		`local directory (-v /local/path/:/inside/docker/path) containing ` +
 		`your script and modules so that they're accessible by k6 from ` +
 		`inside of the container, see ` +
-		`https://grafana.com/docs/k6/latest/using-k6/modules/#local-modules-2.`
+		`https://grafana.com/docs/k6/latest/using-k6/modules/#use-modules-with-docker`
 )
 
 type unresolvableURLError string

--- a/internal/loader/loader.go
+++ b/internal/loader/loader.go
@@ -34,7 +34,7 @@ const (
 		`local directory (-v /local/path/:/inside/docker/path) containing ` +
 		`your script and modules so that they're accessible by k6 from ` +
 		`inside of the container, see ` +
-		`https://grafana.com/docs/k6/latest/using-k6/modules/#use-modules-with-docker`
+		`https://grafana.com/docs/k6/latest/using-k6/modules/#use-modules-with-docker.`
 )
 
 type unresolvableURLError string


### PR DESCRIPTION
## What?
 
Update anchor link to the official docs in the error message `The moduleSpecifier "%s" couldn't be found on local disk`. New anchor link is `https://grafana.com/docs/k6/latest/using-k6/modules/#local-modules-2`.

## Why?

Anchor link  `https://grafana.com/docs/k6/latest/using-k6/modules/#using-local-modules-with-docker` in the error message `The moduleSpecifier "%s" couldn't be found on local disk...`  is not up-to date, so anchor link is being resolved to the beginning of the page. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER
- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
