### PR TITLE
wptTests: run without tags or skip if repos not checkout

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -24,10 +24,10 @@ jobs:
           set -x
           cd internal/js/modules/k6/experimental/streams/tests
           sh checkout.sh
-          go test -race ../... -tags=wpt
+          go test -race ../...
       - name: Run Webcrypto Tests
         run: |
           set -x
           cd internal/js/modules/k6/webcrypto/tests
           sh checkout.sh
-          go test -race ./... -tags=wpt
+          go test -race ./...

--- a/internal/js/modules/k6/experimental/streams/readable_streams_test.go
+++ b/internal/js/modules/k6/experimental/streams/readable_streams_test.go
@@ -1,8 +1,7 @@
-//go:build wpt
-
 package streams
 
 import (
+	"os"
 	"testing"
 
 	"go.k6.io/k6/js/modules"
@@ -12,8 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const webPlatformTestSuite = "tests/wpt"
+
 func TestReadableStream(t *testing.T) {
 	t.Parallel()
+	if _, err := os.Stat(webPlatformTestSuite); err != nil { //nolint:forbidigo
+		t.Skipf("If you want to run Streams tests, you need to run the 'checkout.sh` script in the directory to get "+
+			"https://github.com/web-platform-tests/wpt at the correct last tested commit (%v)", err)
+	}
 
 	suites := []string{
 		"bad-strategies.any.js",
@@ -34,7 +39,7 @@ func TestReadableStream(t *testing.T) {
 			t.Parallel()
 			ts := newConfiguredRuntime(t)
 			gotErr := ts.EventLoop.Start(func() error {
-				return executeTestScript(ts.VU, "tests/wpt/streams/readable-streams", suite)
+				return executeTestScript(ts.VU, webPlatformTestSuite+"/streams/readable-streams", suite)
 			})
 			assert.NoError(t, gotErr)
 		})
@@ -57,7 +62,7 @@ func newConfiguredRuntime(t testing.TB) *modulestest.Runtime {
 	}
 
 	// Then, we register the Web Platform Tests harness.
-	compileAndRun(t, rt, "tests/wpt", "resources/testharness.js")
+	compileAndRun(t, rt, webPlatformTestSuite, "resources/testharness.js")
 
 	// And the Streams-specific test utilities.
 	files := []string{
@@ -66,7 +71,7 @@ func newConfiguredRuntime(t testing.TB) *modulestest.Runtime {
 		"resources/test-utils.js",
 	}
 	for _, file := range files {
-		compileAndRun(t, rt, "tests/wpt/streams", file)
+		compileAndRun(t, rt, webPlatformTestSuite+"/streams", file)
 	}
 
 	return rt

--- a/internal/js/modules/k6/webcrypto/tests/crypto_test.go
+++ b/internal/js/modules/k6/webcrypto/tests/crypto_test.go
@@ -1,5 +1,3 @@
-//go:build wpt
-
 package tests
 
 import (

--- a/internal/js/modules/k6/webcrypto/tests/subtle_crypto_test.go
+++ b/internal/js/modules/k6/webcrypto/tests/subtle_crypto_test.go
@@ -1,6 +1,4 @@
-// Part of the Web Platform Tests suite for the k6's WebCrypto API
-//go:build wpt
-
+// Package tests runs part of the Web Platform Tests suite for the k6's WebCrypto API
 package tests
 
 import (
@@ -16,13 +14,9 @@ const webPlatformTestSuite = "./wpt/WebCryptoAPI/"
 func TestWebPlatformTestSuite(t *testing.T) {
 	t.Parallel()
 
-	// check if the test is running in the correct environment
-	info, err := os.Stat(webPlatformTestSuite)
-	if os.IsNotExist(err) || err != nil || !info.IsDir() {
-		t.Fatalf(
-			"The Web Platform Test directory does not exist, err: %s. Please check webcrypto/tests/README.md how to setup it",
-			err,
-		)
+	if _, err := os.Stat(webPlatformTestSuite); err != nil { //nolint:forbidigo
+		t.Skipf("If you want to run WebCrypto tests, you need to run the 'checkout.sh` script in the directory to get "+
+			"https://github.com/web-platform-tests/wpt at the correct last tested commit (%v)", err)
 	}
 
 	tests := []struct {
@@ -157,6 +151,8 @@ func TestWebPlatformTestSuite(t *testing.T) {
 			t.Parallel()
 
 			ts := newConfiguredRuntime(t)
+			// We compile the Web Platform testharness script into a sobek.Program
+			compileAndRun(t, ts, "./wpt/resources", "testharness.js")
 
 			gotErr := ts.EventLoop.Start(func() error {
 				for _, script := range tt.files {

--- a/internal/js/modules/k6/webcrypto/tests/test_setup_test.go
+++ b/internal/js/modules/k6/webcrypto/tests/test_setup_test.go
@@ -1,5 +1,3 @@
-//go:build wpt
-
 package tests
 
 import (
@@ -29,9 +27,6 @@ func newConfiguredRuntime(t testing.TB) *modulestest.Runtime {
 	require.NoError(t, err)
 
 	require.NoError(t, webcrypto.SetupGlobally(rt.VU))
-
-	// We compile the Web Platform testharness script into a sobek.Program
-	compileAndRun(t, rt, "./wpt/resources", "testharness.js")
 
 	// We compile the Web Platform helpers script into a sobek.Program
 	// TODO: check if we need to compile the helpers.js script each time


### PR DESCRIPTION
## What?

This changes so WebCrypto and Streams to not require tags and instead get skipped if the repo isn't checkout and tells you that.


## Why?


This improves DX significantly as gopls doesn't work great if tags are required for building. Golangci-lint also has problems.

Also aligning with tc39, Sobek/goja as well.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
