### PR TITLE
k6/browser: allow Invalid UTF-8 as recommended by cdproto author

### DIFF
--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -10,13 +10,14 @@ import (
 	"sync/atomic"
 	"time"
 
-	jsonv2 "github.com/go-json-experiment/json"
 	"go.k6.io/k6/internal/js/modules/k6/browser/log"
 
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
+	jsonv2 "github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
 	"github.com/gorilla/websocket"
 )
 
@@ -32,6 +33,11 @@ const wsWriteBufferSize = 1 << 20
 type msgID struct {
 	id int64
 }
+
+var defaultJSONV2Options = jsonv2.JoinOptions(
+	jsonv2.DefaultOptionsV2(),
+	jsontext.AllowInvalidUTF8(true),
+)
 
 func (m *msgID) newID() int64 {
 	return atomic.AddInt64(&m.id, 1)
@@ -332,7 +338,7 @@ func (c *Connection) recvLoop() {
 		c.logger.Tracef("cdp:recv", "<- %s", buf)
 
 		var msg cdproto.Message
-		err = jsonv2.Unmarshal(buf, &msg)
+		err = jsonv2.Unmarshal(buf, &msg, defaultJSONV2Options)
 		if err != nil {
 			select {
 			case c.errorCh <- err:
@@ -503,7 +509,7 @@ func (c *Connection) send(
 			c.logger.Debugf("Connection:send", "sid:%v tid:%v wsURL:%q, msg err:%v", sid, tid, c.wsURL, msg.Error)
 			return msg.Error
 		case res != nil:
-			return jsonv2.Unmarshal(msg.Result, res)
+			return jsonv2.Unmarshal(msg.Result, res, defaultJSONV2Options)
 		}
 	case err := <-c.errorCh:
 		c.logger.Debugf("Connection:send:<-c.errorCh #2", "sid:%v tid:%v wsURL:%q, err:%v", msg.SessionID, tid, c.wsURL, err)
@@ -532,7 +538,7 @@ func (c *Connection) sendLoop() {
 	for {
 		select {
 		case msg := <-c.sendCh:
-			buf, err := jsonv2.Marshal(msg)
+			buf, err := jsonv2.Marshal(msg, defaultJSONV2Options)
 			if err != nil {
 				sid := msg.SessionID
 				tid := c.findTargetIDForLog(sid)
@@ -623,7 +629,7 @@ func (c *Connection) Execute(
 	var buf []byte
 	if params != nil {
 		var err error
-		buf, err = jsonv2.Marshal(params)
+		buf, err = jsonv2.Marshal(params, defaultJSONV2Options)
 		if err != nil {
 			return err
 		}

--- a/internal/js/modules/k6/browser/common/session.go
+++ b/internal/js/modules/k6/browser/common/session.go
@@ -4,11 +4,10 @@ import (
 	"context"
 	"errors"
 
-	jsonv2 "github.com/go-json-experiment/json"
-
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
+	jsonv2 "github.com/go-json-experiment/json"
 
 	"go.k6.io/k6/internal/js/modules/k6/browser/log"
 )
@@ -152,7 +151,7 @@ func (s *Session) Execute(
 	var buf []byte
 	if params != nil {
 		var err error
-		buf, err = jsonv2.Marshal(params)
+		buf, err = jsonv2.Marshal(params, defaultJSONV2Options)
 		if err != nil {
 			return err
 		}
@@ -181,7 +180,7 @@ func (s *Session) ExecuteWithoutExpectationOnReply(
 	var buf []byte
 	if params != nil {
 		var err error
-		buf, err = jsonv2.Marshal(params)
+		buf, err = jsonv2.Marshal(params, defaultJSONV2Options)
 		if err != nil {
 			s.logger.Debugf("Session:ExecuteWithoutExpectationOnReply:Marshal", "sid:%v tid:%v method:%q err=%v",
 				s.id, s.targetID, method, err)

--- a/internal/js/modules/k6/browser/tests/ws/server.go
+++ b/internal/js/modules/k6/browser/tests/ws/server.go
@@ -11,17 +11,21 @@ import (
 	"testing"
 	"time"
 
-	jsonv2 "github.com/go-json-experiment/json"
-	"github.com/go-json-experiment/json/jsontext"
-
 	k6netext "go.k6.io/k6/lib/netext"
 	k6types "go.k6.io/k6/lib/types"
 
 	"github.com/chromedp/cdproto"
+	jsonv2 "github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
 	"github.com/gorilla/websocket"
 	"github.com/mccutchen/go-httpbin/httpbin"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/http2"
+)
+
+var defaultJSONV2Options = jsonv2.JoinOptions(
+	jsonv2.DefaultOptionsV2(),
+	jsontext.AllowInvalidUTF8(true),
 )
 
 // Server can be used as a test alternative to a real CDP compatible browser.
@@ -168,7 +172,7 @@ func WithCDPHandler(
 				}
 
 				var msg cdproto.Message
-				err = jsonv2.Unmarshal(buf, &msg)
+				err = jsonv2.Unmarshal(buf, &msg, defaultJSONV2Options)
 				if err != nil {
 					return nil, err
 				}
@@ -204,7 +208,7 @@ func WithCDPHandler(
 					return
 				}
 				encoder := jsontext.NewEncoder(writer)
-				err = jsonv2.MarshalEncode(encoder, msg)
+				err = jsonv2.MarshalEncode(encoder, msg, defaultJSONV2Options)
 				if err != nil {
 					return
 				}


### PR DESCRIPTION
## What?
Configure the jsonv2 experimental marshal/unmarshal to work with invalid utf-8

This was missed as a thing that is needed in #4785.

This is basically what easyjson was doing before.

Due to some internal package structure I opted for a little copying over a little dependency. Mostly as the common package tests depend on tests/ws.

## Why?

Apparently it is not uncommon to get invalid utf-8 from chromium and we need to not crash on it.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
