### PR TITLE
Add Prometheus Pushgateway Support

### DIFF
--- a/internal/js/modules/k6/browser/common/helpers_test.go
+++ b/internal/js/modules/k6/browser/common/helpers_test.go
@@ -58,7 +58,7 @@ func TestConvertArgument(t *testing.T) {
 
 		execCtx, ctx := newExecCtx()
 
-		var value float64 = 777.0
+		value := 777.0
 		arg, _ := convertArgument(ctx, execCtx, value)
 
 		require.NotNil(t, arg)

--- a/internal/output/prometheusrw/remote/pushgateway_client.go
+++ b/internal/output/prometheusrw/remote/pushgateway_client.go
@@ -1,0 +1,78 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
+)
+
+// PushgatewayClient is a client that pushes the metrics of prometheus registries
+// to a Pushgateway.
+type PushgatewayClient struct {
+	hc  *http.Client
+	url *url.URL
+	job string
+	cfg *HTTPConfig
+}
+
+// RegistryPusher is an interface to enable mocking of PushgatewayClient in unit tests
+type RegistryPusher interface {
+	Push(ctx context.Context, registries []*prometheus.Registry) error
+}
+
+var _ RegistryPusher = new(PushgatewayClient)
+
+// NewPushgatewayClient creates a new PushgatewayClient
+func NewPushgatewayClient(endpoint string, job string, cfg *HTTPConfig) (*PushgatewayClient, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	pgwc := &PushgatewayClient{
+		hc: &http.Client{
+			Timeout: cfg.Timeout,
+		},
+		url: u,
+		job: job,
+		cfg: cfg,
+	}
+
+	if cfg.TLSConfig != nil {
+		pgwc.hc.Transport = &http.Transport{
+			TLSClientConfig: cfg.TLSConfig,
+		}
+	}
+
+	return pgwc, nil
+}
+
+// Push pushes the given registries to the Pushgateway
+func (pgwc *PushgatewayClient) Push(ctx context.Context, registries []*prometheus.Registry) error {
+	pusher := push.New(pgwc.url.String(), pgwc.job)
+
+	header := http.Header{}
+	if len(pgwc.cfg.Headers) > 0 {
+		header = pgwc.cfg.Headers.Clone()
+	}
+	header.Set("User-Agent", "k6-prometheus-rw-output")
+	pusher.Header(header)
+
+	if pgwc.cfg.BasicAuth != nil {
+		pusher.BasicAuth(pgwc.cfg.BasicAuth.Username, pgwc.cfg.BasicAuth.Password)
+	}
+
+	for _, registry := range registries {
+		pusher.Gatherer(registry)
+	}
+
+	if err := pusher.AddContext(ctx); err != nil {
+		return fmt.Errorf("could not push metrics to pushgateway: %w", err)
+	}
+
+	return nil
+}

--- a/internal/output/prometheusrw/remote/pushgateway_client_test.go
+++ b/internal/output/prometheusrw/remote/pushgateway_client_test.go
@@ -1,0 +1,84 @@
+package remote
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewPushgatewayClient(t *testing.T) {
+	t.Parallel()
+
+	t.Run("CustomConfig", func(t *testing.T) {
+		t.Parallel()
+		hc := &HTTPConfig{Timeout: time.Second}
+		wc, err := NewPushgatewayClient("http://example.com/api/v1/write", "job", hc)
+		require.NoError(t, err)
+		require.NotNil(t, wc)
+		assert.Equal(t, wc.cfg, hc)
+	})
+
+	t.Run("InvalidURL", func(t *testing.T) {
+		t.Parallel()
+		wc, err := NewPushgatewayClient("fake://bad url", "job", nil)
+		require.Error(t, err)
+		assert.Nil(t, wc)
+	})
+}
+
+func TestPushgatewayPush(t *testing.T) {
+	t.Parallel()
+	h := func(rw http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, r.Header.Get("Content-Type"), "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited")
+		assert.Equal(t, r.Header.Get("User-Agent"), "k6-prometheus-rw-output")
+		assert.Equal(t, r.Header.Get("X-MY-CUSTOM-HEADER"), "fake")
+		assert.Equal(t, r.URL.Path, "/metrics/job/myjob")
+		username, password, ok := r.BasicAuth()
+		assert.Equal(t, username, "foo")
+		assert.Equal(t, password, "bar")
+		assert.True(t, ok)
+		assert.NotEmpty(t, r.Header.Get("Content-Length"))
+
+		b, err := io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, len(b))
+
+		rw.WriteHeader(http.StatusOK)
+	}
+	ts := httptest.NewServer(http.HandlerFunc(h))
+	defer ts.Close()
+
+	u, err := url.Parse(ts.URL)
+	require.NoError(t, err)
+
+	c := &PushgatewayClient{
+		hc:  ts.Client(),
+		url: u,
+		job: "myjob",
+		cfg: &HTTPConfig{
+			BasicAuth: &BasicAuth{
+				Username: "foo",
+				Password: "bar",
+			},
+			Headers: map[string][]string{
+				"X-MY-CUSTOM-HEADER": {"fake"},
+			},
+		},
+	}
+
+	reg1 := prometheus.NewRegistry()
+	err = reg1.Register(prometheus.NewGauge(prometheus.GaugeOpts{Name: "test", Help: "test"}))
+	assert.NoError(t, err)
+
+	err = c.Push(context.Background(), []*prometheus.Registry{reg1})
+	assert.NoError(t, err)
+}

--- a/internal/output/prometheusrw/remotewrite/config_test.go
+++ b/internal/output/prometheusrw/remotewrite/config_test.go
@@ -592,3 +592,79 @@ func TestOptionStaleMarker(t *testing.T) {
 		})
 	}
 }
+
+func TestOptionUsePushgateway(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		arg     string
+		env     map[string]string
+		jsonRaw json.RawMessage
+	}{
+		"JSON": {jsonRaw: json.RawMessage(`{"usePushgateway":true}`)},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_USE_PUSHGATEWAY": "true"}},
+		//nolint:gocritic
+		//"Arg":  {arg: "usePushgateway=true"},
+	}
+
+	expconfig := Config{
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
+		InsecureSkipTLSVerify: null.BoolFrom(false),
+		Username:              null.NewString("", false),
+		Password:              null.NewString("", false),
+		PushInterval:          types.NullDurationFrom(5 * time.Second),
+		Headers:               make(map[string]string),
+		TrendStats:            []string{"p(99)"},
+		StaleMarkers:          null.BoolFrom(false),
+		UsePushgateway:        null.BoolFrom(true),
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c, err := GetConsolidatedConfig(
+				tc.jsonRaw, tc.env, tc.arg)
+			require.NoError(t, err)
+			assert.Equal(t, expconfig, c)
+		})
+	}
+}
+
+func TestOptionPushgatewayJob(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		arg     string
+		env     map[string]string
+		jsonRaw json.RawMessage
+	}{
+		"JSON": {jsonRaw: json.RawMessage(`{"pushgatewayJob":"expectedJobname"}`)},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_PUSHGATEWAY_JOB": "expectedJobname"}},
+		//nolint:gocritic
+		//"Arg":  {arg: "pushgatewayJob=expectedJobname"},
+	}
+
+	expconfig := Config{
+		ServerURL:             null.StringFrom("http://localhost:9090/api/v1/write"),
+		InsecureSkipTLSVerify: null.BoolFrom(false),
+		Username:              null.NewString("", false),
+		Password:              null.NewString("", false),
+		PushInterval:          types.NullDurationFrom(5 * time.Second),
+		Headers:               make(map[string]string),
+		TrendStats:            []string{"p(99)"},
+		StaleMarkers:          null.BoolFrom(false),
+		PushgatewayJob:        null.NewString("expectedJobname", true),
+	}
+
+	for name, tc := range cases {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c, err := GetConsolidatedConfig(
+				tc.jsonRaw, tc.env, tc.arg)
+			require.NoError(t, err)
+			assert.Equal(t, expconfig, c)
+		})
+	}
+}

--- a/internal/output/prometheusrw/remotewrite/prometheus_test.go
+++ b/internal/output/prometheusrw/remotewrite/prometheus_test.go
@@ -72,10 +72,23 @@ func assertTimeSeriesEqual(t *testing.T, expected []*prompb.TimeSeries, actual [
 }
 
 // sortByLabelName sorts a slice of time series by Name label.
-//
-// TODO: remove the assumption that Name label is the first.
+func nameLabelVal(labels []*prompb.Label) string {
+	for _, label := range labels {
+		if label.Name == "__name__" {
+			return label.Value
+		}
+	}
+	panic("label with name '__name__' does not exist")
+}
+
 func sortByNameLabel(s []*prompb.TimeSeries) {
 	sort.Slice(s, func(i, j int) bool {
-		return s[i].Labels[0].Value <= s[j].Labels[0].Value
+		return nameLabelVal(s[i].Labels) <= nameLabelVal(s[j].Labels)
+	})
+}
+
+func sortWithTypeByNameLabel(s []prompbSeriesWithType) {
+	sort.Slice(s, func(i, j int) bool {
+		return nameLabelVal(s[i].Series.Labels) <= nameLabelVal(s[j].Series.Labels)
 	})
 }

--- a/internal/output/prometheusrw/remotewrite/remotewrite_test.go
+++ b/internal/output/prometheusrw/remotewrite/remotewrite_test.go
@@ -2,10 +2,15 @@ package remotewrite
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"testing"
 	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"go.k6.io/k6/internal/output/prometheusrw/remote"
 
 	prompb "buf.build/gen/go/prometheus/prometheus/protocolbuffers/go"
 	"github.com/sirupsen/logrus"
@@ -108,8 +113,16 @@ func TestOutputConvertToPbSeries(t *testing.T) {
 		},
 	}
 
-	sortByNameLabel(pbseries)
-	assert.Equal(t, exp, pbseries)
+	sortWithTypeByNameLabel(pbseries)
+
+	series := make([]*prompb.TimeSeries, len(pbseries))
+	types := make([]metrics.MetricType, len(pbseries))
+	for i, s := range pbseries {
+		series[i] = s.Series
+		types[i] = s.Type
+	}
+	assert.Equal(t, exp, series)
+	assert.Equal(t, []metrics.MetricType{metrics.Counter, metrics.Counter, metrics.Rate}, types)
 }
 
 //nolint:paralleltest,tparallel
@@ -234,6 +247,7 @@ func TestNewSeriesWithNativeHistogramMeasure(t *testing.T) {
 	registry := metrics.NewRegistry()
 	s := metrics.TimeSeries{
 		Metric: registry.MustNewMetric("metric1", metrics.Trend),
+		Tags:   registry.RootTagSet(),
 	}
 
 	swm := newSeriesWithMeasure(s, true, nil)
@@ -386,4 +400,223 @@ func TestOutputStopWithStaleMarkers(t *testing.T) {
 		}
 		assertfn(t, messages, msg)
 	}
+}
+
+type MockPushgatewayClient struct {
+	r []*prometheus.Registry
+}
+
+func (m *MockPushgatewayClient) Push(_ context.Context, registries []*prometheus.Registry) error {
+	m.r = registries
+	return nil
+}
+
+var _ remote.RegistryPusher = new(MockPushgatewayClient)
+
+func TestUsePushgateway(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	var client remote.RegistryPusher = &MockPushgatewayClient{}
+
+	registry := metrics.NewRegistry()
+	metric1 := registry.MustNewMetric("metric1", metrics.Counter)
+	metric2 := registry.MustNewMetric("metric2", metrics.Gauge)
+	metric3 := registry.MustNewMetric("metric3", metrics.Rate)
+	tagset1 := registry.RootTagSet().With("tagk1", "tagv1")
+	t0 := time.Date(2022, time.September, 1, 0, 0, 0, 0, time.UTC)
+	series1 := metrics.TimeSeries{
+		Metric: metric1,
+		Tags:   tagset1,
+	}
+	series2 := metrics.TimeSeries{
+		Metric: metric2,
+		Tags:   tagset1,
+	}
+	series3 := metrics.TimeSeries{
+		Metric: metric3,
+		Tags:   tagset1,
+	}
+
+	output := Output{
+		logger:    logger,
+		pgwClient: client,
+		tsdb:      map[metrics.TimeSeries]*seriesWithMeasure{},
+	}
+
+	samples := []metrics.SampleContainer{
+		metrics.Sample{
+			TimeSeries: series1,
+			Time:       t0.Add(10 * time.Millisecond),
+			Value:      3,
+		},
+		metrics.Sample{
+			TimeSeries: series2,
+			Time:       t0.Add(10 * time.Millisecond),
+			Value:      5,
+		},
+		metrics.Sample{
+			TimeSeries: series3,
+			Time:       t0.Add(10 * time.Millisecond),
+			Value:      7,
+		},
+	}
+
+	output.AddMetricSamples(samples)
+
+	output.flush()
+
+	assert.Len(t, client.(*MockPushgatewayClient).r, 3)
+
+	sinks := make(map[string]*dto.MetricFamily)
+
+	for _, r := range client.(*MockPushgatewayClient).r {
+		mf, err := r.Gather()
+		require.NoError(t, err)
+		for _, m := range mf {
+			sinks[m.GetName()] = m
+		}
+	}
+
+	assert.InDelta(t, 3., *sinks["k6_metric1_total"].Metric[0].Counter.Value, 1e-6)
+	assert.Equal(t, "tagk1", *sinks["k6_metric1_total"].Metric[0].GetLabel()[0].Name)
+	assert.Equal(t, "tagv1", *sinks["k6_metric1_total"].Metric[0].GetLabel()[0].Value)
+
+	assert.InDelta(t, 5., *sinks["k6_metric2"].Metric[0].Gauge.Value, 1e-6)
+	assert.Equal(t, "tagk1", *sinks["k6_metric2"].Metric[0].GetLabel()[0].Name)
+	assert.Equal(t, "tagv1", *sinks["k6_metric2"].Metric[0].GetLabel()[0].Value)
+
+	assert.InDelta(t, 1., *sinks["k6_metric3_rate"].Metric[0].Gauge.Value, 1e-6)
+	assert.Equal(t, "tagk1", *sinks["k6_metric3_rate"].Metric[0].GetLabel()[0].Name)
+	assert.Equal(t, "tagv1", *sinks["k6_metric3_rate"].Metric[0].GetLabel()[0].Value)
+}
+
+func TestUsePushgatewayTrendAsGauges(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	var client remote.RegistryPusher = &MockPushgatewayClient{}
+
+	registry := metrics.NewRegistry()
+	metric1 := registry.MustNewMetric("metric1", metrics.Trend)
+	tagset1 := registry.RootTagSet().With("tagk1", "tagv1")
+	t0 := time.Date(2022, time.September, 1, 0, 0, 0, 0, time.UTC)
+	series1 := metrics.TimeSeries{
+		Metric: metric1,
+		Tags:   tagset1,
+	}
+
+	output := Output{
+		logger:    logger,
+		pgwClient: client,
+		tsdb:      map[metrics.TimeSeries]*seriesWithMeasure{},
+	}
+	err := output.setTrendStatsResolver([]string{"avg", "min", "max"})
+	require.NoError(t, err)
+
+	samples := []metrics.SampleContainer{
+		metrics.Sample{
+			TimeSeries: series1,
+			Time:       t0.Add(10 * time.Millisecond),
+			Value:      0,
+		},
+		metrics.Sample{
+			TimeSeries: series1,
+			Time:       t0.Add(10 * time.Millisecond),
+			Value:      10,
+		},
+	}
+
+	output.AddMetricSamples(samples)
+
+	output.flush()
+
+	assert.Len(t, client.(*MockPushgatewayClient).r, 3)
+
+	sinks := make(map[string]*dto.MetricFamily)
+
+	for _, r := range client.(*MockPushgatewayClient).r {
+		mf, err := r.Gather()
+		require.NoError(t, err)
+		for _, m := range mf {
+			sinks[m.GetName()] = m
+		}
+	}
+
+	assert.InDelta(t, 5., *sinks["k6_metric1_avg"].Metric[0].Gauge.Value, 1e-6)
+	assert.Equal(t, "tagk1", *sinks["k6_metric1_avg"].Metric[0].GetLabel()[0].Name)
+	assert.Equal(t, "tagv1", *sinks["k6_metric1_avg"].Metric[0].GetLabel()[0].Value)
+
+	assert.InDelta(t, 0., *sinks["k6_metric1_min"].Metric[0].Gauge.Value, 1e-6)
+	assert.Equal(t, "tagk1", *sinks["k6_metric1_min"].Metric[0].GetLabel()[0].Name)
+	assert.Equal(t, "tagv1", *sinks["k6_metric1_min"].Metric[0].GetLabel()[0].Value)
+
+	assert.InDelta(t, 10., *sinks["k6_metric1_max"].Metric[0].Gauge.Value, 1e-6)
+	assert.Equal(t, "tagk1", *sinks["k6_metric1_max"].Metric[0].GetLabel()[0].Name)
+	assert.Equal(t, "tagv1", *sinks["k6_metric1_max"].Metric[0].GetLabel()[0].Value)
+}
+
+func TestUsePushgatewayTrendAsNativeHistogram(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+
+	var client remote.RegistryPusher = &MockPushgatewayClient{}
+
+	registry := metrics.NewRegistry()
+	metric1 := registry.MustNewMetric("metric1", metrics.Trend)
+	tagset1 := registry.RootTagSet().With("tagk1", "tagv1")
+	t0 := time.Date(2022, time.September, 1, 0, 0, 0, 0, time.UTC)
+	series1 := metrics.TimeSeries{
+		Metric: metric1,
+		Tags:   tagset1,
+	}
+
+	output := Output{
+		logger:    logger,
+		pgwClient: client,
+		tsdb:      map[metrics.TimeSeries]*seriesWithMeasure{},
+		config:    Config{TrendAsNativeHistogram: null.BoolFrom(true)},
+	}
+	err := output.setTrendStatsResolver([]string{"avg", "min", "max"})
+	require.NoError(t, err)
+
+	samples := []metrics.SampleContainer{
+		metrics.Sample{
+			TimeSeries: series1,
+			Time:       t0.Add(10 * time.Millisecond),
+			Value:      0,
+		},
+		metrics.Sample{
+			TimeSeries: series1,
+			Time:       t0.Add(10 * time.Millisecond),
+			Value:      10,
+		},
+	}
+
+	output.AddMetricSamples(samples)
+
+	output.flush()
+
+	assert.Len(t, client.(*MockPushgatewayClient).r, 1)
+
+	sinks := make(map[string]*dto.MetricFamily)
+
+	for _, r := range client.(*MockPushgatewayClient).r {
+		mf, err := r.Gather()
+		require.NoError(t, err)
+		for _, m := range mf {
+			sinks[m.GetName()] = m
+		}
+	}
+
+	assert.Equal(t, uint64(2), *sinks["k6_metric1"].Metric[0].Histogram.SampleCount)
+	assert.InDelta(t, 10., *sinks["k6_metric1"].Metric[0].Histogram.SampleSum, 1e-6)
+	assert.Equal(t, "tagk1", *sinks["k6_metric1"].Metric[0].GetLabel()[0].Name)
+	assert.Equal(t, "tagv1", *sinks["k6_metric1"].Metric[0].GetLabel()[0].Value)
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/push/push.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/push/push.go
@@ -1,0 +1,356 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package push provides functions to push metrics to a Pushgateway. It uses a
+// builder approach. Create a Pusher with New and then add the various options
+// by using its methods, finally calling Add or Push, like this:
+//
+//	// Easy case:
+//	push.New("http://example.org/metrics", "my_job").Gatherer(myRegistry).Push()
+//
+//	// Complex case:
+//	push.New("http://example.org/metrics", "my_job").
+//	    Collector(myCollector1).
+//	    Collector(myCollector2).
+//	    Grouping("zone", "xy").
+//	    Client(&myHTTPClient).
+//	    BasicAuth("top", "secret").
+//	    Add()
+//
+// See the examples section for more detailed examples.
+//
+// See the documentation of the Pushgateway to understand the meaning of
+// the grouping key and the differences between Push and Add:
+// https://github.com/prometheus/pushgateway
+package push
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	contentTypeHeader = "Content-Type"
+	// base64Suffix is appended to a label name in the request URL path to
+	// mark the following label value as base64 encoded.
+	base64Suffix = "@base64"
+)
+
+var errJobEmpty = errors.New("job name is empty")
+
+// HTTPDoer is an interface for the one method of http.Client that is used by Pusher
+type HTTPDoer interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+// Pusher manages a push to the Pushgateway. Use New to create one, configure it
+// with its methods, and finally use the Add or Push method to push.
+type Pusher struct {
+	error error
+
+	url, job string
+	grouping map[string]string
+
+	gatherers  prometheus.Gatherers
+	registerer prometheus.Registerer
+
+	client             HTTPDoer
+	header             http.Header
+	useBasicAuth       bool
+	username, password string
+
+	expfmt expfmt.Format
+}
+
+// New creates a new Pusher to push to the provided URL with the provided job
+// name (which must not be empty). You can use just host:port or ip:port as url,
+// in which case “http://” is added automatically. Alternatively, include the
+// schema in the URL. However, do not include the “/metrics/jobs/…” part.
+func New(url, job string) *Pusher {
+	var (
+		reg = prometheus.NewRegistry()
+		err error
+	)
+	if job == "" {
+		err = errJobEmpty
+	}
+	if !strings.Contains(url, "://") {
+		url = "http://" + url
+	}
+	url = strings.TrimSuffix(url, "/")
+
+	return &Pusher{
+		error:      err,
+		url:        url,
+		job:        job,
+		grouping:   map[string]string{},
+		gatherers:  prometheus.Gatherers{reg},
+		registerer: reg,
+		client:     &http.Client{},
+		expfmt:     expfmt.FmtProtoDelim,
+	}
+}
+
+// Push collects/gathers all metrics from all Collectors and Gatherers added to
+// this Pusher. Then, it pushes them to the Pushgateway configured while
+// creating this Pusher, using the configured job name and any added grouping
+// labels as grouping key. All previously pushed metrics with the same job and
+// other grouping labels will be replaced with the metrics pushed by this
+// call. (It uses HTTP method “PUT” to push to the Pushgateway.)
+//
+// Push returns the first error encountered by any method call (including this
+// one) in the lifetime of the Pusher.
+func (p *Pusher) Push() error {
+	return p.push(context.Background(), http.MethodPut)
+}
+
+// PushContext is like Push but includes a context.
+//
+// If the context expires before HTTP request is complete, an error is returned.
+func (p *Pusher) PushContext(ctx context.Context) error {
+	return p.push(ctx, http.MethodPut)
+}
+
+// Add works like push, but only previously pushed metrics with the same name
+// (and the same job and other grouping labels) will be replaced. (It uses HTTP
+// method “POST” to push to the Pushgateway.)
+func (p *Pusher) Add() error {
+	return p.push(context.Background(), http.MethodPost)
+}
+
+// AddContext is like Add but includes a context.
+//
+// If the context expires before HTTP request is complete, an error is returned.
+func (p *Pusher) AddContext(ctx context.Context) error {
+	return p.push(ctx, http.MethodPost)
+}
+
+// Gatherer adds a Gatherer to the Pusher, from which metrics will be gathered
+// to push them to the Pushgateway. The gathered metrics must not contain a job
+// label of their own.
+//
+// For convenience, this method returns a pointer to the Pusher itself.
+func (p *Pusher) Gatherer(g prometheus.Gatherer) *Pusher {
+	p.gatherers = append(p.gatherers, g)
+	return p
+}
+
+// Collector adds a Collector to the Pusher, from which metrics will be
+// collected to push them to the Pushgateway. The collected metrics must not
+// contain a job label of their own.
+//
+// For convenience, this method returns a pointer to the Pusher itself.
+func (p *Pusher) Collector(c prometheus.Collector) *Pusher {
+	if p.error == nil {
+		p.error = p.registerer.Register(c)
+	}
+	return p
+}
+
+// Error returns the error that was encountered.
+func (p *Pusher) Error() error {
+	return p.error
+}
+
+// Grouping adds a label pair to the grouping key of the Pusher, replacing any
+// previously added label pair with the same label name. Note that setting any
+// labels in the grouping key that are already contained in the metrics to push
+// will lead to an error.
+//
+// For convenience, this method returns a pointer to the Pusher itself.
+func (p *Pusher) Grouping(name, value string) *Pusher {
+	if p.error == nil {
+		if !model.LabelName(name).IsValid() {
+			p.error = fmt.Errorf("grouping label has invalid name: %s", name)
+			return p
+		}
+		p.grouping[name] = value
+	}
+	return p
+}
+
+// Client sets a custom HTTP client for the Pusher. For convenience, this method
+// returns a pointer to the Pusher itself.
+// Pusher only needs one method of the custom HTTP client: Do(*http.Request).
+// Thus, rather than requiring a fully fledged http.Client,
+// the provided client only needs to implement the HTTPDoer interface.
+// Since *http.Client naturally implements that interface, it can still be used normally.
+func (p *Pusher) Client(c HTTPDoer) *Pusher {
+	p.client = c
+	return p
+}
+
+// Header sets a custom HTTP header for the Pusher's client. For convenience, this method
+// returns a pointer to the Pusher itself.
+func (p *Pusher) Header(header http.Header) *Pusher {
+	p.header = header
+	return p
+}
+
+// BasicAuth configures the Pusher to use HTTP Basic Authentication with the
+// provided username and password. For convenience, this method returns a
+// pointer to the Pusher itself.
+func (p *Pusher) BasicAuth(username, password string) *Pusher {
+	p.useBasicAuth = true
+	p.username = username
+	p.password = password
+	return p
+}
+
+// Format configures the Pusher to use an encoding format given by the
+// provided expfmt.Format. The default format is expfmt.FmtProtoDelim and
+// should be used with the standard Prometheus Pushgateway. Custom
+// implementations may require different formats. For convenience, this
+// method returns a pointer to the Pusher itself.
+func (p *Pusher) Format(format expfmt.Format) *Pusher {
+	p.expfmt = format
+	return p
+}
+
+// Delete sends a “DELETE” request to the Pushgateway configured while creating
+// this Pusher, using the configured job name and any added grouping labels as
+// grouping key. Any added Gatherers and Collectors added to this Pusher are
+// ignored by this method.
+//
+// Delete returns the first error encountered by any method call (including this
+// one) in the lifetime of the Pusher.
+func (p *Pusher) Delete() error {
+	if p.error != nil {
+		return p.error
+	}
+	req, err := http.NewRequest(http.MethodDelete, p.fullURL(), nil)
+	if err != nil {
+		return err
+	}
+	if p.header != nil {
+		req.Header = p.header
+	}
+	if p.useBasicAuth {
+		req.SetBasicAuth(p.username, p.password)
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body) // Ignore any further error as this is for an error message only.
+		return fmt.Errorf("unexpected status code %d while deleting %s: %s", resp.StatusCode, p.fullURL(), body)
+	}
+	return nil
+}
+
+func (p *Pusher) push(ctx context.Context, method string) error {
+	if p.error != nil {
+		return p.error
+	}
+	mfs, err := p.gatherers.Gather()
+	if err != nil {
+		return err
+	}
+	buf := &bytes.Buffer{}
+	enc := expfmt.NewEncoder(buf, p.expfmt)
+	// Check for pre-existing grouping labels:
+	for _, mf := range mfs {
+		for _, m := range mf.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "job" {
+					return fmt.Errorf("pushed metric %s (%s) already contains a job label", mf.GetName(), m)
+				}
+				if _, ok := p.grouping[l.GetName()]; ok {
+					return fmt.Errorf(
+						"pushed metric %s (%s) already contains grouping label %s",
+						mf.GetName(), m, l.GetName(),
+					)
+				}
+			}
+		}
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf(
+				"failed to encode metric familty %s, error is %w",
+				mf.GetName(), err)
+		}
+	}
+	req, err := http.NewRequestWithContext(ctx, method, p.fullURL(), buf)
+	if err != nil {
+		return err
+	}
+	if p.header != nil {
+		req.Header = p.header
+	}
+	if p.useBasicAuth {
+		req.SetBasicAuth(p.username, p.password)
+	}
+	req.Header.Set(contentTypeHeader, string(p.expfmt))
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Depending on version and configuration of the PGW, StatusOK or StatusAccepted may be returned.
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body) // Ignore any further error as this is for an error message only.
+		return fmt.Errorf("unexpected status code %d while pushing to %s: %s", resp.StatusCode, p.fullURL(), body)
+	}
+	return nil
+}
+
+// fullURL assembles the URL used to push/delete metrics and returns it as a
+// string. The job name and any grouping label values containing a '/' will
+// trigger a base64 encoding of the affected component and proper suffixing of
+// the preceding component. Similarly, an empty grouping label value will be
+// encoded as base64 just with a single `=` padding character (to avoid an empty
+// path component). If the component does not contain a '/' but other special
+// characters, the usual url.QueryEscape is used for compatibility with older
+// versions of the Pushgateway and for better readability.
+func (p *Pusher) fullURL() string {
+	urlComponents := []string{}
+	if encodedJob, base64 := encodeComponent(p.job); base64 {
+		urlComponents = append(urlComponents, "job"+base64Suffix, encodedJob)
+	} else {
+		urlComponents = append(urlComponents, "job", encodedJob)
+	}
+	for ln, lv := range p.grouping {
+		if encodedLV, base64 := encodeComponent(lv); base64 {
+			urlComponents = append(urlComponents, ln+base64Suffix, encodedLV)
+		} else {
+			urlComponents = append(urlComponents, ln, encodedLV)
+		}
+	}
+	return fmt.Sprintf("%s/metrics/%s", p.url, strings.Join(urlComponents, "/"))
+}
+
+// encodeComponent encodes the provided string with base64.RawURLEncoding in
+// case it contains '/' and as "=" in case it is empty. If neither is the case,
+// it uses url.QueryEscape instead. It returns true in the former two cases.
+func encodeComponent(s string) (string, bool) {
+	if s == "" {
+		return "=", true
+	}
+	if strings.Contains(s, "/") {
+		return base64.RawURLEncoding.EncodeToString([]byte(s)), true
+	}
+	return url.QueryEscape(s), false
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -274,6 +274,7 @@ github.com/pmezard/go-difflib/difflib
 ## explicit; go 1.17
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
+github.com/prometheus/client_golang/prometheus/push
 # github.com/prometheus/client_model v0.4.0
 ## explicit; go 1.18
 github.com/prometheus/client_model/go


### PR DESCRIPTION
## What?

Hi everyone,

This PR adds support to the Prometheus Remote Write module to send metrics to a Prometheus Push Gateway instead.

I initially created the PR in the xk6-output-prometheus-remote repo. However, since the module has been merged into the core, you asked me to also port my changes to the core. So here they are.
The initial PR can be found here: https://github.com/grafana/xk6-output-prometheus-remote/pull/175

I will also create a separate PR in the documentation repository to update the manual accordingly.

I'd like to reiterate a point I mentioned in the original PR:

> Notes on Native Histograms:
> 
> Currently, the Pushgateway accepts native histograms but is not able to export them in OpenMetrics/Text format via /metrics. It only exports an "+Inf" bucket. This could be addressed by either:
> 
>  1. Using a "classic" histogram internally when sending data to the Pushgateway.
>  2. Waiting until the Pushgateway supports native histogram export.
> 

Do you have any thoughts on this? I looked into option 1, which would be relatively easy to implement. It would only require not setting `NativeHistogramBucketFactor` at [internal/output/prometheusrw/remotewrite/trend.go:142](https://github.com/grafana/k6/blob/master/internal/output/prometheusrw/remotewrite/trend.go#L134). However, this does add complexity. What do you think?


## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#PR-NUMBER
- [ ] I have updated the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#PR-NUMBER
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/xk6-output-prometheus-remote/pull/175

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
