### PR TITLE
Fix options parsing error printing the most of the options

### DIFF
--- a/internal/js/bundle.go
+++ b/internal/js/bundle.go
@@ -213,7 +213,6 @@ func (b *Bundle) populateExports(updateOptions bool, bi *BundleInstance) error {
 					err = fmt.Errorf("error parsing script options: %w", err)
 					return
 				}
-				fmt.Println(string(data))
 				dec := json.NewDecoder(bytes.NewReader(data))
 				dec.DisallowUnknownFields()
 				if err = dec.Decode(&b.Options); err != nil {

--- a/internal/js/bundle.go
+++ b/internal/js/bundle.go
@@ -217,8 +217,7 @@ func (b *Bundle) populateExports(updateOptions bool, bi *BundleInstance) error {
 				dec.DisallowUnknownFields()
 				if err = dec.Decode(&b.Options); err != nil {
 					if uerr := json.Unmarshal(data, &b.Options); uerr != nil {
-// comment about the intentions here like
-// Beautify the error because we want to return only the failing key and not the entire options' body as it would be without it. 
+						// Beautify the error so we can try to show the user the key and potential value that is failing to parse
 						uerr = beautifyOptionsJSONUnmarshalError(data, uerr)
 						err = errext.WithAbortReasonIfNone(
 							errext.WithExitCodeIfNone(uerr, exitcodes.InvalidConfig),

--- a/internal/js/bundle.go
+++ b/internal/js/bundle.go
@@ -217,6 +217,8 @@ func (b *Bundle) populateExports(updateOptions bool, bi *BundleInstance) error {
 				dec.DisallowUnknownFields()
 				if err = dec.Decode(&b.Options); err != nil {
 					if uerr := json.Unmarshal(data, &b.Options); uerr != nil {
+// comment about the intentions here like
+// Beautify the error because we want to return only the failing key and not the entire options' body as it would be without it. 
 						uerr = beautifyOptionsJSONUnmarshalError(data, uerr)
 						err = errext.WithAbortReasonIfNone(
 							errext.WithExitCodeIfNone(uerr, exitcodes.InvalidConfig),

--- a/internal/js/bundle.go
+++ b/internal/js/bundle.go
@@ -218,7 +218,7 @@ func (b *Bundle) populateExports(updateOptions bool, bi *BundleInstance) error {
 				dec.DisallowUnknownFields()
 				if err = dec.Decode(&b.Options); err != nil {
 					if uerr := json.Unmarshal(data, &b.Options); uerr != nil {
-						uerr = beautifyJSONUnmarshalError(data, uerr)
+						uerr = beautifyOptionsJSONUnmarshalError(data, uerr)
 						err = errext.WithAbortReasonIfNone(
 							errext.WithExitCodeIfNone(uerr, exitcodes.InvalidConfig),
 							errext.AbortedByScriptError,
@@ -249,7 +249,7 @@ func (b *Bundle) populateExports(updateOptions bool, bi *BundleInstance) error {
 	return nil
 }
 
-func beautifyJSONUnmarshalError(data []byte, err error) error {
+func beautifyOptionsJSONUnmarshalError(data []byte, err error) error {
 	unmarshalTypError := new(json.UnmarshalTypeError)
 	if errors.As(err, &unmarshalTypError) {
 		e := unmarshalTypError

--- a/internal/js/bundle.go
+++ b/internal/js/bundle.go
@@ -208,11 +208,12 @@ func (b *Bundle) populateExports(updateOptions bool, bi *BundleInstance) error {
 					continue
 				}
 				var data []byte
-				data, err = json.Marshal(v.Export())
+				data, err = json.MarshalIndent(v.Export(), "", "  ")
 				if err != nil {
 					err = fmt.Errorf("error parsing script options: %w", err)
 					return
 				}
+				fmt.Println(string(data))
 				dec := json.NewDecoder(bytes.NewReader(data))
 				dec.DisallowUnknownFields()
 				if err = dec.Decode(&b.Options); err != nil {
@@ -253,7 +254,7 @@ func beautifyJSONUnmarshalError(data []byte, err error) error {
 	if errors.As(err, &unmarshalTypError) {
 		e := unmarshalTypError
 		previousNewLineIndex := max(bytes.LastIndexByte(data[:e.Offset], '\n'), 0)
-		nextNewLineIndex := max(bytes.IndexByte(data[e.Offset:], '\n'), len(data)-1)
+		nextNewLineIndex := max(min(bytes.IndexByte(data[e.Offset:], '\n'), len(data)-1), (int)(e.Offset))
 
 		info := strings.TrimSpace(string(data[previousNewLineIndex:nextNewLineIndex]))
 		err = fmt.Errorf("parsing options from script got error while parsing %q: %w", info, e)

--- a/internal/js/bundle_test.go
+++ b/internal/js/bundle_test.go
@@ -236,8 +236,12 @@ func TestNewBundle(t *testing.T) {
 						`json: cannot unmarshal array into Go value of type lib.Options`,
 				},
 				"Bad value": {
-					`{"tags":["something"]}`,
-					`parsing options from script got error while parsing "{\"tags\":[\"something\"]": ` +
+					`{
+						"duration": "5m",
+						"tags":["something"],
+						"vus": 5
+					}`,
+					`parsing options from script got error while parsing "\"tags\": [": ` +
 						`json: cannot unmarshal array into Go struct field Options.tags of type map[string]string`,
 				},
 				"Function": {


### PR DESCRIPTION

## What?

Make the error message not print practically the whole options on error.

## Why?

The original idea of #4602 was to report at least the key with potentially the option in question. Due to the lack of support from the error - it can't parse it. The commit was trying to get everything between the previous and next new line.

But in practice was getting anything until the end, both because of error in the coed to get the index, but also because there were no newlines due to how we marshal the data before that.

This should fix both and make it less likely we just get everything until the end.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER
- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
