### PR TITLE
Summary: Filter out samples tagged with group: setup/teardown

### DIFF
--- a/internal/output/summary/summary.go
+++ b/internal/output/summary/summary.go
@@ -5,6 +5,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"go.k6.io/k6/internal/lib/consts"
 	"go.k6.io/k6/internal/lib/summary"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
@@ -99,6 +100,9 @@ func (o *Output) flushSample(sample metrics.Sample) {
 
 	if groupTag, exists := sample.Tags.Get("group"); exists && len(groupTag) > 0 {
 		normalizedGroupName := strings.TrimPrefix(groupTag, lib.GroupSeparator)
+		if normalizedGroupName == consts.SetupFn || normalizedGroupName == consts.TeardownFn {
+			return // Essentially skip samples tagged with group: setup/teardown.
+		}
 		groupNames := strings.Split(normalizedGroupName, lib.GroupSeparator)
 
 		// We traverse over all the groups to create a nested structure,

--- a/internal/output/summary/summary_test.go
+++ b/internal/output/summary/summary_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
 
+	"go.k6.io/k6/internal/lib/consts"
 	"go.k6.io/k6/internal/lib/summary"
 	"go.k6.io/k6/internal/lib/testutils"
 	"go.k6.io/k6/lib"
@@ -228,6 +229,22 @@ func TestOutput_AddMetricSamples(t *testing.T) {
 				TimeSeries: metrics.TimeSeries{
 					Metric: httpReqsMetric,
 					Tags:   reg.RootTagSet().With("group", lib.RootGroupPath),
+				},
+				Time:  time.Now(),
+				Value: 1,
+			},
+			{
+				TimeSeries: metrics.TimeSeries{
+					Metric: httpReqsMetric,
+					Tags:   reg.RootTagSet().With("group", lib.GroupSeparator+consts.SetupFn),
+				},
+				Time:  time.Now(),
+				Value: 1,
+			},
+			{
+				TimeSeries: metrics.TimeSeries{
+					Metric: httpReqsMetric,
+					Tags:   reg.RootTagSet().With("group", lib.GroupSeparator+consts.TeardownFn),
 				},
 				Time:  time.Now(),
 				Value: 1,


### PR DESCRIPTION
## What?

It filters out samples tagged with `group: ::setup` or `group: ::teardown` so they aren't collected as "group samples".

## Why?

Since #4089, we modified not only how the data in the summary is displayed but also how it is collected. So, since then, we started to collect samples with `group: ::setup` or `group: ::teardown`, while previously we did not because there are no groups named like `::setup` or `::teardown`, we only "artificially" tag samples with the `group` label (more details [here](https://grafana.com/docs/k6/latest/using-k6/workaround-iteration-duration/)).

So, for now, and until we decide the opposite (if any), we want to preserve the old behavior, where none of these two are displayed in the summary as "real" groups.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Contribute to #4724 
