### PR TITLE
packager: Use the shared workflow for Docker login

### DIFF
--- a/.github/workflows/packager.yml
+++ b/.github/workflows/packager.yml
@@ -22,6 +22,9 @@ jobs:
       S3CMD_VERSION: 2.1.0
       DOCKER_IMAGE_ID: ghcr.io/grafana/k6packager
       GITHUB_ACTOR: ${{ github.actor }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -31,6 +34,8 @@ jobs:
         run: |
           cd packaging
           docker compose build packager
+      - name: Login to DockerHub
+        uses: grafana/shared-workflows/actions/dockerhub-login@117d8511cbc5da0337972deeb400c4298b057af3 # dockerhub-login-v1.0.1
       - name: Publish
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

Use the shared workflow to login to the DockerHub registry instead of using a custom logic