### PR TITLE
Binary provisioning/configure binary cache dir

### DIFF
--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -204,9 +205,20 @@ func k6buildProvision(gs *state.GlobalState, deps k6deps.Dependencies) (commandE
 			" Set K6_CLOUD_TOKEN environment variable or execute the `k6 cloud login` command")
 	}
 
+	buildsDir := gs.Env["K6_BINARY_CACHE"]
+	if buildsDir == "" {
+		cacheDir, err := os.UserCacheDir() //nolint:forbidigo
+		if err != nil {
+			gs.Logger.WithError(err).Debug("Failed to get user cache dir")
+			return nil, errors.New("failed to find the user's cache dir")
+		}
+		buildsDir = filepath.Join(cacheDir, "k6", "builds")
+	}
+
 	config := k6provider.Config{
 		BuildServiceURL:  gs.Flags.BuildServiceURL,
 		BuildServiceAuth: token,
+		BinaryCacheDir:   buildsDir,
 	}
 
 	provider, err := k6provider.NewProvider(config)


### PR DESCRIPTION
## What?

Configure the directory used for caching provisioned binaries.

Note: this implementation avoids introducing a new flag to minimize the impact of the change. See #4743 for an alternative implementation.

## Why?

The default value may result confusing as it makes reference to the `k6provider` library. 

Fixes #4741 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
