### PR TITLE
handle signals

### DIFF
--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/grafana/k6deps"
@@ -132,21 +133,42 @@ func (b *customBinary) run(gs *state.GlobalState) {
 	}
 	cmd.Env = env
 
+	// handle signals
+	sigC := make(chan os.Signal, 2)
+	gs.SignalNotify(sigC, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
+
 	gs.Logger.Debug("Launching the provisioned k6 binary")
 
-	rc := 0
-	if err := cmd.Run(); err != nil {
-		rc = 1
+	if err := cmd.Start(); err != nil {
 		gs.Logger.
 			WithError(err).
 			Error("Failed to run the provisioned k6 binary")
+		gs.OSExit(1)
+	}
 
-		var eerr *exec.ExitError
-		if errors.As(err, &eerr) {
-			rc = eerr.ExitCode()
+	// wait for the subprocess to end
+	done := make(chan error)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	for {
+		select {
+		case err := <-done:
+			rc := 0
+			if err != nil {
+				rc = 1
+				var eerr *exec.ExitError
+				if errors.As(err, &eerr) {
+					rc = eerr.ExitCode()
+				}
+			}
+			gs.OSExit(rc)
+		case <-sigC:
+			// TODO: maybe we should set a timeout while waiting for the subprocess
+			gs.Logger.Debug("Signal received. Waiting for subprocess to end.")
 		}
 	}
-	gs.OSExit(rc)
 }
 
 // currentBinary runs the requested commands on the current binary

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -164,9 +164,10 @@ func (b *customBinary) run(gs *state.GlobalState) {
 				}
 			}
 			gs.OSExit(rc)
-		case <-sigC:
-			// TODO: maybe we should set a timeout while waiting for the subprocess
-			gs.Logger.Debug("Signal received. Waiting for subprocess to end.")
+		case sig := <-sigC:
+			gs.Logger.
+				WithField("signal", sig.String()).
+				Debug("Signal received, waiting for the subprocess to handle it and return.")
 		}
 	}
 }


### PR DESCRIPTION
## What?

Handle signals in the parent process when calling a subprocess.

## Why?

Prevent the parent from ending prematurely before the subprocess ends.

Also fixes https://github.com/grafana/k6/issues/4735. By separating the `Start` of the process from waiting for the child to end, we can handle separately errors like binary not found (and report them) from the non-zero return codes from the child.   

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
