### PR TITLE
Fix deprecated `GetLayoutMetrics.VisualViewport`

### DIFF
--- a/internal/js/modules/k6/browser/common/screenshotter.go
+++ b/internal/js/modules/k6/browser/common/screenshotter.go
@@ -239,29 +239,24 @@ func getViewPortDimensions(ctx context.Context, sess session, logger *log.Logger
 
 	// Add clip region
 	//nolint:dogsled
-	_, visualViewport, _, _, cssVisualViewport, _, err := cdppage.GetLayoutMetrics().Do(cdp.WithExecutor(ctx, sess))
+	_, _, _, _, cssVisualViewport, _, err := cdppage.GetLayoutMetrics().Do(cdp.WithExecutor(ctx, sess))
 	if err != nil {
 		return 0, 0, 0, fmt.Errorf("getting layout metrics for screenshot: %w", err)
 	}
 
 	// we had a null pointer panic cases, when visualViewport is nil
 	// instead of the erroring out, we fallback to defaults and still try to do a screenshot
-	switch {
-	case cssVisualViewport != nil:
+	if cssVisualViewport != nil {
 		visualViewportScale = cssVisualViewport.Scale
 		visualViewportPageX = cssVisualViewport.PageX
 		visualViewportPageY = cssVisualViewport.PageY
-	case visualViewport != nil:
-		visualViewportScale = visualViewport.Scale
-		visualViewportPageX = visualViewport.PageX
-		visualViewportPageY = visualViewport.PageY
-	default:
+	} else {
 		logger.Warnf(
 			"Screenshotter::screenshot",
-			"chrome browser returned nil on page.getLayoutMetrics, falling back to defaults for visualViewport "+
+			"chrome browser returned nil on page.getLayoutMetrics, falling back to defaults for cssVisualViewport "+
 				"(scale: %v, pageX: %v, pageY: %v)."+
-				"This is non-standard behavior, if possible please report this issue (with reproducible script) "+
-				"to the https://go.k6.io/k6/js/modules/k6/browser/issues/1502.",
+				"This is non-standard behavior, if possible please report this issue (with a reproducible script) "+
+				"to the https://github.com/grafana/k6/issues/new.",
 			visualViewportScale, visualViewportPageX, visualViewportPageY,
 		)
 	}


### PR DESCRIPTION
## What?

Removes the deprecated `GetLayoutMetrics.VisualViewport` usage.

See https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-getLayoutMetrics.

## Why?

The CDP API, `GetLayoutMetrics.VisualViewport`, is deprecated. It doesn't pose an issue for our public surface area. However, it might fail sporadically, which is why we had a check for it.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [x] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
