### PR TITLE
Fix --summary-export by marshalling the root group with its original name

### DIFF
--- a/internal/lib/summary/summary.go
+++ b/internal/lib/summary/summary.go
@@ -95,8 +95,8 @@ func ValidateMode(val string) (m Mode, err error) {
 // as well as some other information, like certain rendering options.
 type Summary struct {
 	Thresholds `js:"thresholds"`
-	Group
-	Scenarios map[string]Group
+	Group      `js:"root_group"`
+	Scenarios  map[string]Group
 
 	TestRunDuration time.Duration
 	NoColor         bool // TODO: drop this when noColor is part of the (runtime) options


### PR DESCRIPTION
## What?

Without this adding `--summary-export` wil fail because `root_group` isn't defined and then it can be used to seriallize it.

## Why?

This is part of the k6 functionality.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
