### PR TITLE
Binary provisioning/process stdin

### DIFF
--- a/cmd/execute.go
+++ b/cmd/execute.go
@@ -13,16 +13,5 @@ import (
 func Execute() {
 	gs := state.NewGlobalState(context.Background())
 
-	if gs.Flags.BinaryProvisioning {
-		internalcmd.NewLauncher(gs).Launch()
-		return
-	}
-
-	// If Binary Provisioning is not enabled, continue with the regular k6 execution path
-
-	// TODO: this is temporary defensive programming
-	// The Launcher has already the support for this specific execution path, but we decided to play safe here.
-	// After the v1.0 release, we want to fully delegate this control to the Launcher.
-	gs.Logger.Debug("Binary Provisioning feature is disabled.")
 	internalcmd.ExecuteWithGlobalState(gs)
 }

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/grafana/k6deps v0.2.6
+	github.com/grafana/k6deps v0.3.0
 	github.com/grafana/k6provider v0.1.15
 	github.com/grafana/sobek v0.0.0-20250320150027-203dc85b6d98
 	github.com/grafana/xk6-dashboard v0.7.6

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/k6build v0.5.11 h1:nuYV5DOMz5PEU8/XFRcDcfgzxUlLujeYNkU7NVEbdfc=
 github.com/grafana/k6build v0.5.11/go.mod h1:SA6/5cnnCLQ99IpFrqVfcuO+SxCRo/yLGtcnj3bfpII=
-github.com/grafana/k6deps v0.2.6 h1:T9t5pGnL4697SJ6fCF36fNCNSFSH/kDBI9Do/W+5TqA=
-github.com/grafana/k6deps v0.2.6/go.mod h1:y+pBsBemOJHML6ObuJFVgcNgO9RSfRvBklltI194aTE=
+github.com/grafana/k6deps v0.3.0 h1:jmI+miMW28hfteRhLvtzERbjJ1+JVK/b3V3spo3dghY=
+github.com/grafana/k6deps v0.3.0/go.mod h1:31pACKFJApQMMcu4hb4N3ti+Kz4s6PomUR63Y6S0bWM=
 github.com/grafana/k6foundry v0.4.6 h1:fFgR72Pw0dzo8wVWyggu35SGGjdt31Dktil1bDE1MCM=
 github.com/grafana/k6foundry v0.4.6/go.mod h1:eLsr0whhH+5Y1y7YpDxJi3Jv5wHMuf+80vdRyMH10pg=
 github.com/grafana/k6provider v0.1.15 h1:aUStpqDMEnEL9aGCcSKmpcreHRZsr8IELna+ttKMOYI=

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 
@@ -16,11 +17,6 @@ import (
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/internal/build"
-)
-
-var (
-	errScriptNotFound     = errors.New("script not found")
-	errUnsupportedFeature = errors.New("not supported")
 )
 
 // commandExecutor executes the requested k6 command line command.
@@ -71,7 +67,7 @@ func (l *launcher) launch(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	deps, err := analyze(l.gs, args)
+	deps, err := analyze(l.gs, cmd, args)
 	if err != nil {
 		l.gs.Logger.
 			WithError(err).
@@ -277,37 +273,32 @@ func extractToken(gs *state.GlobalState) (string, error) {
 // Presently, only the k6 input script or archive (if any) is passed to k6deps for scanning.
 // TODO: if k6 receives the input from stdin, it is not used for scanning because we don't know
 // if it is a script or an archive
-func analyze(gs *state.GlobalState, args []string) (k6deps.Dependencies, error) {
+func analyze(gs *state.GlobalState, _ *cobra.Command, args []string) (k6deps.Dependencies, error) {
 	dopts := &k6deps.Options{
 		LookupEnv: func(key string) (string, bool) { v, ok := gs.Env[key]; return v, ok },
 		Manifest:  k6deps.Source{Ignore: true},
 	}
 
-	if len(args) == 0 {
-		gs.Logger.
-			Debug("The command did not receive an input script.")
-		return nil, errScriptNotFound
+	if len(args) < 1 {
+		return nil, fmt.Errorf("k6 needs at least one argument to load the test")
 	}
 
-	scriptname := args[0]
-	if scriptname == "-" {
-		gs.Logger.
-			Debug("Test script provided by Stdin is not yet supported from Binary provisioning feature.")
-		return nil, errUnsupportedFeature
+	sourceRootPath := args[0]
+	gs.Logger.Debugf("Resolving and reading test '%s'...", sourceRootPath)
+	src, _, pwd, err := readSource(gs, sourceRootPath)
+	if err != nil {
+		return nil, err
 	}
 
-	if _, err := gs.FS.Stat(scriptname); err != nil {
-		gs.Logger.
-			WithField("path", scriptname).
-			WithError(err).
-			Debug("The requested test script's file is not available on the file system.")
-		return nil, errScriptNotFound
-	}
-
-	if strings.HasSuffix(scriptname, ".tar") {
-		dopts.Archive.Name = scriptname
+	if strings.HasSuffix(sourceRootPath, ".tar") {
+		dopts.Archive.Contents = src.Data
 	} else {
-		dopts.Script.Name = scriptname
+		if !filepath.IsAbs(sourceRootPath) {
+			sourceRootPath = filepath.Join(pwd, sourceRootPath)
+		}
+		dopts.Script.Name = sourceRootPath
+		dopts.Script.Contents = src.Data
+		dopts.Fs = gs.FS
 	}
 
 	return k6deps.Analyze(dopts)

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -120,7 +120,10 @@ func (b *customBinary) run(gs *state.GlobalState) error {
 	// the subprocess detects the type of terminal
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
-	cmd.Stdin = os.Stdin
+
+	// is we are here, it is possible that the analyze function read the stdin to analyse it
+	// and restored the content into gs.Stdin, so we pass it to the command
+	cmd.Stdin = gs.Stdin
 
 	// Copy environment variables to the k6 process and skip binary provisioning feature flag to disable it.
 	// If not disabled, then the executed k6 binary would enter an infinite loop, where it continuously
@@ -288,6 +291,11 @@ func analyze(gs *state.GlobalState, _ *cobra.Command, args []string) (k6deps.Dep
 	src, _, pwd, err := readSource(gs, sourceRootPath)
 	if err != nil {
 		return nil, err
+	}
+
+	// if sourceRooPath is stdin ('-') we need to preserve the content
+	if sourceRootPath == "-" {
+		gs.Stdin = bytes.NewBuffer(src.Data)
 	}
 
 	if strings.HasSuffix(sourceRootPath, ".tar") {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -43,12 +43,20 @@ type rootCommand struct {
 	stopLoggersCh  chan struct{}
 	loggersWg      sync.WaitGroup
 	loggerIsRemote bool
+	launcher       *launcher
 }
 
+// creates a root command with a default launcher
 func newRootCommand(gs *state.GlobalState) *rootCommand {
+	return newRootWithLauncher(gs, newLauncher(gs))
+}
+
+// creates a root command with a launcher. Used to facilitate testing
+func newRootWithLauncher(gs *state.GlobalState, l *launcher) *rootCommand {
 	c := &rootCommand{
 		globalState:   gs,
 		stopLoggersCh: make(chan struct{}),
+		launcher:      l,
 	}
 	// the base command when called without any subcommands.
 	rootCmd := &cobra.Command{
@@ -89,13 +97,24 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 	return c
 }
 
-func (c *rootCommand) persistentPreRunE(_ *cobra.Command, _ []string) error {
+func (c *rootCommand) persistentPreRunE(cmd *cobra.Command, args []string) error {
 	err := c.setupLoggers(c.stopLoggersCh)
 	if err != nil {
 		return err
 	}
+
 	c.globalState.Logger.Debugf("k6 version: v%s", fullVersion())
-	return nil
+
+	// If binary provisioning is not enabled, continue with the regular k6 execution path
+	if !c.globalState.Flags.BinaryProvisioning {
+		c.globalState.Logger.Debug("Binary Provisioning feature is disabled.")
+		return nil
+	}
+
+	c.globalState.Logger.
+		Debug("Binary Provisioning feature is enabled.")
+
+	return c.launcher.launch(cmd, args)
 }
 
 func (c *rootCommand) execute() {

--- a/vendor/github.com/grafana/k6deps/analyze.go
+++ b/vendor/github.com/grafana/k6deps/analyze.go
@@ -4,47 +4,144 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"os"
+	"io"
 )
 
-// Analyze searches, loads and analyzes the specified sources,
-// extracting the k6 extensions and their version constraints.
-// Note: if archive is specified, the other three sources will not be taken into account,
-// since the archive may contain them.
-func Analyze(opts *Options) (Dependencies, error) {
-	if !opts.Archive.Ignore && !opts.Archive.IsEmpty() {
-		return archiveAnalizer(opts.Archive)()
-	}
-
-	// if the manifest is not provided, we try to find it
-	// if not found, it will be empty and ignored by the analyzer
-	if !opts.Manifest.Ignore && opts.Manifest.IsEmpty() {
-		if err := opts.setManifest(); err != nil {
-			return nil, err
-		}
-	}
-
-	if !opts.Script.Ignore {
-		if err := loadScript(opts); err != nil {
-			return nil, err
-		}
-	}
-
-	if !opts.Env.Ignore {
-		loadEnv(opts)
-	}
-
-	return mergeAnalyzers(
-		scriptAnalyzer(opts.Script),
-		manifestAnalyzer(opts.Manifest),
-		envAnalyzer(opts.Env),
-	)()
+// analyzer defines the interface for a dependency analyzer
+type analyzer interface {
+	analyze() (Dependencies, error)
 }
 
-type analyzer func() (Dependencies, error)
+// emptyAnalyzer returns empty Dependencies
+type emptyAnalyzer struct{}
 
-func empty() (Dependencies, error) {
+func newEmptyAnalyzer() analyzer {
+	return &emptyAnalyzer{}
+}
+
+func (e *emptyAnalyzer) analyze() (Dependencies, error) {
 	return make(Dependencies), nil
+}
+
+type manifestAnalyzer struct {
+	src io.ReadCloser
+}
+
+func newManifestAnalyzer(src io.ReadCloser) analyzer {
+	return &manifestAnalyzer{src: src}
+}
+
+func (m *manifestAnalyzer) analyze() (Dependencies, error) {
+	defer m.src.Close() //nolint:errcheck
+
+	var manifest struct {
+		Dependencies Dependencies `json:"dependencies,omitempty"`
+	}
+
+	err := json.NewDecoder(m.src).Decode(&manifest)
+
+	if err == nil {
+		return filterInvalid(manifest.Dependencies), nil
+	}
+
+	if errors.Is(err, io.EOF) {
+		return make(Dependencies), nil
+	}
+
+	return nil, err
+}
+
+type scriptAnalyzer struct {
+	src io.ReadCloser
+}
+
+func newScriptAnalyzer(src io.ReadCloser) analyzer {
+	return &scriptAnalyzer{src: src}
+}
+
+func (s *scriptAnalyzer) analyze() (Dependencies, error) {
+	var deps Dependencies
+	defer s.src.Close() //nolint:errcheck
+
+	buffer := new(bytes.Buffer)
+	if _, err := buffer.ReadFrom(s.src); err != nil {
+		return nil, err
+	}
+
+	if err := (&deps).UnmarshalJS(buffer.Bytes()); err != nil {
+		return nil, err
+	}
+
+	return deps, nil
+}
+
+// textAnalyzer analyzes dependencies from a text format
+type textAnalyzer struct {
+	src io.ReadCloser
+}
+
+func newTextAnalyzer(src io.ReadCloser) analyzer {
+	return &textAnalyzer{src: src}
+}
+
+func (e *textAnalyzer) analyze() (Dependencies, error) {
+	var deps Dependencies
+	content := &bytes.Buffer{}
+	_, err := content.ReadFrom(e.src)
+	if err != nil {
+		return nil, err
+	}
+
+	if content.Len() == 0 {
+		return make(Dependencies), nil
+	}
+
+	if err := (&deps).UnmarshalText(content.Bytes()); err != nil {
+		return nil, err
+	}
+
+	return filterInvalid(deps), nil
+}
+
+// archiveAnalizer analizes a k6 archive in .tar format
+type archiveAnalizer struct {
+	src io.ReadCloser
+}
+
+func newArchiveAnalyzer(src io.ReadCloser) analyzer {
+	return &archiveAnalizer{src: src}
+}
+
+func (a *archiveAnalizer) analyze() (Dependencies, error) {
+	defer a.src.Close() //nolint:errcheck
+
+	return processArchive(a.src)
+}
+
+type mergeAnalyzer struct {
+	analyzers []analyzer
+}
+
+func newMergeAnalyzer(analyzers ...analyzer) analyzer {
+	return &mergeAnalyzer{analyzers: analyzers}
+}
+
+func (m *mergeAnalyzer) analyze() (Dependencies, error) {
+	deps := make(Dependencies)
+
+	for _, a := range m.analyzers {
+		dep, err := a.analyze()
+		if err != nil {
+			return nil, err
+		}
+
+		err = deps.Merge(dep)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return deps, nil
 }
 
 func filterInvalid(from Dependencies) Dependencies {
@@ -57,120 +154,4 @@ func filterInvalid(from Dependencies) Dependencies {
 	}
 
 	return deps
-}
-
-func manifestAnalyzer(src Source) analyzer {
-	if src.IsEmpty() {
-		return empty
-	}
-
-	return func() (Dependencies, error) {
-		reader, closer, err := src.contentReader()
-
-		// we tolerate the manifest file not existing
-		if errors.Is(err, os.ErrNotExist) { //nolint:forbidigo
-			return make(Dependencies), nil
-		}
-
-		if err != nil {
-			return nil, err
-		}
-		defer closer() //nolint:errcheck
-
-		var manifest struct {
-			Dependencies Dependencies `json:"dependencies,omitempty"`
-		}
-
-		err = json.NewDecoder(reader).Decode(&manifest)
-		if err != nil {
-			return nil, err
-		}
-
-		return filterInvalid(manifest.Dependencies), nil
-	}
-}
-
-func scriptAnalyzer(src Source) analyzer {
-	if src.IsEmpty() {
-		return empty
-	}
-
-	return func() (Dependencies, error) {
-		var deps Dependencies
-
-		reader, closer, err := src.contentReader()
-		if err != nil {
-			return nil, err
-		}
-		defer closer() //nolint:errcheck
-
-		buffer := new(bytes.Buffer)
-		_, err = buffer.ReadFrom(reader)
-		if err != nil {
-			return nil, err
-		}
-
-		if err := (&deps).UnmarshalJS(buffer.Bytes()); err != nil {
-			return nil, err
-		}
-
-		return deps, nil
-	}
-}
-
-func envAnalyzer(src Source) analyzer {
-	if len(src.Contents) == 0 {
-		return empty
-	}
-
-	return func() (Dependencies, error) {
-		var deps Dependencies
-
-		if err := (&deps).UnmarshalText(src.Contents); err != nil {
-			return nil, err
-		}
-
-		return filterInvalid(deps), nil
-	}
-}
-
-func archiveAnalizer(src Source) analyzer {
-	if src.IsEmpty() {
-		return empty
-	}
-
-	return func() (Dependencies, error) {
-		input := src.Reader
-		if input == nil {
-			tar, err := os.Open(src.Name) //nolint:forbidigo
-			if err != nil {
-				return nil, err
-			}
-			defer tar.Close() //nolint:errcheck
-
-			input = tar
-		}
-
-		return processArchive(input)
-	}
-}
-
-func mergeAnalyzers(sources ...analyzer) analyzer {
-	return func() (Dependencies, error) {
-		deps := make(Dependencies)
-
-		for _, src := range sources {
-			dep, err := src()
-			if err != nil {
-				return nil, err
-			}
-
-			err = deps.Merge(dep)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		return deps, nil
-	}
 }

--- a/vendor/github.com/grafana/k6deps/internal/pack/plugins/file/plugin.go
+++ b/vendor/github.com/grafana/k6deps/internal/pack/plugins/file/plugin.go
@@ -1,0 +1,105 @@
+// Package file contains esbuild file plugin.
+package file
+
+import (
+	"io"
+	"path/filepath"
+
+	"github.com/evanw/esbuild/pkg/api"
+	"github.com/grafana/k6deps/internal/rootfs"
+)
+
+const (
+	pluginName = "file"
+)
+
+var loaderByExtension = map[string]api.Loader{ //nolint:gochecknoglobals
+	".js":   api.LoaderJS,
+	".json": api.LoaderJSON,
+	".txt":  api.LoaderText,
+	".ts":   api.LoaderTS,
+}
+
+type plugin struct {
+	fs      rootfs.FS
+	resolve func(path string, options api.ResolveOptions) api.ResolveResult
+	options *api.BuildOptions
+}
+
+// New creates new http plugin instance.
+func New(fs rootfs.FS) api.Plugin {
+	plugin := &plugin{
+		fs: fs,
+	}
+
+	return api.Plugin{
+		Name:  pluginName,
+		Setup: plugin.setup,
+	}
+}
+
+func (plugin *plugin) setup(build api.PluginBuild) {
+	plugin.resolve = build.Resolve
+	plugin.options = build.InitialOptions
+
+	build.OnResolve(api.OnResolveOptions{Filter: ".*", Namespace: "file"}, plugin.onResolve)
+	build.OnLoad(api.OnLoadOptions{Filter: ".*", Namespace: "file"}, plugin.onLoad)
+}
+
+func (plugin *plugin) load(path string) (*api.OnLoadResult, error) {
+	file, err := plugin.fs.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close() //nolint:errcheck
+
+	bytes, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+
+	contents := string(bytes)
+
+	// FIXME: what happens if the extension is not supported?
+	var loader api.Loader
+	if ldr, ok := loaderByExtension[filepath.Ext(path)]; ok {
+		loader = ldr
+	}
+
+	return &api.OnLoadResult{
+			Contents:   &contents,
+			PluginName: pluginName,
+			Loader:     loader,
+		},
+		nil
+}
+
+func (plugin *plugin) onLoad(args api.OnLoadArgs) (api.OnLoadResult, error) {
+	loadResult, err := plugin.load(args.Path)
+	if err != nil {
+		return onLoadError(args, err)
+	}
+
+	return *loadResult, nil
+}
+
+func onLoadError(_ api.OnLoadArgs, err error) (api.OnLoadResult, error) {
+	return api.OnLoadResult{}, err
+}
+
+func newOnResolveResult(path string) api.OnResolveResult {
+	return api.OnResolveResult{
+		Namespace: "file",
+		Path:      path,
+	}
+}
+
+func (plugin *plugin) onResolve(args api.OnResolveArgs) (api.OnResolveResult, error) {
+	path := args.Path
+
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(filepath.Dir(args.Importer), path)
+	}
+
+	return newOnResolveResult(path), nil
+}

--- a/vendor/github.com/grafana/k6deps/internal/rootfs/rootfs.go
+++ b/vendor/github.com/grafana/k6deps/internal/rootfs/rootfs.go
@@ -1,0 +1,62 @@
+// Package rootfs implements extensions to go's fs.FS to work around its limitations
+package rootfs
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+var ErrInvalidPath = errors.New("invalid path") //nolint:revive
+
+// FS defines an interface that extends go's fs.FS with a mechanism for working with absolute paths
+type FS interface {
+	// Opens a File given its path. Path can be absolute or relative.
+	// If path is relative, it is joined to the root to get the effective path.
+	// The path must be  within the FS's root directory
+	Open(path string) (fs.File, error)
+	// returns FS's root dir
+	Root() string
+}
+
+type rootFS struct {
+	afero.Fs
+	root string
+}
+
+// NewFromDir create a rootFS from a root directory. The root must be an absolute path
+func NewFromDir(root string) (FS, error) {
+	if !filepath.IsAbs(root) {
+		return nil, fmt.Errorf("%w: %q is not absolute", ErrInvalidPath, root)
+	}
+
+	return &rootFS{
+		Fs:   afero.NewOsFs(),
+		root: root,
+	}, nil
+}
+
+func (f *rootFS) Root() string {
+	return f.root
+}
+
+func (f *rootFS) Open(path string) (fs.File, error) {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(f.root, path)
+	}
+	// check if the path is outside the root
+	if !strings.HasPrefix(path, f.root) {
+		return nil, &fs.PathError{Path: path, Err: fs.ErrNotExist}
+	}
+
+	return f.Fs.Open(filepath.Clean(path))
+}
+
+// NewFromFS return a FS from a FS
+func NewFromFS(root string, fs afero.Fs) FS {
+	return &rootFS{root: root, Fs: fs}
+}

--- a/vendor/github.com/grafana/k6deps/options.go
+++ b/vendor/github.com/grafana/k6deps/options.go
@@ -2,16 +2,19 @@ package k6deps
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"os"
-	"path/filepath"
+
+	"github.com/spf13/afero"
 
 	"github.com/grafana/k6deps/internal/pack"
+	"github.com/grafana/k6deps/internal/rootfs"
 )
 
-// EnvDependencies holds the name of the environment variable thet describes additional dependencies.
-const EnvDependencies = "K6_DEPENDENCIES"
+const (
+	// EnvDependencies holds the name of the environment variable that describes additional dependencies.
+	EnvDependencies = "K6_DEPENDENCIES"
+)
 
 // Source describes a generic dependency source.
 // Such a source can be the k6 script, the manifest file, or an environment variable (e.g. K6_DEPENDENCIES).
@@ -19,7 +22,7 @@ type Source struct {
 	// Name contains the name of the source (file, environment variable, etc.).
 	Name string
 	// Reader provides streaming access to the source content as an alternative to Contents.
-	Reader io.Reader
+	Reader io.ReadCloser
 	// Contents contains the content of the source (e.g. script)
 	Contents []byte
 	// Ignore disables automatic search and processing of that source.
@@ -29,33 +32,6 @@ type Source struct {
 // IsEmpty returns true if the source is empty.
 func (s *Source) IsEmpty() bool {
 	return len(s.Contents) == 0 && s.Reader == nil && len(s.Name) == 0
-}
-
-func nopCloser() error {
-	return nil
-}
-
-// contentReader returns a reader for the source content.
-func (s *Source) contentReader() (io.Reader, func() error, error) {
-	if s.Reader != nil {
-		return s.Reader, nopCloser, nil
-	}
-
-	if len(s.Contents) > 0 {
-		return bytes.NewReader(s.Contents), nopCloser, nil
-	}
-
-	fileName, err := filepath.Abs(s.Name)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	file, err := os.Open(filepath.Clean(fileName)) //nolint:forbidigo
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return file, file.Close, nil
 }
 
 // Options contains the parameters of the dependency analysis.
@@ -81,14 +57,12 @@ type Options struct {
 	Env Source
 	// LookupEnv function is used to query the value of the environment variable
 	// specified in the Env option Name if the Contents of the Env option is empty.
-	// If empty, os.LookupEnv will be used.
+	// If not provided, os.LookupEnv will be used.
 	LookupEnv func(key string) (value string, ok bool)
-	// FindManifest function is used to find manifest file for the given script file
-	// if the Contents of Manifest option is empty.
-	// If the scriptfile parameter is empty, FindManifest starts searching
-	// for the manifest file from the current directory
-	// If missing, the closest manifest file will be used.
-	FindManifest func(scriptfile string) (filename string, ok bool, err error)
+	// Fs is the file system to use for accessing files. If not provided, os file system is used
+	Fs afero.Fs
+	// Root directory for searching for files. Must an absolute path. If omitted, CWD is used
+	RootDir string
 }
 
 func (opts *Options) lookupEnv(key string) (string, bool) {
@@ -99,35 +73,131 @@ func (opts *Options) lookupEnv(key string) (string, bool) {
 	return os.LookupEnv(key) //nolint:forbidigo
 }
 
-func loadScript(opts *Options) error {
-	if len(opts.Script.Name) == 0 || len(opts.Script.Contents) > 0 || opts.Script.Ignore {
-		return nil
+// returns the FS to use with this options
+func (opts *Options) fs() (rootfs.FS, error) {
+	var err error
+
+	dir := opts.RootDir
+	if dir == "" {
+		dir, err = os.Getwd() //nolint:forbidigo
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	scriptfile, err := filepath.Abs(opts.Script.Name)
-	if err != nil {
-		return err
+	if opts.Fs == nil {
+		return rootfs.NewFromDir(dir)
 	}
 
-	contents, err := os.ReadFile(scriptfile) //nolint:forbidigo,gosec
-	if err != nil {
-		return err
-	}
-
-	script, _, err := pack.Pack(string(contents), &pack.Options{Filename: scriptfile})
-	if err != nil {
-		return err
-	}
-
-	opts.Script.Name = scriptfile
-	opts.Script.Contents = script
-
-	return nil
+	return rootfs.NewFromFS(dir, opts.Fs), nil
 }
 
-func loadEnv(opts *Options) {
-	if len(opts.Env.Contents) > 0 || opts.Env.Ignore {
-		return
+// Analyze searches, loads and analyzes the specified sources,
+// extracting the k6 extensions and their version constraints.
+// Note: if archive is specified, the other three sources will not be taken into account,
+// since the archive may contain them.
+func Analyze(opts *Options) (Dependencies, error) {
+	var err error
+
+	if !opts.Archive.Ignore && !opts.Archive.IsEmpty() {
+		archiveAnalyzer, err := opts.archiveAnalyzer()
+		if err != nil {
+			return nil, err
+		}
+		return archiveAnalyzer.analyze()
+	}
+
+	manifestAnalyzer, err := opts.manifestAnalyzer()
+	if err != nil {
+		return nil, err
+	}
+
+	scriptAnalyzeer, err := opts.scriptAnalyzer()
+	if err != nil {
+		return nil, err
+	}
+
+	return newMergeAnalyzer(scriptAnalyzeer, manifestAnalyzer, opts.envAnalyzer()).analyze()
+}
+
+// scriptAnalyzer loads a script Source and alls its dependencies into the Script's content
+// from either a file of a reader
+func (opts *Options) scriptAnalyzer() (analyzer, error) {
+	source, err := opts.loadSource(&opts.Script)
+	if err != nil {
+		return nil, err
+	}
+	defer source.Close() //nolint:errcheck
+
+	contents := &bytes.Buffer{}
+	_, err = contents.ReadFrom(source)
+	if err != nil {
+		return nil, err
+	}
+
+	fs, err := opts.fs()
+	if err != nil {
+		return nil, err
+	}
+	script, _, err := pack.Pack(contents.String(), &pack.Options{FS: fs, Filename: opts.Script.Name})
+	if err != nil {
+		return nil, err
+	}
+
+	return newScriptAnalyzer(io.NopCloser(bytes.NewReader(script))), nil
+}
+
+func (opts *Options) manifestAnalyzer() (analyzer, error) {
+	source, err := opts.loadSource(&opts.Manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return newManifestAnalyzer(source), nil
+}
+
+func (opts *Options) archiveAnalyzer() (analyzer, error) {
+	source, err := opts.loadSource(&opts.Archive)
+	if err != nil {
+		return nil, err
+	}
+
+	return newArchiveAnalyzer(source), nil
+}
+
+func (opts *Options) loadSource(s *Source) (io.ReadCloser, error) {
+	var err error
+	if s.Ignore || s.IsEmpty() {
+		return io.NopCloser(bytes.NewReader(nil)), nil
+	}
+
+	if len(s.Contents) != 0 {
+		return io.NopCloser(bytes.NewReader(s.Contents)), nil
+	}
+
+	fs, err := opts.fs()
+	if err != nil {
+		return nil, err
+	}
+	reader := s.Reader
+	if reader == nil {
+		reader, err = fs.Open(s.Name)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return reader, nil
+}
+
+func (opts *Options) envAnalyzer() analyzer {
+	if opts.Env.Ignore {
+		return newEmptyAnalyzer()
+	}
+
+	if len(opts.Env.Contents) > 0 {
+		content := io.NopCloser(bytes.NewBuffer(opts.Env.Contents))
+		return newTextAnalyzer(content)
 	}
 
 	key := opts.Env.Name
@@ -135,49 +205,8 @@ func loadEnv(opts *Options) {
 		key = EnvDependencies
 	}
 
-	value, found := opts.lookupEnv(key)
-	if !found || len(value) == 0 {
-		return
-	}
+	value, _ := opts.lookupEnv(key)
 
-	opts.Env.Name = key
-	opts.Env.Contents = []byte(value)
-}
-
-func (opts *Options) setManifest() error {
-	// if the manifest is not provided, we try to find it
-	// starting from the location of the script
-	path, found, err := findManifest(opts.Script.Name)
-	if err != nil {
-		return err
-	}
-	if found {
-		opts.Manifest.Name = path
-	}
-
-	return nil
-}
-
-func findManifest(filename string) (string, bool, error) {
-	if len(filename) == 0 {
-		filename = "any_file"
-	}
-
-	abs, err := filepath.Abs(filename)
-	if err != nil {
-		return "", false, err
-	}
-
-	for dir := filepath.Dir(abs); ; dir = filepath.Dir(dir) {
-		filename := filepath.Clean(filepath.Join(dir, "package.json"))
-		if _, err := os.Stat(filename); !errors.Is(err, os.ErrNotExist) { //nolint:forbidigo
-			return filename, err == nil, err
-		}
-
-		if dir[len(dir)-1] == filepath.Separator {
-			break
-		}
-	}
-
-	return "", false, nil
+	content := io.NopCloser(bytes.NewBuffer([]byte(value)))
+	return newTextAnalyzer(content)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,12 +184,14 @@ github.com/gorilla/websocket
 github.com/grafana/k6build
 github.com/grafana/k6build/pkg/api
 github.com/grafana/k6build/pkg/client
-# github.com/grafana/k6deps v0.2.6
+# github.com/grafana/k6deps v0.3.0
 ## explicit; go 1.23.0
 github.com/grafana/k6deps
 github.com/grafana/k6deps/internal/pack
+github.com/grafana/k6deps/internal/pack/plugins/file
 github.com/grafana/k6deps/internal/pack/plugins/http
 github.com/grafana/k6deps/internal/pack/plugins/k6
+github.com/grafana/k6deps/internal/rootfs
 # github.com/grafana/k6provider v0.1.15
 ## explicit; go 1.23.0
 github.com/grafana/k6provider


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

Process stdi
## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

Presently, the logic of binary provisioning happens before the k6 root command is executed. This brings some additional complexity and some problems because the arguments passed to k6 have not yet been parsed (see list of related issues).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Closes https://github.com/grafana/k6/issues/4727
Closes https://github.com/grafana/k6/issues/4737
Closes https://github.com/grafana/k6/issues/4758
Closes https://github.com/grafana/k6/issues/4696


<!-- Thanks for your contribution! 🙏🏼 -->
