### PR TITLE
Drop the link of the k6 website from the user agent

### DIFF
--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -37,7 +37,7 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.Int64("batch", 20, "max parallel batch reqs")
 	flags.Int64("batch-per-host", 6, "max parallel batch reqs per host")
 	flags.Int64("rps", 0, "limit requests per second")
-	flags.String("user-agent", fmt.Sprintf("k6/%s (https://k6.io/)", build.Version), "user agent for http requests")
+	flags.String("user-agent", fmt.Sprintf("Grafana k6/%s", build.Version), "user agent for http requests")
 	flags.String("http-debug", "", "log all HTTP requests and responses. Excludes body by default. To include body use '--http-debug=full'") //nolint:lll
 	flags.Lookup("http-debug").NoOptDefVal = "headers"
 	flags.Bool("insecure-skip-tls-verify", false, "skip verification of TLS certificates")


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

Drop the `https://k6.io` link from the user agent. In addition, rename `k6` to `Grafana k6`.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

The k6.io website has been deprecated, which initially required a link update. However, we reevaluated this decision and ultimately opted to remove the website from the user agent. We found no clear historical justification for its inclusion; it may have been for marketing purposes. Currently, we don't see any tangible benefits to keeping it.

Closes #4653 