### PR TITLE
Fix: tagset json buffer content

### DIFF
--- a/metrics/tags.go
+++ b/metrics/tags.go
@@ -131,7 +131,7 @@ func (ts *TagSet) MarshalEasyJSON(w *jwriter.Writer) {
 func (ts *TagSet) MarshalJSON() ([]byte, error) {
 	w := &jwriter.Writer{NoEscapeHTML: true}
 	ts.MarshalEasyJSON(w)
-	return w.Buffer.Buf, w.Error
+	return w.Buffer.BuildBytes(), w.Error
 }
 
 // UnmarshalEasyJSON WILL ALWAYS RETURN AN ERROR because a TagSet needs to be

--- a/metrics/tags_test.go
+++ b/metrics/tags_test.go
@@ -97,10 +97,7 @@ func TestBigTagSetMarshalJSON(t *testing.T) {
 	expextedJSON := `{"tag0":"value0","tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5","tag6":"value6","tag7":"value7"}`
 	assert.Greater(t, len(expextedJSON), 128)
 
-	r := NewRegistry()
-	root := r.RootTagSet()
-
-	tags := root
+	tags := NewRegistry().RootTagSet()
 	for i := range 8 {
 		tags = tags.With(fmt.Sprintf("tag%d", i), fmt.Sprintf("value%d", i))
 	}

--- a/metrics/tags_test.go
+++ b/metrics/tags_test.go
@@ -94,8 +94,8 @@ func TestTagSets(t *testing.T) {
 func TestBigTagSetMarshalJSON(t *testing.T) {
 	t.Parallel()
 
-	expextedJSON := `{"tag0":"value0","tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5","tag6":"value6","tag7":"value7"}`
-	assert.Greater(t, len(expextedJSON), 128)
+	expectedJSON := `{"tag0":"value0","tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5","tag6":"value6","tag7":"value7"}`
+	assert.Greater(t, len(expectedJSON), 128)
 
 	tags := NewRegistry().RootTagSet()
 	for i := range 8 {
@@ -104,7 +104,7 @@ func TestBigTagSetMarshalJSON(t *testing.T) {
 
 	rJSON, err := tags.MarshalJSON()
 	require.NoError(t, err)
-	assert.Equal(t, expextedJSON, string(rJSON))
+	assert.Equal(t, expectedJSON, string(rJSON))
 }
 
 func TestTagSetContains(t *testing.T) {

--- a/metrics/tags_test.go
+++ b/metrics/tags_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -88,6 +89,25 @@ func TestTagSets(t *testing.T) {
 	assert.False(t, tags4.Contains(tags2))
 	assert.True(t, tags4.Contains(tags3))
 	assert.True(t, tags4.Contains(tags4))
+}
+
+func TestBigTagSetMarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	expextedJSON := `{"tag0":"value0","tag1":"value1","tag2":"value2","tag3":"value3","tag4":"value4","tag5":"value5","tag6":"value6","tag7":"value7"}`
+	assert.Greater(t, len(expextedJSON), 128)
+
+	r := NewRegistry()
+	root := r.RootTagSet()
+
+	tags := root
+	for i := range 8 {
+		tags = tags.With(fmt.Sprintf("tag%d", i), fmt.Sprintf("value%d", i))
+	}
+
+	rJSON, err := tags.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, expextedJSON, string(rJSON))
 }
 
 func TestTagSetContains(t *testing.T) {


### PR DESCRIPTION
## What?

Fix easyjson behaviour when buffer grows

## Why?

Tried to output samples as json and it failed

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
