### PR TITLE
k6/browser: Fix race conditions from stringifying types

### DIFF
--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -43,6 +43,16 @@ type ElementHandle struct {
 	frame *Frame
 }
 
+// String returns a string repesentation of ElementHandle.
+// It exists mostly for debugging where we don't want fmt.Sprintf to just
+// go through a complex object and try to stringify it.
+func (h *ElementHandle) String() string {
+	return "ElementHandle{" +
+		" BaseJSHandle:  " + h.BaseJSHandle.String() +
+		" frame: " + h.frame.String() +
+		"}"
+}
+
 func (h *ElementHandle) boundingBox() (*Rect, error) {
 	var box *dom.BoxModel
 	var err error

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -120,6 +120,17 @@ type Frame struct {
 	log *log.Logger
 }
 
+// String returns a string repesentation of Frame.
+// It exists mostly for debugging where we don't want fmt.Sprintf to just
+// go through a complex object and try to stringify it.
+func (f *Frame) String() string {
+	return "Frame: {" +
+		" id: " + f.id.String() +
+		" name: " + f.name +
+		" url: " + f.url +
+		"}"
+}
+
 // NewFrame creates a new HTML document frame.
 func NewFrame(
 	ctx context.Context, m *FrameManager, parentFrame *Frame, frameID cdp.FrameID, log *log.Logger,

--- a/internal/js/modules/k6/browser/common/js_handle.go
+++ b/internal/js/modules/k6/browser/common/js_handle.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"go.k6.io/k6/internal/js/modules/k6/browser/log"
@@ -41,6 +42,16 @@ type BaseJSHandle struct {
 	execCtx      *ExecutionContext
 	remoteObject *runtime.RemoteObject
 	disposed     bool
+}
+
+// String returns a string repesentation of BaseJSHandle.
+// It exists mostly for debugging where we don't want fmt.Sprintf to just
+// go through a complex object and try to stringify it.
+func (h *BaseJSHandle) String() string {
+	return "BaseJSHandle{ " +
+		"SessionID: " + h.session.ID().String() + ", " +
+		"dispose: " + strconv.FormatBool(h.disposed) +
+		"}"
 }
 
 // NewJSHandle creates a new JS handle referencing a remote object.


### PR DESCRIPTION
## What?

Before this in cases like #4564 you can have an error that stringifies ElementHandle object. That object has many other objects inside of it, some of which have maps or other more complex structure. None of which are thread safe to be accessed without locking.

This is very likely the reason for the race conditions in #4564 (maybe other cases as well). In this case we do have ElementHandle as the argument - we get an error due to likely it getting disposed while converting it. And then we start returning an error that has it just stringified. While fmt goes through the object we get another event (maybe exactly the same) modifying one of the many maps within the object - likely under the Frame specifically.

This also likely leads to pretty useless logs due to the amount of fields both have. With this change we only logs some fields that are less likely to be racy, or at least won't lead to a runtime race condition without the race detector being on.

## Why?

Fixing race conditions

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Fixes #4564
