### PR TITLE
Summary: Adjust JSON output to the new data structure

### DIFF
--- a/internal/js/runner.go
+++ b/internal/js/runner.go
@@ -394,7 +394,8 @@ func (r *Runner) HandleSummary(
 		return nil, fmt.Errorf("unexpected error did not get a callable summary wrapper")
 	}
 
-	wrapperArgs := prepareHandleWrapperArgs(vu, noColor, enableColors, callbackResult, handleSummaryDataAsValue)
+	wrapperArgs := prepareHandleWrapperArgs(
+		vu, noColor, enableColors, callbackResult, handleSummaryDataAsValue, legacy != nil)
 	rawResult, _, _, err := vu.runFn(summaryCtx, false, handleSummaryWrapper, nil, wrapperArgs...)
 
 	if deadlineError := r.checkDeadline(summaryCtx, consts.HandleSummaryFn, rawResult, err); deadlineError != nil {
@@ -469,6 +470,7 @@ func prepareHandleWrapperArgs(
 	noColor bool, enableColors bool,
 	callbackResult sobek.Value,
 	summaryDataForJS interface{},
+	isLegacy bool,
 ) []sobek.Value {
 	options := map[string]interface{}{
 		// TODO: improve when we can easily export all option values, including defaults?
@@ -476,6 +478,7 @@ func prepareHandleWrapperArgs(
 		"summaryTimeUnit":   vu.Runner.Bundle.Options.SummaryTimeUnit.String,
 		"noColor":           noColor, // TODO: move to the (runtime) options
 		"enableColors":      enableColors,
+		"isLegacy":          isLegacy,
 	}
 
 	wrapperArgs := []sobek.Value{

--- a/internal/js/summary-wrapper.js
+++ b/internal/js/summary-wrapper.js
@@ -75,13 +75,6 @@
 				}
 			}
 
-			if (data?.checks?.metrics && typeof data.checks.metrics === 'object') {
-				for (const metricName in data.checks.metrics) {
-					const {values} = data.checks.metrics[metricName];
-					group.metrics[metricName] = {...values};
-				}
-			}
-
 			if (data?.metrics && typeof data.metrics === 'object') {
 				for (const metricsGroupName of Object.keys(data.metrics).sort()) {
 					const metrics = data.metrics[metricsGroupName];
@@ -117,7 +110,7 @@
 			}
 		}
 
-		results.root_group = summarizeGroup('root_group', data.root_group);
+		results.root_group = summarizeGroup("", data.root_group);
 		results.metrics = results.root_group.metrics
 
 		results.root_group.groups = {}


### PR DESCRIPTION
## What?

It adjusts the code responsible for the JSON format of the end-of-test summary to be compatible with the new data structure introduced in https://github.com/grafana/k6/pull/4089.

## Why?

As pointed out in https://github.com/grafana/k6/issues/4640, the new data structure for summary data introduced in the aforementioned PR isn't compatible with the existing code, _completely_ breaking that feature.

We quickly fixed the feature with https://github.com/grafana/k6/pull/4642, which was nice.

However, I think we can do better, and keep the JSON summary structure much closer to the existing one. 
Complete compatibility isn't possible (or isn't worth the effort), but there's room for improvement.

In summary, the new code produces an JSON document that looks like:

```
{
  "thresholds": {...},
  "metrics": {...},
  "root_group": {
    "name": "...",
    "metrics": {...},
    "groups": {...},
    "scenarios": {...}
  }
}
```

So, the main remarkable changes are:
- _Checks_ and _groups_ now don't have `path` and `id` attributes.
- Now it includes _thresholds_ as a separate -root-level- section, instead of being part of the _metrics_ object.
- _Groups_ also contain _metrics_ inside, so "partial" metrics are included for groups other than the "root group".
- _Scenarios_ are also included, following the same structure as _groups_.
- Some metrics previously added (e.g. `group_duration`), now aren't unless you use `--summary-mode=full`.
- Sub-groups checks aren't included unless you use `--summary-mode=full`. 

If you want to compare a concrete example, based on the same test case used for the revamped summary, you can have a look at these two files attached:
- [results.json](https://github.com/user-attachments/files/19427110/results.json)
- [results-old.json](https://github.com/user-attachments/files/19427112/results-old.json)

You can also see the comparison with https://nosmileface.dev/jsondiff/ in the following screenshot:

![screencapture-nosmileface-dev-jsondiff-2025-03-24-10_48_07](https://github.com/user-attachments/assets/1c9076a0-40bd-4459-8e87-51dff52f28a5)

However, certain diffs aren't very easy, because the order of most of the information displayed in the legacy (old) format is not predictable (every execution it has different order). I tried to make the new output a bit more predictable by sorting certain keys.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [X] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
