### PR TITLE
secretsource: also ignore float32 and float64 values when redacting

### DIFF
--- a/secretsource/hook.go
+++ b/secretsource/hook.go
@@ -58,7 +58,7 @@ func recursiveReplace(v any, replacer *strings.Replacer) any {
 	switch s := v.(type) {
 	case string:
 		return replacer.Replace(s)
-	case int, uint, int64, int32, int16, int8, uint64, uint32, uint16, uint8:
+	case int, uint, int64, int32, int16, int8, uint64, uint32, uint16, uint8, float32, float64:
 		// if the secret is encodable in 64 bits ... it is probably not a great secret
 		return v
 	case time.Duration:


### PR DESCRIPTION
## What?

Ignore float32 and float64 values when trying to redact secrets in logs

## Why?

It is one more type that is commonly found in log values that is unlikely to be secret and more importantly a very bad candidate for one. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
