### PR TITLE
Fix user in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,10 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -o /usr/b
 # Runtime stage
 FROM alpine:3.21 as release
 
-RUN adduser -D -u 12345 -g 12345 k6
+RUN adduser -D -u 12345 -g 12345
 COPY --from=builder /usr/bin/k6 /usr/bin/k6
 
-USER k6
+USER 12345
 WORKDIR /home/k6
 
 ENTRYPOINT ["k6"]
@@ -24,7 +24,7 @@ USER root
 COPY --from=release /usr/bin/k6 /usr/bin/k6
 RUN apk --no-cache add chromium-swiftshader
 
-USER k6
+USER 12345
 
 ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV CHROME_PATH=/usr/lib/chromium/


### PR DESCRIPTION
## What?

Defaults to using user `12345` instead of `k6`.

## Why?

This fix helps those who are working with the image in k8s. Before this change the user had to work with runAsUser in the pod manifest file, which could lead to issues if the correct user wasn't used (which is only 12345). This will mitigate that risk since we default to working with 12345 and not k6.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
