### PR TITLE
Try to fix lint GHA

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         branch="master"
         if [ "${REPO_FULL_NAME}" = "grafana/k6" ]; then
-          branch="${GITHUB_ACTION_REF:-GITHUB_HEAD_REF}"
+          branch="${GITHUB_ACTION_REF:-${GITHUB_HEAD_REF}}"
         fi
         rules_url="https://raw.githubusercontent.com/grafana/k6/${branch}/.golangci.yml"
         echo "Downloading '${rules_url}' ..."

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -12,12 +12,13 @@ runs:
     - name: Get golangci-lint version and download rules
       shell: bash
       env: #TODO: remove after https://github.com/actions/runner/issues/2473 is fixed
-        GITHUB_ACTION_REF: ${{ github.action_ref || github.head_ref }}
+        GITHUB_ACTION_REF: ${{ github.action_ref }}
+        GITHUB_HEAD_REF: ${{  github.head_ref }}
         REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
       run: |
         branch="master"
         if [ "${REPO_FULL_NAME}" = "grafana/k6" ]; then
-            branch="${GITHUB_ACTION_REF}"
+          branch="${GITHUB_ACTION_REF:-GITHUB_HEAD_REF}"
         fi
         rules_url="https://raw.githubusercontent.com/grafana/k6/${branch}/.golangci.yml"
         echo "Downloading '${rules_url}' ..."


### PR DESCRIPTION
## What?

Try to fix the lint github action.



## Why?
Lint action needs to be reusable in different repos. And if used in grafana/k6 it needs to the config from the PR- otherwise use the one from master.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
