### PR TITLE
Local templates support in `k6 new`

### DIFF
--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -25,7 +25,7 @@ func (c *newScriptCmd) flagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	flags.SortFlags = false
 	flags.BoolVarP(&c.overwriteFiles, "force", "f", false, "overwrite existing files")
-	flags.StringVar(&c.templateType, "template", "minimal", "template type (choices: minimal, protocol, browser)")
+	flags.StringVar(&c.templateType, "template", "minimal", "template type (choices: minimal, protocol, browser) or relative/absolute path to a custom template file") //nolint:lll
 	flags.StringVar(&c.projectID, "project-id", "", "specify the Grafana Cloud project ID for the test")
 	return flags
 }

--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -45,7 +45,7 @@ func (c *newScriptCmd) run(_ *cobra.Command, args []string) (err error) {
 	}
 
 	// Initialize template manager and validate template before creating any files
-	tm, err := templates.NewTemplateManager()
+	tm, err := templates.NewTemplateManager(c.gs.FS)
 	if err != nil {
 		return fmt.Errorf("error initializing template manager: %w", err)
 	}

--- a/internal/cmd/new.go
+++ b/internal/cmd/new.go
@@ -75,10 +75,10 @@ func (c *newScriptCmd) run(_ *cobra.Command, args []string) (err error) {
 
 	defer func() {
 		if cerr := fd.Close(); cerr != nil {
-			if _, err := fmt.Fprintf(c.gs.Stderr, "error closing file: %v\n", cerr); err != nil {
-				err = fmt.Errorf("error writing error message to stderr: %w", err) //nolint:staticcheck,ineffassign,wastedassign
+			if _, werr := fmt.Fprintf(c.gs.Stderr, "error closing file: %v\n", cerr); werr != nil {
+				err = fmt.Errorf("error writing error message to stderr: %w", werr)
 			} else {
-				err = cerr //nolint:staticcheck,ineffassign,wastedassign
+				err = cerr
 			}
 		}
 	}()

--- a/internal/cmd/new_test.go
+++ b/internal/cmd/new_test.go
@@ -144,7 +144,7 @@ func TestNewScriptCmd_LocalTemplate(t *testing.T) {
 	data, err := fsext.ReadFile(ts.FS, defaultNewScriptName)
 	require.NoError(t, err)
 
-	assert.Equal(t, templateContent, string(data), "generated file matches the template content")
+	assert.Equal(t, templateContent, string(data), "generated file should match the template content")
 }
 
 func TestNewScriptCmd_LocalTemplateWith_ProjectID(t *testing.T) {

--- a/internal/cmd/templates/templates.go
+++ b/internal/cmd/templates/templates.go
@@ -87,7 +87,13 @@ func (tm *TemplateManager) GetTemplate(templateType string) (*template.Template,
 		return tmpl, nil
 	}
 
-	return nil, fmt.Errorf("invalid template type: %s", templateType)
+	// Check if there's a file with this name in current directory
+	exists, err := fsext.Exists(tm.fs, fsext.JoinFilePath(".", templateType))
+	if err == nil && exists {
+		return nil, fmt.Errorf("invalid template type %q, did you mean ./%s?", templateType, templateType)
+	}
+
+	return nil, fmt.Errorf("invalid template type %q", templateType)
 }
 
 // isFilePath checks if the given string looks like a file path

--- a/internal/cmd/templates/templates.go
+++ b/internal/cmd/templates/templates.go
@@ -76,15 +76,22 @@ func (tm *TemplateManager) GetTemplate(tpl string) (*template.Template, error) {
 
 	// Then check if it's a file path
 	if isFilePath(tpl) {
-		content, err := fsext.ReadFile(tm.fs, tpl)
+		tplPath, err := filepath.Abs(tpl)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get absolute path for template %s: %w", tpl, err)
+		}
+
+		// Read the template content using the provided filesystem
+		content, err := fsext.ReadFile(tm.fs, tplPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read template file %s: %w", tpl, err)
 		}
 
-		tmpl, err := template.New(filepath.Base(tpl)).Parse(string(content))
+		tmpl, err := template.New(filepath.Base(tplPath)).Parse(string(content))
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse template file %s: %w", tpl, err)
 		}
+
 		return tmpl, nil
 	}
 


### PR DESCRIPTION
## What?

This PR adds support for local templates and addresses a bug when an empty script file is created even if the template name is invalid.

## Why?

The current script templating feature is limited to three pre-defined templates that are bundled with `k6`: minimal, protocol and browser. While this already reduces the amount of boilerplate code to write when starting a new project, being able to use custom user-defined templates would help to simplify the first steps even further, by allowing users to extract common parts, such as authentication, custom sets of options, into a template file that can be used to initialize tests.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [x] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): https://github.com/grafana/k6-docs/pull/1889
- [x] I have updated the release notes

## Related PR(s)/Issue(s)

Relevant issue https://github.com/grafana/k6/issues/4154