### PR TITLE
[Binary provisioning] Rename runners

### DIFF
--- a/internal/launcher/launcher_test.go
+++ b/internal/launcher/launcher_test.go
@@ -236,11 +236,11 @@ func TestLauncherLaunch(t *testing.T) {
 			provisionCalled := false
 			launcher := &Launcher{
 				gs: ts.GlobalState,
-				provision: func(_ *state.GlobalState, _ k6deps.Dependencies) (k6Runner, error) {
+				provision: func(_ *state.GlobalState, _ k6deps.Dependencies) (binaryRunner, error) {
 					provisionCalled = true
 					return provisionRunner, tc.provisionError
 				},
-				runner: defaultRunner,
+				binaryRunner: defaultRunner,
 			}
 
 			launcher.Launch()

--- a/internal/launcher/provision.go
+++ b/internal/launcher/provision.go
@@ -13,7 +13,7 @@ import (
 )
 
 // k6buildProvision returns the path to a k6 binary that satisfies the dependencies and the list of versions it provides
-func k6buildProvision(gs *state.GlobalState, deps k6deps.Dependencies) (k6Runner, error) {
+func k6buildProvision(gs *state.GlobalState, deps k6deps.Dependencies) (binaryRunner, error) {
 	opt := newOptions(gs)
 	if opt.BuildServiceToken == "" {
 		return nil, errors.New("k6 cloud token is required when Binary provisioning feature is enabled." +
@@ -38,7 +38,7 @@ func k6buildProvision(gs *state.GlobalState, deps k6deps.Dependencies) (k6Runner
 	gs.Logger.
 		Info("A new k6 binary has been provisioned with version(s): ", formatDependencies(binary.Dependencies))
 
-	return newK6Runner(binary.Path), nil
+	return &customBinary{binary.Path}, nil
 }
 
 func formatDependencies(deps map[string]string) string {

--- a/internal/launcher/runner.go
+++ b/internal/launcher/runner.go
@@ -8,33 +8,24 @@ import (
 	k6Cmd "go.k6.io/k6/internal/cmd"
 )
 
-// k6Runner defines the interface for running a k6 command
-type k6Runner interface {
-	run(*state.GlobalState)
+// customBinary runs the requested commands
+// on a different binary on a subprocess passing the original arguments
+type customBinary struct {
+	// path represents the local file path
+	// on the file system of the binary
+	path string
 }
 
-// execRunner executes a k6 command in a subprocess
-type execRunner struct {
-	binPath string
-}
-
-// newK6Runner returns a k6Runner given the path to the k6 binary and the arguments to pass
-func newK6Runner(binPath string) k6Runner {
-	return &execRunner{
-		binPath: binPath,
-	}
-}
-
-// run executes the k6 binary in a process passing the original arguments
-func (r *execRunner) run(gs *state.GlobalState) {
-	cmd := exec.CommandContext(gs.Ctx, r.binPath, gs.CmdArgs[1:]...) //nolint:gosec
+func (b *customBinary) run(gs *state.GlobalState) {
+	cmd := exec.CommandContext(gs.Ctx, b.path, gs.CmdArgs[1:]...) //nolint:gosec
 	cmd.Stderr = gs.Stderr
 	cmd.Stdout = gs.Stdout
 	cmd.Stdin = gs.Stdin
 
-	// disable binary provisioning to avoid a provisioning loop.
-	// if we keep it enabled the k6 binary executed here will receive the same input script
-	// will analyze it and detect the dependencies, triggering the binary provisioning again
+	// Disable binary provisioning to avoid a recursive loop.
+	// If we keep it enabled then the k6 binary executed here will receive the same input script,
+	// and it will repeat the process again. It will analyze, detect the dependencies then triggering
+	// again the binary provisioning.
 	gs.Env["K6_BINARY_PROVISIONING"] = "false"
 
 	gs.Logger.Debug("Launching the new provisioned k6 binary")
@@ -54,14 +45,9 @@ func (r *execRunner) run(gs *state.GlobalState) {
 	gs.OSExit(rc)
 }
 
-// defaultK6Runner defines a k6Runner that executes k6 using the current binary
-type defaultK6Runner struct{}
+// currentBinary runs the requested commands on the current binary
+type currentBinary struct{}
 
-// newDefaultK6Runner returns a defaultK6Runner
-func newDefaultK6Runner() k6Runner {
-	return &defaultK6Runner{}
-}
-
-func (r *defaultK6Runner) run(gs *state.GlobalState) {
+func (b *currentBinary) run(gs *state.GlobalState) {
 	k6Cmd.ExecuteWithGlobalState(gs)
 }


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

It refactors by renaming a few components.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

The current naming doesn't sound consistent with the name commonly used. It tries to apply the principle of ubiquitous language.  

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
