### PR TITLE
Revert to json from go-json-experiment/json

### DIFF
--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,7 +11,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	jsonv2 "github.com/go-json-experiment/json"
 	"go.k6.io/k6/internal/js/modules/k6/browser/log"
 
 	"github.com/chromedp/cdproto"
@@ -332,7 +332,7 @@ func (c *Connection) recvLoop() {
 		c.logger.Tracef("cdp:recv", "<- %s", buf)
 
 		var msg cdproto.Message
-		err = jsonv2.Unmarshal(buf, &msg)
+		err = json.Unmarshal(buf, &msg)
 		if err != nil {
 			select {
 			case c.errorCh <- err:
@@ -503,7 +503,7 @@ func (c *Connection) send(
 			c.logger.Debugf("Connection:send", "sid:%v tid:%v wsURL:%q, msg err:%v", sid, tid, c.wsURL, msg.Error)
 			return msg.Error
 		case res != nil:
-			return jsonv2.Unmarshal(msg.Result, res)
+			return json.Unmarshal(msg.Result, res)
 		}
 	case err := <-c.errorCh:
 		c.logger.Debugf("Connection:send:<-c.errorCh #2", "sid:%v tid:%v wsURL:%q, err:%v", msg.SessionID, tid, c.wsURL, err)
@@ -532,7 +532,7 @@ func (c *Connection) sendLoop() {
 	for {
 		select {
 		case msg := <-c.sendCh:
-			buf, err := jsonv2.Marshal(msg)
+			buf, err := json.Marshal(msg)
 			if err != nil {
 				sid := msg.SessionID
 				tid := c.findTargetIDForLog(sid)
@@ -623,7 +623,7 @@ func (c *Connection) Execute(
 	var buf []byte
 	if params != nil {
 		var err error
-		buf, err = jsonv2.Marshal(params)
+		buf, err = json.Marshal(params)
 		if err != nil {
 			return err
 		}

--- a/internal/js/modules/k6/browser/common/session.go
+++ b/internal/js/modules/k6/browser/common/session.go
@@ -2,9 +2,8 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
-
-	jsonv2 "github.com/go-json-experiment/json"
 
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
@@ -152,7 +151,7 @@ func (s *Session) Execute(
 	var buf []byte
 	if params != nil {
 		var err error
-		buf, err = jsonv2.Marshal(params)
+		buf, err = json.Marshal(params)
 		if err != nil {
 			return err
 		}
@@ -181,7 +180,7 @@ func (s *Session) ExecuteWithoutExpectationOnReply(
 	var buf []byte
 	if params != nil {
 		var err error
-		buf, err = jsonv2.Marshal(params)
+		buf, err = json.Marshal(params)
 		if err != nil {
 			s.logger.Debugf("Session:ExecuteWithoutExpectationOnReply:Marshal", "sid:%v tid:%v method:%q err=%v",
 				s.id, s.targetID, method, err)

--- a/internal/js/modules/k6/browser/tests/ws/server.go
+++ b/internal/js/modules/k6/browser/tests/ws/server.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	jsonv2 "github.com/go-json-experiment/json"
+	json "github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 
 	k6netext "go.k6.io/k6/lib/netext"
@@ -168,7 +168,7 @@ func WithCDPHandler(
 				}
 
 				var msg cdproto.Message
-				err = jsonv2.Unmarshal(buf, &msg)
+				err = json.Unmarshal(buf, &msg)
 				if err != nil {
 					return nil, err
 				}
@@ -204,7 +204,7 @@ func WithCDPHandler(
 					return
 				}
 				encoder := jsontext.NewEncoder(writer)
-				err = jsonv2.MarshalEncode(encoder, msg)
+				err = json.MarshalEncode(encoder, msg)
 				if err != nil {
 					return
 				}


### PR DESCRIPTION
## What?

Revert to `encoding/json` from `go-json-experiment/json`.

## Why?

`go-json-experiment/json` is [experimental](https://github.com/go-json-experiment/json) and may cause unexpected issues.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
