### PR TITLE
Push latest even for the RC tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,19 +199,18 @@ jobs:
             -t $DOCKER_IMAGE_ID:$VERSION-with-browser \
             -t ghcr.io/$GHCR_IMAGE_ID:$VERSION-with-browser .
           # We also want to tag the latest stable version as latest
-          if [[ ! "$VERSION" =~ (RC|rc) ]]; then
-            echo "Publish $GHCR_IMAGE_ID:latest"
-            docker buildx build --push \
-              --target release \
-              --platform linux/amd64,linux/arm64 \
-              -t $DOCKER_IMAGE_ID:latest \
-              -t ghcr.io/$GHCR_IMAGE_ID:latest .
-            docker buildx build --push \
-              --target with-browser \
-              --platform linux/amd64,linux/arm64 \
-              -t $DOCKER_IMAGE_ID:latest-with-browser \
-              -t ghcr.io/$GHCR_IMAGE_ID:latest-with-browser .
-          fi
+          echo "Publish $GHCR_IMAGE_ID:latest"
+          docker buildx build --push \
+            --target release \
+            --platform linux/amd64,linux/arm64 \
+            -t $DOCKER_IMAGE_ID:latest \
+            -t ghcr.io/$GHCR_IMAGE_ID:latest .
+          docker buildx build --push \
+            --target with-browser \
+            --platform linux/amd64,linux/arm64 \
+            -t $DOCKER_IMAGE_ID:latest-with-browser \
+            -t ghcr.io/$GHCR_IMAGE_ID:latest-with-browser .
+
 
   package-windows:
     runs-on: windows-latest


### PR DESCRIPTION
## What?

This change should also unblock labeling the v1.0.0-rc1 as the latest.

## Why?

We're going to release v1.0.0-rc1

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
