### PR TITLE
Drop the redundant NO_COLOR detection

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -90,18 +90,6 @@ func NewGlobalState(ctx context.Context) *GlobalState {
 		IsTTY:    stderrTTY,
 	}
 
-	env := BuildEnvMap(os.Environ())
-	_, noColorsSet := env["NO_COLOR"] // even empty values disable colors
-	logger := &logrus.Logger{
-		Out: stderr,
-		Formatter: &logrus.TextFormatter{
-			ForceColors:   stderrTTY,
-			DisableColors: !stderrTTY || noColorsSet || env["K6_NO_COLOR"] != "",
-		},
-		Hooks: make(logrus.LevelHooks),
-		Level: logrus.InfoLevel,
-	}
-
 	confDir, err := os.UserConfigDir()
 	if err != nil {
 		confDir = ".config"
@@ -112,7 +100,19 @@ func NewGlobalState(ctx context.Context) *GlobalState {
 		binary = "k6"
 	}
 
+	env := BuildEnvMap(os.Environ())
 	defaultFlags := GetDefaultFlags(confDir)
+	globalFlags := getFlags(defaultFlags, env)
+
+	logger := &logrus.Logger{
+		Out: stderr,
+		Formatter: &logrus.TextFormatter{
+			ForceColors:   stderrTTY,
+			DisableColors: !stderrTTY || globalFlags.NoColor,
+		},
+		Hooks: make(logrus.LevelHooks),
+		Level: logrus.InfoLevel,
+	}
 
 	return &GlobalState{
 		Ctx:             ctx,
@@ -124,7 +124,7 @@ func NewGlobalState(ctx context.Context) *GlobalState {
 		Env:             env,
 		Events:          event.NewEventSystem(100, logger),
 		DefaultFlags:    defaultFlags,
-		Flags:           getFlags(defaultFlags, env),
+		Flags:           globalFlags,
 		OutMutex:        outMutex,
 		Stdout:          stdout,
 		Stderr:          stderr,


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

It drops a redundant logic about `NO_COLOR`.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->
Because we are already checking here https://github.com/grafana/k6/blob/b61ca160537a021d26695b2b36d2b63259b7016f/cmd/state/state.go#L188-L192

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.
