### PR TITLE
Log metrics & traces flush to cloud as 'trace'

### DIFF
--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -267,7 +267,7 @@ func (o *Output) flushMetrics() {
 		return
 	}
 
-	o.logger.WithField("t", time.Since(start)).Debug("Successfully flushed buffered samples to the cloud")
+	o.logger.WithField("t", time.Since(start)).Trace("Successfully flushed buffered samples to the cloud")
 }
 
 func (o *Output) runFlushRequestMetadatas() {
@@ -304,7 +304,7 @@ func (o *Output) flushRequestMetadatas() {
 		return
 	}
 
-	o.logger.WithField("t", time.Since(start)).Debug("Successfully flushed buffered trace samples to the cloud")
+	o.logger.WithField("t", time.Since(start)).Trace("Successfully flushed buffered trace samples to the cloud")
 }
 
 // handleFlushError handles errors generated from the flushing operation.


### PR DESCRIPTION
## What?

It creates log lines that announce that metrics and traces have been flushed to the cloud at the `trace` level instead of `debug`.

## Why?

Because these operations are executed many times per test execution, these lines are repeated repeatedly, generating noise rather than bringing value. We generally use `debug` as the "default" log level when monitoring our systems and/or in integration tests, but these log lines are generally filtered out.

In case of error while flushing, the error will be handled and reported as such (with `error` log level).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

N/A

<!-- Thanks for your contribution! 🙏🏼 -->
