### PR TITLE
chore: bump golangci-lint-action in reusable GHA

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -11,7 +11,7 @@ runs:
         check-latest: true
     - name: Get golangci-lint version and download rules
       shell: bash
-      env: #TODO: remove after https://github.com/actions/runner/issues/2473 is fixed
+      env:
         GITHUB_ACTION_REF: ${{ github.action_ref }}
         GITHUB_HEAD_REF: ${{  github.head_ref }}
         REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
@@ -27,10 +27,7 @@ runs:
         echo "GolangCIVersion=$(head -n 1 "${{ github.action_path }}/.golangci.yml" | tr -d '# ')" >> "${GITHUB_OUTPUT}"
       id: getenv
     - name: golangci-lint
-      # Here, we play safe and use directly the hash of the version,
-      # instead of using a versioning tag that might be overwritten in the future.
-      # The hash below links to v6.2.0
-      uses: golangci/golangci-lint-action@ec5d18412c0aeab7936cb16880d708ba2a64e1ae
+      uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
       with:
         version: ${{ steps.getenv.outputs.GolangCIVersion }}
         args: "--config=${{ github.action_path }}/.golangci.yml"


### PR DESCRIPTION
## What?

Update golangci-lint to the latest version and some comment cleanup

## Why?

As we moved to v2, the older version might not work very well with the new functionality. It seems here it was just updated enough to work, but still probably better to bump it to latest one.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
