### PR TITLE
browser: fix web vitals test flakiness on Windows

### DIFF
--- a/internal/js/modules/k6/browser/tests/webvital_test.go
+++ b/internal/js/modules/k6/browser/tests/webvital_test.go
@@ -94,12 +94,6 @@ func TestWebVitalMetric(t *testing.T) {
 func TestWebVitalMetricNoInteraction(t *testing.T) {
 	t.Parallel()
 
-	// Increase timeout for Windows
-	timeout := 5 * time.Second
-	if runtime.GOOS == "windows" {
-		timeout = 10 * time.Second
-	}
-
 	var (
 		samples  = make(chan k6metrics.SampleContainer)
 		browser  = newTestBrowser(t, withFileServer(), withSamples(samples))
@@ -112,7 +106,7 @@ func TestWebVitalMetricNoInteraction(t *testing.T) {
 	)
 
 	done := make(chan struct{})
-	ctx, cancel := context.WithTimeout(browser.context(), timeout)
+	ctx, cancel := context.WithTimeout(browser.context(), common.DefaultTimeout)
 	defer cancel()
 	go func() {
 		for {
@@ -137,7 +131,7 @@ func TestWebVitalMetricNoInteraction(t *testing.T) {
 	opts := &common.FrameGotoOptions{
 		// Wait for both load and network idle events
 		WaitUntil: common.LifecycleEventNetworkIdle,
-		Timeout:   timeout,
+		Timeout:   common.DefaultTimeout,
 	}
 	resp, err := page.Goto(
 		browser.staticURL("web_vitals.html"),


### PR DESCRIPTION
## What?

Increase timeout and add a 1s delay after page load to ensure metrics are collected.

## Why?

The `TestWebVitalMetricNoInteraction` test is [failing on Windows](https://github.com/grafana/k6/actions/runs/13816953723/job/38652540550#step:4:69) due to timing issues when collecting web vital metrics.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.