### PR TITLE
Add fix to reduce memory and cpu consumption

### DIFF
--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -328,6 +328,7 @@ func (c *Connection) findTargetIDForLog(id target.SessionID) target.ID {
 
 //nolint:funlen,gocognit,cyclop
 func (c *Connection) recvLoop() {
+	decoder := jlexer.Lexer{}
 	var buffer bytes.Buffer
 	c.logger.Debugf("Connection:recvLoop", "wsURL:%q", c.wsURL)
 	for {
@@ -352,7 +353,8 @@ func (c *Connection) recvLoop() {
 		c.logger.Tracef("cdp:recv", "<- %s", buf)
 
 		var msg cdproto.Message
-		c.decoder = jlexer.Lexer{Data: buf}
+		decoder.Data = buf
+		c.decoder = decoder
 		msg.UnmarshalEasyJSON(&c.decoder)
 		if err := c.decoder.Error(); err != nil {
 			select {


### PR DESCRIPTION
## What?

Using a single `bytes.Buffer` across the lifespan of the connection when reading from the websocket.

## Why?

By reducing how much memory it uses as well as how often it is allocated, we should also reduce the cpu usage since GC will have an easier time cleaning up.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
