### PR TITLE
skip binary provisioning for run command

### DIFF
--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -251,7 +251,7 @@ func analyze(gs *state.GlobalState, args []string) (k6deps.Dependencies, error) 
 
 	if !isScriptRequired(args) {
 		gs.Logger.
-			Debug("command does not require Binary provisioning")
+			Debug("The command to execute does not require Binary provisioning")
 		return k6deps.Dependencies{}, nil
 	}
 

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -300,7 +300,7 @@ func isScriptRequired(args []string) bool {
 				}
 			}
 			return true
-		case "run", "archive", "inspect":
+		case "archive", "inspect":
 			return true
 		}
 	}

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -68,8 +68,8 @@ func (l *Launcher) Launch() {
 	if err != nil {
 		l.gs.Logger.
 			WithError(err).
-			Error("Binary provisioning enabled but failed to analyze dependencies. Please, make sure to report this issue by" +
-				" opening a bug report.")
+			Error("Binary provisioning is enabled but it failed to analyze the dependencies." +
+				" Please, make sure to report this issue by opening a bug report.")
 		l.gs.OSExit(1)
 		return // this is required for testing
 	}
@@ -77,7 +77,8 @@ func (l *Launcher) Launch() {
 	// if the command does not have dependencies or a custom build
 	if !customBuildRequired(build.Version, deps) {
 		l.gs.Logger.
-			Debug("Binary provisioning is not required to execute this command.")
+			Debug("The current k6 binary already satisfies all the required dependencies," +
+				" it isn't required to provision a new binary.")
 		l.commandExecutor.run(l.gs)
 		return
 	}
@@ -194,7 +195,7 @@ func k6buildProvision(gs *state.GlobalState, deps k6deps.Dependencies) (commandE
 	}
 
 	if config.BuildServiceAuth == "" {
-		return nil, errors.New("k6 cloud token is required when the binary provisioning feature is enabled." +
+		return nil, errors.New("k6 cloud token is required when the Binary provisioning feature is enabled." +
 			" Set K6_CLOUD_TOKEN environment variable or execute the `k6 cloud login` command")
 	}
 
@@ -250,7 +251,7 @@ func analyze(gs *state.GlobalState, args []string) (k6deps.Dependencies, error) 
 
 	if !isScriptRequired(args) {
 		gs.Logger.
-			Debug("command does not require binary provisioning")
+			Debug("command does not require Binary provisioning")
 		return k6deps.Dependencies{}, nil
 	}
 

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -90,7 +90,7 @@ func TestLauncherLaunch(t *testing.T) {
 	}{
 		{
 			name:            "disable binary provisioning",
-			k6Cmd:           "run",
+			k6Cmd:           "cloud",
 			disableBP:       true,
 			script:          fakerTest,
 			expectProvision: false,
@@ -100,7 +100,7 @@ func TestLauncherLaunch(t *testing.T) {
 		},
 		{
 			name:            "execute binary provisioned",
-			k6Cmd:           "run",
+			k6Cmd:           "cloud",
 			script:          fakerTest,
 			expectProvision: true,
 			expectK6Run:     true,
@@ -109,7 +109,7 @@ func TestLauncherLaunch(t *testing.T) {
 		},
 		{
 			name:            "require unsatisfied k6 version",
-			k6Cmd:           "run",
+			k6Cmd:           "cloud",
 			script:          requireUnsatisfiedK6Version,
 			expectProvision: true,
 			expectK6Run:     true,
@@ -118,7 +118,7 @@ func TestLauncherLaunch(t *testing.T) {
 		},
 		{
 			name:            "require satisfied k6 version",
-			k6Cmd:           "run",
+			k6Cmd:           "cloud",
 			script:          requireSatisfiedK6Version,
 			expectProvision: false,
 			expectK6Run:     false,
@@ -127,7 +127,7 @@ func TestLauncherLaunch(t *testing.T) {
 		},
 		{
 			name:            "script with no dependencies",
-			k6Cmd:           "run",
+			k6Cmd:           "cloud",
 			script:          noDepsTest,
 			expectProvision: false,
 			expectK6Run:     false,
@@ -143,8 +143,16 @@ func TestLauncherLaunch(t *testing.T) {
 			expectOsExit:    0,
 		},
 		{
-			name:            "failed binary provisioning",
+			name:            "binary provisioning is not enabled for run command",
 			k6Cmd:           "run",
+			expectProvision: false,
+			expectK6Run:     false,
+			expectDefault:   true,
+			expectOsExit:    0,
+		},
+		{
+			name:            "failed binary provisioning",
+			k6Cmd:           "cloud",
 			script:          fakerTest,
 			provisionError:  errors.New("test error"),
 			expectProvision: true,
@@ -154,7 +162,7 @@ func TestLauncherLaunch(t *testing.T) {
 		},
 		{
 			name:            "failed k6 execution",
-			k6Cmd:           "run",
+			k6Cmd:           "cloud",
 			script:          fakerTest,
 			k6ReturnCode:    108,
 			expectProvision: true,
@@ -164,7 +172,7 @@ func TestLauncherLaunch(t *testing.T) {
 		},
 		{
 			name:            "missing input script",
-			k6Cmd:           "run",
+			k6Cmd:           "cloud",
 			k6Args:          []string{},
 			script:          "",
 			expectProvision: false,
@@ -174,7 +182,7 @@ func TestLauncherLaunch(t *testing.T) {
 		},
 		{
 			name:            "script in stdin",
-			k6Cmd:           "run",
+			k6Cmd:           "cloud",
 			k6Args:          []string{"-"},
 			script:          "",
 			expectProvision: false,
@@ -314,7 +322,7 @@ func TestScriptNameFromArgs(t *testing.T) {
 		},
 		{
 			name:     "complex case with multiple flags",
-			args:     []string{"-v", "--quiet", "run", "-o", "output.json", "--console-output", "loadtest.log", "script.js", "--tag", "env=staging"},
+			args:     []string{"-v", "--quiet", "cloud", "run", "-o", "output.json", "--console-output", "loadtest.log", "script.js", "--tag", "env=staging"},
 			expected: "script.js",
 		},
 		{
@@ -370,26 +378,36 @@ func TestIsScriptRequired(t *testing.T) {
 		{
 			name:     "run command",
 			args:     []string{"run", "script.js"},
-			expected: true,
-		},
-		{
-			name:     "flag before command",
-			args:     []string{"-v", "run", "script.js"},
-			expected: true,
-		},
-		{
-			name:     "verbose flag before command",
-			args:     []string{"--verbose", "run", "script.js"},
-			expected: true,
-		},
-		{
-			name:     "cloud run with flag in the middle",
-			args:     []string{"cloud", "-v", "run", "archive.tar"},
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "cloud command",
 			args:     []string{"cloud", "script.js"},
+			expected: true,
+		},
+		{
+			name:     "cloud run command",
+			args:     []string{"cloud", "run", "script.js"},
+			expected: true,
+		},
+		{
+			name:     "flag before command",
+			args:     []string{"-v", "cloud", "script.js"},
+			expected: true,
+		},
+		{
+			name:     "verbose flag before command",
+			args:     []string{"--verbose", "cloud", "script.js"},
+			expected: true,
+		},
+		{
+			name:     "cloud run with flag in the middle",
+			args:     []string{"cloud", "-v", "cloud", "archive.tar"},
+			expected: true,
+		},
+		{
+			name:     "cloud upload command",
+			args:     []string{"cloud", "upload", "script.js"},
 			expected: true,
 		},
 		{
@@ -409,7 +427,7 @@ func TestIsScriptRequired(t *testing.T) {
 		},
 		{
 			name:     "complex case with multiple flags",
-			args:     []string{"-v", "--quiet", "run", "-o", "output.json", "--console-output", "loadtest.log", "script.js", "--tag", "env=staging"},
+			args:     []string{"-v", "--quiet", "cloud", "run", "-o", "output.json", "--console-output", "loadtest.log", "script.js", "--tag", "env=staging"},
 			expected: true,
 		},
 	}


### PR DESCRIPTION
## What?

skip binary provisioning for `k6 run` command

## Why?

Binary provisioning is currently supported only for users who have a cloud account, because it requires authenticating to GCK6.
Enabling binary provisioning only for cloud command (e.g. `k6 cloud run`) offers a more consistent user experience. The exception to this are the `k6 archive` and `k6 inspect` commands that are require for the users to upload tests to the cloud.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
