### PR TITLE
fix scan of cloud login command

### DIFF
--- a/internal/launcher/analyze.go
+++ b/internal/launcher/analyze.go
@@ -64,9 +64,17 @@ func isScriptRequired(args []string) bool {
 	}
 
 	// search for a command that requires binary provisioning and then get the target script or archive
-	for _, arg := range args {
+	// we handle cloud login subcommand as a special case because it does not require binary provisioning
+	for i, arg := range args {
 		switch arg {
-		case "run", "archive", "inspect", "cloud":
+		case "cloud":
+			for _, arg = range args[i+1:] {
+				if arg == "login" {
+					return false
+				}
+			}
+			return true
+		case "run", "archive", "inspect":
 			return true
 		}
 	}

--- a/internal/launcher/analyze_test.go
+++ b/internal/launcher/analyze_test.go
@@ -164,6 +164,11 @@ func TestIsScriptRequired(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "cloud login command",
+			args:     []string{"cloud", "login"},
+			expected: false,
+		},
+		{
 			name:     "archive command",
 			args:     []string{"archive", "script.js"},
 			expected: true,


### PR DESCRIPTION
## What?

fixes the scanning of commands that require binary provisioning by excluding `cloud login`

## Why?

Cloud logging does not require binary provisioning
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
