### PR TITLE
Update PR template for docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,8 +24,8 @@ and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 
 - [ ] I have added the correct milestone and labels to the PR.
 - [ ] I have updated the release notes: _link_
-- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER
-- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER
+- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
+- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable
 
 <!-- - [ ] Any other relevant item -->
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,9 +23,9 @@ and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md
 **Please do not merge this PR until the following items are filled out.**
 
 - [ ] I have added the correct milestone and labels to the PR.
-- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER
-- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER
 - [ ] I have updated the release notes: _link_
+- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER
+- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER
 
 <!-- - [ ] Any other relevant item -->
 


### PR DESCRIPTION
## What?

This is for linking issues/PRs if needed.

## Why?

Updating the documentation right away is no longer necessary. However, we'll link issues/PRs if relevant. Updating the release notes is still a must.
