### PR TITLE
timers: Fix test by waiting on the eventloop if it was ran too fast

### DIFF
--- a/internal/js/tc55/timers/timers_test.go
+++ b/internal/js/tc55/timers/timers_test.go
@@ -121,6 +121,7 @@ func TestSetIntervalOrder(t *testing.T) {
 			print("outside");
 		`)
 		require.NoError(t, err)
+		runtime.EventLoop.WaitOnRegistered()
 		require.GreaterOrEqual(t, len(log), 5)
 		require.Equal(t, log[0], "outside")
 		for i := 1; i < len(log)-1; i += 3 {


### PR DESCRIPTION
## What?

Fix for timers tests

## Why?
It seems to everyonce in a while failing in CI and my only explanations is that the timers tick fast enough most times, but not always.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
