### PR TITLE
Fix : add warning in RSA PSS webcrypto

### DIFF
--- a/internal/js/modules/k6/webcrypto/rsa.go
+++ b/internal/js/modules/k6/webcrypto/rsa.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/grafana/sobek"
 )
 
@@ -386,6 +388,11 @@ func (rsasv *RSAPssParams) Sign(key CryptoKey, data []byte) ([]byte, error) {
 
 	hashedData := hash.New()
 	hashedData.Write(data)
+	if rsasv.SaltLength == 0 {
+		logger := logrus.New()
+		warnMsg := "K6 RSA-PSS use standard Golang SDK, doesn't support salt length=0. Sign result might be different!"
+		logger.Warn(warnMsg)
+	}
 
 	signature, err := rsa.SignPSS(rand.Reader, rsaKey, hash, hashedData.Sum(nil), &rsa.PSSOptions{
 		SaltLength: rsasv.SaltLength,
@@ -411,6 +418,12 @@ func (rsasv *RSAPssParams) Verify(key CryptoKey, signature []byte, data []byte) 
 
 	hashedData := hash.New()
 	hashedData.Write(data)
+
+	if rsasv.SaltLength == 0 {
+		logger := logrus.New()
+		warnMsg := "K6 RSA-PSS use standard Golang SDK, doesn't support salt length=0. Verify result might be different!"
+		logger.Warn(warnMsg)
+	}
 
 	err = rsa.VerifyPSS(rsaKey, hash, hashedData.Sum(nil), signature, &rsa.PSSOptions{
 		SaltLength: rsasv.SaltLength,


### PR DESCRIPTION
## What?

Implement warning in RSA PSS, when given salt length = 0, in Sign / Verify function 


## Why?
It improves UX and makes implementation predictable.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/issues/4265 

<!-- Does it close an issue? -->
Yes
