### PR TITLE
skip binary provisioning for help commands

### DIFF
--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -259,9 +259,9 @@ func analyze(gs *state.GlobalState, args []string) (k6deps.Dependencies, error) 
 		Manifest:  k6deps.Source{Ignore: true},
 	}
 
-	if !isScriptRequired(args) {
+	if !isAnalysisRequired(args) {
 		gs.Logger.
-			Debug("The command to execute does not require Binary provisioning")
+			Debug("The command to execute does not require dependency analysis.")
 		return k6deps.Dependencies{}, nil
 	}
 
@@ -295,8 +295,8 @@ func analyze(gs *state.GlobalState, args []string) (k6deps.Dependencies, error) 
 	return k6deps.Analyze(dopts)
 }
 
-// isScriptRequired searches for the command and returns a boolean indicating if it is required to pass a script or not
-func isScriptRequired(args []string) bool {
+// isAnalysisRequired searches for the command and returns a boolean indicating if dependency analysis is required
+func isAnalysisRequired(args []string) bool {
 	// return early if no arguments passed
 	if len(args) == 0 {
 		return false
@@ -306,9 +306,11 @@ func isScriptRequired(args []string) bool {
 	// we handle cloud login subcommand as a special case because it does not require binary provisioning
 	for i, arg := range args {
 		switch arg {
+		case "--help", "-h":
+			return false
 		case "cloud":
 			for _, arg = range args[i+1:] {
-				if arg == "login" {
+				if arg == "login" || arg == "--help" || arg == "-h" {
 					return false
 				}
 			}

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -353,7 +353,7 @@ func TestScriptNameFromArgs(t *testing.T) {
 	}
 }
 
-func TestIsScriptRequired(t *testing.T) {
+func TestIsAnalysisRequired(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
 		name     string
@@ -389,6 +389,21 @@ func TestIsScriptRequired(t *testing.T) {
 			name:     "cloud run command",
 			args:     []string{"cloud", "run", "script.js"},
 			expected: true,
+		},
+		{
+			name:     "cloud run command with help",
+			args:     []string{"cloud", "run", "--help"},
+			expected: false,
+		},
+		{
+			name:     "cloud run command with short help",
+			args:     []string{"cloud", "run", "-h"},
+			expected: false,
+		},
+		{
+			name:     "cloud command with short help in front",
+			args:     []string{"-h", "cloud"},
+			expected: false,
 		},
 		{
 			name:     "flag before command",
@@ -436,7 +451,7 @@ func TestIsScriptRequired(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			actual := isScriptRequired(tc.args)
+			actual := isAnalysisRequired(tc.args)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}


### PR DESCRIPTION
## What?

Skip baniry provisioning  for help commands

## Why?

Help should be provided by the currently running k6 binary

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
