### PR TITLE
fix: added man page Closes #2347

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ FROM alpine:3.20 as release
 RUN adduser -D -u 12345 -g 12345 k6
 COPY --from=builder /usr/bin/k6 /usr/bin/k6
 
+# Copy the man page from the repo (ensure "man/k6.1" exists in your repo)
+COPY man/k6.1 /usr/share/man/man1/k6.1
+
+# Set MANPATH so that the man page is discoverable
+ENV MANPATH="/usr/share/man"
+
 USER k6
 WORKDIR /home/k6
 

--- a/man/k6.1
+++ b/man/k6.1
@@ -1,0 +1,48 @@
+.\" k6.1 - Manual page for the k6 command-line tool with TLDR summary
+.TH K6 1 "2025-03-12" "k6 0.57.0" "k6 Manual"
+.SH NAME
+k6 \- open source load testing tool for engineering teams
+.SH SYNOPSIS
+.B k6
+[\fIOPTIONS\fR] \fIscript.js\fR
+.SH DESCRIPTION
+k6 is an open source load testing tool designed for performance testing and monitoring.
+For detailed documentation, visit: <https://k6.io/docs/>.
+.SH TLDR
+The following examples offer a quick summary of common usage:
+.IP "$ tldr k6" 4
+.IP "Open source load testing tool and SaaS for engineering teams. More information: <https://k6.io>."
+.IP "Run load test locally:"
+.RS
+.B k6 run script.js
+.RE
+.IP "Run load test locally with a given number of virtual users and duration:"
+.RS
+.B k6 run --vus 10 --duration 30s script.js
+.RE
+.IP "Run load test locally with a given environment variable:"
+.RS
+.B k6 run -e HOSTNAME=example.com script.js
+.RE
+.IP "Run load test locally using InfluxDB to store results:"
+.RS
+.B k6 run --out influxdb=http://localhost:8086/k6db script.js
+.RE
+.IP "Run load test locally and discard response bodies (significantly faster):"
+.RS
+.B k6 run --discard-response-bodies script.js
+.RE
+.IP "Run load test locally using the base JavaScript compatibility mode (significantly faster):"
+.RS
+.B k6 run --compatibility-mode=base script.js
+.RE
+.IP "Log in to cloud service using secret token:"
+.RS
+.B k6 login cloud --token secret
+.RE
+.IP "Run load test on cloud infrastructure:"
+.RS
+.B k6 cloud script.js
+.RE
+.SH SEE ALSO
+.B https://k6.io/docs/


### PR DESCRIPTION
## What?

Added a general man page for *nix users to improve CLI usability and provide documentation for k6 commands.

## Why?

The issue #2347 was open, requesting better documentation for *nix users in the form of a man page.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER
- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Closes #2347 

<!-- Thanks for your contribution! 🙏🏼 -->
