### PR TITLE
Fix web-dashboard output conflict

### DIFF
--- a/internal/cmd/outputs.go
+++ b/internal/cmd/outputs.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -124,9 +125,9 @@ func createOutputs(
 	if test.derivedConfig.WebDashboard.Bool {
 		outputs = append(outputs, dashboard.OutputName)
 	}
+	outputs = slices.Compact(outputs) // avoid duplicate outputs
 
 	result := make([]output.Output, 0, len(outputs))
-
 	for _, outputFullArg := range outputs {
 		outputType, outputArg, _ := strings.Cut(outputFullArg, "=")
 		outputConstructor, ok := outputConstructors[outputType]


### PR DESCRIPTION
## What?

Fix web-dashboard output conflict.

## Why?

Running:
```
K6_WEB_DASHBOARD=true k6 run --out web-dashboard script.js
```

Results:
```
...listen tcp :port: bind: address already in use
```

Also see #4707.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#4707