### PR TITLE
Release notes for k6 v1.0.0

### DIFF
--- a/release notes/v1.0.0.md
+++ b/release notes/v1.0.0.md
@@ -104,12 +104,3 @@ k6 run --summary-mode=full script.ts
 
 - Stable modules: `k6/browser`, `k6/net/grpc`, and `k6/crypto` are now production-ready.
 - Better Cloud integration: Stream local test results to Grafana Cloud with `k6 cloud run --local-execution`.
-
-## UX improvements and enhancements
-
-TODO
-
-
-## Maintenance and internal improvements
-
-TODO

--- a/release notes/v1.0.0.md
+++ b/release notes/v1.0.0.md
@@ -87,7 +87,7 @@ k6 cloud run --local-execution
 ### 4. Revamped test summary
 
 
-The new end of test summary makes it easier to **understand results and spot issues*:
+The new end of test summary makes it easier to **understand results and spot issues**:
 📊 **Hierarchical output**: Metrics are grouped by scenario, group, and category
 ✅ **Improved thresholds & checks**: Clearer layout for faster debugging
 🔍 **Multiple summary modes**:

--- a/release notes/v1.0.0.md
+++ b/release notes/v1.0.0.md
@@ -1,0 +1,114 @@
+# Grafana k6 v1.0 is here! 🎉
+
+After 9 years of iteration and countless community contributions, we're thrilled to announce **Grafana k6 v1.0**. 
+
+While many the features and capabilities in this release were introduced gradually over past versions, **k6 v1.0 marks a turning point**: a commitment to stability, formal support guarantees, and transparency in how we evolve and develop the project from here. This milestone is more than a version number; it's about trust, reliability, and empowering you to test with confidence.
+
+## Thank You, k6 Community! 🌍
+
+This release wouldn't be possible without you:
+
+- ⭐️ 27000+ GitHub stars
+- 🧠 9000+ git commits
+- 🤝 200+ contributors
+- 🔁 Countless test runs of any scale, in every timezone.
+
+
+It's been amazing to watch k6 grow, from a simple load testing CLI into a comprehensive reliability tool, used by teams worldwide and supported by a passionate and dedicated community.
+
+To everyone who filed bugs, built extensions and libraries, or championed k6:️
+**Thank you!** You've shaped what k6 is today 🙇‍♂️ 
+
+## What's New in k6 1.0?
+
+### 1. Stability You Can Build On
+
+- ✅ **Semantic Versioning**: k6 now follows [semantic versioning 2.0](https://semver.org/). Breaking changes will only happen in major releases, with prior deprecation warnings.
+- 🔒 **2-Year Support Guarantees**: Every major version will be supported with critical fixes for **at least two years**; upgrade on your schedule.
+- 📦 **Public API Surface**: We've established a clearly delineated and supported API surface for the k6 codebase. Extensions, integrations, and projects building on top of the k6 code now have a stable foundation to rely on.
+
+🔎 Read more in our [Versioning & Stability guarantees](https://grafana.com/docs/k6/latest/reference/versioning-and-stability-guarantees/) guide.
+
+### 2. First-Class TypeScript Support
+
+Write type-safe, maintainable tests—no transpilation required. Just save your file with a `.ts` extension and run it directly with `k6 run script.ts`.
+
+```typescript
+import http from 'k6/http';  
+
+// PizzaRequest defines the request body format the quickpizza API expects
+export interface PizzaRequest {
+    maxCaloriesPerSlice: number;
+    mustBeVegetarian: boolean;
+}
+
+export default function () {  
+    const payload: PizzaRequest = {
+        maxCaloriesPerSlice: 500, // Type-checked!  
+        mustBeVegetarian: true,
+    }
+
+  http.post(
+    'https://quickpizza.grafana.com/api/pizza',
+    JSON.stringify(payload),
+    { 
+        headers: { 
+          "Content-Type": "application/json",
+          "Authorization": "Token " + "abcdef0123456789"
+        } as Record<string, string>
+    });  
+}  
+```
+
+### 3. Extensions Made Simple
+
+With k6 v1.0, extensions now work out of the box in `k6 cloud run` and `k6 cloud run --local-execution`. Support for `k6 run` is coming soon.
+
+✅ No more xk6 toolchain.
+✅ No manual builds.
+✅ Import an extension's module, and go.
+
+```javascript
+import faker from 'k6/x/faker';
+
+export default function () {
+  console.log(faker.person.firstName());
+}
+```
+
+Run it with:
+
+```bash
+k6 cloud run script.js
+# or
+k6 cloud run --local-execution
+```
+
+### 4. Revamped test summary
+
+
+The new end of test summary makes it easier to **understand results and spot issues*:
+📊 **Hierarchical output**: Metrics are grouped by scenario, group, and category
+✅ **Improved thresholds & checks**: Clearer layout for faster debugging
+🔍 **Multiple summary modes**:
+    * `compact` (default): big picture results, focusing on essentials.
+    * `full`: full picture results, providing granularity.
+ 
+```
+k6 run --summary-mode=full script.ts
+```
+
+
+### 5. Quality of Life Upgrades
+
+- Stable modules: `k6/browser`, `k6/net/grpc`, and `k6/crypto` are now production-ready.
+- Better Cloud integration: Stream local test results to Grafana Cloud with `k6 cloud run --local-execution`.
+
+## UX improvements and enhancements
+
+TODO
+
+
+## Maintenance and internal improvements
+
+TODO

--- a/release notes/v1.0.0.md
+++ b/release notes/v1.0.0.md
@@ -13,7 +13,6 @@ This release wouldn't be possible without you:
 - 🤝 200+ contributors.
 - 🔁 Countless test runs of any scale, in every timezone.
 
-
 It's been amazing to watch k6 grow from a simple load testing command-line tool into a comprehensive reliability tool, used by teams worldwide and supported by a passionate and dedicated community.
 
 To everyone who filed bugs, built extensions and libraries, or championed k6:️
@@ -76,16 +75,19 @@ export default function () {
 }
 ```
 
-Run it with:
+To try the experimental feature, first enable its feature flag, then run it on Grafana Cloud with the following command:
 
 ```bash
-k6 cloud run script.js
-# or
-k6 cloud run --local-execution
+K6_BINARY_PROVISIONING=true k6 cloud run script.js,
+```
+
+or if you want to run it locally and stream the results to Grafana Cloud then use:
+
+```bash
+K6_BINARY_PROVISIONING=true k6 cloud run --local-execution script.js
 ```
 
 ### 4. Revamped test summary
-
 
 The new end-of-test summary makes it easier to **understand results and spot issues**:
 

--- a/release notes/v1.0.0.md
+++ b/release notes/v1.0.0.md
@@ -98,6 +98,7 @@ The new end of test summary makes it easier to **understand results and spot iss
 k6 run --summary-mode=full script.ts
 ```
 
+![end-of-test-summary](https://github.com/user-attachments/assets/02984ff9-6ed2-4eb2-9637-daf5058f2de6)
 
 ### 5. Quality of Life Upgrades
 

--- a/release notes/v1.0.0.md
+++ b/release notes/v1.0.0.md
@@ -2,36 +2,36 @@
 
 After 9 years of iteration and countless community contributions, we're thrilled to announce **Grafana k6 v1.0**. 
 
-While many the features and capabilities in this release were introduced gradually over past versions, **k6 v1.0 marks a turning point**: a commitment to stability, formal support guarantees, and transparency in how we evolve and develop the project from here. This milestone is more than a version number; it's about trust, reliability, and empowering you to test with confidence.
+While many features and capabilities in this release were introduced gradually in previous versions, **k6 v1.0 marks a turning point**: a commitment to stability, formal support guarantees, and transparency in how we evolve and develop the project from here. This milestone is more than a version number; it's about trust, reliability, and empowering you to test confidently.
 
-## Thank You, k6 Community! 🌍
+## Thank you, k6 community! 🌍
 
 This release wouldn't be possible without you:
 
-- ⭐️ 27000+ GitHub stars
-- 🧠 9000+ git commits
-- 🤝 200+ contributors
+- ⭐️ 27000+ GitHub stars.
+- 🧠 9000+ git commits.
+- 🤝 200+ contributors.
 - 🔁 Countless test runs of any scale, in every timezone.
 
 
-It's been amazing to watch k6 grow, from a simple load testing CLI into a comprehensive reliability tool, used by teams worldwide and supported by a passionate and dedicated community.
+It's been amazing to watch k6 grow from a simple load testing command-line tool into a comprehensive reliability tool, used by teams worldwide and supported by a passionate and dedicated community.
 
 To everyone who filed bugs, built extensions and libraries, or championed k6:️
-**Thank you!** You've shaped what k6 is today 🙇‍♂️ 
+**Thank you!** You've shaped what k6 is today. 🙇‍♂️
 
 ## What's New in k6 1.0?
 
 ### 1. Stability You Can Build On
 
-- ✅ **Semantic Versioning**: k6 now follows [semantic versioning 2.0](https://semver.org/). Breaking changes will only happen in major releases, with prior deprecation warnings.
+- ✅ **Semantic Versioning**: k6 now follows [Semantic Versioning 2.0](https://semver.org/). Breaking changes will only happen in major releases, with prior deprecation warnings.
 - 🔒 **2-Year Support Guarantees**: Every major version will be supported with critical fixes for **at least two years**; upgrade on your schedule.
 - 📦 **Public API Surface**: We've established a clearly delineated and supported API surface for the k6 codebase. Extensions, integrations, and projects building on top of the k6 code now have a stable foundation to rely on.
 
-🔎 Read more in our [Versioning & Stability guarantees](https://grafana.com/docs/k6/latest/reference/versioning-and-stability-guarantees/) guide.
+🔎 Read more in our [versioning and stability guarantees](https://grafana.com/docs/k6/latest/reference/versioning-and-stability-guarantees/) guide.
 
 ### 2. First-Class TypeScript Support
 
-Write type-safe, maintainable tests—no transpilation required. Just save your file with a `.ts` extension and run it directly with `k6 run script.ts`.
+Write type-safe and maintainable tests—no transpilation needed. Simply save your file with a `.ts` extension and run it directly using `k6 run script.ts`.
 
 ```typescript
 import http from 'k6/http';  
@@ -66,7 +66,7 @@ With k6 v1.0, extensions now work out of the box in `k6 cloud run` and `k6 cloud
 
 ✅ No more xk6 toolchain.
 ✅ No manual builds.
-✅ Import an extension's module, and go.
+✅ Import an extension's module and go.
 
 ```javascript
 import faker from 'k6/x/faker';
@@ -87,12 +87,13 @@ k6 cloud run --local-execution
 ### 4. Revamped test summary
 
 
-The new end of test summary makes it easier to **understand results and spot issues**:
-📊 **Hierarchical output**: Metrics are grouped by scenario, group, and category
-✅ **Improved thresholds & checks**: Clearer layout for faster debugging
-🔍 **Multiple summary modes**:
-    * `compact` (default): big picture results, focusing on essentials.
-    * `full`: full picture results, providing granularity.
+The new end-of-test summary makes it easier to **understand results and spot issues**:
+
+* 📊 **Hierarchical output**: Metrics are grouped by scenario, group, and category.
+* ✅ **Improved thresholds & checks**: Clearer layout for faster debugging.
+* 🔍 **Multiple summary modes**:
+  * `compact` (default): big picture results, focusing on essentials.
+  * `full`: full picture results, providing granularity.
  
 ```
 k6 run --summary-mode=full script.ts
@@ -103,4 +104,4 @@ k6 run --summary-mode=full script.ts
 ### 5. Quality of Life Upgrades
 
 - Stable modules: `k6/browser`, `k6/net/grpc`, and `k6/crypto` are now production-ready.
-- Better Cloud integration: Stream local test results to Grafana Cloud with `k6 cloud run --local-execution`.
+- Improved Grafana Cloud integration: Stream local test results to Grafana Cloud with `k6 cloud run --local-execution`.


### PR DESCRIPTION
## What?

Release notes for k6 v1.0.0. Because we've shipped most of the stuff already, and it also builds on top of release candidates, I've extracted a couple of highlights based on my presentation and the upcoming blog article.

Pending task is to list the merged PRs for UX/bugs since v1.0.0-rc1 (rc2?)