### PR TITLE
Fix thresholds evaluated incorrectly

### DIFF
--- a/internal/output/summary/data.go
+++ b/internal/output/summary/data.go
@@ -296,7 +296,11 @@ func populateSummaryChecks(
 
 	summaryGroup.Checks.Metrics.Fail.Values["passes"] = totalChecks - successChecks
 	summaryGroup.Checks.Metrics.Fail.Values["fails"] = successChecks
-	summaryGroup.Checks.Metrics.Fail.Values["rate"] = (totalChecks - successChecks) / totalChecks
+	if totalChecks > 0 {
+		summaryGroup.Checks.Metrics.Fail.Values["rate"] = (totalChecks - successChecks) / totalChecks
+	} else {
+		summaryGroup.Checks.Metrics.Fail.Values["rate"] = 0
+	}
 
 	summaryGroup.Checks.OrderedChecks = groupData.checks.orderedChecks
 }

--- a/metrics/thresholds.go
+++ b/metrics/thresholds.go
@@ -205,6 +205,8 @@ func (ts *Thresholds) Run(sink Sink, duration time.Duration) (bool, error) {
 		// would lead to [#2520](https://github.com/grafana/k6/issues/2520)
 		if sinkImpl.Total > 0 {
 			ts.sinked["rate"] = float64(sinkImpl.Trues) / float64(sinkImpl.Total)
+		} else {
+			ts.sinked["rate"] = 0
 		}
 	default:
 		return false, fmt.Errorf("unable to run Thresholds; reason: unknown sink type")

--- a/metrics/thresholds_test.go
+++ b/metrics/thresholds_test.go
@@ -731,6 +731,16 @@ func TestThresholdsRun(t *testing.T) {
 			want:    false,
 			wantErr: false,
 		},
+		{
+			name: "when sink type is rate and sink.Total is 0, should set rate with 0",
+			args: args{
+				sink:                 &RateSink{Trues: 0, Total: 0},
+				thresholdExpressions: []string{"rate>=0.5"},
+				duration:             0,
+			},
+			want:    false,
+			wantErr: false,
+		},
 	}
 	for _, testCase := range tests {
 		testCase := testCase


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->
This PR ensures that once thresholds are defined, they are still evaluated correctly even if check(...) is never called.

## Why?
Guarantee that if an error occurs before any checks are executed, the threshold evaluation will correctly register a failure.

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Closes #4283

<!-- Thanks for your contribution! 🙏🏼 -->
