### PR TITLE
Summary: Use lib.LegacySummary to avoid breaking the API

### DIFF
--- a/.github/workflows/xk6-tests/xk6-test.js
+++ b/.github/workflows/xk6-tests/xk6-test.js
@@ -11,7 +11,7 @@ export let options = {
 
 export function handleSummary(data) {
     return {
-        'summary-results.txt': data.metrics.custom.foos.values.count.toString(),
+        'summary-results.txt': data.metrics.foos.values.count.toString(),
     };
 }
 

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -329,17 +329,17 @@ func TestMetricsAndThresholds(t *testing.T) {
 	var summary map[string]interface{}
 	require.NoError(t, json.Unmarshal(ts.Stdout.Bytes(), &summary))
 
-	thresholds, ok := summary["thresholds"].(map[string]interface{})
+	metrics, ok := summary["metrics"].(map[string]interface{})
 	require.True(t, ok)
 
-	teardownCounter, ok := thresholds["teardown_counter"].(map[string]interface{})
+	teardownCounter, ok := metrics["teardown_counter"].(map[string]interface{})
 	require.True(t, ok)
 
-	teardownCounterThresholds, ok := teardownCounter["thresholds"].([]interface{})
+	teardownThresholds, ok := teardownCounter["thresholds"].(map[string]interface{})
 	require.True(t, ok)
 
-	expected := []interface{}{map[string]interface{}{"source": "count == 1", "ok": true}}
-	require.Equal(t, expected, teardownCounterThresholds)
+	expected := map[string]interface{}{"count == 1": map[string]interface{}{"ok": true}}
+	require.Equal(t, expected, teardownThresholds)
 }
 
 func TestSSLKEYLOGFILEAbsolute(t *testing.T) {

--- a/internal/js/summary-wrapper.js
+++ b/internal/js/summary-wrapper.js
@@ -60,7 +60,7 @@
         return JSON.stringify(results, null, 4);
     };
 
-    return function (summaryCallbackResult, jsonSummaryPath, data, options) {
+    return function (summaryCallbackResult, jsonSummaryPath, legacyData, data, options) {
         let result = summaryCallbackResult;
         if (!result) {
             result = {
@@ -72,7 +72,7 @@
         // and if not, log an error and generate the default summary?
 
         if (jsonSummaryPath != '') {
-            result[jsonSummaryPath] = oldJSONSummary(data);
+            result[jsonSummaryPath] = oldJSONSummary(legacyData);
         }
 
         return result;


### PR DESCRIPTION
## What?

It moves back _"programmatic"_ interfaces of the end-of-test summary (both custom `handleSummary()` and JSON output through `--summary-export`) to the legacy data structure (`lib.LegacySummary`), despite of the `--summary-mode`.

It technically makes https://github.com/grafana/k6/pull/4089 non-breaking.

## Why?

Because after having caught https://github.com/grafana/k6/issues/4640, and while discussing https://github.com/grafana/k6/pull/4647, we realized that _maybe_ it's better to play safe and don't break this until v2.0, whenever that comes. Also, because the re-design of the machine-readable format (JSON) hasn't been planned until then.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
