### PR TITLE
Switch k6 packager to Vault

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,6 +370,7 @@ jobs:
       actions: read
       contents: read
       packages: read
+      id-token: write # Required for Vault
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -391,6 +392,11 @@ jobs:
           mv "dist/k6-$VERSION-windows-amd64.msi" "dist/k6-$VERSION-amd64.msi"
           mv "dist/k6-$VERSION-linux-amd64.rpm" "dist/k6-$VERSION-amd64.rpm"
           mv "dist/k6-$VERSION-linux-amd64.deb" "dist/k6-$VERSION-amd64.deb"
+      - uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        with:
+          repo_secrets: |
+            PGP_SIGN_KEY_PASSPHRASE=pgp:PGP_SIGN_KEY_PASSPHRASE
+            PGP_SIGN_KEY=pgp:PGP_SIGN_KEY
       - name: Setup docker compose environment
         run: |
           cat > packaging/.env <<EOF
@@ -398,9 +404,9 @@ jobs:
           AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION=us-east-1
           AWS_CF_DISTRIBUTION="${{ secrets.AWS_CF_DISTRIBUTION }}"
-          PGP_SIGN_KEY_PASSPHRASE=${{ secrets.PGP_SIGN_KEY_PASSPHRASE }}
+          PGP_SIGN_KEY_PASSPHRASE=${{ env.PGP_SIGN_KEY_PASSPHRASE }}
           EOF
-          echo "${{ secrets.PGP_SIGN_KEY }}" > packaging/sign-key.gpg
+          echo "${{ env.PGP_SIGN_KEY }}" > packaging/sign-key.gpg
       - name: Publish packages
         env:
           GITHUB_ACTOR: ${{ github.actor }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -232,6 +232,7 @@ jobs:
     permissions:
       contents: read
       actions: read
+      id-token: write # Required for Vault
 
     runs-on: windows-latest
     defaults:
@@ -273,6 +274,12 @@ jobs:
           candle.exe -arch x64 "-dVERSION=$env:VERSION" k6.wxs
           light.exe -ext WixUIExtension k6.wixobj
 
+      - uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        with:
+          repo_secrets: |
+            WIN_SIGN_CERT=winsign:WIN_SIGN_CERT
+            WIN_SIGN_PASS=winsign:WIN_SIGN_PASS
+
       - name: Sign Windows binary and .msi package
         # GH secrets are unavailable when building from project forks, so this
         # will fail for external PRs, even if we wanted to do it. And we don't.
@@ -282,17 +289,17 @@ jobs:
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
         run: |
           # Convert base64 certificate to PFX
-          $bytes = [Convert]::FromBase64String("${{ secrets.WIN_SIGN_CERT }}")
+          $bytes = [Convert]::FromBase64String("${{ env.WIN_SIGN_CERT }}")
           [IO.File]::WriteAllBytes("k6.pfx", $bytes)
 
           # Get the latest signtool executable
           $SignTool = Get-ChildItem -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin" -Recurse -Filter signtool.exe | Where-Object { $_.DirectoryName -like "*\x64" } | Sort-Object -Descending | Select-Object -First 1
 
           # Sign the Windows binary
-          & $SignTool sign /f k6.pfx /p "${{ secrets.WIN_SIGN_PASS }}" /tr "http://timestamp.digicert.com" /td sha256 /fd sha256 "packaging\k6.exe"
+          & $SignTool sign /f k6.pfx /p "${{ env.WIN_SIGN_PASS }}" /tr "http://timestamp.digicert.com" /td sha256 /fd sha256 "packaging\k6.exe"
 
           # Sign the MSI package
-          & $SignTool sign /f k6.pfx /p "${{ secrets.WIN_SIGN_PASS }}" /tr "http://timestamp.digicert.com" /td sha256 /fd sha256 "packaging\k6.msi"
+          & $SignTool sign /f k6.pfx /p "${{ env.WIN_SIGN_PASS }}" /tr "http://timestamp.digicert.com" /td sha256 /fd sha256 "packaging\k6.msi"
 
           # Cleanup signing artifacts
           del k6.pfx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,15 +395,22 @@ jobs:
       - uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
           repo_secrets: |
+            IAM_ROLE_ARN=deploy:packager-iam-role
             PGP_SIGN_KEY_PASSPHRASE=pgp:PGP_SIGN_KEY_PASSPHRASE
             PGP_SIGN_KEY=pgp:PGP_SIGN_KEY
+      - uses: grafana/shared-workflows/actions/aws-auth@aws-auth/v1.0.2
+        with:
+          aws-region: "us-east-2"
+          role-arn: ${{ env.IAM_ROLE_ARN }}
+          set-creds-in-environment: true
       - name: Setup docker compose environment
         run: |
           cat > packaging/.env <<EOF
-          AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION=us-east-1
-          AWS_CF_DISTRIBUTION="${{ secrets.AWS_CF_DISTRIBUTION }}"
+          AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
+          AWS_CF_DISTRIBUTION="${{ env.AWS_CF_DISTRIBUTION }}"
+          AWS_DEFAULT_REGION=us-east-2
+          AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
+          AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
           PGP_SIGN_KEY_PASSPHRASE=${{ env.PGP_SIGN_KEY_PASSPHRASE }}
           EOF
           echo "${{ env.PGP_SIGN_KEY }}" > packaging/sign-key.gpg

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -396,6 +396,7 @@ jobs:
         with:
           repo_secrets: |
             IAM_ROLE_ARN=deploy:packager-iam-role
+            AWS_CF_DISTRIBUTION=cloudfront:AWS_CF_DISTRIBUTION
             PGP_SIGN_KEY_PASSPHRASE=pgp:PGP_SIGN_KEY_PASSPHRASE
             PGP_SIGN_KEY=pgp:PGP_SIGN_KEY
       - uses: grafana/shared-workflows/actions/aws-auth@aws-auth/v1.0.2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -399,6 +399,7 @@ jobs:
             AWS_CF_DISTRIBUTION=cloudfront:AWS_CF_DISTRIBUTION
             PGP_SIGN_KEY_PASSPHRASE=pgp:PGP_SIGN_KEY_PASSPHRASE
             PGP_SIGN_KEY=pgp:PGP_SIGN_KEY
+            S3_BUCKET=s3:AWS_S3_BUCKET
       - uses: grafana/shared-workflows/actions/aws-auth@aws-auth/v1.0.2
         with:
           aws-region: "us-east-2"
@@ -413,6 +414,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
           AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
           PGP_SIGN_KEY_PASSPHRASE=${{ env.PGP_SIGN_KEY_PASSPHRASE }}
+          S3_BUCKET=${{ env.S3_BUCKET }}
           EOF
           echo "${{ env.PGP_SIGN_KEY }}" > packaging/sign-key.gpg
       - name: Publish packages

--- a/packaging/bin/create-deb-repo.sh
+++ b/packaging/bin/create-deb-repo.sh
@@ -42,7 +42,9 @@ sync_to_s3() {
   s3cmd sync --delete-removed "${REPODIR}/" "s3://${S3PATH}/"
 
   # Set a short cache expiration for index and repo metadata files.
-  s3cmd modify --recursive --exclude='*' \
+  # We set --acl-private since we manage ACLs ourselves and don't want
+  # s3cmd to modify them. Otherwise, we receive AccessControlListNotSupported.
+  s3cmd modify --acl-private --recursive --exclude='*' \
     --include='index.html' --include='*Release*' --include='Packages*' \
     --add-header='Cache-Control: max-age=60,must-revalidate' "s3://${S3PATH}/"
 }

--- a/packaging/bin/create-deb-repo.sh
+++ b/packaging/bin/create-deb-repo.sh
@@ -14,7 +14,7 @@ set -eEuo pipefail
 #   For generating the index.html of each directory. It's available in the
 #   packaging/bin directory of the k6 repo, and should be in $PATH.
 
-_s3bucket="${S3_BUCKET-dl.k6.io}"
+_s3bucket="${S3_BUCKET}"
 _usage="Usage: $0 <pkgdir> <repodir> [s3bucket=${_s3bucket}]"
 PKGDIR="${1?${_usage}}"  # The directory where .deb files are located
 REPODIR="${2?${_usage}}" # The package repository working directory

--- a/packaging/bin/create-msi-repo.sh
+++ b/packaging/bin/create-msi-repo.sh
@@ -30,7 +30,9 @@ sync_to_s3() {
   s3cmd sync --delete-removed "${REPODIR}/" "s3://${S3PATH}/"
 
   # Set a short cache expiration for index files and the latest MSI package.
-  s3cmd modify --recursive --exclude='*' \
+  # We set --private-acl since we manage ACLs ourselves and don't want
+  # s3cmd to modify them. Otherwise, we receive AccessControlListNotSupported.
+  s3cmd modify --acl-private --recursive --exclude='*' \
     --include='index.html' --include='k6-latest-amd64.msi' \
     --add-header='Cache-Control: max-age=60,must-revalidate' "s3://${S3PATH}/"
 }

--- a/packaging/bin/create-msi-repo.sh
+++ b/packaging/bin/create-msi-repo.sh
@@ -9,7 +9,7 @@ set -eEuo pipefail
 #   For generating the index.html of each directory. It's available in the
 #   packaging/bin directory of the k6 repo, and should be in $PATH.
 
-_s3bucket="${S3_BUCKET-dl.k6.io}"
+_s3bucket="${S3_BUCKET}"
 _usage="Usage: $0 <pkgdir> <repodir> [s3bucket=${_s3bucket}]"
 PKGDIR="${1?${_usage}}"  # The directory where .msi files are located
 REPODIR="${2?${_usage}}" # The package repository working directory

--- a/packaging/bin/create-rpm-repo.sh
+++ b/packaging/bin/create-rpm-repo.sh
@@ -13,7 +13,7 @@ set -eEuo pipefail
 #   For generating the index.html of each directory. It's available in the
 #   packaging/bin directory of the k6 repo, and should be in $PATH.
 
-_s3bucket="${S3_BUCKET-dl.k6.io}"
+_s3bucket="${S3_BUCKET}"
 _usage="Usage: $0 <pkgdir> <repodir> [s3bucket=${_s3bucket}]"
 PKGDIR="${1?${_usage}}"  # The directory where .rpm files are located
 REPODIR="${2?${_usage}}" # The package repository working directory

--- a/packaging/bin/create-rpm-repo.sh
+++ b/packaging/bin/create-rpm-repo.sh
@@ -34,7 +34,9 @@ sync_to_s3() {
   s3cmd sync --delete-removed "${REPODIR}/" "s3://${S3PATH}/"
 
   # Set a short cache expiration for index and repo metadata files.
-  s3cmd modify --recursive --exclude='*' \
+  # We set --acl-private since we manage ACLs ourselves and don't want
+  # s3cmd to modify them. Otherwise, we receive AccessControlListNotSupported.
+  s3cmd modify --acl-private --recursive --exclude='*' \
     --include='index.html' --include='/repodata/*' \
     --add-header='Cache-Control: max-age=60,must-revalidate' "s3://${S3PATH}/"
 }

--- a/packaging/bin/entrypoint.sh
+++ b/packaging/bin/entrypoint.sh
@@ -17,7 +17,7 @@ log() {
 }
 
 signkeypath="$PWD/sign-key.gpg"
-s3bucket="${S3_BUCKET-dl.k6.io}"
+s3bucket="${S3_BUCKET}"
 pkgdir="$PWD/Packages"
 
 if ! [ -r "$signkeypath" ]; then

--- a/packaging/docker-compose.yml
+++ b/packaging/docker-compose.yml
@@ -10,9 +10,10 @@ services:
     image: ghcr.io/grafana/k6packager:latest
     environment:
       - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
-      - AWS_DEFAULT_REGION
       - AWS_CF_DISTRIBUTION
+      - AWS_DEFAULT_REGION
+      - AWS_SECRET_ACCESS_KEY
+      - AWS_SESSION_TOKEN
       - PGP_SIGN_KEY_PASSPHRASE
       - S3_BUCKET=dl.k6.io
     volumes:

--- a/packaging/docker-compose.yml
+++ b/packaging/docker-compose.yml
@@ -5,8 +5,8 @@ services:
     build:
       context: .
       args:
-        - AWSCLI_VERSION=${AWSCLI_VERSION:-2.1.36}
-        - S3CMD_VERSION=${S3CMD_VERSION:-2.1.0}
+        - AWSCLI_VERSION=${AWSCLI_VERSION:-2.26.5}
+        - S3CMD_VERSION=${S3CMD_VERSION:-2.4.0}
     image: ghcr.io/grafana/k6packager:latest
     environment:
       - AWS_ACCESS_KEY_ID

--- a/packaging/docker-compose.yml
+++ b/packaging/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   packager:
     build:

--- a/packaging/docker-compose.yml
+++ b/packaging/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - AWS_SECRET_ACCESS_KEY
       - AWS_SESSION_TOKEN
       - PGP_SIGN_KEY_PASSPHRASE
-      - S3_BUCKET=dl.k6.io
+      - S3_BUCKET
     volumes:
       - ../dist:/home/k6/dist
       - ./sign-key.gpg:/home/k6/sign-key.gpg


### PR DESCRIPTION
## What?

Retrieves secrets from Vault and adjusts the k6packager deployment process.

Passing builds:
- https://github.com/grafana/k6/actions/runs/15641571150/job/44070316796
- https://github.com/grafana/k6/actions/runs/15641760295/job/44070908513

See grafana/k6-cloud#3483 for more details.

## Why?

For stronger security.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- grafana/k6-cloud#3483