### PR TITLE
Unify the internal/cmd.Execute methods

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -8,7 +8,7 @@ import (
 	"go.k6.io/k6/internal/cmd"
 )
 
-// Execute exectues the k6 command
+// Execute the k6 command
 // It only is exported here for backwards compatibility and the ability to use xk6 to build extended k6
 func Execute() {
 	gs := state.NewGlobalState(context.Background())

--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -1,10 +1,16 @@
 // Package cmd is here to provide a way for xk6 to build a binary with added extensions
 package cmd
 
-import "go.k6.io/k6/internal/cmd"
+import (
+	"context"
+
+	"go.k6.io/k6/cmd/state"
+	"go.k6.io/k6/internal/cmd"
+)
 
 // Execute exectues the k6 command
 // It only is exported here for backwards compatibility and the ability to use xk6 to build extended k6
 func Execute() {
-	cmd.Execute()
+	gs := state.NewGlobalState(context.Background())
+	cmd.ExecuteWithGlobalState(gs)
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -28,6 +28,13 @@ import (
 
 const waitLoggerCloseTimeout = time.Second * 5
 
+// ExecuteWithGlobalState runs the root command with an existing GlobalState.
+// It adds all child commands to the root command and it sets flags appropriately.
+// It is called by main.main(). It only needs to happen once to the rootCmd.
+func ExecuteWithGlobalState(gs *state.GlobalState) {
+	newRootCommand(gs).execute()
+}
+
 // This is to keep all fields needed for the main/root k6 command
 type rootCommand struct {
 	globalState *state.GlobalState
@@ -124,13 +131,6 @@ func (c *rootCommand) execute() {
 	if c.loggerIsRemote {
 		c.globalState.FallbackLogger.WithFields(fields).Error(errText)
 	}
-}
-
-// ExecuteWithGlobalState runs the root command with an existing GlobalState.
-// It adds all child commands to the root command and it sets flags appropriately.
-// It is called by main.main(). It only needs to happen once to the rootCmd.
-func ExecuteWithGlobalState(gs *state.GlobalState) {
-	newRootCommand(gs).execute()
 }
 
 func (c *rootCommand) stopLoggers() {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -126,16 +126,9 @@ func (c *rootCommand) execute() {
 	}
 }
 
-// Execute adds all child commands to the root command sets flags appropriately.
-// This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	gs := state.NewGlobalState(context.Background())
-	newRootCommand(gs).execute()
-}
-
 // ExecuteWithGlobalState runs the root command with an existing GlobalState.
-// This is needed by integration tests, and we don't want to modify the
-// Execute() signature to avoid breaking k6 extensions.
+// It adds all child commands to the root command and it sets flags appropriately.
+// It is called by main.main(). It only needs to happen once to the rootCmd.
 func ExecuteWithGlobalState(gs *state.GlobalState) {
 	newRootCommand(gs).execute()
 }


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->
It unifies the Execute methods.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

It simplifies the API, reducing the surface to one single method. It has the benefit to clarify the execution path. This is a blocking work for Binary provisioning, as it is a prerequisite.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
