### PR TITLE
Block the new stats.grafana.org in tests instead of the old reports

### DIFF
--- a/internal/cmd/tests/tests.go
+++ b/internal/cmd/tests/tests.go
@@ -39,10 +39,10 @@ func Main(m *testing.M) {
 	bt := &blockingTransport{
 		fallback: http.DefaultTransport,
 		forbiddenHosts: map[string]bool{
-			"ingest.k6.io":    true,
-			"cloudlogs.k6.io": true,
-			"app.k6.io":       true,
-			"reports.k6.io":   true,
+			"ingest.k6.io":      true,
+			"cloudlogs.k6.io":   true,
+			"app.k6.io":         true,
+			"stats.grafana.org": true,
 		},
 	}
 	http.DefaultTransport = bt


### PR DESCRIPTION
## What?

Block the usage endpoint in cmd tests so that we do not report those as runs

## Why?

So we do not report those as runs. Also probably makes the test a bit faster.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
