### PR TITLE
Add item to lock the issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -18,6 +18,7 @@ labels: ["release"]
     - [ ] Go through the potential [dependencies updates](https://github.com/grafana/k6/blob/master/Dependencies.md) and create a dedicated PR if any of them is relevant to this release.
 - [ ] Create a new `release-v{major}.{minor}.0` branch on the [grafana/k6-DefinitelyTyped](https://github.com/grafana/k6-DefinitelyTyped) fork repository.
     - [ ] Bump the version in [types/k6/package.json](https://github.com/grafana/k6-DefinitelyTyped/blob/master/types/k6/package.json#L4) to the next one.
+- [ ] [Lock the conversation](https://docs.github.com/en/communities/moderating-comments-and-conversations/locking-conversations) of the current issue to prevent any abuse or misuse of the issue. Note, it still allow the maintainers to edit the issue's description and to add comments.
 
 ### Release Preparation
 


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

It adds an item to lock the conversation on release issues.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

Release issues are functional only for the maintainers. The community's members should create new issues or comment on ones already available relevant to their topic.
