### PR TITLE
browser: fix race on workers being accessed concurrently

### DIFF
--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -1045,9 +1045,7 @@ func (fs *FrameSession) attachWorkerToTarget(ti *target.Info, session *Session) 
 		return fmt.Errorf("attaching worker target ID %v to session ID %v: %w",
 			ti.TargetID, session.ID(), err)
 	}
-	fs.page.workersMu.Lock()
-	defer fs.page.workersMu.Unlock()
-	fs.page.workers[session.ID()] = w
+	fs.page.addWorker(session.ID(), w)
 
 	return nil
 }

--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -1045,6 +1045,8 @@ func (fs *FrameSession) attachWorkerToTarget(ti *target.Info, session *Session) 
 		return fmt.Errorf("attaching worker target ID %v to session ID %v: %w",
 			ti.TargetID, session.ID(), err)
 	}
+	fs.page.workersMu.Lock()
+	defer fs.page.workersMu.Unlock()
 	fs.page.workers[session.ID()] = w
 
 	return nil

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -233,6 +233,7 @@ type Page struct {
 	frameSessions    map[cdp.FrameID]*FrameSession
 	frameSessionsMu  sync.RWMutex
 	workers          map[target.SessionID]*Worker
+	workersMu        sync.Mutex
 	routes           []any // TODO: Implement
 	vu               k6modules.VU
 
@@ -604,6 +605,8 @@ func (p *Page) consoleMsgFromConsoleEvent(e *runtime.EventConsoleAPICalled) (*Co
 func (p *Page) removeWorker(sessionID target.SessionID) {
 	p.logger.Debugf("Page:removeWorker", "sid:%v", sessionID)
 
+	p.workersMu.Lock()
+	defer p.workersMu.Unlock()
 	delete(p.workers, sessionID)
 }
 
@@ -1603,6 +1606,8 @@ func (p *Page) WaitForTimeout(timeout int64) {
 
 // Workers returns all WebWorkers of page.
 func (p *Page) Workers() []*Worker {
+	p.workersMu.Lock()
+	defer p.workersMu.Unlock()
 	workers := make([]*Worker, 0, len(p.workers))
 	for _, w := range p.workers {
 		workers = append(workers, w)

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -602,6 +602,14 @@ func (p *Page) consoleMsgFromConsoleEvent(e *runtime.EventConsoleAPICalled) (*Co
 	}, nil
 }
 
+func (p *Page) addWorker(sessionID target.SessionID, w *Worker) {
+	p.logger.Debugf("Page:addWorker", "sid:%v", sessionID)
+
+	p.workersMu.Lock()
+	defer p.workersMu.Unlock()
+	p.workers[sessionID] = w
+}
+
 func (p *Page) removeWorker(sessionID target.SessionID) {
 	p.logger.Debugf("Page:removeWorker", "sid:%v", sessionID)
 


### PR DESCRIPTION
## What?

As browser workers get accessed from different events it is possible for this to race. So a new mutex was added so this doesn't happen and abort the test.

Fixes #4566

## Why?

Races are bad.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
