### PR TITLE
fix: `make lint` fails locally

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v2.1.6
+# 2.1.6
 # Please don't remove the first line. It uses in CI to determine the golangci version
 version: "2"
 linters:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ check-linter-version:
 ## lint: Runs the linters.
 lint: check-linter-version
 	echo "Running linters..."
-	golangci-lint run --out-format=tab ./...
+	golangci-lint run ./...
 
 ## tests: Executes any unit tests.
 tests:


### PR DESCRIPTION
## What?

When running the project locally, I noticed there were a couple of issues with `make lint`:
1. The version check for `golangci-lint` reports a version without a `v` prefix, yet the check against `.golangci.yml` defines it, thus failing
2. The makefile is referencing an old flag that has since been removed, thus fails to execute with a non zero exit code
    - I'm not clear if it's desirable to replace it with a new flag, so opted for simplicity and removed it: let me know if that's not the case.


### The deprecated flag
More information: 
- Found a [discussion here](https://github.com/golangci/golangci-lint/discussions/5612) around the new flags. 
- Docs also explain the [removed flags here.](https://golangci-lint.run/product/migration-guide/#output)

## Why?

The command failed to run locally.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/issues/4795

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
