### PR TITLE
Binary provisioning/add cache dir flag

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -227,9 +227,6 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 	if val, ok := env["K6_BUILD_SERVICE_URL"]; ok {
 		result.BuildServiceURL = val
 	}
-	if val, ok := env["K6_BINARY_CACHE"]; ok {
-		result.BinaryCache = val
-	}
 
 	// check if verbose flag is set
 	if slices.Contains(args, "-v") || slices.Contains(args, "--verbose") {

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -29,6 +29,7 @@ const (
 
 	defaultBuildServiceURL = "https://ingest.k6.io/builder/api/v1"
 	defaultConfigFileName  = "config.json"
+	defaultBinaryCacheDir  = "builds"
 )
 
 // GlobalState contains the GlobalFlags and accessors for most of the global
@@ -103,13 +104,18 @@ func NewGlobalState(ctx context.Context) *GlobalState {
 		confDir = ".config"
 	}
 
+	cacheDir, err := os.UserCacheDir()
+	if err != nil {
+		confDir = ".cache"
+	}
+
 	binary, err := os.Executable()
 	if err != nil {
 		binary = "k6"
 	}
 
 	env := BuildEnvMap(os.Environ())
-	defaultFlags := GetDefaultFlags(confDir)
+	defaultFlags := GetDefaultFlags(confDir, cacheDir)
 	globalFlags := getFlags(defaultFlags, env, os.Args)
 
 	logLevel := logrus.InfoLevel
@@ -171,16 +177,18 @@ type GlobalFlags struct {
 
 	BinaryProvisioning bool
 	BuildServiceURL    string
+	BinaryCache        string
 }
 
 // GetDefaultFlags returns the default global flags.
-func GetDefaultFlags(homeDir string) GlobalFlags {
+func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 	return GlobalFlags{
 		Address:          "localhost:6565",
 		ProfilingEnabled: false,
 		ConfigFilePath:   filepath.Join(homeDir, "k6", defaultConfigFileName),
 		LogOutput:        "stderr",
 		BuildServiceURL:  defaultBuildServiceURL,
+		BinaryCache:      filepath.Join(cacheDir, "k6", defaultBinaryCacheDir),
 	}
 }
 
@@ -218,6 +226,9 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 	}
 	if val, ok := env["K6_BUILD_SERVICE_URL"]; ok {
 		result.BuildServiceURL = val
+	}
+	if val, ok := env["K6_BINARY_CACHE"]; ok {
+		result.BinaryCache = val
 	}
 
 	// check if verbose flag is set

--- a/internal/cmd/config_consolidation_test.go
+++ b/internal/cmd/config_consolidation_test.go
@@ -144,7 +144,7 @@ type configConsolidationTestCase struct {
 }
 
 func getConfigConsolidationTestCases() []configConsolidationTestCase {
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	defaultConfig := func(jsonConfig string) fsext.Fs {
 		return getFS([]file{{defaultFlags.ConfigFilePath, jsonConfig}})
 	}

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -218,7 +218,7 @@ func TestReadDiskConfigWithDefaultFlags(t *testing.T) {
 	defaultConfigPath := ".config/k6/config.json"
 	require.NoError(t, fsext.WriteFile(memfs, defaultConfigPath, conf, 0o644))
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:           memfs,
 		Flags:        defaultFlags,
@@ -238,7 +238,7 @@ func TestReadDiskConfigCustomFilePath(t *testing.T) {
 	conf := []byte(`{"iterations":1028,"cloud":{"field1":"testvalue"}}`)
 	require.NoError(t, fsext.WriteFile(memfs, "custom-path/config.json", conf, 0o644))
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:           memfs,
 		Flags:        defaultFlags,
@@ -262,7 +262,7 @@ func TestReadDiskConfigNotFoundSilenced(t *testing.T) {
 	defaultConfigPath := ".config/unknown-folder/k6/config.json"
 	require.NoError(t, fsext.WriteFile(memfs, defaultConfigPath, conf, 0o644))
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:           memfs,
 		Flags:        defaultFlags,
@@ -280,7 +280,7 @@ func TestReadDiskConfigNotJSONExtension(t *testing.T) {
 	conf := []byte(`{"iterations":1028,"cloud":{"field1":"testvalue"}}`)
 	require.NoError(t, fsext.WriteFile(memfs, "custom-path/config.txt", conf, 0o644))
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:           memfs,
 		DefaultFlags: defaultFlags,
@@ -305,7 +305,7 @@ func TestReadDiskConfigNotJSONContentError(t *testing.T) {
 
 	gs := &state.GlobalState{
 		FS:    memfs,
-		Flags: state.GetDefaultFlags(".config"),
+		Flags: state.GetDefaultFlags(".config", ".cache"),
 	}
 	_, err := readDiskConfig(gs)
 	var serr *json.SyntaxError
@@ -316,7 +316,7 @@ func TestReadDiskConfigNotFoundErrorWithCustomPath(t *testing.T) {
 	t.Parallel()
 	memfs := fsext.NewMemMapFs()
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:           memfs,
 		Flags:        defaultFlags,
@@ -333,7 +333,7 @@ func TestWriteDiskConfigWithDefaultFlags(t *testing.T) {
 	t.Parallel()
 	memfs := fsext.NewMemMapFs()
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:           memfs,
 		Flags:        defaultFlags,
@@ -357,7 +357,7 @@ func TestWriteDiskConfigOverwrite(t *testing.T) {
 	defaultConfigPath := ".config/k6/config.json"
 	require.NoError(t, fsext.WriteFile(memfs, defaultConfigPath, conf, 0o644))
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:           memfs,
 		Flags:        defaultFlags,
@@ -373,7 +373,7 @@ func TestWriteDiskConfigCustomPath(t *testing.T) {
 	t.Parallel()
 	memfs := fsext.NewMemMapFs()
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:           memfs,
 		Flags:        defaultFlags,
@@ -390,7 +390,7 @@ func TestWriteDiskConfigNoJSONContentError(t *testing.T) {
 	t.Parallel()
 	memfs := fsext.NewMemMapFs()
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:           memfs,
 		Flags:        defaultFlags,
@@ -419,7 +419,7 @@ func TestMigrateLegacyConfigFileIfAny(t *testing.T) {
 	l, hook := testutils.NewLoggerWithHook(t)
 	logger := l.(*logrus.Logger) //nolint:forbidigo // no alternative, required
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:              memfs,
 		Flags:           defaultFlags,
@@ -442,7 +442,7 @@ func TestMigrateLegacyConfigFileIfAnyWhenFileDoesNotExist(t *testing.T) {
 	t.Parallel()
 	memfs := fsext.NewMemMapFs()
 
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	gs := &state.GlobalState{
 		FS:              memfs,
 		Flags:           defaultFlags,
@@ -505,7 +505,7 @@ func TestLoadConfig(t *testing.T) {
 			l, hook := testutils.NewLoggerWithHook(t)
 			logger := l.(*logrus.Logger) //nolint:forbidigo // no alternative, required
 
-			defaultFlags := state.GetDefaultFlags(".config")
+			defaultFlags := state.GetDefaultFlags(".config", ".cache")
 			gs := &state.GlobalState{
 				FS:              tc.memfs,
 				Flags:           defaultFlags,

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -207,6 +207,7 @@ func k6buildProvision(gs *state.GlobalState, deps k6deps.Dependencies) (commandE
 	config := k6provider.Config{
 		BuildServiceURL:  gs.Flags.BuildServiceURL,
 		BuildServiceAuth: token,
+		BinaryCacheDir:   gs.Flags.BinaryCache,
 	}
 
 	provider, err := k6provider.NewProvider(config)

--- a/internal/cmd/tests/test_state.go
+++ b/internal/cmd/tests/test_state.go
@@ -84,7 +84,7 @@ func NewGlobalTestState(tb testing.TB) *GlobalTestState {
 	})
 
 	outMutex := &sync.Mutex{}
-	defaultFlags := state.GetDefaultFlags(".config")
+	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 	defaultFlags.Address = getFreeBindAddr(tb)
 
 	ts.GlobalState = &state.GlobalState{


### PR DESCRIPTION
## What?

Adds a flag for configuring the directory used to cache provisioned binaries.

## Why?

The default value may result confusing as it makes reference to the `k6provider` library. 

Fixes #4741 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
