### PR TITLE
Feat/binary provisioning handle stdin

### DIFF
--- a/internal/launcher/analyze.go
+++ b/internal/launcher/analyze.go
@@ -1,56 +1,68 @@
 package launcher
 
 import (
+	"archive/tar"
+	"bytes"
+	"os"
 	"strings"
 
 	"github.com/grafana/k6deps"
 	"go.k6.io/k6/cmd/state"
 )
 
-// newDepsOptions returns the options for dependency resolution.
-// Presently, only the k6 input script or archive (if any) is passed to k6deps for scanning.
-// TODO: if k6 receives the input from stdin, it is not used for scanning because we don't know
-// if it is a script or an archive
-func newDepsOptions(gs *state.GlobalState, args []string) *k6deps.Options {
-	dopts := &k6deps.Options{
-		LookupEnv: func(key string) (string, bool) { v, ok := gs.Env[key]; return v, ok },
-		// TODO: figure out if we need to set FindManifest
+// analyze looks for the input argument to the k6 command and analyzes its dependencies.
+// If the command does not require an input file, it returns no dependencies
+// It the cases when the argument is a file or when it comes from stdin it must determine its format
+// (tar or a js) and pass the options to k6deps accordingly
+func analyze(gs *state.GlobalState, args []string) (k6deps.Dependencies, error) {
+	dopts := &k6deps.Options{}
+
+	var err error
+
+	scriptFile := scriptNameFromArgs(args)
+	switch scriptFile {
+	case "":
+		return k6deps.Dependencies{}, nil
+	case "-":
+		scriptFile, err = readStdin(gs)
+		if err != nil {
+			gs.Logger.
+				WithError(err).
+				Error("failed to read stdin into tmp file")
+			return nil, err
+		}
+		defer func() {
+			if errd := os.Remove(scriptFile); errd != nil {
+				gs.Logger.
+					WithError(errd).
+					Debug("failed to remove tmp file")
+			}
+		}()
+	default:
+		if _, err := gs.FS.Stat(scriptFile); err != nil {
+			gs.Logger.
+				WithField("scriptname", scriptFile).
+				WithError(err).
+				Error("failed to stat script")
+
+			return nil, err
+		}
 	}
 
-	scriptname, hasScript := scriptNameFromArgs(args)
-	if !hasScript {
-		return dopts
-	}
-
-	if scriptname == "-" {
-		gs.Logger.
-			Warn("binary provisioning is not supported when using input from stdin")
-		return dopts
-	}
-
-	if _, err := gs.FS.Stat(scriptname); err != nil {
-		gs.Logger.
-			WithField("scriptname", scriptname).
-			WithError(err).
-			Error("failed to stat script")
-
-		return dopts
-	}
-
-	if strings.HasSuffix(scriptname, ".tar") {
-		dopts.Archive.Name = scriptname
+	if strings.HasSuffix(scriptFile, ".tar") {
+		dopts.Archive.Name = scriptFile
 	} else {
-		dopts.Script.Name = scriptname
+		dopts.Script.Name = scriptFile
 	}
 
-	return dopts
+	return k6deps.Analyze(dopts)
 }
 
-// scriptNameFromArgs returns the file name passed as input and true if it's a valid script name
-func scriptNameFromArgs(args []string) (string, bool) {
+// scriptNameFromArgs returns the argument passed as input to the k6 command
+func scriptNameFromArgs(args []string) string {
 	// return early if no arguments passed
 	if len(args) == 0 {
-		return "", false
+		return ""
 	}
 
 	// search for a command that requires binary provisioning and then get the target script or archive
@@ -61,20 +73,61 @@ func scriptNameFromArgs(args []string) (string, bool) {
 			for _, arg = range args[i+1:] {
 				if strings.HasPrefix(arg, "-") {
 					if arg == "-" { // we are running a script from stdin
-						return arg, true
+						return arg
 					}
 					continue
 				}
 				if strings.HasSuffix(arg, ".js") ||
 					strings.HasSuffix(arg, ".tar") ||
 					strings.HasSuffix(arg, ".ts") {
-					return arg, true
+					return arg
 				}
 			}
-			return "", false
+			return ""
 		}
 	}
 
 	// not found
-	return "", false
+	return ""
+}
+
+// read the stdin into a tmp file
+// TODO: implement this logic without using os package
+func readStdin(gs *state.GlobalState) (string, error) {
+	buffer := bytes.NewBuffer(nil)
+	_, err := buffer.ReadFrom(gs.Stdin)
+	if err != nil {
+		return "", err
+	}
+
+	fileName := "k6*" + detectInputType(buffer.Bytes())
+	tmp, err := os.CreateTemp(os.TempDir(), fileName)
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		if errc := tmp.Close(); errc != nil {
+			gs.Logger.
+				WithError(err).
+				Error("closing temporary file used to process stdin")
+		}
+	}()
+
+	_, err = tmp.Write(buffer.Bytes())
+	if err != nil {
+		return "", err
+	}
+
+	// make the content of stdin available if we fallback to running without binary provisioning
+	gs.Stdin = buffer
+
+	return tmp.Name(), nil
+}
+
+// figure out the type of input from a reader. If we can't read it as a tar, assume it is js
+func detectInputType(content []byte) string {
+	if _, err := tar.NewReader(bytes.NewBuffer(content)).Next(); err == nil {
+		return ".tar"
+	}
+	return ".js"
 }

--- a/internal/launcher/analyze_test.go
+++ b/internal/launcher/analyze_test.go
@@ -134,9 +134,8 @@ func TestScriptArg(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			script, hasScript := scriptNameFromArgs(tc.args)
+			script := scriptNameFromArgs(tc.args)
 
-			assert.Equal(t, tc.hasScript, hasScript)
 			assert.Equal(t, tc.expected, script)
 		})
 	}

--- a/internal/launcher/launcher.go
+++ b/internal/launcher/launcher.go
@@ -53,12 +53,13 @@ func (l *launcher) launch() {
 
 	l.gs.Logger.Info("trying to provision binary")
 
-	deps, err := k6deps.Analyze(newDepsOptions(l.gs, l.gs.CmdArgs[1:]))
+	deps, err := analyze(l.gs, l.gs.CmdArgs[1:])
 	if err != nil {
 		l.gs.Logger.
 			WithError(err).
 			Error("failed to analyze dependencies, can't try binary provisioning, please report this issue")
 		l.gs.OSExit(1)
+		return
 	}
 
 	// binary provisioning enabled but not required by this command


### PR DESCRIPTION
## What?

A follow-up to https://github.com/grafana/k6/pull/4671 to add support to process scripts from stdin

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
