### PR TITLE
Add `locator` APIs `nth`, `first`, and `last`

### DIFF
--- a/internal/js/modules/k6/browser/browser/locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/locator_mapping.go
@@ -123,6 +123,10 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
 				return lo.InnerText(opts) //nolint:wrapcheck
 			})
 		},
+		"last": func() *sobek.Object {
+			ml := mapLocator(vu, lo.Last())
+			return rt.ToValue(ml).ToObject(rt)
+		},
 		"nth": func(nth int) *sobek.Object {
 			ml := mapLocator(vu, lo.Nth(nth))
 			return rt.ToValue(ml).ToObject(rt)

--- a/internal/js/modules/k6/browser/browser/locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/locator_mapping.go
@@ -92,6 +92,10 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
 				return nil, lo.Fill(value, opts) //nolint:wrapcheck
 			})
 		},
+		"first": func() *sobek.Object {
+			ml := mapLocator(vu, lo.First())
+			return rt.ToValue(ml).ToObject(rt)
+		},
 		"focus": func(opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				return nil, lo.Focus(opts) //nolint:wrapcheck

--- a/internal/js/modules/k6/browser/browser/locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/locator_mapping.go
@@ -11,6 +11,7 @@ import (
 
 // mapLocator API to the JS module.
 func mapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
+	rt := vu.Runtime()
 	return mapping{
 		"clear": func(opts sobek.Value) (*sobek.Promise, error) {
 			copts := common.NewFrameFillOptions(lo.Timeout())
@@ -117,6 +118,10 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				return lo.InnerText(opts) //nolint:wrapcheck
 			})
+		},
+		"nth": func(nth int) *sobek.Object {
+			ml := mapLocator(vu, lo.Nth(nth))
+			return rt.ToValue(ml).ToObject(rt)
 		},
 		"textContent": func(opts sobek.Value) *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -536,6 +536,7 @@ type locatorAPI interface { //nolint:interfacebloat
 	InnerText(opts sobek.Value) (string, error)
 	TextContent(opts sobek.Value) (string, bool, error)
 	InputValue(opts sobek.Value) (string, error)
+	Nth(nth int) *common.Locator
 	SelectOption(values sobek.Value, opts sobek.Value) ([]string, error)
 	Press(key string, opts sobek.Value) error
 	Type(text string, opts sobek.Value) error

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -537,6 +537,7 @@ type locatorAPI interface { //nolint:interfacebloat
 	InnerText(opts sobek.Value) (string, error)
 	TextContent(opts sobek.Value) (string, bool, error)
 	InputValue(opts sobek.Value) (string, error)
+	Last() *common.Locator
 	Nth(nth int) *common.Locator
 	SelectOption(values sobek.Value, opts sobek.Value) ([]string, error)
 	Press(key string, opts sobek.Value) error

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -530,6 +530,7 @@ type locatorAPI interface { //nolint:interfacebloat
 	IsVisible(opts sobek.Value) (bool, error)
 	IsHidden(opts sobek.Value) (bool, error)
 	Fill(value string, opts sobek.Value) error
+	First() *common.Locator
 	Focus(opts sobek.Value) error
 	GetAttribute(name string, opts sobek.Value) (string, bool, error)
 	InnerHTML(opts sobek.Value) (string, error)

--- a/internal/js/modules/k6/browser/common/js/injected_script.js
+++ b/internal/js/modules/k6/browser/common/js/injected_script.js
@@ -250,7 +250,7 @@ class InjectedScript {
         if (typeof selector.capture === "number") {
           return "error:nthnocapture";
         }
-        const nth = part.body;
+        const nth = parseInt(part.body, 10);
         const set = new k6BrowserNative.Set();
         for (const root of roots) {
           set.add(root.element);

--- a/internal/js/modules/k6/browser/common/locator.go
+++ b/internal/js/modules/k6/browser/common/locator.go
@@ -429,6 +429,12 @@ func (l *Locator) innerText(opts *FrameInnerTextOptions) (string, error) {
 	return l.frame.innerText(l.selector, opts)
 }
 
+// Last will return the last child of the element matching the locator's
+// selector.
+func (l *Locator) Last() *Locator {
+	return NewLocator(l.ctx, fmt.Sprintf("%s >> nth=-1", l.selector), l.frame, l.log)
+}
+
 // Nth will return the nth child of the element matching the locator's
 // selector.
 func (l *Locator) Nth(nth int) *Locator {

--- a/internal/js/modules/k6/browser/common/locator.go
+++ b/internal/js/modules/k6/browser/common/locator.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/grafana/sobek"
@@ -335,7 +336,7 @@ func (l *Locator) fill(value string, opts *FrameFillOptions) error {
 // First will return the first child of the element matching the locator's
 // selector.
 func (l *Locator) First() *Locator {
-	return NewLocator(l.ctx, fmt.Sprintf("%s >> nth=0", l.selector), l.frame, l.log)
+	return NewLocator(l.ctx, l.selector+" >> nth=0", l.frame, l.log)
 }
 
 // Focus on the element using locator's selector with strict mode on.
@@ -432,13 +433,13 @@ func (l *Locator) innerText(opts *FrameInnerTextOptions) (string, error) {
 // Last will return the last child of the element matching the locator's
 // selector.
 func (l *Locator) Last() *Locator {
-	return NewLocator(l.ctx, fmt.Sprintf("%s >> nth=-1", l.selector), l.frame, l.log)
+	return NewLocator(l.ctx, l.selector+" >> nth=-1", l.frame, l.log)
 }
 
 // Nth will return the nth child of the element matching the locator's
 // selector.
 func (l *Locator) Nth(nth int) *Locator {
-	return NewLocator(l.ctx, fmt.Sprintf("%s >> nth=%d", l.selector, nth), l.frame, l.log)
+	return NewLocator(l.ctx, l.selector+" >> nth="+strconv.Itoa(nth), l.frame, l.log)
 }
 
 // TextContent returns the element's text content that matches

--- a/internal/js/modules/k6/browser/common/locator.go
+++ b/internal/js/modules/k6/browser/common/locator.go
@@ -332,6 +332,12 @@ func (l *Locator) fill(value string, opts *FrameFillOptions) error {
 	return l.frame.fill(l.selector, value, opts)
 }
 
+// First will return the first child of the element matching the locator's
+// selector.
+func (l *Locator) First() *Locator {
+	return NewLocator(l.ctx, fmt.Sprintf("%s >> nth=0", l.selector), l.frame, l.log)
+}
+
 // Focus on the element using locator's selector with strict mode on.
 func (l *Locator) Focus(opts sobek.Value) error {
 	l.log.Debugf("Locator:Focus", "fid:%s furl:%q sel:%q opts:%+v", l.frame.ID(), l.frame.URL(), l.selector, opts)

--- a/internal/js/modules/k6/browser/common/locator.go
+++ b/internal/js/modules/k6/browser/common/locator.go
@@ -423,6 +423,12 @@ func (l *Locator) innerText(opts *FrameInnerTextOptions) (string, error) {
 	return l.frame.innerText(l.selector, opts)
 }
 
+// Nth will return the nth child of the element matching the locator's
+// selector.
+func (l *Locator) Nth(nth int) *Locator {
+	return NewLocator(l.ctx, fmt.Sprintf("%s >> nth=%d", l.selector, nth), l.frame, l.log)
+}
+
 // TextContent returns the element's text content that matches
 // the locator's selector with strict mode on. The second return
 // value is true if the returned text content is not null or empty,

--- a/internal/js/modules/k6/browser/common/selectors.go
+++ b/internal/js/modules/k6/browser/common/selectors.go
@@ -73,6 +73,9 @@ func (s *Selector) parse() error {
 		var name, body string
 
 		switch {
+		case strings.HasPrefix(part, "nth="):
+			name = "nth"
+			body = part[eqIndex+1:]
 		case eqIndex != -1 && reQueryEngine.Match([]byte(strings.TrimSpace(part[0:eqIndex]))):
 			name = strings.TrimSpace(part[0:eqIndex])
 			body = part[eqIndex+1:]

--- a/internal/js/modules/k6/browser/common/selectors.go
+++ b/internal/js/modules/k6/browser/common/selectors.go
@@ -65,7 +65,7 @@ func (s *Selector) appendPart(p *SelectorPart, capture bool) error {
 	return nil
 }
 
-//nolint:cyclop
+//nolint:cyclop,funlen
 func (s *Selector) parse() error {
 	parsePart := func(selector string, start, index int) (*SelectorPart, bool) {
 		part := strings.TrimSpace(selector[start:index])

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -157,6 +157,13 @@ func TestLocator(t *testing.T) {
 			},
 		},
 		{
+			"First", func(_ *testBrowser, p *common.Page) {
+				text, err := p.Locator("a", nil).First().InnerText(nil)
+				require.NoError(t, err)
+				require.Equal(t, `Click`, text)
+			},
+		},
+		{
 			"Focus", func(_ *testBrowser, p *common.Page) {
 				focused := func() bool {
 					v, err := p.Evaluate(

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -235,6 +235,13 @@ func TestLocator(t *testing.T) {
 			},
 		},
 		{
+			"Last", func(_ *testBrowser, p *common.Page) {
+				text, err := p.Locator("div", nil).Last().InnerText(nil)
+				require.NoError(t, err)
+				require.Equal(t, `bye`, text)
+			},
+		},
+		{
 			"Nth", func(_ *testBrowser, p *common.Page) {
 				text, err := p.Locator("a", nil).Nth(0).InnerText(nil)
 				require.NoError(t, err)

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -228,6 +228,13 @@ func TestLocator(t *testing.T) {
 			},
 		},
 		{
+			"Nth", func(_ *testBrowser, p *common.Page) {
+				text, err := p.Locator("a", nil).Nth(0).InnerText(nil)
+				require.NoError(t, err)
+				require.Equal(t, `Click`, text)
+			},
+		},
+		{
 			"Press", func(_ *testBrowser, p *common.Page) {
 				lo := p.Locator("#inputText", nil)
 				require.NoError(t, lo.Press("x", nil))


### PR DESCRIPTION
## What?

This PR adds three APIs for the `locator` class. These are:

* `nth` which can be used to return the nth element given a selector (e.g. if we have many rows, and we want to select the 5th row in a table, then we can do `locator.nth(4)`).
* `first` which will return the first element (0th) given a selector (e.g. if we have many rows, and we want to select the first row in a table, then we can do `locator.first()` instead of `locator.nth(0)`).
* `last` which will return the last element given a selector (e.g. if we have many rows, and we want to select the last row in a table, then we can do `locator.last()` instead of `locator.nth(-1)`).

## Why?

There are many benefits of working with `locator` based APIs over element based APIs such as `$` and `$$`. The main two are that we can declare it once and use it over an over again even when the page navigates or the underlying DOM changes, and it performs actionability checks such as auto waiting for the element to be visible before trying to work with it. I.e. it's less fragile and easier to work with.

If we wanted to select a row in a table, before we would have to do:

```js
    const links = await page.$$('a[class="thumbnail"]');
    if (links && links.length > 0) {
        const link = links[0];
        while (!link.isVisible()) {
            sleep(1);
        }
        link.click();
    }
```

Now we can do:

```js
    await page.locator('a[class="thumbnail"]').first().click();
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/issues/4490