### PR TITLE
Prevent testcov running on public forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,7 @@ jobs:
           repo_secrets: |
             CODECOV_TOKEN=CODECOV_TOKEN:CODECOV_TOKEN
       - name: Upload coverage to Codecov
+        if: github.event.repository.fork == false && github.event.sender.login != 'dependabot[bot]'
         env:
           CODECOV_BASH_VERSION: 1.0.1
           CODECOV_BASH_SHA512SUM: d075b412a362a9a2b7aedfec3b8b9a9a927b3b99e98c7c15a2b76ef09862aeb005e91d76a5fd71b511141496d0fd23d1b42095f722ebcd509d768fba030f159e


### PR DESCRIPTION
## What?

- Pass a blank `CODECOV_TOKEN` for public forks.
- Prevent testcov running on public forks.

## Why?

We can't retrieve secrets for public forks ([example](https://github.com/grafana/k6/pull/4659)). Otherwise, we see:

```
Run grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1 Run ${GITHUB_ACTION_PATH}/translate-secrets.bash
Secrets that will be queried from Vault:
ci/data/repo/grafana/k6/CODECOV_TOKEN CODECOV_TOKEN | CODECOV_TOKEN;

Run actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea Error: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
    at OidcClient.<anonymous> (/home/runner/work/_actions/actions/github-script/60a0d83039c74a4aee543508d2ffcb1c3799cdea/dist/index.js:585:23)
    at Generator.next (<anonymous>)
    at /home/runner/work/_actions/actions/github-script/60a0d83039c74a4aee543508d2ffcb1c3799cdea/dist/index.js:522:71
    at new Promise (<anonymous>)
    at __webpack_modules__.8041.__awaiter (/home/runner/work/_actions/actions/github-script/60a0d83039c74a4aee543508d2ffcb1c3799cdea/dist/index.js:518:12)
    at OidcClient.getIDToken (/home/runner/work/_actions/actions/github-script/60a0d83039c74a4aee543508d2ffcb1c3799cdea/dist/index.js:571:16)
    at Object.<anonymous> (/home/runner/work/_actions/actions/github-script/60a0d83039c74a4aee543508d2ffcb1c3799cdea/dist/index.js:421:46)
    at Generator.next (<anonymous>)
    at /home/runner/work/_actions/actions/github-script/60a0d83039c74a4aee543508d2ffcb1c3799cdea/dist/index.js:133:71
    at new Promise (<anonymous>)
Error: Unhandled error: Error: Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Updates grafana/k6-cloud#3525