### PR TITLE
chore: fix TestSetTimeoutOrder flakiness

### DIFF
--- a/internal/js/tc55/timers/timers_test.go
+++ b/internal/js/tc55/timers/timers_test.go
@@ -86,7 +86,7 @@ func TestSetTimeoutOrder(t *testing.T) {
 			setTimeout((_) => print("one"), 1);
 			setTimeout((_) => print("two"), 1);
 			setTimeout((_) => print("three"), 1);
-			setTimeout((_) => print("last"), 10);
+			setTimeout((_) => print("last"), 20);
 			setTimeout((_) => print("four"), 1);
 			setTimeout((_) => print("five"), 1);
 			setTimeout((_) => print("six"), 1);


### PR DESCRIPTION
## What?

Try to reduce flakiness in a test

## Why?

Test sometimes fails for no reason, due to the timings being too small - it is better if we do not have a flaky test

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
