### PR TITLE
examples: move from test.k6.io to quickpizza and related fixes

### DIFF
--- a/examples/browser/colorscheme.js
+++ b/examples/browser/colorscheme.js
@@ -26,7 +26,7 @@ export default async function() {
 
   try {
     await page.goto(
-      'https://test.k6.io',
+      'https://quickpizza.grafana.com/test.k6.io',
       { waitUntil: 'load' },
     )
     await check(page, {

--- a/examples/browser/device_emulation.js
+++ b/examples/browser/device_emulation.js
@@ -27,7 +27,7 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
     const dimensions = await page.evaluate(() => {
       return {
         width: document.documentElement.clientWidth,

--- a/examples/browser/dispatch.js
+++ b/examples/browser/dispatch.js
@@ -22,7 +22,7 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
 
     const contacts = page.locator('a[href="/contacts.php"]');
     await contacts.dispatchEvent("click");

--- a/examples/browser/evaluate.js
+++ b/examples/browser/evaluate.js
@@ -22,7 +22,7 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto("https://test.k6.io/", { waitUntil: "load" });
+    await page.goto("https://quickpizza.grafana.com/test.k6.io/", { waitUntil: "load" });
 
     // calling evaluate without arguments
     await check(page, {

--- a/examples/browser/fillform.js
+++ b/examples/browser/fillform.js
@@ -23,7 +23,7 @@ export default async function() {
 
   try {
     // Goto front page, find login link and click it
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
     await Promise.all([
       page.waitForNavigation(),
       page.locator('a[href="/my_messages.php"]').click(),

--- a/examples/browser/fillform.js
+++ b/examples/browser/fillform.js
@@ -51,7 +51,7 @@ export default async function() {
     await check(context, {
       'session cookie is set': async ctx => {
         const cookies = await ctx.cookies();
-        return cookies.find(c => c.name == 'sid') !== undefined;
+        return cookies.find(c => c.name == 'AWSALB') !== undefined;
       }
     });
   } finally {

--- a/examples/browser/grant_permission.js
+++ b/examples/browser/grant_permission.js
@@ -26,7 +26,7 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/');
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/');
     await page.screenshot({ path: `example-chromium.png` });
     await context.clearPermissions();
   } finally {

--- a/examples/browser/hosts.js
+++ b/examples/browser/hosts.js
@@ -12,7 +12,7 @@ export const options = {
       },
     },
   },
-  hosts: { 'test.k6.io': '127.0.0.254' },
+  hosts: { 'quickpizza.grafana.com/test.k6.io': '127.0.0.254' },
   thresholds: {
     checks: ["rate==1.0"]
   }
@@ -23,7 +23,7 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    const res = await page.goto('http://test.k6.io/', {
+    const res = await page.goto('http://quickpizza.grafana.com/test.k6.io/', {
       waitUntil: 'load'
     });
     await check(res, {

--- a/examples/browser/hosts.js
+++ b/examples/browser/hosts.js
@@ -12,7 +12,7 @@ export const options = {
       },
     },
   },
-  hosts: { 'quickpizza.grafana.com/test.k6.io': '127.0.0.254' },
+  hosts: { 'quickpizza.grafana.com': '127.0.0.254' },
   thresholds: {
     checks: ["rate==1.0"]
   }

--- a/examples/browser/keyboard.js
+++ b/examples/browser/keyboard.js
@@ -16,7 +16,7 @@ export const options = {
 export default async function () {
   const page = await browser.newPage();
 
-  await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
+  await page.goto('https://quickpizza.grafana.com/test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
 
   const userInput = page.locator('input[name="login"]');
   await userInput.click();

--- a/examples/browser/locator.js
+++ b/examples/browser/locator.js
@@ -21,7 +21,7 @@ export default async function() {
   const page = await context.newPage();
   
   try {
-    await page.goto("https://test.k6.io/flip_coin.php", {
+    await page.goto("https://quickpizza.grafana.com/test.k6.io/flip_coin.php", {
       waitUntil: "networkidle",
     })
 

--- a/examples/browser/locator_pom.js
+++ b/examples/browser/locator_pom.js
@@ -34,7 +34,7 @@ export class Bet {
   }
 
   goto() {
-    return this.page.goto("https://test.k6.io/flip_coin.php", { waitUntil: "networkidle" });
+    return this.page.goto("https://quickpizza.grafana.com/test.k6.io/flip_coin.php", { waitUntil: "networkidle" });
   }
 
   heads() {

--- a/examples/browser/mouse.js
+++ b/examples/browser/mouse.js
@@ -16,7 +16,7 @@ export const options = {
 export default async function () {
   const page = await browser.newPage();
 
-  await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+  await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
 
   // Obtain ElementHandle for news link and navigate to it
   // by clicking in the 'a' element's bounding box

--- a/examples/browser/multiple-scenario.js
+++ b/examples/browser/multiple-scenario.js
@@ -36,7 +36,7 @@ export async function messages() {
   const page = await browser.newPage();
 
   try {
-    await page.goto('https://test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
   } finally {
     await page.close();
   }
@@ -46,7 +46,7 @@ export async function news() {
   const page = await browser.newPage();
 
   try {
-    await page.goto('https://test.k6.io/news.php', { waitUntil: 'networkidle' });
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/news.php', { waitUntil: 'networkidle' });
   } finally {
     await page.close();
   }

--- a/examples/browser/pageon-metric.js
+++ b/examples/browser/pageon-metric.js
@@ -26,8 +26,8 @@ export default async function() {
   });
 
   try {
-    await page.goto('https://test.k6.io/?q=abc123');
-    await page.goto('https://test.k6.io/?q=def456');
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/?q=abc123');
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/?q=def456');
   } finally {
     await page.close();
   }

--- a/examples/browser/pageon.js
+++ b/examples/browser/pageon.js
@@ -21,7 +21,7 @@ export default async function() {
   const page = await browser.newPage();
   
   try {
-    await page.goto('https://test.k6.io/');
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/');
 
     page.on('console', async msg => check(msg, {
       'assert console message type': msg =>

--- a/examples/browser/querying.js
+++ b/examples/browser/querying.js
@@ -22,16 +22,16 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/');
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/');
 
     await check(page, {
       'Title with CSS selector': async p => {
         const e = await p.$('header h1.title');
-        return await e.textContent() === 'test.k6.io';
+        return await e.textContent() === 'quickpizza.grafana.com/test.k6.io';
       },
       'Title with XPath selector': async p => {
         const e = await p.$('//header//h1[@class="title"]');
-        return await e.textContent() === 'test.k6.io';
+        return await e.textContent() === 'quickpizza.grafana.com/test.k6.io';
       }
     });
   } finally {

--- a/examples/browser/querying.js
+++ b/examples/browser/querying.js
@@ -27,11 +27,11 @@ export default async function() {
     await check(page, {
       'Title with CSS selector': async p => {
         const e = await p.$('header h1.title');
-        return await e.textContent() === 'quickpizza.grafana.com/test.k6.io';
+        return await e.textContent() === 'QuickPizza Legacy';
       },
       'Title with XPath selector': async p => {
         const e = await p.$('//header//h1[@class="title"]');
-        return await e.textContent() === 'quickpizza.grafana.com/test.k6.io';
+        return await e.textContent() === 'QuickPizza Legacy';
       }
     });
   } finally {

--- a/examples/browser/screenshot.js
+++ b/examples/browser/screenshot.js
@@ -21,7 +21,7 @@ export default async function() {
   const page = await context.newPage();
   
   try {
-    await page.goto('https://test.k6.io/');
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/');
     await page.screenshot({ path: 'screenshot.png' });
     // TODO: Assert this somehow. Upload as CI artifact or just an external `ls`?
     // Maybe even do a fuzzy image comparison against a preset known good screenshot?

--- a/examples/browser/throttle.js
+++ b/examples/browser/throttle.js
@@ -45,7 +45,7 @@ export async function normal() {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
   } finally {
     await page.close();
   }
@@ -58,7 +58,7 @@ export async function networkThrottled() {
   try {
     await page.throttleNetwork(networkProfiles["Slow 3G"]);
 
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
   } finally {
     await page.close();
   }
@@ -71,7 +71,7 @@ export async function cpuThrottled() {
   try {
     await page.throttleCPU({ rate: 4 });
 
-    await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+    await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
   } finally {
     await page.close();
   }

--- a/examples/browser/touchscreen.js
+++ b/examples/browser/touchscreen.js
@@ -16,7 +16,7 @@ export const options = {
 export default async function () {
   const page = await browser.newPage();
 
-  await page.goto("https://test.k6.io/", { waitUntil: "networkidle" });
+  await page.goto("https://quickpizza.grafana.com/test.k6.io/", { waitUntil: "networkidle" });
 
   // Obtain ElementHandle for news link and navigate to it
   // by tapping in the 'a' element's bounding box

--- a/examples/es6sample.js
+++ b/examples/es6sample.js
@@ -3,7 +3,6 @@ import { Counter, Rate } from "k6/metrics";
 import http from "k6/http";
 
 export let options = {
-	vus: 5,
 	thresholds: {
 		my_rate: ["rate>=0.4"], // Require my_rate's success rate to be >=40%
 		http_req_duration: ["avg<1000"], // Require http_req_duration's average to be <1000ms
@@ -36,10 +35,12 @@ export default function() {
 		});
 
 		group("html", function() {
-			check(http.get("http://test.k6.io/"), {
+			const res = http.get("https://quickpizza.grafana.com/test.k6.io/")
+			console.log(res.html("p.description").text())
+			check(res, {
 				"status is 200": (res) => res.status === 200,
 				"content type is html": (res) => res.headers['Content-Type'].startsWith("text/html"),
-				"welcome message is correct": (res) => res.html("p.description").text() === "Collection of simple web-pages suitable for load testing.",
+				"welcome message is correct": (res) => res.html("p.description").text().includes("This is a replacement"),
 			});
 		});
 

--- a/examples/http_batch.js
+++ b/examples/http_batch.js
@@ -3,8 +3,8 @@ import http from 'k6/http';
 
 export default function() {
   const responses = http.batch([
-    "http://test.k6.io",
-    "http://test.k6.io/pi.php"
+    "https://quickpizza.grafana.com/test.k6.io",
+    "https://quickpizza.grafana.com/pi.php"
   ]);
 
   check(responses[0], {

--- a/examples/thresholds_readme_example.js
+++ b/examples/thresholds_readme_example.js
@@ -18,9 +18,9 @@ export let options = {
     ],
     thresholds: {
         // We want the 95th percentile of all HTTP request durations to be less than 500ms
-        "http_req_duration": ["p(95)<500"],
+        "http_req_duration": ["p(95)<750"],
         // Requests with the staticAsset tag should finish even faster
-        "http_req_duration{staticAsset:yes}": ["p(99)<250"],
+        "http_req_duration{staticAsset:yes}": ["p(99)<500"],
         // Thresholds based on the custom metric we defined and use to track application failures
         "check_failure_rate": [
             // Global failure rate should be less than 1%
@@ -33,13 +33,13 @@ export let options = {
 
 // Main function
 export default function () {
-    let response = http.get("https://test.k6.io/");
+    let response = http.get("https://quickpizza.grafana.com/test.k6.io/");
 
     // check() returns false if any of the specified conditions fail
     let checkRes = check(response, {
         "http2 is used": (r) => r.proto === "HTTP/2.0",
         "status is 200": (r) => r.status === 200,
-        "content is present": (r) => r.body.indexOf("Collection of simple web-pages suitable for load testing.") !== -1,
+        "content is present": (r) => r.body.indexOf("This is a replacement of the service ") !== -1,
     });
 
     // We reverse the check() result since we want to count the failures
@@ -49,9 +49,9 @@ export default function () {
     group("Static Assets", function () {
         // Execute multiple requests in parallel like a browser, to fetch some static resources
         let resps = http.batch([
-            ["GET", "https://test.k6.io/static/css/site.css", null, { tags: { staticAsset: "yes" } }],
-            ["GET", "https://test.k6.io/static/favicon.ico", null, { tags: { staticAsset: "yes" } }],
-            ["GET", "https://test.k6.io/static/js/prisms.js", null, { tags: { staticAsset: "yes" } }],
+            ["GET", "https://quickpizza.grafana.com/test.k6.io/static/css/site.css", null, { tags: { staticAsset: "yes" } }],
+            ["GET", "https://quickpizza.grafana.com/test.k6.io/static/favicon.ico", null, { tags: { staticAsset: "yes" } }],
+            ["GET", "https://quickpizza.grafana.com/test.k6.io/static/js/prisms.js", null, { tags: { staticAsset: "yes" } }],
         ]);
         // Combine check() call with failure tracking
         failureRate.add(!check(resps, {


### PR DESCRIPTION
## What?

Replace test.k6.io with the quickpizza variant to fix e2e tests and examples

## Why?

test.k6.io was shutdown which leads to the e2e browser tests to fail

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
