### PR TITLE
Add getByRole in the browser module

### DIFF
--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -318,6 +318,7 @@ type pageAPI interface { //nolint:interfacebloat
 	Focus(selector string, opts sobek.Value) error
 	Frames() []*common.Frame
 	GetAttribute(selector string, name string, opts sobek.Value) (string, bool, error)
+	GetByRole(role string, opts *common.GetByRoleOptions) (*common.ElementHandle, error)
 	GetKeyboard() *common.Keyboard
 	GetMouse() *common.Mouse
 	GetTouchscreen() *common.Touchscreen

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -163,6 +163,15 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return s, nil
 			}), nil
 		},
+		"getByRole": func(role string, opts sobek.Value) (*sobek.Object, error) {
+			popts := common.NewGetByRoleOptions()
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing getByRole options: %w", err)
+			}
+
+			ml := mapLocator(vu, p.GetByRole(role, popts))
+			return rt.ToValue(ml).ToObject(rt), nil
+		},
 		"goto": func(url string, opts sobek.Value) (*sobek.Promise, error) {
 			gopts := common.NewFrameGotoOptions(
 				p.Referrer(),

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -165,10 +165,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			}), nil
 		},
 		"getByRole": func(role string, opts sobek.Value) (*sobek.Object, error) {
-			popts, err := parseGetByRoleOptions(vu.Context(), opts)
-			if err != nil {
-				return nil, fmt.Errorf("parsing getByRole options: %w", err)
-			}
+			popts := parseGetByRoleOptions(vu.Context(), opts)
 
 			ml := mapLocator(vu, p.GetByRole(role, popts))
 			return rt.ToValue(ml).ToObject(rt), nil
@@ -692,9 +689,9 @@ func parseWaitForFunctionArgs(
 }
 
 // parseGetByRoleOptions parses the GetByRole options from the Sobek.Value.
-func parseGetByRoleOptions(ctx context.Context, opts sobek.Value) (*common.GetByRoleOptions, error) {
+func parseGetByRoleOptions(ctx context.Context, opts sobek.Value) *common.GetByRoleOptions {
 	if !sobekValueExists(opts) {
-		return nil, nil
+		return nil
 	}
 
 	o := &common.GetByRoleOptions{}
@@ -742,5 +739,5 @@ func parseGetByRoleOptions(ctx context.Context, opts sobek.Value) (*common.GetBy
 		}
 	}
 
-	return o, nil
+	return o
 }

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -165,8 +165,8 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			}), nil
 		},
 		"getByRole": func(role string, opts sobek.Value) (*sobek.Object, error) {
-			popts := common.NewGetByRoleOptions()
-			if err := popts.Parse(vu.Context(), opts); err != nil {
+			popts, err := parseGetByRoleOptions(vu.Context(), opts)
+			if err != nil {
 				return nil, fmt.Errorf("parsing getByRole options: %w", err)
 			}
 

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/grafana/sobek"
@@ -688,4 +689,58 @@ func parseWaitForFunctionArgs(
 	}
 
 	return js, popts, exportArgs(gargs), nil
+}
+
+// parseGetByRoleOptions parses the GetByRole options from the Sobek.Value.
+func parseGetByRoleOptions(ctx context.Context, opts sobek.Value) (*common.GetByRoleOptions, error) {
+	if !sobekValueExists(opts) {
+		return nil, nil
+	}
+
+	o := &common.GetByRoleOptions{}
+
+	rt := k6ext.Runtime(ctx)
+
+	obj := opts.ToObject(rt)
+	for _, k := range obj.Keys() {
+		switch k {
+		case "checked":
+			val := obj.Get(k).ToBoolean()
+			o.Checked = &val
+		case "disabled":
+			val := obj.Get(k).ToBoolean()
+			o.Disabled = &val
+		case "exact":
+			val := obj.Get(k).ToBoolean()
+			o.Exact = &val
+		case "expanded":
+			val := obj.Get(k).ToBoolean()
+			o.Expanded = &val
+		case "includeHidden":
+			val := obj.Get(k).ToBoolean()
+			o.IncludeHidden = &val
+		case "level":
+			val := obj.Get(k).ToInteger()
+			o.Level = &val
+		case "name":
+			var val string
+			switch obj.Get(k).ExportType() {
+			case reflect.TypeOf(string("")):
+				val = fmt.Sprintf("'%s'", obj.Get(k).String()) // Strings require quotes
+			case reflect.TypeOf(map[string]interface{}(nil)): // JS RegExp
+				val = obj.Get(k).String() // No quotes
+			default: // CSS, numbers or booleans
+				val = obj.Get(k).String() // No quotes
+			}
+			o.Name = &val
+		case "pressed":
+			val := obj.Get(k).ToBoolean()
+			o.Pressed = &val
+		case "selected":
+			val := obj.Get(k).ToBoolean()
+			o.Selected = &val
+		}
+	}
+
+	return o, nil
 }

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1009,7 +1009,7 @@ func (f *Frame) GetByRole(role string, opts *GetByRoleOptions) *Locator {
 	properties := make(map[string]string)
 
 	if opts == nil {
-		return f.Locator(fmt.Sprintf("role=%s", role), nil)
+		return f.Locator(fmt.Sprintf("internal:role=%s", role), nil)
 	}
 
 	if opts.Checked != nil {
@@ -1046,7 +1046,7 @@ func (f *Frame) GetByRole(role string, opts *GetByRoleOptions) *Locator {
 	}
 
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("role=%s", role))
+	builder.WriteString(fmt.Sprintf("internal:role=%s", role))
 	for key, value := range properties {
 		builder.WriteString(fmt.Sprintf("[%s=%s]", key, value))
 	}

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1002,6 +1002,58 @@ func (f *Frame) getAttribute(selector, name string, opts *FrameBaseOptions) (str
 	return s, true, nil
 }
 
+// Locator creates and returns a new locator for this frame.
+func (f *Frame) GetByRole(role string, opts *GetByRoleOptions) *Locator {
+	f.log.Debugf("Frame:Locator", "fid:%s furl:%q role:%q opts:%+v", f.ID(), f.URL(), role, opts)
+
+	properties := make(map[string]string)
+
+	if opts == nil {
+		return f.Locator(fmt.Sprintf("role=%s", role), nil)
+	}
+
+	if opts.Checked != nil {
+		properties["checked"] = fmt.Sprintf("%v", *opts.Checked)
+	}
+	if opts.Disabled != nil {
+		properties["disabled"] = fmt.Sprintf("%v", *opts.Disabled)
+	}
+	if opts.Selected != nil {
+		properties["selected"] = fmt.Sprintf("%v", *opts.Selected)
+	}
+	if opts.Expanded != nil {
+		properties["expanded"] = fmt.Sprintf("%v", *opts.Expanded)
+	}
+	if opts.IncludeHidden != nil {
+		properties["include-hidden"] = fmt.Sprintf("%v", *opts.IncludeHidden)
+	}
+	if opts.Level != nil {
+		properties["level"] = fmt.Sprintf("%v", *opts.Level)
+	}
+	if opts.Name != nil && *opts.Name != "" {
+		// Exact option can only be applied to quoted strings.
+		if (*opts.Name)[0] == '\'' && (*opts.Name)[len(*opts.Name)-1] == '\'' {
+			if opts.Exact != nil && *opts.Exact {
+				*opts.Name = fmt.Sprintf("%vs", *opts.Name)
+			} else {
+				*opts.Name = fmt.Sprintf("%vi", *opts.Name)
+			}
+		}
+		properties["name"] = *opts.Name
+	}
+	if opts.Pressed != nil {
+		properties["pressed"] = fmt.Sprintf("%v", *opts.Pressed)
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("role=%s", role))
+	for key, value := range properties {
+		builder.WriteString(fmt.Sprintf("[%s=%s]", key, value))
+	}
+
+	return f.Locator(builder.String(), nil)
+}
+
 // Referrer returns the referrer of the frame from the network manager
 // of the frame's session.
 // It's an internal method not to be exposed as a JS API.

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1002,9 +1002,10 @@ func (f *Frame) getAttribute(selector, name string, opts *FrameBaseOptions) (str
 	return s, true, nil
 }
 
-// Locator creates and returns a new locator for this frame.
+// GetByRole creates and returns a new locator for this frame using the ARIA role
+// and any additional options.
 func (f *Frame) GetByRole(role string, opts *GetByRoleOptions) *Locator {
-	f.log.Debugf("Frame:Locator", "fid:%s furl:%q role:%q opts:%+v", f.ID(), f.URL(), role, opts)
+	f.log.Debugf("Frame:GetByRole", "fid:%s furl:%q role:%q opts:%+v", f.ID(), f.URL(), role, opts)
 
 	properties := make(map[string]string)
 

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -1010,46 +1011,46 @@ func (f *Frame) GetByRole(role string, opts *GetByRoleOptions) *Locator {
 	properties := make(map[string]string)
 
 	if opts == nil {
-		return f.Locator(fmt.Sprintf("internal:role=%s", role), nil)
+		return f.Locator("internal:role="+role, nil)
 	}
 
 	if opts.Checked != nil {
-		properties["checked"] = fmt.Sprintf("%v", *opts.Checked)
+		properties["checked"] = strconv.FormatBool(*opts.Checked)
 	}
 	if opts.Disabled != nil {
-		properties["disabled"] = fmt.Sprintf("%v", *opts.Disabled)
+		properties["disabled"] = strconv.FormatBool(*opts.Disabled)
 	}
 	if opts.Selected != nil {
-		properties["selected"] = fmt.Sprintf("%v", *opts.Selected)
+		properties["selected"] = strconv.FormatBool(*opts.Selected)
 	}
 	if opts.Expanded != nil {
-		properties["expanded"] = fmt.Sprintf("%v", *opts.Expanded)
+		properties["expanded"] = strconv.FormatBool(*opts.Expanded)
 	}
 	if opts.IncludeHidden != nil {
-		properties["include-hidden"] = fmt.Sprintf("%v", *opts.IncludeHidden)
+		properties["include-hidden"] = strconv.FormatBool(*opts.IncludeHidden)
 	}
 	if opts.Level != nil {
-		properties["level"] = fmt.Sprintf("%v", *opts.Level)
+		properties["level"] = strconv.FormatInt(*opts.Level, 10)
 	}
 	if opts.Name != nil && *opts.Name != "" {
 		// Exact option can only be applied to quoted strings.
 		if (*opts.Name)[0] == '\'' && (*opts.Name)[len(*opts.Name)-1] == '\'' {
 			if opts.Exact != nil && *opts.Exact {
-				*opts.Name = fmt.Sprintf("%vs", *opts.Name)
+				*opts.Name = *opts.Name + "s"
 			} else {
-				*opts.Name = fmt.Sprintf("%vi", *opts.Name)
+				*opts.Name = *opts.Name + "i"
 			}
 		}
 		properties["name"] = *opts.Name
 	}
 	if opts.Pressed != nil {
-		properties["pressed"] = fmt.Sprintf("%v", *opts.Pressed)
+		properties["pressed"] = strconv.FormatBool(*opts.Pressed)
 	}
 
 	var builder strings.Builder
-	builder.WriteString(fmt.Sprintf("internal:role=%s", role))
+	builder.WriteString("internal:role=" + role)
 	for key, value := range properties {
-		builder.WriteString(fmt.Sprintf("[%s=%s]", key, value))
+		builder.WriteString("[" + key + "=" + value + "]")
 	}
 
 	return f.Locator(builder.String(), nil)

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1036,9 +1036,9 @@ func (f *Frame) GetByRole(role string, opts *GetByRoleOptions) *Locator {
 		// Exact option can only be applied to quoted strings.
 		if (*opts.Name)[0] == '\'' && (*opts.Name)[len(*opts.Name)-1] == '\'' {
 			if opts.Exact != nil && *opts.Exact {
-				*opts.Name = *opts.Name + "s"
+				*opts.Name = (*opts.Name) + "s"
 			} else {
-				*opts.Name = *opts.Name + "i"
+				*opts.Name = (*opts.Name) + "i"
 			}
 		}
 		properties["name"] = *opts.Name

--- a/internal/js/modules/k6/browser/common/js/injected_script.js
+++ b/internal/js/modules/k6/browser/common/js/injected_script.js
@@ -14,6 +14,1259 @@
  * limitations under the License.
  */
 
+// packages/playwright-core/src/utils/isomorphic/stringUtils.ts
+var normalizedWhitespaceCache;
+function normalizeWhiteSpace(text) {
+  let result = normalizedWhitespaceCache == null ? void 0 : normalizedWhitespaceCache.get(text);
+  if (result === void 0) {
+    result = text.replace(/[\u200b\u00ad]/g, "").trim().replace(/\s+/g, " ");
+    normalizedWhitespaceCache == null ? void 0 : normalizedWhitespaceCache.set(text, result);
+  }
+  return result;
+}
+
+// packages/injected/src/domUtils.ts
+var globalOptions = {};
+function getGlobalOptions() {
+  return globalOptions;
+}
+function parentElementOrShadowHost(element) {
+  if (element.parentElement)
+    return element.parentElement;
+  if (!element.parentNode)
+    return;
+  if (element.parentNode.nodeType === 11 && element.parentNode.host)
+    return element.parentNode.host;
+}
+function enclosingShadowRootOrDocument(element) {
+  let node = element;
+  while (node.parentNode)
+    node = node.parentNode;
+  if (node.nodeType === 11 || node.nodeType === 9)
+    return node;
+}
+function enclosingShadowHost(element) {
+  while (element.parentElement)
+    element = element.parentElement;
+  return parentElementOrShadowHost(element);
+}
+function closestCrossShadow(element, css, scope) {
+  while (element) {
+    const closest = element.closest(css);
+    if (scope && closest !== scope && (closest == null ? void 0 : closest.contains(scope)))
+      return;
+    if (closest)
+      return closest;
+    element = enclosingShadowHost(element);
+  }
+}
+function getElementComputedStyle(element, pseudo) {
+  return element.ownerDocument && element.ownerDocument.defaultView ? element.ownerDocument.defaultView.getComputedStyle(element, pseudo) : void 0;
+}
+function isElementStyleVisibilityVisible(element, style) {
+  style = style != null ? style : getElementComputedStyle(element);
+  if (!style)
+    return true;
+  if (Element.prototype.checkVisibility && globalOptions.browserNameForWorkarounds !== "webkit") {
+    if (!element.checkVisibility())
+      return false;
+  } else {
+    const detailsOrSummary = element.closest("details,summary");
+    if (detailsOrSummary !== element && (detailsOrSummary == null ? void 0 : detailsOrSummary.nodeName) === "DETAILS" && !detailsOrSummary.open)
+      return false;
+  }
+  if (style.visibility !== "visible")
+    return false;
+  return true;
+}
+function isVisibleTextNode(node) {
+  const range = node.ownerDocument.createRange();
+  range.selectNode(node);
+  const rect = range.getBoundingClientRect();
+  return rect.width > 0 && rect.height > 0;
+}
+function elementSafeTagName(element) {
+  if (element instanceof HTMLFormElement)
+    return "FORM";
+  return element.tagName.toUpperCase();
+}
+
+// packages/injected/src/roleUtils.ts
+function hasExplicitAccessibleName(e) {
+  return e.hasAttribute("aria-label") || e.hasAttribute("aria-labelledby");
+}
+var kAncestorPreventingLandmark = "article:not([role]), aside:not([role]), main:not([role]), nav:not([role]), section:not([role]), [role=article], [role=complementary], [role=main], [role=navigation], [role=region]";
+var kGlobalAriaAttributes = [
+  ["aria-atomic", void 0],
+  ["aria-busy", void 0],
+  ["aria-controls", void 0],
+  ["aria-current", void 0],
+  ["aria-describedby", void 0],
+  ["aria-details", void 0],
+  // Global use deprecated in ARIA 1.2
+  // ['aria-disabled', undefined],
+  ["aria-dropeffect", void 0],
+  // Global use deprecated in ARIA 1.2
+  // ['aria-errormessage', undefined],
+  ["aria-flowto", void 0],
+  ["aria-grabbed", void 0],
+  // Global use deprecated in ARIA 1.2
+  // ['aria-haspopup', undefined],
+  ["aria-hidden", void 0],
+  // Global use deprecated in ARIA 1.2
+  // ['aria-invalid', undefined],
+  ["aria-keyshortcuts", void 0],
+  ["aria-label", ["caption", "code", "deletion", "emphasis", "generic", "insertion", "paragraph", "presentation", "strong", "subscript", "superscript"]],
+  ["aria-labelledby", ["caption", "code", "deletion", "emphasis", "generic", "insertion", "paragraph", "presentation", "strong", "subscript", "superscript"]],
+  ["aria-live", void 0],
+  ["aria-owns", void 0],
+  ["aria-relevant", void 0],
+  ["aria-roledescription", ["generic"]]
+];
+function hasGlobalAriaAttribute(element, forRole) {
+  return kGlobalAriaAttributes.some(([attr, prohibited]) => {
+    return !(prohibited == null ? void 0 : prohibited.includes(forRole || "")) && element.hasAttribute(attr);
+  });
+}
+function hasTabIndex(element) {
+  return !Number.isNaN(Number(String(element.getAttribute("tabindex"))));
+}
+function isFocusable(element) {
+  return !isNativelyDisabled(element) && (isNativelyFocusable(element) || hasTabIndex(element));
+}
+function isNativelyFocusable(element) {
+  const tagName = elementSafeTagName(element);
+  if (["BUTTON", "DETAILS", "SELECT", "TEXTAREA"].includes(tagName))
+    return true;
+  if (tagName === "A" || tagName === "AREA")
+    return element.hasAttribute("href");
+  if (tagName === "INPUT")
+    return !element.hidden;
+  return false;
+}
+var kImplicitRoleByTagName = {
+  "A": (e) => {
+    return e.hasAttribute("href") ? "link" : null;
+  },
+  "AREA": (e) => {
+    return e.hasAttribute("href") ? "link" : null;
+  },
+  "ARTICLE": () => "article",
+  "ASIDE": () => "complementary",
+  "BLOCKQUOTE": () => "blockquote",
+  "BUTTON": () => "button",
+  "CAPTION": () => "caption",
+  "CODE": () => "code",
+  "DATALIST": () => "listbox",
+  "DD": () => "definition",
+  "DEL": () => "deletion",
+  "DETAILS": () => "group",
+  "DFN": () => "term",
+  "DIALOG": () => "dialog",
+  "DT": () => "term",
+  "EM": () => "emphasis",
+  "FIELDSET": () => "group",
+  "FIGURE": () => "figure",
+  "FOOTER": (e) => closestCrossShadow(e, kAncestorPreventingLandmark) ? null : "contentinfo",
+  "FORM": (e) => hasExplicitAccessibleName(e) ? "form" : null,
+  "H1": () => "heading",
+  "H2": () => "heading",
+  "H3": () => "heading",
+  "H4": () => "heading",
+  "H5": () => "heading",
+  "H6": () => "heading",
+  "HEADER": (e) => closestCrossShadow(e, kAncestorPreventingLandmark) ? null : "banner",
+  "HR": () => "separator",
+  "HTML": () => "document",
+  "IMG": (e) => e.getAttribute("alt") === "" && !e.getAttribute("title") && !hasGlobalAriaAttribute(e) && !hasTabIndex(e) ? "presentation" : "img",
+  "INPUT": (e) => {
+    const type = e.type.toLowerCase();
+    if (type === "search")
+      return e.hasAttribute("list") ? "combobox" : "searchbox";
+    if (["email", "tel", "text", "url", ""].includes(type)) {
+      const list = getIdRefs(e, e.getAttribute("list"))[0];
+      return list && elementSafeTagName(list) === "DATALIST" ? "combobox" : "textbox";
+    }
+    if (type === "hidden")
+      return null;
+    if (type === "file" && !getGlobalOptions().inputFileRoleTextbox)
+      return "button";
+    return inputTypeToRole[type] || "textbox";
+  },
+  "INS": () => "insertion",
+  "LI": () => "listitem",
+  "MAIN": () => "main",
+  "MARK": () => "mark",
+  "MATH": () => "math",
+  "MENU": () => "list",
+  "METER": () => "meter",
+  "NAV": () => "navigation",
+  "OL": () => "list",
+  "OPTGROUP": () => "group",
+  "OPTION": () => "option",
+  "OUTPUT": () => "status",
+  "P": () => "paragraph",
+  "PROGRESS": () => "progressbar",
+  "SECTION": (e) => hasExplicitAccessibleName(e) ? "region" : null,
+  "SELECT": (e) => e.hasAttribute("multiple") || e.size > 1 ? "listbox" : "combobox",
+  "STRONG": () => "strong",
+  "SUB": () => "subscript",
+  "SUP": () => "superscript",
+  // For <svg> we default to Chrome behavior:
+  // - Chrome reports 'img'.
+  // - Firefox reports 'diagram' that is not in official ARIA spec yet.
+  // - Safari reports 'no role', but still computes accessible name.
+  "SVG": () => "img",
+  "TABLE": () => "table",
+  "TBODY": () => "rowgroup",
+  "TD": (e) => {
+    const table = closestCrossShadow(e, "table");
+    const role = table ? getExplicitAriaRole(table) : "";
+    return role === "grid" || role === "treegrid" ? "gridcell" : "cell";
+  },
+  "TEXTAREA": () => "textbox",
+  "TFOOT": () => "rowgroup",
+  "TH": (e) => {
+    if (e.getAttribute("scope") === "col")
+      return "columnheader";
+    if (e.getAttribute("scope") === "row")
+      return "rowheader";
+    const table = closestCrossShadow(e, "table");
+    const role = table ? getExplicitAriaRole(table) : "";
+    return role === "grid" || role === "treegrid" ? "gridcell" : "cell";
+  },
+  "THEAD": () => "rowgroup",
+  "TIME": () => "time",
+  "TR": () => "row",
+  "UL": () => "list"
+};
+var kPresentationInheritanceParents = {
+  "DD": ["DL", "DIV"],
+  "DIV": ["DL"],
+  "DT": ["DL", "DIV"],
+  "LI": ["OL", "UL"],
+  "TBODY": ["TABLE"],
+  "TD": ["TR"],
+  "TFOOT": ["TABLE"],
+  "TH": ["TR"],
+  "THEAD": ["TABLE"],
+  "TR": ["THEAD", "TBODY", "TFOOT", "TABLE"]
+};
+function getImplicitAriaRole(element) {
+  var _a;
+  const implicitRole = ((_a = kImplicitRoleByTagName[elementSafeTagName(element)]) == null ? void 0 : _a.call(kImplicitRoleByTagName, element)) || "";
+  if (!implicitRole)
+    return null;
+  let ancestor = element;
+  while (ancestor) {
+    const parent = parentElementOrShadowHost(ancestor);
+    const parents = kPresentationInheritanceParents[elementSafeTagName(ancestor)];
+    if (!parents || !parent || !parents.includes(elementSafeTagName(parent)))
+      break;
+    const parentExplicitRole = getExplicitAriaRole(parent);
+    if ((parentExplicitRole === "none" || parentExplicitRole === "presentation") && !hasPresentationConflictResolution(parent, parentExplicitRole))
+      return parentExplicitRole;
+    ancestor = parent;
+  }
+  return implicitRole;
+}
+var validRoles = [
+  "alert",
+  "alertdialog",
+  "application",
+  "article",
+  "banner",
+  "blockquote",
+  "button",
+  "caption",
+  "cell",
+  "checkbox",
+  "code",
+  "columnheader",
+  "combobox",
+  "complementary",
+  "contentinfo",
+  "definition",
+  "deletion",
+  "dialog",
+  "directory",
+  "document",
+  "emphasis",
+  "feed",
+  "figure",
+  "form",
+  "generic",
+  "grid",
+  "gridcell",
+  "group",
+  "heading",
+  "img",
+  "insertion",
+  "link",
+  "list",
+  "listbox",
+  "listitem",
+  "log",
+  "main",
+  "mark",
+  "marquee",
+  "math",
+  "meter",
+  "menu",
+  "menubar",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "navigation",
+  "none",
+  "note",
+  "option",
+  "paragraph",
+  "presentation",
+  "progressbar",
+  "radio",
+  "radiogroup",
+  "region",
+  "row",
+  "rowgroup",
+  "rowheader",
+  "scrollbar",
+  "search",
+  "searchbox",
+  "separator",
+  "slider",
+  "spinbutton",
+  "status",
+  "strong",
+  "subscript",
+  "superscript",
+  "switch",
+  "tab",
+  "table",
+  "tablist",
+  "tabpanel",
+  "term",
+  "textbox",
+  "time",
+  "timer",
+  "toolbar",
+  "tooltip",
+  "tree",
+  "treegrid",
+  "treeitem"
+];
+function getExplicitAriaRole(element) {
+  const roles = (element.getAttribute("role") || "").split(" ").map((role) => role.trim());
+  return roles.find((role) => validRoles.includes(role)) || null;
+}
+function hasPresentationConflictResolution(element, role) {
+  return hasGlobalAriaAttribute(element, role) || isFocusable(element);
+}
+function getAriaRole(element) {
+  const explicitRole = getExplicitAriaRole(element);
+  if (!explicitRole)
+    return getImplicitAriaRole(element);
+  if (explicitRole === "none" || explicitRole === "presentation") {
+    const implicitRole = getImplicitAriaRole(element);
+    if (hasPresentationConflictResolution(element, implicitRole))
+      return implicitRole;
+  }
+  return explicitRole;
+}
+function getAriaBoolean(attr) {
+  return attr === null ? void 0 : attr.toLowerCase() === "true";
+}
+function isElementIgnoredForAria(element) {
+  return ["STYLE", "SCRIPT", "NOSCRIPT", "TEMPLATE"].includes(elementSafeTagName(element));
+}
+function isElementHiddenForAria(element) {
+  if (isElementIgnoredForAria(element))
+    return true;
+  const style = getElementComputedStyle(element);
+  const isSlot = element.nodeName === "SLOT";
+  if ((style == null ? void 0 : style.display) === "contents" && !isSlot) {
+    for (let child = element.firstChild; child; child = child.nextSibling) {
+      if (child.nodeType === 1 && !isElementHiddenForAria(child))
+        return false;
+      if (child.nodeType === 3 && isVisibleTextNode(child))
+        return false;
+    }
+    return true;
+  }
+  const isOptionInsideSelect = element.nodeName === "OPTION" && !!element.closest("select");
+  if (!isOptionInsideSelect && !isSlot && !isElementStyleVisibilityVisible(element, style))
+    return true;
+  return belongsToDisplayNoneOrAriaHiddenOrNonSlotted(element);
+}
+function belongsToDisplayNoneOrAriaHiddenOrNonSlotted(element) {
+  let hidden = cacheIsHidden == null ? void 0 : cacheIsHidden.get(element);
+  if (hidden === void 0) {
+    hidden = false;
+    if (element.parentElement && element.parentElement.shadowRoot && !element.assignedSlot)
+      hidden = true;
+    if (!hidden) {
+      const style = getElementComputedStyle(element);
+      hidden = !style || style.display === "none" || getAriaBoolean(element.getAttribute("aria-hidden")) === true;
+    }
+    if (!hidden) {
+      const parent = parentElementOrShadowHost(element);
+      if (parent)
+        hidden = belongsToDisplayNoneOrAriaHiddenOrNonSlotted(parent);
+    }
+    cacheIsHidden == null ? void 0 : cacheIsHidden.set(element, hidden);
+  }
+  return hidden;
+}
+function getIdRefs(element, ref) {
+  if (!ref)
+    return [];
+  const root = enclosingShadowRootOrDocument(element);
+  if (!root)
+    return [];
+  try {
+    const ids = ref.split(" ").filter((id) => !!id);
+    const result = [];
+    for (const id of ids) {
+      const firstElement = root.querySelector("#" + CSS.escape(id));
+      if (firstElement && !result.includes(firstElement))
+        result.push(firstElement);
+    }
+    return result;
+  } catch (e) {
+    return [];
+  }
+}
+function trimFlatString(s) {
+  return s.trim();
+}
+function asFlatString(s) {
+  return s.split("\xA0").map((chunk) => chunk.replace(/\r\n/g, "\
+").replace(/[\u200b\u00ad]/g, "").replace(/\s\s*/g, " ")).join("\xA0").trim();
+}
+function queryInAriaOwned(element, selector) {
+  const result = [...element.querySelectorAll(selector)];
+  for (const owned of getIdRefs(element, element.getAttribute("aria-owns"))) {
+    if (owned.matches(selector))
+      result.push(owned);
+    result.push(...owned.querySelectorAll(selector));
+  }
+  return result;
+}
+function getPseudoContent(element, pseudo) {
+  const cache = pseudo === "::before" ? cachePseudoContentBefore : cachePseudoContentAfter;
+  if (cache == null ? void 0 : cache.has(element))
+    return (cache == null ? void 0 : cache.get(element)) || "";
+  const pseudoStyle = getElementComputedStyle(element, pseudo);
+  const content = getPseudoContentImpl(element, pseudoStyle);
+  if (cache)
+    cache.set(element, content);
+  return content;
+}
+function getPseudoContentImpl(element, pseudoStyle) {
+  if (!pseudoStyle || pseudoStyle.display === "none" || pseudoStyle.visibility === "hidden")
+    return "";
+  const content = pseudoStyle.content;
+  let resolvedContent;
+  if (content[0] === "'" && content[content.length - 1] === "'" || content[0] === '"' && content[content.length - 1] === '"') {
+    resolvedContent = content.substring(1, content.length - 1);
+  } else if (content.startsWith("attr(") && content.endsWith(")")) {
+    const attrName = content.substring("attr(".length, content.length - 1).trim();
+    resolvedContent = element.getAttribute(attrName) || "";
+  }
+  if (resolvedContent !== void 0) {
+    const display = pseudoStyle.display || "inline";
+    if (display !== "inline")
+      return " " + resolvedContent + " ";
+    return resolvedContent;
+  }
+  return "";
+}
+function getAriaLabelledByElements(element) {
+  const ref = element.getAttribute("aria-labelledby");
+  if (ref === null)
+    return null;
+  const refs = getIdRefs(element, ref);
+  return refs.length ? refs : null;
+}
+function allowsNameFromContent(role, targetDescendant) {
+  const alwaysAllowsNameFromContent = ["button", "cell", "checkbox", "columnheader", "gridcell", "heading", "link", "menuitem", "menuitemcheckbox", "menuitemradio", "option", "radio", "row", "rowheader", "switch", "tab", "tooltip", "treeitem"].includes(role);
+  const descendantAllowsNameFromContent = targetDescendant && ["", "caption", "code", "contentinfo", "definition", "deletion", "emphasis", "insertion", "list", "listitem", "mark", "none", "paragraph", "presentation", "region", "row", "rowgroup", "section", "strong", "subscript", "superscript", "table", "term", "time"].includes(role);
+  return alwaysAllowsNameFromContent || descendantAllowsNameFromContent;
+}
+function getElementAccessibleName(element, includeHidden) {
+  const cache = includeHidden ? cacheAccessibleNameHidden : cacheAccessibleName;
+  let accessibleName = cache == null ? void 0 : cache.get(element);
+  if (accessibleName === void 0) {
+    accessibleName = "";
+    const elementProhibitsNaming = ["caption", "code", "definition", "deletion", "emphasis", "generic", "insertion", "mark", "paragraph", "presentation", "strong", "subscript", "suggestion", "superscript", "term", "time"].includes(getAriaRole(element) || "");
+    if (!elementProhibitsNaming) {
+      accessibleName = asFlatString(getTextAlternativeInternal(element, {
+        includeHidden,
+        visitedElements: new Set(),
+        embeddedInTargetElement: "self"
+      }));
+    }
+    cache == null ? void 0 : cache.set(element, accessibleName);
+  }
+  return accessibleName;
+}
+function getTextAlternativeInternal(element, options) {
+  var _a, _b, _c, _d;
+  if (options.visitedElements.has(element))
+    return "";
+  const childOptions = {
+    ...options,
+    embeddedInTargetElement: options.embeddedInTargetElement === "self" ? "descendant" : options.embeddedInTargetElement
+  };
+  if (!options.includeHidden) {
+    const isEmbeddedInHiddenReferenceTraversal = !!((_a = options.embeddedInLabelledBy) == null ? void 0 : _a.hidden) || !!((_b = options.embeddedInDescribedBy) == null ? void 0 : _b.hidden) || !!((_c = options.embeddedInNativeTextAlternative) == null ? void 0 : _c.hidden) || !!((_d = options.embeddedInLabel) == null ? void 0 : _d.hidden);
+    if (isElementIgnoredForAria(element) || !isEmbeddedInHiddenReferenceTraversal && isElementHiddenForAria(element)) {
+      options.visitedElements.add(element);
+      return "";
+    }
+  }
+  const labelledBy = getAriaLabelledByElements(element);
+  if (!options.embeddedInLabelledBy) {
+    const accessibleName = (labelledBy || []).map((ref) => getTextAlternativeInternal(ref, {
+      ...options,
+      embeddedInLabelledBy: { element: ref, hidden: isElementHiddenForAria(ref) },
+      embeddedInDescribedBy: void 0,
+      embeddedInTargetElement: void 0,
+      embeddedInLabel: void 0,
+      embeddedInNativeTextAlternative: void 0
+    })).join(" ");
+    if (accessibleName)
+      return accessibleName;
+  }
+  const role = getAriaRole(element) || "";
+  const tagName = elementSafeTagName(element);
+  if (!!options.embeddedInLabel || !!options.embeddedInLabelledBy || options.embeddedInTargetElement === "descendant") {
+    const isOwnLabel = [...element.labels || []].includes(element);
+    const isOwnLabelledBy = (labelledBy || []).includes(element);
+    if (!isOwnLabel && !isOwnLabelledBy) {
+      if (role === "textbox") {
+        options.visitedElements.add(element);
+        if (tagName === "INPUT" || tagName === "TEXTAREA")
+          return element.value;
+        return element.textContent || "";
+      }
+      if (["combobox", "listbox"].includes(role)) {
+        options.visitedElements.add(element);
+        let selectedOptions;
+        if (tagName === "SELECT") {
+          selectedOptions = [...element.selectedOptions];
+          if (!selectedOptions.length && element.options.length)
+            selectedOptions.push(element.options[0]);
+        } else {
+          const listbox = role === "combobox" ? queryInAriaOwned(element, "*").find((e) => getAriaRole(e) === "listbox") : element;
+          selectedOptions = listbox ? queryInAriaOwned(listbox, '[aria-selected="true"]').filter((e) => getAriaRole(e) === "option") : [];
+        }
+        if (!selectedOptions.length && tagName === "INPUT") {
+          return element.value;
+        }
+        return selectedOptions.map((option) => getTextAlternativeInternal(option, childOptions)).join(" ");
+      }
+      if (["progressbar", "scrollbar", "slider", "spinbutton", "meter"].includes(role)) {
+        options.visitedElements.add(element);
+        if (element.hasAttribute("aria-valuetext"))
+          return element.getAttribute("aria-valuetext") || "";
+        if (element.hasAttribute("aria-valuenow"))
+          return element.getAttribute("aria-valuenow") || "";
+        return element.getAttribute("value") || "";
+      }
+      if (["menu"].includes(role)) {
+        options.visitedElements.add(element);
+        return "";
+      }
+    }
+  }
+  const ariaLabel = element.getAttribute("aria-label") || "";
+  if (trimFlatString(ariaLabel)) {
+    options.visitedElements.add(element);
+    return ariaLabel;
+  }
+  if (!["presentation", "none"].includes(role)) {
+    if (tagName === "INPUT" && ["button", "submit", "reset"].includes(element.type)) {
+      options.visitedElements.add(element);
+      const value = element.value || "";
+      if (trimFlatString(value))
+        return value;
+      if (element.type === "submit")
+        return "Submit";
+      if (element.type === "reset")
+        return "Reset";
+      const title = element.getAttribute("title") || "";
+      return title;
+    }
+    if (!getGlobalOptions().inputFileRoleTextbox && tagName === "INPUT" && element.type === "file") {
+      options.visitedElements.add(element);
+      const labels = element.labels || [];
+      if (labels.length && !options.embeddedInLabelledBy)
+        return getAccessibleNameFromAssociatedLabels(labels, options);
+      return "Choose File";
+    }
+    if (tagName === "INPUT" && element.type === "image") {
+      options.visitedElements.add(element);
+      const labels = element.labels || [];
+      if (labels.length && !options.embeddedInLabelledBy)
+        return getAccessibleNameFromAssociatedLabels(labels, options);
+      const alt = element.getAttribute("alt") || "";
+      if (trimFlatString(alt))
+        return alt;
+      const title = element.getAttribute("title") || "";
+      if (trimFlatString(title))
+        return title;
+      return "Submit";
+    }
+    if (!labelledBy && tagName === "BUTTON") {
+      options.visitedElements.add(element);
+      const labels = element.labels || [];
+      if (labels.length)
+        return getAccessibleNameFromAssociatedLabels(labels, options);
+    }
+    if (!labelledBy && tagName === "OUTPUT") {
+      options.visitedElements.add(element);
+      const labels = element.labels || [];
+      if (labels.length)
+        return getAccessibleNameFromAssociatedLabels(labels, options);
+      return element.getAttribute("title") || "";
+    }
+    if (!labelledBy && (tagName === "TEXTAREA" || tagName === "SELECT" || tagName === "INPUT")) {
+      options.visitedElements.add(element);
+      const labels = element.labels || [];
+      if (labels.length)
+        return getAccessibleNameFromAssociatedLabels(labels, options);
+      const usePlaceholder = tagName === "INPUT" && ["text", "password", "search", "tel", "email", "url"].includes(element.type) || tagName === "TEXTAREA";
+      const placeholder = element.getAttribute("placeholder") || "";
+      const title = element.getAttribute("title") || "";
+      if (!usePlaceholder || title)
+        return title;
+      return placeholder;
+    }
+    if (!labelledBy && tagName === "FIELDSET") {
+      options.visitedElements.add(element);
+      for (let child = element.firstElementChild; child; child = child.nextElementSibling) {
+        if (elementSafeTagName(child) === "LEGEND") {
+          return getTextAlternativeInternal(child, {
+            ...childOptions,
+            embeddedInNativeTextAlternative: { element: child, hidden: isElementHiddenForAria(child) }
+          });
+        }
+      }
+      const title = element.getAttribute("title") || "";
+      return title;
+    }
+    if (!labelledBy && tagName === "FIGURE") {
+      options.visitedElements.add(element);
+      for (let child = element.firstElementChild; child; child = child.nextElementSibling) {
+        if (elementSafeTagName(child) === "FIGCAPTION") {
+          return getTextAlternativeInternal(child, {
+            ...childOptions,
+            embeddedInNativeTextAlternative: { element: child, hidden: isElementHiddenForAria(child) }
+          });
+        }
+      }
+      const title = element.getAttribute("title") || "";
+      return title;
+    }
+    if (tagName === "IMG") {
+      options.visitedElements.add(element);
+      const alt = element.getAttribute("alt") || "";
+      if (trimFlatString(alt))
+        return alt;
+      const title = element.getAttribute("title") || "";
+      return title;
+    }
+    if (tagName === "TABLE") {
+      options.visitedElements.add(element);
+      for (let child = element.firstElementChild; child; child = child.nextElementSibling) {
+        if (elementSafeTagName(child) === "CAPTION") {
+          return getTextAlternativeInternal(child, {
+            ...childOptions,
+            embeddedInNativeTextAlternative: { element: child, hidden: isElementHiddenForAria(child) }
+          });
+        }
+      }
+      const summary = element.getAttribute("summary") || "";
+      if (summary)
+        return summary;
+    }
+    if (tagName === "AREA") {
+      options.visitedElements.add(element);
+      const alt = element.getAttribute("alt") || "";
+      if (trimFlatString(alt))
+        return alt;
+      const title = element.getAttribute("title") || "";
+      return title;
+    }
+    if (tagName === "SVG" || element.ownerSVGElement) {
+      options.visitedElements.add(element);
+      for (let child = element.firstElementChild; child; child = child.nextElementSibling) {
+        if (elementSafeTagName(child) === "TITLE" && child.ownerSVGElement) {
+          return getTextAlternativeInternal(child, {
+            ...childOptions,
+            embeddedInLabelledBy: { element: child, hidden: isElementHiddenForAria(child) }
+          });
+        }
+      }
+    }
+    if (element.ownerSVGElement && tagName === "A") {
+      const title = element.getAttribute("xlink:title") || "";
+      if (trimFlatString(title)) {
+        options.visitedElements.add(element);
+        return title;
+      }
+    }
+  }
+  const shouldNameFromContentForSummary = tagName === "SUMMARY" && !["presentation", "none"].includes(role);
+  if (allowsNameFromContent(role, options.embeddedInTargetElement === "descendant") || shouldNameFromContentForSummary || !!options.embeddedInLabelledBy || !!options.embeddedInDescribedBy || !!options.embeddedInLabel || !!options.embeddedInNativeTextAlternative) {
+    options.visitedElements.add(element);
+    const accessibleName = innerAccumulatedElementText(element, childOptions);
+    const maybeTrimmedAccessibleName = options.embeddedInTargetElement === "self" ? trimFlatString(accessibleName) : accessibleName;
+    if (maybeTrimmedAccessibleName)
+      return accessibleName;
+  }
+  if (!["presentation", "none"].includes(role) || tagName === "IFRAME") {
+    options.visitedElements.add(element);
+    const title = element.getAttribute("title") || "";
+    if (trimFlatString(title))
+      return title;
+  }
+  options.visitedElements.add(element);
+  return "";
+}
+function innerAccumulatedElementText(element, options) {
+  const tokens = [];
+  const visit = (node, skipSlotted) => {
+    var _a;
+    if (skipSlotted && node.assignedSlot)
+      return;
+    if (node.nodeType === 1) {
+      const display = ((_a = getElementComputedStyle(node)) == null ? void 0 : _a.display) || "inline";
+      let token = getTextAlternativeInternal(node, options);
+      if (display !== "inline" || node.nodeName === "BR")
+        token = " " + token + " ";
+      tokens.push(token);
+    } else if (node.nodeType === 3) {
+      tokens.push(node.textContent || "");
+    }
+  };
+  tokens.push(getPseudoContent(element, "::before"));
+  const assignedNodes = element.nodeName === "SLOT" ? element.assignedNodes() : [];
+  if (assignedNodes.length) {
+    for (const child of assignedNodes)
+      visit(child, false);
+  } else {
+    for (let child = element.firstChild; child; child = child.nextSibling)
+      visit(child, true);
+    if (element.shadowRoot) {
+      for (let child = element.shadowRoot.firstChild; child; child = child.nextSibling)
+        visit(child, true);
+    }
+    for (const owned of getIdRefs(element, element.getAttribute("aria-owns")))
+      visit(owned, true);
+  }
+  tokens.push(getPseudoContent(element, "::after"));
+  return tokens.join("");
+}
+var kAriaSelectedRoles = ["gridcell", "option", "row", "tab", "rowheader", "columnheader", "treeitem"];
+function getAriaSelected(element) {
+  if (elementSafeTagName(element) === "OPTION")
+    return element.selected;
+  if (kAriaSelectedRoles.includes(getAriaRole(element) || ""))
+    return getAriaBoolean(element.getAttribute("aria-selected")) === true;
+  return false;
+}
+var kAriaCheckedRoles = ["checkbox", "menuitemcheckbox", "option", "radio", "switch", "menuitemradio", "treeitem"];
+function getAriaChecked(element) {
+  const result = getChecked(element, true);
+  return result === "error" ? false : result;
+}
+function getChecked(element, allowMixed) {
+  const tagName = elementSafeTagName(element);
+  if (allowMixed && tagName === "INPUT" && element.indeterminate)
+    return "mixed";
+  if (tagName === "INPUT" && ["checkbox", "radio"].includes(element.type))
+    return element.checked;
+  if (kAriaCheckedRoles.includes(getAriaRole(element) || "")) {
+    const checked = element.getAttribute("aria-checked");
+    if (checked === "true")
+      return true;
+    if (allowMixed && checked === "mixed")
+      return "mixed";
+    return false;
+  }
+  return "error";
+}
+var kAriaPressedRoles = ["button"];
+function getAriaPressed(element) {
+  if (kAriaPressedRoles.includes(getAriaRole(element) || "")) {
+    const pressed = element.getAttribute("aria-pressed");
+    if (pressed === "true")
+      return true;
+    if (pressed === "mixed")
+      return "mixed";
+  }
+  return false;
+}
+var kAriaExpandedRoles = ["application", "button", "checkbox", "combobox", "gridcell", "link", "listbox", "menuitem", "row", "rowheader", "tab", "treeitem", "columnheader", "menuitemcheckbox", "menuitemradio", "rowheader", "switch"];
+function getAriaExpanded(element) {
+  if (elementSafeTagName(element) === "DETAILS")
+    return element.open;
+  if (kAriaExpandedRoles.includes(getAriaRole(element) || "")) {
+    const expanded = element.getAttribute("aria-expanded");
+    if (expanded === null)
+      return void 0;
+    if (expanded === "true")
+      return true;
+    return false;
+  }
+  return void 0;
+}
+var kAriaLevelRoles = ["heading", "listitem", "row", "treeitem"];
+function getAriaLevel(element) {
+  const native = { "H1": 1, "H2": 2, "H3": 3, "H4": 4, "H5": 5, "H6": 6 }[elementSafeTagName(element)];
+  if (native)
+    return native;
+  if (kAriaLevelRoles.includes(getAriaRole(element) || "")) {
+    const attr = element.getAttribute("aria-level");
+    const value = attr === null ? Number.NaN : Number(attr);
+    if (Number.isInteger(value) && value >= 1)
+      return value;
+  }
+  return 0;
+}
+var kAriaDisabledRoles = ["application", "button", "composite", "gridcell", "group", "input", "link", "menuitem", "scrollbar", "separator", "tab", "checkbox", "columnheader", "combobox", "grid", "listbox", "menu", "menubar", "menuitemcheckbox", "menuitemradio", "option", "radio", "radiogroup", "row", "rowheader", "searchbox", "select", "slider", "spinbutton", "switch", "tablist", "textbox", "toolbar", "tree", "treegrid", "treeitem"];
+function getAriaDisabled(element) {
+  return isNativelyDisabled(element) || hasExplicitAriaDisabled(element);
+}
+function isNativelyDisabled(element) {
+  const isNativeFormControl = ["BUTTON", "INPUT", "SELECT", "TEXTAREA", "OPTION", "OPTGROUP"].includes(element.tagName);
+  return isNativeFormControl && (element.hasAttribute("disabled") || belongsToDisabledFieldSet(element));
+}
+function belongsToDisabledFieldSet(element) {
+  const fieldSetElement = element == null ? void 0 : element.closest("FIELDSET[DISABLED]");
+  if (!fieldSetElement)
+    return false;
+  const legendElement = fieldSetElement.querySelector(":scope > LEGEND");
+  return !legendElement || !legendElement.contains(element);
+}
+function hasExplicitAriaDisabled(element, isAncestor = false) {
+  if (!element)
+    return false;
+  if (isAncestor || kAriaDisabledRoles.includes(getAriaRole(element) || "")) {
+    const attribute = (element.getAttribute("aria-disabled") || "").toLowerCase();
+    if (attribute === "true")
+      return true;
+    if (attribute === "false")
+      return false;
+    return hasExplicitAriaDisabled(parentElementOrShadowHost(element), true);
+  }
+  return false;
+}
+function getAccessibleNameFromAssociatedLabels(labels, options) {
+  return [...labels].map((label) => getTextAlternativeInternal(label, {
+    ...options,
+    embeddedInLabel: { element: label, hidden: isElementHiddenForAria(label) },
+    embeddedInNativeTextAlternative: void 0,
+    embeddedInLabelledBy: void 0,
+    embeddedInDescribedBy: void 0,
+    embeddedInTargetElement: void 0
+  })).filter((accessibleName) => !!accessibleName).join(" ");
+}
+var cacheAccessibleName;
+var cacheAccessibleNameHidden;
+var cacheAccessibleDescription;
+var cacheAccessibleDescriptionHidden;
+var cacheAccessibleErrorMessage;
+var cacheIsHidden;
+var cachePseudoContentBefore;
+var cachePseudoContentAfter;
+var cachesCounter = 0;
+function beginAriaCaches() {
+  ++cachesCounter;
+  cacheAccessibleName != null ? cacheAccessibleName : cacheAccessibleName = new Map();
+  cacheAccessibleNameHidden != null ? cacheAccessibleNameHidden : cacheAccessibleNameHidden = new Map();
+  cacheAccessibleDescription != null ? cacheAccessibleDescription : cacheAccessibleDescription = new Map();
+  cacheAccessibleDescriptionHidden != null ? cacheAccessibleDescriptionHidden : cacheAccessibleDescriptionHidden = new Map();
+  cacheAccessibleErrorMessage != null ? cacheAccessibleErrorMessage : cacheAccessibleErrorMessage = new Map();
+  cacheIsHidden != null ? cacheIsHidden : cacheIsHidden = new Map();
+  cachePseudoContentBefore != null ? cachePseudoContentBefore : cachePseudoContentBefore = new Map();
+  cachePseudoContentAfter != null ? cachePseudoContentAfter : cachePseudoContentAfter = new Map();
+}
+function endAriaCaches() {
+  if (!--cachesCounter) {
+    cacheAccessibleName = void 0;
+    cacheAccessibleNameHidden = void 0;
+    cacheAccessibleDescription = void 0;
+    cacheAccessibleDescriptionHidden = void 0;
+    cacheAccessibleErrorMessage = void 0;
+    cacheIsHidden = void 0;
+    cachePseudoContentBefore = void 0;
+    cachePseudoContentAfter = void 0;
+  }
+}
+var inputTypeToRole = {
+  "button": "button",
+  "checkbox": "checkbox",
+  "image": "button",
+  "number": "spinbutton",
+  "radio": "radio",
+  "range": "slider",
+  "reset": "button",
+  "submit": "button"
+};
+
+// packages/injected/src/selectorUtils.ts
+function matchesAttributePart(value, attr) {
+  const objValue = typeof value === "string" && !attr.caseSensitive ? value.toUpperCase() : value;
+  const attrValue = typeof attr.value === "string" && !attr.caseSensitive ? attr.value.toUpperCase() : attr.value;
+  if (attr.op === "<truthy>")
+    return !!objValue;
+  if (attr.op === "=") {
+    if (attrValue instanceof RegExp)
+      return typeof objValue === "string" && !!objValue.match(attrValue);
+    return objValue === attrValue;
+  }
+  if (typeof objValue !== "string" || typeof attrValue !== "string")
+    return false;
+  if (attr.op === "*=")
+    return objValue.includes(attrValue);
+  if (attr.op === "^=")
+    return objValue.startsWith(attrValue);
+  if (attr.op === "$=")
+    return objValue.endsWith(attrValue);
+  if (attr.op === "|=")
+    return objValue === attrValue || objValue.startsWith(attrValue + "-");
+  if (attr.op === "~=")
+    return objValue.split(" ").includes(attrValue);
+  return false;
+}
+
+// packages/playwright-core/src/utils/isomorphic/cssParser.ts
+var InvalidSelectorError = class extends Error {
+};
+
+// packages/playwright-core/src/utils/isomorphic/selectorParser.ts
+function parseAttributeSelector(selector, allowUnquotedStrings) {
+  let wp = 0;
+  let EOL = selector.length === 0;
+  const next = () => selector[wp] || "";
+  const eat1 = () => {
+    const result2 = next();
+    ++wp;
+    EOL = wp >= selector.length;
+    return result2;
+  };
+  const syntaxError = (stage) => {
+    if (EOL)
+      throw new InvalidSelectorError(`Unexpected end of selector while parsing selector \`${selector}\``);
+    throw new InvalidSelectorError(`Error while parsing selector \`${selector}\` - unexpected symbol "${next()}" at position ${wp}` + (stage ? " during " + stage : ""));
+  };
+  function skipSpaces() {
+    while (!EOL && /\s/.test(next()))
+      eat1();
+  }
+  function isCSSNameChar(char) {
+    return char >= "\x80" || char >= "0" && char <= "9" || char >= "A" && char <= "Z" || char >= "a" && char <= "z" || char >= "0" && char <= "9" || char === "_" || char === "-";
+  }
+  function readIdentifier() {
+    let result2 = "";
+    skipSpaces();
+    while (!EOL && isCSSNameChar(next()))
+      result2 += eat1();
+    return result2;
+  }
+  function readQuotedString(quote) {
+    let result2 = eat1();
+    if (result2 !== quote)
+      syntaxError("parsing quoted string");
+    while (!EOL && next() !== quote) {
+      if (next() === "\\")
+        eat1();
+      result2 += eat1();
+    }
+    if (next() !== quote)
+      syntaxError("parsing quoted string");
+    result2 += eat1();
+    return result2;
+  }
+  function readRegularExpression() {
+    if (eat1() !== "/")
+      syntaxError("parsing regular expression");
+    let source = "";
+    let inClass = false;
+    while (!EOL) {
+      if (next() === "\\") {
+        source += eat1();
+        if (EOL)
+          syntaxError("parsing regular expression");
+      } else if (inClass && next() === "]") {
+        inClass = false;
+      } else if (!inClass && next() === "[") {
+        inClass = true;
+      } else if (!inClass && next() === "/") {
+        break;
+      }
+      source += eat1();
+    }
+    if (eat1() !== "/")
+      syntaxError("parsing regular expression");
+    let flags = "";
+    while (!EOL && next().match(/[dgimsuy]/))
+      flags += eat1();
+    try {
+      return new RegExp(source, flags);
+    } catch (e) {
+      throw new InvalidSelectorError(`Error while parsing selector \`${selector}\`: ${e.message}`);
+    }
+  }
+  function readAttributeToken() {
+    let token = "";
+    skipSpaces();
+    if (next() === `'` || next() === `"`)
+      token = readQuotedString(next()).slice(1, -1);
+    else
+      token = readIdentifier();
+    if (!token)
+      syntaxError("parsing property path");
+    return token;
+  }
+  function readOperator() {
+    skipSpaces();
+    let op = "";
+    if (!EOL)
+      op += eat1();
+    if (!EOL && op !== "=")
+      op += eat1();
+    if (!["=", "*=", "^=", "$=", "|=", "~="].includes(op))
+      syntaxError("parsing operator");
+    return op;
+  }
+  function readAttribute() {
+    eat1();
+    const jsonPath = [];
+    jsonPath.push(readAttributeToken());
+    skipSpaces();
+    while (next() === ".") {
+      eat1();
+      jsonPath.push(readAttributeToken());
+      skipSpaces();
+    }
+    if (next() === "]") {
+      eat1();
+      return { name: jsonPath.join("."), jsonPath, op: "<truthy>", value: null, caseSensitive: false };
+    }
+    const operator = readOperator();
+    let value = void 0;
+    let caseSensitive = true;
+    skipSpaces();
+    if (next() === "/") {
+      if (operator !== "=")
+        throw new InvalidSelectorError(`Error while parsing selector \`${selector}\` - cannot use ${operator} in attribute with regular expression`);
+      value = readRegularExpression();
+    } else if (next() === `'` || next() === `"`) {
+      value = readQuotedString(next()).slice(1, -1);
+      skipSpaces();
+      if (next() === "i" || next() === "I") {
+        caseSensitive = false;
+        eat1();
+      } else if (next() === "s" || next() === "S") {
+        caseSensitive = true;
+        eat1();
+      }
+    } else {
+      value = "";
+      while (!EOL && (isCSSNameChar(next()) || next() === "+" || next() === "."))
+        value += eat1();
+      if (value === "true") {
+        value = true;
+      } else if (value === "false") {
+        value = false;
+      } else {
+        if (!allowUnquotedStrings) {
+          value = +value;
+          if (Number.isNaN(value))
+            syntaxError("parsing attribute value");
+        }
+      }
+    }
+    skipSpaces();
+    if (next() !== "]")
+      syntaxError("parsing attribute value");
+    eat1();
+    if (operator !== "=" && typeof value !== "string")
+      throw new InvalidSelectorError(`Error while parsing selector \`${selector}\` - cannot use ${operator} in attribute with non-string matching value - ${value}`);
+    return { name: jsonPath.join("."), jsonPath, op: operator, value, caseSensitive };
+  }
+  const result = {
+    name: "",
+    attributes: []
+  };
+  result.name = readIdentifier();
+  skipSpaces();
+  while (next() === "[") {
+    result.attributes.push(readAttribute());
+    skipSpaces();
+  }
+  if (!EOL)
+    syntaxError(void 0);
+  if (!result.name && !result.attributes.length)
+    throw new InvalidSelectorError(`Error while parsing selector \`${selector}\` - selector cannot be empty`);
+  return result;
+}
+
+// packages/injected/src/roleSelectorEngine.ts
+var kSupportedAttributes = ["selected", "checked", "pressed", "expanded", "level", "disabled", "name", "include-hidden"];
+kSupportedAttributes.sort();
+function validateSupportedRole(attr, roles, role) {
+  if (!roles.includes(role))
+    throw new Error(`"${attr}" attribute is only supported for roles: ${roles.slice().sort().map((role2) => `"${role2}"`).join(", ")}`);
+}
+function validateSupportedValues(attr, values) {
+  if (attr.op !== "<truthy>" && !values.includes(attr.value))
+    throw new Error(`"${attr.name}" must be one of ${values.map((v) => JSON.stringify(v)).join(", ")}`);
+}
+function validateSupportedOp(attr, ops) {
+  if (!ops.includes(attr.op))
+    throw new Error(`"${attr.name}" does not support "${attr.op}" matcher`);
+}
+function validateAttributes(attrs, role) {
+  const options = { role };
+  for (const attr of attrs) {
+    switch (attr.name) {
+      case "checked": {
+        validateSupportedRole(attr.name, kAriaCheckedRoles, role);
+        validateSupportedValues(attr, [true, false, "mixed"]);
+        validateSupportedOp(attr, ["<truthy>", "="]);
+        options.checked = attr.op === "<truthy>" ? true : attr.value;
+        break;
+      }
+      case "pressed": {
+        validateSupportedRole(attr.name, kAriaPressedRoles, role);
+        validateSupportedValues(attr, [true, false, "mixed"]);
+        validateSupportedOp(attr, ["<truthy>", "="]);
+        options.pressed = attr.op === "<truthy>" ? true : attr.value;
+        break;
+      }
+      case "selected": {
+        validateSupportedRole(attr.name, kAriaSelectedRoles, role);
+        validateSupportedValues(attr, [true, false]);
+        validateSupportedOp(attr, ["<truthy>", "="]);
+        options.selected = attr.op === "<truthy>" ? true : attr.value;
+        break;
+      }
+      case "expanded": {
+        validateSupportedRole(attr.name, kAriaExpandedRoles, role);
+        validateSupportedValues(attr, [true, false]);
+        validateSupportedOp(attr, ["<truthy>", "="]);
+        options.expanded = attr.op === "<truthy>" ? true : attr.value;
+        break;
+      }
+      case "level": {
+        validateSupportedRole(attr.name, kAriaLevelRoles, role);
+        if (typeof attr.value === "string")
+          attr.value = +attr.value;
+        if (attr.op !== "=" || typeof attr.value !== "number" || Number.isNaN(attr.value))
+          throw new Error(`"level" attribute must be compared to a number`);
+        options.level = attr.value;
+        break;
+      }
+      case "disabled": {
+        validateSupportedValues(attr, [true, false]);
+        validateSupportedOp(attr, ["<truthy>", "="]);
+        options.disabled = attr.op === "<truthy>" ? true : attr.value;
+        break;
+      }
+      case "name": {
+        if (attr.op === "<truthy>")
+          throw new Error(`"name" attribute must have a value`);
+        if (typeof attr.value !== "string" && !(attr.value instanceof RegExp))
+          throw new Error(`"name" attribute must be a string or a regular expression`);
+        options.name = attr.value;
+        options.nameOp = attr.op;
+        options.exact = attr.caseSensitive;
+        break;
+      }
+      case "include-hidden": {
+        validateSupportedValues(attr, [true, false]);
+        validateSupportedOp(attr, ["<truthy>", "="]);
+        options.includeHidden = attr.op === "<truthy>" ? true : attr.value;
+        break;
+      }
+      default: {
+        throw new Error(`Unknown attribute "${attr.name}", must be one of ${kSupportedAttributes.map((a) => `"${a}"`).join(", ")}.`);
+      }
+    }
+  }
+  return options;
+}
+function queryRole(scope, options, internal) {
+  const result = [];
+  const match = (element) => {
+    if (getAriaRole(element) !== options.role)
+      return;
+    if (options.selected !== void 0 && getAriaSelected(element) !== options.selected)
+      return;
+    if (options.checked !== void 0 && getAriaChecked(element) !== options.checked)
+      return;
+    if (options.pressed !== void 0 && getAriaPressed(element) !== options.pressed)
+      return;
+    if (options.expanded !== void 0 && getAriaExpanded(element) !== options.expanded)
+      return;
+    if (options.level !== void 0 && getAriaLevel(element) !== options.level)
+      return;
+    if (options.disabled !== void 0 && getAriaDisabled(element) !== options.disabled)
+      return;
+    if (!options.includeHidden) {
+      const isHidden = isElementHiddenForAria(element);
+      if (isHidden)
+        return;
+    }
+    if (options.name !== void 0) {
+      const accessibleName = normalizeWhiteSpace(getElementAccessibleName(element, !!options.includeHidden));
+      if (typeof options.name === "string")
+        options.name = normalizeWhiteSpace(options.name);
+      if (internal && !options.exact && options.nameOp === "=")
+        options.nameOp = "*=";
+      if (!matchesAttributePart(accessibleName, { name: "", jsonPath: [], op: options.nameOp || "=", value: options.name, caseSensitive: !!options.exact }))
+        return;
+    }
+    result.push(element);
+  };
+  const query = (root) => {
+    const shadows = [];
+    if (root.shadowRoot)
+      shadows.push(root.shadowRoot);
+    for (const element of root.querySelectorAll("*")) {
+      match(element);
+      if (element.shadowRoot)
+        shadows.push(element.shadowRoot);
+    }
+    shadows.forEach(query);
+  };
+  query(scope);
+  return result;
+}
+function createRoleEngine(internal) {
+  return {
+    queryAll: (scope, selector) => {
+      const parsed = parseAttributeSelector(selector, true);
+      const role = parsed.name.toLowerCase();
+      if (!role)
+        throw new Error(`Role must not be empty`);
+      const options = validateAttributes(parsed.attributes, role);
+      beginAriaCaches();
+      try {
+        return queryRole(scope, options, internal);
+      } finally {
+        endAriaCaches();
+      }
+    }
+  };
+}
+
+
 // k6BrowserNative allows accessing native browser objects
 // even if the page under test has overridden them.
 const k6BrowserNative = (() => {
@@ -225,6 +1478,7 @@ class InjectedScript {
       css: new CSSQueryEngine(),
       text: new TextQueryEngine(),
       xpath: new XPathQueryEngine(),
+      role: createRoleEngine(false),
     };
   }
 

--- a/internal/js/modules/k6/browser/common/js/injected_script.js
+++ b/internal/js/modules/k6/browser/common/js/injected_script.js
@@ -1478,7 +1478,7 @@ class InjectedScript {
       css: new CSSQueryEngine(),
       text: new TextQueryEngine(),
       xpath: new XPathQueryEngine(),
-      role: createRoleEngine(false),
+      'internal:role': createRoleEngine(true),
     };
   }
 

--- a/internal/js/modules/k6/browser/common/locator_options.go
+++ b/internal/js/modules/k6/browser/common/locator_options.go
@@ -1,0 +1,81 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/internal/js/modules/k6/browser/k6ext"
+)
+
+// GetByRoleOptions are the optional options fow when working with the
+// GetByRole API.
+type GetByRoleOptions struct {
+	Checked       *bool   `json:"checked"`
+	Disabled      *bool   `json:"disabled"`
+	Exact         *bool   `json:"exact"`
+	Expanded      *bool   `json:"expanded"`
+	IncludeHidden *bool   `json:"includeHidden"`
+	Level         *int64  `json:"level"`
+	Name          *string `json:"name"`
+	Pressed       *bool   `json:"pressed"`
+	Selected      *bool   `json:"selected"`
+}
+
+// NewGetByRoleOptions will create a new empty GetByRoleOptions instance.
+func NewGetByRoleOptions() *GetByRoleOptions {
+	return &GetByRoleOptions{}
+}
+
+// Parse parses the GetByRole options from the Sobek.Value.
+func (o *GetByRoleOptions) Parse(ctx context.Context, opts sobek.Value) error {
+	if !sobekValueExists(opts) {
+		return nil
+	}
+
+	rt := k6ext.Runtime(ctx)
+
+	obj := opts.ToObject(rt)
+	for _, k := range obj.Keys() {
+		switch k {
+		case "checked":
+			val := obj.Get(k).ToBoolean()
+			o.Checked = &val
+		case "disabled":
+			val := obj.Get(k).ToBoolean()
+			o.Disabled = &val
+		case "exact":
+			val := obj.Get(k).ToBoolean()
+			o.Exact = &val
+		case "expanded":
+			val := obj.Get(k).ToBoolean()
+			o.Expanded = &val
+		case "includeHidden":
+			val := obj.Get(k).ToBoolean()
+			o.IncludeHidden = &val
+		case "level":
+			val := obj.Get(k).ToInteger()
+			o.Level = &val
+		case "name":
+			var val string
+			switch obj.Get(k).ExportType() {
+			case reflect.TypeOf(string("")):
+				val = fmt.Sprintf("'%s'", obj.Get(k).String()) // Strings require quotes
+			case reflect.TypeOf(map[string]interface{}(nil)): // JS RegExp
+				val = obj.Get(k).String() // No quotes
+			default: // CSS, numbers or booleans
+				val = obj.Get(k).String() // No quotes
+			}
+			o.Name = &val
+		case "pressed":
+			val := obj.Get(k).ToBoolean()
+			o.Pressed = &val
+		case "selected":
+			val := obj.Get(k).ToBoolean()
+			o.Selected = &val
+		}
+	}
+
+	return nil
+}

--- a/internal/js/modules/k6/browser/common/locator_options.go
+++ b/internal/js/modules/k6/browser/common/locator_options.go
@@ -1,14 +1,5 @@
 package common
 
-import (
-	"context"
-	"fmt"
-	"reflect"
-
-	"github.com/grafana/sobek"
-	"go.k6.io/k6/internal/js/modules/k6/browser/k6ext"
-)
-
 // GetByRoleOptions are the optional options fow when working with the
 // GetByRole API.
 type GetByRoleOptions struct {
@@ -21,61 +12,4 @@ type GetByRoleOptions struct {
 	Name          *string `json:"name"`
 	Pressed       *bool   `json:"pressed"`
 	Selected      *bool   `json:"selected"`
-}
-
-// NewGetByRoleOptions will create a new empty GetByRoleOptions instance.
-func NewGetByRoleOptions() *GetByRoleOptions {
-	return &GetByRoleOptions{}
-}
-
-// Parse parses the GetByRole options from the Sobek.Value.
-func (o *GetByRoleOptions) Parse(ctx context.Context, opts sobek.Value) error {
-	if !sobekValueExists(opts) {
-		return nil
-	}
-
-	rt := k6ext.Runtime(ctx)
-
-	obj := opts.ToObject(rt)
-	for _, k := range obj.Keys() {
-		switch k {
-		case "checked":
-			val := obj.Get(k).ToBoolean()
-			o.Checked = &val
-		case "disabled":
-			val := obj.Get(k).ToBoolean()
-			o.Disabled = &val
-		case "exact":
-			val := obj.Get(k).ToBoolean()
-			o.Exact = &val
-		case "expanded":
-			val := obj.Get(k).ToBoolean()
-			o.Expanded = &val
-		case "includeHidden":
-			val := obj.Get(k).ToBoolean()
-			o.IncludeHidden = &val
-		case "level":
-			val := obj.Get(k).ToInteger()
-			o.Level = &val
-		case "name":
-			var val string
-			switch obj.Get(k).ExportType() {
-			case reflect.TypeOf(string("")):
-				val = fmt.Sprintf("'%s'", obj.Get(k).String()) // Strings require quotes
-			case reflect.TypeOf(map[string]interface{}(nil)): // JS RegExp
-				val = obj.Get(k).String() // No quotes
-			default: // CSS, numbers or booleans
-				val = obj.Get(k).String() // No quotes
-			}
-			o.Name = &val
-		case "pressed":
-			val := obj.Get(k).ToBoolean()
-			o.Pressed = &val
-		case "selected":
-			val := obj.Get(k).ToBoolean()
-			o.Selected = &val
-		}
-	}
-
-	return nil
 }

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1087,6 +1087,13 @@ func (p *Page) GetAttribute(selector string, name string, popts *FrameBaseOption
 	return p.MainFrame().GetAttribute(selector, name, popts)
 }
 
+// GetByRole creates and returns a new locator for this page (main frame) based on their ARIA role.
+func (p *Page) GetByRole(role string, opts *GetByRoleOptions) *Locator {
+	p.logger.Debugf("Page:GetByRole", "sid:%s role: %q opts:%+v", p.sessionID(), role, opts)
+
+	return p.MainFrame().GetByRole(role, opts)
+}
+
 // GetKeyboard returns the keyboard for the page.
 func (p *Page) GetKeyboard() *Keyboard {
 	return p.Keyboard

--- a/internal/js/modules/k6/browser/common/selectors.go
+++ b/internal/js/modules/k6/browser/common/selectors.go
@@ -91,6 +91,9 @@ func (s *Selector) parse() error {
 			// If selector starts with '..', consider xpath as well.
 			name = "xpath"
 			body = part
+		case strings.HasPrefix(part, "role="):
+			name = "role"
+			body = part
 		default:
 			name = "css"
 			body = part

--- a/internal/js/modules/k6/browser/common/selectors.go
+++ b/internal/js/modules/k6/browser/common/selectors.go
@@ -91,8 +91,8 @@ func (s *Selector) parse() error {
 			// If selector starts with '..', consider xpath as well.
 			name = "xpath"
 			body = part
-		case strings.HasPrefix(part, "role="):
-			name = "role"
+		case strings.HasPrefix(part, "internal:role="):
+			name = "internal:role"
 			body = part
 		default:
 			name = "css"

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -1,3 +1,6 @@
+// practically none of this work on windows
+//go:build !windows
+
 package tests
 
 import (

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -12,10 +12,6 @@ import (
 	"go.k6.io/k6/internal/js/modules/k6/browser/common"
 )
 
-func ptr[T any](v T) *T {
-	return &v
-}
-
 func TestGetByRoleSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -47,31 +43,31 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "link",
 				role:     "link",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Link text'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Link text'`)},
 				expected: 1, expectedText: "Link text",
 			},
 			{
 				name:     "area",
 				role:     "link",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Map area'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Map area'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "button",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Click'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Click'`)},
 				expected: 1, expectedText: "Click",
 			},
 			{
 				name:     "submit_type",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Submit'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Submit'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "image_type",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Image Button'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Image Button'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -87,13 +83,13 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "text_type",
 				role:     "textbox",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Text type'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Text type'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "textarea",
 				role:     "textbox",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Text area'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Text area'`)},
 				expected: 1, expectedText: "Textarea",
 			},
 			{
@@ -124,7 +120,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "details_summary",
 				role:     "group",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'details'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'details'`)},
 				expected: 1, expectedText: "SummaryDetails",
 			},
 			{
@@ -135,37 +131,37 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "h1",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: ptr(int64(1))},
+				opts:     &common.GetByRoleOptions{Level: toPtr(int64(1))},
 				expected: 1, expectedText: "Heading1",
 			},
 			{
 				name:     "h2",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: ptr(int64(2))},
+				opts:     &common.GetByRoleOptions{Level: toPtr(int64(2))},
 				expected: 1, expectedText: "Heading2",
 			},
 			{
 				name:     "h3",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: ptr(int64(3))},
+				opts:     &common.GetByRoleOptions{Level: toPtr(int64(3))},
 				expected: 1, expectedText: "Heading3",
 			},
 			{
 				name:     "h4",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: ptr(int64(4))},
+				opts:     &common.GetByRoleOptions{Level: toPtr(int64(4))},
 				expected: 1, expectedText: "Heading4",
 			},
 			{
 				name:     "h5",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: ptr(int64(5))},
+				opts:     &common.GetByRoleOptions{Level: toPtr(int64(5))},
 				expected: 1, expectedText: "Heading5",
 			},
 			{
 				name:     "h6",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: ptr(int64(6))},
+				opts:     &common.GetByRoleOptions{Level: toPtr(int64(6))},
 				expected: 1, expectedText: "Heading6",
 			},
 			{
@@ -176,7 +172,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "img",
 				role:     "img",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Img'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Img'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -187,25 +183,25 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "ul_list",
 				role:     "list",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'ul'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'ul'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "ol_list",
 				role:     "list",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'ol'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'ol'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "ul_li_listitem",
 				role:     "listitem",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'ul-li'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'ul-li'`)},
 				expected: 1, expectedText: "Item1",
 			},
 			{
 				name:     "ol_li_listitem",
 				role:     "listitem",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'ol-li'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'ol-li'`)},
 				expected: 1, expectedText: "Item2",
 			},
 			{
@@ -221,19 +217,19 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "fieldset_legend",
 				role:     "group",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Legend'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Legend'`)},
 				expected: 1, expectedText: "Legend",
 			},
 			{
 				name:     "figure_figcaption",
 				role:     "figure",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Caption'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Caption'`)},
 				expected: 1, expectedText: "Caption",
 			},
 			{
 				name:     "table",
 				role:     "table",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'table1'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'table1'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -249,43 +245,43 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "table_head_cell",
 				role:     "cell",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'th'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'th'`)},
 				expected: 1, expectedText: "Head Cell",
 			},
 			{
 				name:     "table_head_gridcell",
 				role:     "gridcell",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'th gridcell'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'th gridcell'`)},
 				expected: 1, expectedText: "Head Gridcell",
 			},
 			{
 				name:     "table_body",
 				role:     "rowgroup",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'tbody'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'tbody'`)},
 				expected: 1, expectedText: "Cell",
 			},
 			{
 				name:     "table_foot",
 				role:     "rowgroup",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'tfoot'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'tfoot'`)},
 				expected: 1, expectedText: "Foot",
 			},
 			{
 				name:     "table_tr",
 				role:     "row",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'tr'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'tr'`)},
 				expected: 1, expectedText: "Row",
 			},
 			{
 				name:     "table_td_cell",
 				role:     "cell",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'td'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'td'`)},
 				expected: 1, expectedText: "Column Cell",
 			},
 			{
 				name:     "table_td_gridcell",
 				role:     "gridcell",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'td gridcell'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'td gridcell'`)},
 				expected: 1, expectedText: "Column Gridcell",
 			},
 			{
@@ -324,14 +320,14 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "form",
 				role:     "form",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'form'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'form'`)},
 				expected: 1, expectedText: "",
 			},
 			// Only works with aria labels.
 			{
 				name:     "section",
 				role:     "region",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Region Section'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Region Section'`)},
 				expected: 1, expectedText: "Region content",
 			},
 			{
@@ -377,7 +373,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "menu",
 				role:     "list",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'menu'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'menu'`)},
 				expected: 1, expectedText: "Menu item",
 			},
 			{
@@ -408,7 +404,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "svg",
 				role:     "img",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'svg'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'svg'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -419,13 +415,13 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "select",
 				role:     "combobox",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'select'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'select'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "select_multiple",
 				role:     "listbox",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'select multiple'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'select multiple'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -437,7 +433,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			// {
 			// 	name:     "optgroup",
 			// 	role:     "group",
-			// 	opts:     &common.GetByRoleOptions{Name: ptr(`'optgroup'`)},
+			// 	opts:     &common.GetByRoleOptions{Name: toPtr(`'optgroup'`)},
 			// 	expected: 1, expectedText: "",
 			// },
 		}
@@ -612,97 +608,97 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "text_content_as_name",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Submit Form'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Submit Form'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "aria_label_as_name",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Save Draft'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Save Draft'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "aria_labelledby_as_name",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Upload'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Upload'`)},
 				expected: 1, expectedText: "labelledby-upload-button",
 			},
 			{
 				name:     "hidden_text_nodes_should_be_ignored",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'FooBar'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'FooBar'`)},
 				expected: 0, expectedText: "",
 			},
 			{
 				name:     "only_visible_node",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Bar'`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Bar'`)},
 				expected: 1, expectedText: "Bar",
 			},
 			{
 				name:     "regex_matching",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Name: ptr(`/^[a-z0-9]+$/`)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`/^[a-z0-9]+$/`)},
 				expected: 1, expectedText: "abc123",
 			},
 			{
 				name:     "selected_option",
 				role:     "option",
-				opts:     &common.GetByRoleOptions{Selected: ptr(true)},
+				opts:     &common.GetByRoleOptions{Selected: toPtr(true)},
 				expected: 1, expectedText: "One",
 			},
 			{
 				name:     "pressed_option",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Pressed: ptr(true)},
+				opts:     &common.GetByRoleOptions{Pressed: toPtr(true)},
 				expected: 1, expectedText: "Toggle",
 			},
 			{
 				name:     "expanded_option",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Expanded: ptr(true)},
+				opts:     &common.GetByRoleOptions{Expanded: toPtr(true)},
 				expected: 1, expectedText: "Expanded",
 			},
 			{
 				name:     "level_option",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: ptr(int64(6))},
+				opts:     &common.GetByRoleOptions{Level: toPtr(int64(6))},
 				expected: 1, expectedText: "Section",
 			},
 			{
 				name:     "checked_option",
 				role:     "checkbox",
-				opts:     &common.GetByRoleOptions{Checked: ptr(true)},
+				opts:     &common.GetByRoleOptions{Checked: toPtr(true)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "radio_checked_option",
 				role:     "radio",
-				opts:     &common.GetByRoleOptions{Checked: ptr(true)},
+				opts:     &common.GetByRoleOptions{Checked: toPtr(true)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "disabled_option",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Disabled: ptr(true)},
+				opts:     &common.GetByRoleOptions{Disabled: toPtr(true)},
 				expected: 1, expectedText: "Go",
 			},
 			{
 				name:     "include_css_hidden",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Hidden X Button'`), IncludeHidden: ptr(true)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Hidden X Button'`), IncludeHidden: toPtr(true)},
 				expected: 1, expectedText: "X",
 			},
 			{
 				name:     "include_aria_hidden",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: ptr(`'Hidden Hi Button'`), IncludeHidden: ptr(true)},
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Hidden Hi Button'`), IncludeHidden: toPtr(true)},
 				expected: 1, expectedText: "Hi",
 			},
 			{
 				name:     "combo_options",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Pressed: ptr(false), Name: ptr(`'Archive'`), IncludeHidden: ptr(true)},
+				opts:     &common.GetByRoleOptions{Pressed: toPtr(false), Name: toPtr(`'Archive'`), IncludeHidden: toPtr(true)},
 				expected: 1, expectedText: "Combo Options Button",
 			},
 		}
@@ -737,7 +733,7 @@ func TestGetByRoleFailure(t *testing.T) {
 		{
 			"missing_quotes_on_string",
 			"button",
-			&common.GetByRoleOptions{Name: ptr(`Submit Form`)},
+			&common.GetByRoleOptions{Name: toPtr(`Submit Form`)},
 			"Error while parsing selector `button[name=Submit Form]` - unexpected symbol",
 		},
 		{

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -241,7 +241,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "table",
 				role:     "table",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'table'`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'table1'`)},
 				expected: 1, expectedText: "",
 			},
 			{

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -24,6 +24,132 @@ func int64Ptr(i int64) *int64 {
 func TestGetByRoleSuccess(t *testing.T) {
 	t.Parallel()
 
+	// This test all the explicit roles that are valid for the role based
+	// selector engine that is in the injectd_script.js file. Explicit roles
+	// are roles that are explicitly defined in the HTML using the correct
+	// role attribute.
+	t.Run("explicit", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t, withFileServer())
+		p := tb.NewPage(nil)
+		opts := &common.FrameGotoOptions{
+			Timeout: common.DefaultTimeout,
+		}
+		_, err := p.Goto(
+			tb.staticURL("get_by_role_explicit.html"),
+			opts,
+		)
+		require.NoError(t, err)
+
+		tests := []struct {
+			role         string
+			expected     int
+			expectedText string
+		}{
+			{role: "alert", expected: 1, expectedText: "Alert"},
+			{role: "alertdialog", expected: 1, expectedText: "Alert Dialog"},
+			{role: "application", expected: 1, expectedText: "Application"},
+			{role: "article", expected: 1, expectedText: "Article"},
+			{role: "banner", expected: 1, expectedText: "Banner"},
+			{role: "blockquote", expected: 1, expectedText: "Blockquote"},
+			{role: "button", expected: 1, expectedText: "Button"},
+			{role: "caption", expected: 1, expectedText: "Caption"},
+			{role: "cell", expected: 1, expectedText: "Cell"},
+			{role: "checkbox", expected: 1, expectedText: "Checkbox"},
+			{role: "code", expected: 1, expectedText: "Code"},
+			{role: "columnheader", expected: 1, expectedText: "Column Header"},
+			{role: "combobox", expected: 1, expectedText: "Combobox"},
+			{role: "complementary", expected: 1, expectedText: "Complementary"},
+			{role: "contentinfo", expected: 1, expectedText: "Content Info"},
+			{role: "definition", expected: 1, expectedText: "Definition"},
+			{role: "deletion", expected: 1, expectedText: "Deletion"},
+			{role: "dialog", expected: 1, expectedText: "Dialog"},
+			{role: "directory", expected: 1, expectedText: "Directory"},
+			// The original document plus the one within the html <section>
+			{role: "document", expected: 2, expectedText: ""},
+			{role: "emphasis", expected: 1, expectedText: "Emphasis"},
+			{role: "feed", expected: 1, expectedText: "Feed"},
+			{role: "figure", expected: 1, expectedText: "Figure"},
+			{role: "form", expected: 1, expectedText: "Form"},
+			{role: "generic", expected: 1, expectedText: "Generic"},
+			{role: "grid", expected: 1, expectedText: "Grid"},
+			{role: "gridcell", expected: 1, expectedText: "Grid Cell"},
+			{role: "group", expected: 1, expectedText: "Group"},
+			{role: "heading", expected: 1, expectedText: "Heading"},
+			{role: "img", expected: 1, expectedText: "Image"},
+			{role: "insertion", expected: 1, expectedText: "Insertion"},
+			{role: "link", expected: 1, expectedText: "Link"},
+			{role: "list", expected: 1, expectedText: "List"},
+			{role: "listbox", expected: 1, expectedText: "List Box"},
+			{role: "listitem", expected: 1, expectedText: "List Item"},
+			{role: "log", expected: 1, expectedText: "Log"},
+			{role: "main", expected: 1, expectedText: "Main"},
+			{role: "mark", expected: 1, expectedText: "Mark"},
+			{role: "marquee", expected: 1, expectedText: "Marquee"},
+			{role: "math", expected: 1, expectedText: "Math"},
+			{role: "meter", expected: 1, expectedText: "Meter"},
+			{role: "menu", expected: 1, expectedText: "Menu"},
+			{role: "menubar", expected: 1, expectedText: "Menu Bar"},
+			{role: "menuitem", expected: 1, expectedText: "Menu Item"},
+			{role: "menuitemcheckbox", expected: 1, expectedText: "Menu Item Checkbox"},
+			{role: "menuitemradio", expected: 1, expectedText: "Menu Item Radio"},
+			{role: "navigation", expected: 1, expectedText: "Navigation"},
+			{role: "note", expected: 1, expectedText: "Note"},
+			{role: "none", expected: 1, expectedText: "None"},
+			{role: "option", expected: 1, expectedText: "Option"},
+			{role: "paragraph", expected: 1, expectedText: "Paragraph"},
+			{role: "presentation", expected: 1, expectedText: "Presentation"},
+			{role: "progressbar", expected: 1, expectedText: "Progress Bar"},
+			{role: "radio", expected: 1, expectedText: "Radio"},
+			{role: "radiogroup", expected: 1, expectedText: "Radio Group"},
+			{role: "region", expected: 1, expectedText: "Region"},
+			{role: "row", expected: 1, expectedText: "Row"},
+			{role: "rowgroup", expected: 1, expectedText: "Row Group"},
+			{role: "rowheader", expected: 1, expectedText: "Row Header"},
+			{role: "scrollbar", expected: 1, expectedText: "Scroll Bar"},
+			{role: "search", expected: 1, expectedText: "Search"},
+			{role: "searchbox", expected: 1, expectedText: "Search Box"},
+			{role: "separator", expected: 1, expectedText: "Separator"},
+			{role: "slider", expected: 1, expectedText: "Slider"},
+			{role: "spinbutton", expected: 1, expectedText: "Spin Button"},
+			{role: "strong", expected: 1, expectedText: "Strong"},
+			{role: "subscript", expected: 1, expectedText: "Subscript"},
+			{role: "superscript", expected: 1, expectedText: "Superscript"},
+			{role: "status", expected: 1, expectedText: "Status"},
+			{role: "switch", expected: 1, expectedText: "Switch"},
+			{role: "tab", expected: 1, expectedText: "Tab"},
+			{role: "tablist", expected: 1, expectedText: "Tab List"},
+			{role: "tabpanel", expected: 1, expectedText: "Tab Panel"},
+			{role: "table", expected: 1, expectedText: "Table"},
+			{role: "term", expected: 1, expectedText: "Term"},
+			{role: "textbox", expected: 1, expectedText: "Text Box"},
+			{role: "time", expected: 1, expectedText: "Time"},
+			{role: "timer", expected: 1, expectedText: "Timer"},
+			{role: "toolbar", expected: 1, expectedText: "Toolbar"},
+			{role: "tooltip", expected: 1, expectedText: "Tooltip"},
+			{role: "tree", expected: 1, expectedText: "Tree"},
+			{role: "treegrid", expected: 1, expectedText: "Tree Grid"},
+			{role: "treeitem", expected: 1, expectedText: "Tree Item"},
+		}
+		for _, tt := range tests {
+			t.Run(tt.role, func(t *testing.T) {
+				t.Parallel()
+
+				l := p.GetByRole(tt.role, nil)
+				c, err := l.Count()
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, c)
+
+				if tt.expectedText != "" {
+					text, err := l.InnerText(sobek.Undefined())
+					assert.NoError(t, err)
+					assert.Equal(t, tt.expectedText, text)
+				}
+			})
+		}
+	})
+
 	// This tests all the options, and different attributes (such as explicit
 	// aria attributes vs the text value of an element) that can be used in
 	// the DOM with the same role.

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -55,31 +55,31 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "link",
 				role:     "link",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Link text"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Link text'`)},
 				expected: 1, expectedText: "Link text",
 			},
 			{
 				name:     "area",
 				role:     "link",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Map area"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Map area'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "button",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Click"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Click'`)},
 				expected: 1, expectedText: "Click",
 			},
 			{
 				name:     "submit_type",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Submit"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Submit'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "image_type",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Image Button"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Image Button'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -95,13 +95,13 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "text_type",
 				role:     "textbox",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Text type"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Text type'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "textarea",
 				role:     "textbox",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Text area"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Text area'`)},
 				expected: 1, expectedText: "Textarea",
 			},
 			{
@@ -132,7 +132,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "details_summary",
 				role:     "group",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"details"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'details'`)},
 				expected: 1, expectedText: "SummaryDetails",
 			},
 			{
@@ -184,7 +184,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "img",
 				role:     "img",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Img"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Img'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -195,25 +195,25 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "ul_list",
 				role:     "list",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"ul"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'ul'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "ol_list",
 				role:     "list",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"ol"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'ol'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "ul_li_listitem",
 				role:     "listitem",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"ul-li"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'ul-li'`)},
 				expected: 1, expectedText: "Item1",
 			},
 			{
 				name:     "ol_li_listitem",
 				role:     "listitem",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"ol-li"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'ol-li'`)},
 				expected: 1, expectedText: "Item2",
 			},
 			{
@@ -229,19 +229,19 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "fieldset_legend",
 				role:     "group",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Legend"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Legend'`)},
 				expected: 1, expectedText: "Legend",
 			},
 			{
 				name:     "figure_figcaption",
 				role:     "figure",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Caption"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Caption'`)},
 				expected: 1, expectedText: "Caption",
 			},
 			{
 				name:     "table",
 				role:     "table",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"table"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'table'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -257,43 +257,43 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "table_head_cell",
 				role:     "cell",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"th"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'th'`)},
 				expected: 1, expectedText: "Head Cell",
 			},
 			{
 				name:     "table_head_gridcell",
 				role:     "gridcell",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"th gridcell"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'th gridcell'`)},
 				expected: 1, expectedText: "Head Gridcell",
 			},
 			{
 				name:     "table_body",
 				role:     "rowgroup",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"tbody"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'tbody'`)},
 				expected: 1, expectedText: "Cell",
 			},
 			{
 				name:     "table_foot",
 				role:     "rowgroup",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"tfoot"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'tfoot'`)},
 				expected: 1, expectedText: "Foot",
 			},
 			{
 				name:     "table_tr",
 				role:     "row",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"tr"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'tr'`)},
 				expected: 1, expectedText: "Row",
 			},
 			{
 				name:     "table_td_cell",
 				role:     "cell",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"td"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'td'`)},
 				expected: 1, expectedText: "Column Cell",
 			},
 			{
 				name:     "table_td_gridcell",
 				role:     "gridcell",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"td gridcell"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'td gridcell'`)},
 				expected: 1, expectedText: "Column Gridcell",
 			},
 			{
@@ -332,14 +332,14 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "form",
 				role:     "form",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"form"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'form'`)},
 				expected: 1, expectedText: "",
 			},
 			// Only works with aria labels.
 			{
 				name:     "section",
 				role:     "region",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Region Section"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Region Section'`)},
 				expected: 1, expectedText: "Region content",
 			},
 			{
@@ -385,7 +385,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "menu",
 				role:     "list",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"menu"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'menu'`)},
 				expected: 1, expectedText: "Menu item",
 			},
 			{
@@ -416,7 +416,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "svg",
 				role:     "img",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"svg"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'svg'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -427,13 +427,13 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "select",
 				role:     "combobox",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"select"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'select'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "select_multiple",
 				role:     "listbox",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"select multiple"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'select multiple'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -445,7 +445,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			// {
 			// 	name:     "optgroup",
 			// 	role:     "group",
-			// 	opts:     &common.GetByRoleOptions{Name: stringPtr(`"optgroup"`)},
+			// 	opts:     &common.GetByRoleOptions{Name: stringPtr(`'optgroup'`)},
 			// 	expected: 1, expectedText: "",
 			// },
 		}
@@ -620,31 +620,31 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "text_content_as_name",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Submit Form"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Submit Form'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "aria_label_as_name",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Save Draft"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Save Draft'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "aria_labelledby_as_name",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Upload"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Upload'`)},
 				expected: 1, expectedText: "labelledby-upload-button",
 			},
 			{
 				name:     "hidden_text_nodes_should_be_ignored",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"FooBar"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'FooBar'`)},
 				expected: 0, expectedText: "",
 			},
 			{
 				name:     "only_visible_node",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Bar"`)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Bar'`)},
 				expected: 1, expectedText: "Bar",
 			},
 			{
@@ -698,19 +698,19 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "include_css_hidden",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Hidden X Button"`), IncludeHidden: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Hidden X Button'`), IncludeHidden: boolPtr(true)},
 				expected: 1, expectedText: "X",
 			},
 			{
 				name:     "include_aria_hidden",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Hidden Hi Button"`), IncludeHidden: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Hidden Hi Button'`), IncludeHidden: boolPtr(true)},
 				expected: 1, expectedText: "Hi",
 			},
 			{
 				name:     "combo_options",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Pressed: boolPtr(false), Name: stringPtr(`"Archive"`), IncludeHidden: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Pressed: boolPtr(false), Name: stringPtr(`'Archive'`), IncludeHidden: boolPtr(true)},
 				expected: 1, expectedText: "Combo Options Button",
 			},
 		}

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -612,6 +612,24 @@ func TestGetByRoleSuccess(t *testing.T) {
 				expected: 1, expectedText: "",
 			},
 			{
+				name:     "not_exact",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'submit form'`), Exact: toPtr(false)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "exact_no_match",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'submit form'`), Exact: toPtr(true)},
+				expected: 0, expectedText: "",
+			},
+			{
+				name:     "exact_match",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: toPtr(`'Submit Form'`), Exact: toPtr(true)},
+				expected: 1, expectedText: "",
+			},
+			{
 				name:     "aria_label_as_name",
 				role:     "button",
 				opts:     &common.GetByRoleOptions{Name: toPtr(`'Save Draft'`)},

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -24,6 +24,446 @@ func int64Ptr(i int64) *int64 {
 func TestGetByRoleSuccess(t *testing.T) {
 	t.Parallel()
 
+	// This test all the implicit roles that are valid for the role based
+	// selector engine that is in the injectd_script.js file. Implicit roles
+	// are roles that are not explicitly defined in the HTML, but are
+	// implied by the context of the element.
+	t.Run("implicit", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t, withFileServer())
+		p := tb.NewPage(nil)
+		opts := &common.FrameGotoOptions{
+			Timeout: common.DefaultTimeout,
+		}
+		_, err := p.Goto(
+			tb.staticURL("get_by_role_implicit.html"),
+			opts,
+		)
+		require.NoError(t, err)
+
+		tests := []struct {
+			name         string
+			role         string
+			opts         *common.GetByRoleOptions
+			expected     int
+			expectedText string
+		}{
+			{
+				name:     "link",
+				role:     "link",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Link text"`)},
+				expected: 1, expectedText: "Link text",
+			},
+			{
+				name:     "area",
+				role:     "link",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Map area"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "button",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Click"`)},
+				expected: 1, expectedText: "Click",
+			},
+			{
+				name:     "submit_type",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Submit"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "image_type",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Image Button"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "checkbox_type",
+				role:     "checkbox",
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "radio_type",
+				role:     "radio",
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "text_type",
+				role:     "textbox",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Text type"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "textarea",
+				role:     "textbox",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Text area"`)},
+				expected: 1, expectedText: "Textarea",
+			},
+			{
+				name:     "search_type",
+				role:     "searchbox",
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "range_type",
+				role:     "slider",
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "number_type",
+				role:     "spinbutton",
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "progress",
+				role:     "progressbar",
+				expected: 1, expectedText: "Progress",
+			},
+			{
+				name:     "output",
+				role:     "status",
+				expected: 1, expectedText: "Output",
+			},
+			{
+				name:     "details_summary",
+				role:     "group",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"details"`)},
+				expected: 1, expectedText: "SummaryDetails",
+			},
+			{
+				name:     "dialog",
+				role:     "dialog",
+				expected: 1, expectedText: "Dialog",
+			},
+			{
+				name:     "h1",
+				role:     "heading",
+				opts:     &common.GetByRoleOptions{Level: int64Ptr(1)},
+				expected: 1, expectedText: "Heading1",
+			},
+			{
+				name:     "h2",
+				role:     "heading",
+				opts:     &common.GetByRoleOptions{Level: int64Ptr(2)},
+				expected: 1, expectedText: "Heading2",
+			},
+			{
+				name:     "h3",
+				role:     "heading",
+				opts:     &common.GetByRoleOptions{Level: int64Ptr(3)},
+				expected: 1, expectedText: "Heading3",
+			},
+			{
+				name:     "h4",
+				role:     "heading",
+				opts:     &common.GetByRoleOptions{Level: int64Ptr(4)},
+				expected: 1, expectedText: "Heading4",
+			},
+			{
+				name:     "h5",
+				role:     "heading",
+				opts:     &common.GetByRoleOptions{Level: int64Ptr(5)},
+				expected: 1, expectedText: "Heading5",
+			},
+			{
+				name:     "h6",
+				role:     "heading",
+				opts:     &common.GetByRoleOptions{Level: int64Ptr(6)},
+				expected: 1, expectedText: "Heading6",
+			},
+			{
+				name:     "hr",
+				role:     "separator",
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "img",
+				role:     "img",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Img"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "img_presentation",
+				role:     "presentation",
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "ul_list",
+				role:     "list",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"ul"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "ol_list",
+				role:     "list",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"ol"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "ul_li_listitem",
+				role:     "listitem",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"ul-li"`)},
+				expected: 1, expectedText: "Item1",
+			},
+			{
+				name:     "ol_li_listitem",
+				role:     "listitem",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"ol-li"`)},
+				expected: 1, expectedText: "Item2",
+			},
+			{
+				name:     "dd",
+				role:     "definition",
+				expected: 1, expectedText: "Description",
+			},
+			{
+				name:     "dt_dfn",
+				role:     "term",
+				expected: 2, expectedText: "",
+			},
+			{
+				name:     "fieldset_legend",
+				role:     "group",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Legend"`)},
+				expected: 1, expectedText: "Legend",
+			},
+			{
+				name:     "figure_figcaption",
+				role:     "figure",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Caption"`)},
+				expected: 1, expectedText: "Caption",
+			},
+			{
+				name:     "table",
+				role:     "table",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"table"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "table_scope_row",
+				role:     "rowheader",
+				expected: 1, expectedText: "Head Row",
+			},
+			{
+				name:     "table_scope_col",
+				role:     "columnheader",
+				expected: 1, expectedText: "Head Column",
+			},
+			{
+				name:     "table_head_cell",
+				role:     "cell",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"th"`)},
+				expected: 1, expectedText: "Head Cell",
+			},
+			{
+				name:     "table_head_gridcell",
+				role:     "gridcell",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"th gridcell"`)},
+				expected: 1, expectedText: "Head Gridcell",
+			},
+			{
+				name:     "table_body",
+				role:     "rowgroup",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"tbody"`)},
+				expected: 1, expectedText: "Cell",
+			},
+			{
+				name:     "table_foot",
+				role:     "rowgroup",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"tfoot"`)},
+				expected: 1, expectedText: "Foot",
+			},
+			{
+				name:     "table_tr",
+				role:     "row",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"tr"`)},
+				expected: 1, expectedText: "Row",
+			},
+			{
+				name:     "table_td_cell",
+				role:     "cell",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"td"`)},
+				expected: 1, expectedText: "Column Cell",
+			},
+			{
+				name:     "table_td_gridcell",
+				role:     "gridcell",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"td gridcell"`)},
+				expected: 1, expectedText: "Column Gridcell",
+			},
+			{
+				name:     "main",
+				role:     "main",
+				expected: 1, expectedText: "Main",
+			},
+			{
+				name:     "nav",
+				role:     "navigation",
+				expected: 1, expectedText: "Nav",
+			},
+			{
+				name:     "article",
+				role:     "article",
+				expected: 1, expectedText: "Article",
+			},
+			{
+				name:     "aside",
+				role:     "complementary",
+				expected: 1, expectedText: "Aside",
+			},
+			// Only works when outside the <section> element.
+			{
+				name:     "header",
+				role:     "banner",
+				expected: 1, expectedText: "Header",
+			},
+			// Only works when outside the <section> element.
+			{
+				name:     "footer",
+				role:     "contentinfo",
+				expected: 1, expectedText: "Footer",
+			},
+			// Only works with aria labels.
+			{
+				name:     "form",
+				role:     "form",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"form"`)},
+				expected: 1, expectedText: "",
+			},
+			// Only works with aria labels.
+			{
+				name:     "section",
+				role:     "region",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Region Section"`)},
+				expected: 1, expectedText: "Region content",
+			},
+			{
+				name:     "blockquote",
+				role:     "blockquote",
+				expected: 1, expectedText: "Blockquote text",
+			},
+			{
+				name:     "caption",
+				role:     "caption",
+				expected: 1, expectedText: "Table Caption",
+			},
+			{
+				name:     "code",
+				role:     "code",
+				expected: 1, expectedText: "Code sample",
+			},
+			{
+				name:     "del",
+				role:     "deletion",
+				expected: 1, expectedText: "Deleted text",
+			},
+			{
+				name:     "em",
+				role:     "emphasis",
+				expected: 1, expectedText: "Emphasized text",
+			},
+			{
+				name:     "ins",
+				role:     "insertion",
+				expected: 1, expectedText: "Inserted text",
+			},
+			{
+				name:     "mark",
+				role:     "mark",
+				expected: 1, expectedText: "Marked text",
+			},
+			{
+				name:     "math",
+				role:     "math",
+				expected: 1, expectedText: "x=1",
+			},
+			{
+				name:     "menu",
+				role:     "list",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"menu"`)},
+				expected: 1, expectedText: "Menu item",
+			},
+			{
+				name:     "meter",
+				role:     "meter",
+				expected: 1, expectedText: "50%",
+			},
+			{
+				name:     "p",
+				role:     "paragraph",
+				expected: 1, expectedText: "Paragraph text",
+			},
+			{
+				name:     "strong",
+				role:     "strong",
+				expected: 1, expectedText: "Strong text",
+			},
+			{
+				name:     "sub",
+				role:     "subscript",
+				expected: 1, expectedText: "Subscript",
+			},
+			{
+				name:     "sup",
+				role:     "superscript",
+				expected: 1, expectedText: "Superscript",
+			},
+			{
+				name:     "svg",
+				role:     "img",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"svg"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "time",
+				role:     "time",
+				expected: 1, expectedText: "June 9, 2025",
+			},
+			{
+				name:     "select",
+				role:     "combobox",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"select"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "select_multiple",
+				role:     "listbox",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"select multiple"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "datalist",
+				role:     "listbox",
+				expected: 1, expectedText: "",
+			},
+			// TODO: This is not working, not even in Playwright.
+			// {
+			// 	name:     "optgroup",
+			// 	role:     "group",
+			// 	opts:     &common.GetByRoleOptions{Name: stringPtr(`"optgroup"`)},
+			// 	expected: 1, expectedText: "",
+			// },
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				l := p.GetByRole(tt.role, tt.opts)
+				c, err := l.Count()
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, c)
+
+				if tt.expectedText != "" {
+					text, _, err := l.TextContent(sobek.Undefined())
+					assert.NoError(t, err)
+					assert.Equal(t, tt.expectedText, text)
+				}
+			})
+		}
+	})
+
 	// This test all the explicit roles that are valid for the role based
 	// selector engine that is in the injectd_script.js file. Explicit roles
 	// are roles that are explicitly defined in the HTML using the correct

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -1,0 +1,209 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/grafana/sobek"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/internal/js/modules/k6/browser/common"
+)
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}
+
+func TestGetByRoleSuccess(t *testing.T) {
+	t.Parallel()
+
+	// This tests all the options, and different attributes (such as explicit
+	// aria attributes vs the text value of an element) that can be used in
+	// the DOM with the same role.
+	t.Run("edge_cases", func(t *testing.T) {
+		t.Parallel()
+
+		tb := newTestBrowser(t, withFileServer())
+		p := tb.NewPage(nil)
+		opts := &common.FrameGotoOptions{
+			Timeout: common.DefaultTimeout,
+		}
+		_, err := p.Goto(
+			tb.staticURL("get_by_role_edge_cases.html"),
+			opts,
+		)
+		require.NoError(t, err)
+
+		tests := []struct {
+			name         string
+			role         string
+			opts         *common.GetByRoleOptions
+			expected     int
+			expectedText string
+		}{
+			{
+				name:     "text_content_as_name",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Submit Form"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "aria_label_as_name",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Save Draft"`)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "aria_labelledby_as_name",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Upload"`)},
+				expected: 1, expectedText: "labelledby-upload-button",
+			},
+			{
+				name:     "hidden_text_nodes_should_be_ignored",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"FooBar"`)},
+				expected: 0, expectedText: "",
+			},
+			{
+				name:     "only_visible_node",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Bar"`)},
+				expected: 1, expectedText: "Bar",
+			},
+			{
+				name:     "regex_matching",
+				role:     "heading",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`/^[a-z0-9]+$/`)},
+				expected: 1, expectedText: "abc123",
+			},
+			{
+				name:     "selected_option",
+				role:     "option",
+				opts:     &common.GetByRoleOptions{Selected: boolPtr(true)},
+				expected: 1, expectedText: "One",
+			},
+			{
+				name:     "pressed_option",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Pressed: boolPtr(true)},
+				expected: 1, expectedText: "Toggle",
+			},
+			{
+				name:     "expanded_option",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Expanded: boolPtr(true)},
+				expected: 1, expectedText: "Expanded",
+			},
+			{
+				name:     "level_option",
+				role:     "heading",
+				opts:     &common.GetByRoleOptions{Level: int64Ptr(6)},
+				expected: 1, expectedText: "Section",
+			},
+			{
+				name:     "checked_option",
+				role:     "checkbox",
+				opts:     &common.GetByRoleOptions{Checked: boolPtr(true)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "radio_checked_option",
+				role:     "radio",
+				opts:     &common.GetByRoleOptions{Checked: boolPtr(true)},
+				expected: 1, expectedText: "",
+			},
+			{
+				name:     "disabled_option",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Disabled: boolPtr(true)},
+				expected: 1, expectedText: "Go",
+			},
+			{
+				name:     "include_css_hidden",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Hidden X Button"`), IncludeHidden: boolPtr(true)},
+				expected: 1, expectedText: "X",
+			},
+			{
+				name:     "include_aria_hidden",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Name: stringPtr(`"Hidden Hi Button"`), IncludeHidden: boolPtr(true)},
+				expected: 1, expectedText: "Hi",
+			},
+			{
+				name:     "combo_options",
+				role:     "button",
+				opts:     &common.GetByRoleOptions{Pressed: boolPtr(false), Name: stringPtr(`"Archive"`), IncludeHidden: boolPtr(true)},
+				expected: 1, expectedText: "Combo Options Button",
+			},
+		}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				t.Parallel()
+
+				l := p.GetByRole(tt.role, tt.opts)
+				c, err := l.Count()
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, c)
+
+				if tt.expectedText != "" {
+					text, err := l.InnerText(sobek.Undefined())
+					assert.NoError(t, err)
+					assert.Equal(t, tt.expectedText, text)
+				}
+			})
+		}
+	})
+}
+
+func TestGetByRoleFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		role          string
+		opts          *common.GetByRoleOptions
+		expectedError string
+	}{
+		{
+			"missing_quotes_on_string",
+			"button",
+			&common.GetByRoleOptions{Name: stringPtr(`Submit Form`)},
+			"InvalidSelectorError: Error while parsing selector `button[name=Submit Form]`",
+		},
+		{
+			"missing_role",
+			"",
+			nil,
+			"counting elements: InvalidSelectorError: Error while parsing selector `` - selector cannot be empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tb := newTestBrowser(t, withFileServer())
+			p := tb.NewPage(nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err := p.Goto(
+				tb.staticURL("get_by_role.html"),
+				opts,
+			)
+			require.NoError(t, err)
+
+			l := p.GetByRole(tt.role, tt.opts)
+			_, err = l.Count()
+			assert.ErrorContains(t, err, tt.expectedError)
+		})
+	}
+}

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -743,13 +743,13 @@ func TestGetByRoleFailure(t *testing.T) {
 			"missing_quotes_on_string",
 			"button",
 			&common.GetByRoleOptions{Name: stringPtr(`Submit Form`)},
-			"InvalidSelectorError: Error while parsing selector `button[name=Submit Form]`",
+			"Error while parsing selector `button[name=Submit Form]` - unexpected symbol",
 		},
 		{
 			"missing_role",
 			"",
 			nil,
-			"counting elements: InvalidSelectorError: Error while parsing selector `` - selector cannot be empty",
+			"Error while parsing selector `` - selector cannot be empty",
 		},
 	}
 	for _, tt := range tests {

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -12,16 +12,8 @@ import (
 	"go.k6.io/k6/internal/js/modules/k6/browser/common"
 )
 
-func stringPtr(s string) *string {
-	return &s
-}
-
-func boolPtr(b bool) *bool {
-	return &b
-}
-
-func int64Ptr(i int64) *int64 {
-	return &i
+func ptr[T any](v T) *T {
+	return &v
 }
 
 func TestGetByRoleSuccess(t *testing.T) {
@@ -55,31 +47,31 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "link",
 				role:     "link",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Link text'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Link text'`)},
 				expected: 1, expectedText: "Link text",
 			},
 			{
 				name:     "area",
 				role:     "link",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Map area'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Map area'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "button",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Click'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Click'`)},
 				expected: 1, expectedText: "Click",
 			},
 			{
 				name:     "submit_type",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Submit'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Submit'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "image_type",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Image Button'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Image Button'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -95,13 +87,13 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "text_type",
 				role:     "textbox",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Text type'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Text type'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "textarea",
 				role:     "textbox",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Text area'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Text area'`)},
 				expected: 1, expectedText: "Textarea",
 			},
 			{
@@ -132,7 +124,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "details_summary",
 				role:     "group",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'details'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'details'`)},
 				expected: 1, expectedText: "SummaryDetails",
 			},
 			{
@@ -143,37 +135,37 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "h1",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: int64Ptr(1)},
+				opts:     &common.GetByRoleOptions{Level: ptr(int64(1))},
 				expected: 1, expectedText: "Heading1",
 			},
 			{
 				name:     "h2",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: int64Ptr(2)},
+				opts:     &common.GetByRoleOptions{Level: ptr(int64(2))},
 				expected: 1, expectedText: "Heading2",
 			},
 			{
 				name:     "h3",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: int64Ptr(3)},
+				opts:     &common.GetByRoleOptions{Level: ptr(int64(3))},
 				expected: 1, expectedText: "Heading3",
 			},
 			{
 				name:     "h4",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: int64Ptr(4)},
+				opts:     &common.GetByRoleOptions{Level: ptr(int64(4))},
 				expected: 1, expectedText: "Heading4",
 			},
 			{
 				name:     "h5",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: int64Ptr(5)},
+				opts:     &common.GetByRoleOptions{Level: ptr(int64(5))},
 				expected: 1, expectedText: "Heading5",
 			},
 			{
 				name:     "h6",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: int64Ptr(6)},
+				opts:     &common.GetByRoleOptions{Level: ptr(int64(6))},
 				expected: 1, expectedText: "Heading6",
 			},
 			{
@@ -184,7 +176,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "img",
 				role:     "img",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Img'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Img'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -195,25 +187,25 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "ul_list",
 				role:     "list",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'ul'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'ul'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "ol_list",
 				role:     "list",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'ol'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'ol'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "ul_li_listitem",
 				role:     "listitem",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'ul-li'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'ul-li'`)},
 				expected: 1, expectedText: "Item1",
 			},
 			{
 				name:     "ol_li_listitem",
 				role:     "listitem",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'ol-li'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'ol-li'`)},
 				expected: 1, expectedText: "Item2",
 			},
 			{
@@ -229,19 +221,19 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "fieldset_legend",
 				role:     "group",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Legend'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Legend'`)},
 				expected: 1, expectedText: "Legend",
 			},
 			{
 				name:     "figure_figcaption",
 				role:     "figure",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Caption'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Caption'`)},
 				expected: 1, expectedText: "Caption",
 			},
 			{
 				name:     "table",
 				role:     "table",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'table1'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'table1'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -257,43 +249,43 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "table_head_cell",
 				role:     "cell",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'th'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'th'`)},
 				expected: 1, expectedText: "Head Cell",
 			},
 			{
 				name:     "table_head_gridcell",
 				role:     "gridcell",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'th gridcell'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'th gridcell'`)},
 				expected: 1, expectedText: "Head Gridcell",
 			},
 			{
 				name:     "table_body",
 				role:     "rowgroup",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'tbody'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'tbody'`)},
 				expected: 1, expectedText: "Cell",
 			},
 			{
 				name:     "table_foot",
 				role:     "rowgroup",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'tfoot'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'tfoot'`)},
 				expected: 1, expectedText: "Foot",
 			},
 			{
 				name:     "table_tr",
 				role:     "row",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'tr'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'tr'`)},
 				expected: 1, expectedText: "Row",
 			},
 			{
 				name:     "table_td_cell",
 				role:     "cell",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'td'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'td'`)},
 				expected: 1, expectedText: "Column Cell",
 			},
 			{
 				name:     "table_td_gridcell",
 				role:     "gridcell",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'td gridcell'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'td gridcell'`)},
 				expected: 1, expectedText: "Column Gridcell",
 			},
 			{
@@ -332,14 +324,14 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "form",
 				role:     "form",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'form'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'form'`)},
 				expected: 1, expectedText: "",
 			},
 			// Only works with aria labels.
 			{
 				name:     "section",
 				role:     "region",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Region Section'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Region Section'`)},
 				expected: 1, expectedText: "Region content",
 			},
 			{
@@ -385,7 +377,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "menu",
 				role:     "list",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'menu'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'menu'`)},
 				expected: 1, expectedText: "Menu item",
 			},
 			{
@@ -416,7 +408,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "svg",
 				role:     "img",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'svg'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'svg'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -427,13 +419,13 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "select",
 				role:     "combobox",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'select'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'select'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "select_multiple",
 				role:     "listbox",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'select multiple'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'select multiple'`)},
 				expected: 1, expectedText: "",
 			},
 			{
@@ -445,7 +437,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 			// {
 			// 	name:     "optgroup",
 			// 	role:     "group",
-			// 	opts:     &common.GetByRoleOptions{Name: stringPtr(`'optgroup'`)},
+			// 	opts:     &common.GetByRoleOptions{Name: ptr(`'optgroup'`)},
 			// 	expected: 1, expectedText: "",
 			// },
 		}
@@ -620,97 +612,97 @@ func TestGetByRoleSuccess(t *testing.T) {
 			{
 				name:     "text_content_as_name",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Submit Form'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Submit Form'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "aria_label_as_name",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Save Draft'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Save Draft'`)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "aria_labelledby_as_name",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Upload'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Upload'`)},
 				expected: 1, expectedText: "labelledby-upload-button",
 			},
 			{
 				name:     "hidden_text_nodes_should_be_ignored",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'FooBar'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'FooBar'`)},
 				expected: 0, expectedText: "",
 			},
 			{
 				name:     "only_visible_node",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Bar'`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Bar'`)},
 				expected: 1, expectedText: "Bar",
 			},
 			{
 				name:     "regex_matching",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`/^[a-z0-9]+$/`)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`/^[a-z0-9]+$/`)},
 				expected: 1, expectedText: "abc123",
 			},
 			{
 				name:     "selected_option",
 				role:     "option",
-				opts:     &common.GetByRoleOptions{Selected: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Selected: ptr(true)},
 				expected: 1, expectedText: "One",
 			},
 			{
 				name:     "pressed_option",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Pressed: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Pressed: ptr(true)},
 				expected: 1, expectedText: "Toggle",
 			},
 			{
 				name:     "expanded_option",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Expanded: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Expanded: ptr(true)},
 				expected: 1, expectedText: "Expanded",
 			},
 			{
 				name:     "level_option",
 				role:     "heading",
-				opts:     &common.GetByRoleOptions{Level: int64Ptr(6)},
+				opts:     &common.GetByRoleOptions{Level: ptr(int64(6))},
 				expected: 1, expectedText: "Section",
 			},
 			{
 				name:     "checked_option",
 				role:     "checkbox",
-				opts:     &common.GetByRoleOptions{Checked: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Checked: ptr(true)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "radio_checked_option",
 				role:     "radio",
-				opts:     &common.GetByRoleOptions{Checked: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Checked: ptr(true)},
 				expected: 1, expectedText: "",
 			},
 			{
 				name:     "disabled_option",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Disabled: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Disabled: ptr(true)},
 				expected: 1, expectedText: "Go",
 			},
 			{
 				name:     "include_css_hidden",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Hidden X Button'`), IncludeHidden: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Hidden X Button'`), IncludeHidden: ptr(true)},
 				expected: 1, expectedText: "X",
 			},
 			{
 				name:     "include_aria_hidden",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Name: stringPtr(`'Hidden Hi Button'`), IncludeHidden: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Name: ptr(`'Hidden Hi Button'`), IncludeHidden: ptr(true)},
 				expected: 1, expectedText: "Hi",
 			},
 			{
 				name:     "combo_options",
 				role:     "button",
-				opts:     &common.GetByRoleOptions{Pressed: boolPtr(false), Name: stringPtr(`'Archive'`), IncludeHidden: boolPtr(true)},
+				opts:     &common.GetByRoleOptions{Pressed: ptr(false), Name: ptr(`'Archive'`), IncludeHidden: ptr(true)},
 				expected: 1, expectedText: "Combo Options Button",
 			},
 		}
@@ -745,7 +737,7 @@ func TestGetByRoleFailure(t *testing.T) {
 		{
 			"missing_quotes_on_string",
 			"button",
-			&common.GetByRoleOptions{Name: stringPtr(`Submit Form`)},
+			&common.GetByRoleOptions{Name: ptr(`Submit Form`)},
 			"Error while parsing selector `button[name=Submit Form]` - unexpected symbol",
 		},
 		{

--- a/internal/js/modules/k6/browser/tests/static/get_by_role_edge_cases.html
+++ b/internal/js/modules/k6/browser/tests/static/get_by_role_edge_cases.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<head>
+  <title>Role Selector Engine Test Suite</title>
+</head>
+<body>
+  <!-- 1. Name Matching -->
+  <section>
+    <!-- Text content as name -->
+    <button>Submit Form</button>
+    <!-- aria-label -->
+    <button aria-label="Save Draft"></button>
+    <!-- aria-labelledby -->
+    <span id="label-source">Upload</span>
+    <div role="button" aria-labelledby="label-source">labelledby-upload-button</div>
+    <!-- Hidden text nodes should be ignored -->
+    <button><span style="display:none">Foo</span>Bar</button>
+  </section>
+
+  <!-- 2. Regex matching -->
+  <section>
+    <h3>abc123</h3>
+  </section>
+
+  <!-- 3. State Filters -->
+  <section>
+    <!-- select (listbox) -->
+    <select>
+      <option selected>One</option>
+      <option>Two</option>
+    </select>
+    <!-- pressed (aria-pressed) -->
+    <button aria-pressed="true">Toggle</button>
+    <!-- expanded (aria-expanded) -->
+    <div role="button" aria-expanded="true">Expanded</div>
+    <!-- level (heading) -->
+    <h6>Section</h6>
+    <!-- checked (checkbox/radio) -->
+    <input type="checkbox" checked>
+    <input type="radio" name="group1" checked>
+    <!-- disabled (native) -->
+    <button disabled>Go</button>
+  </section>
+
+  <!-- 4. Hidden Filtering -->
+  <section>
+    <!-- CSS hidden -->
+    <button style="display:none" aria-label="Hidden X Button">X</button>
+    <!-- aria-hidden -->
+    <div aria-hidden="true">
+      <button aria-label="Hidden Hi Button">Hi</button>
+    </div>
+  </section>
+
+  <!-- 5. Combination Tests -->
+  <section>
+    <!-- hidden + state + name -->
+    <div role="button" aria-label="Archive" aria-pressed="false" hidden>Combo Options Button</div>
+  </section>
+</body>
+</html>

--- a/internal/js/modules/k6/browser/tests/static/get_by_role_explicit.html
+++ b/internal/js/modules/k6/browser/tests/static/get_by_role_explicit.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<head>
+  <title>Role Selector Engine Test Suite</title>
+</head>
+<body>
+  <!-- 6. Explicit ARIA roles -->
+  <section>
+    <div role="alert">Alert</div>
+    <div role="alertdialog">Alert Dialog</div>
+    <div role="application">Application</div>
+    <div role="article">Article</div>
+    <div role="banner">Banner</div>
+    <div role="blockquote">Blockquote</div>
+    <div role="button">Button</div>
+    <div role="caption">Caption</div>
+    <div role="cell">Cell</div>
+    <div role="checkbox">Checkbox</div>
+    <div role="code">Code</div>
+    <div role="columnheader">Column Header</div>
+    <div role="combobox">Combobox</div>
+    <div role="complementary">Complementary</div>
+    <div role="contentinfo">Content Info</div>
+    <div role="definition">Definition</div>
+    <div role="deletion">Deletion</div>
+    <div role="dialog">Dialog</div>
+    <div role="directory">Directory</div>
+    <div role="document">Document</div>
+    <div role="emphasis">Emphasis</div>
+    <div role="feed">Feed</div>
+    <div role="figure">Figure</div>
+    <div role="form">Form</div>
+    <div role="generic">Generic</div>
+    <div role="grid">Grid</div>
+    <div role="gridcell">Grid Cell</div>
+    <div role="group">Group</div>
+    <div role="heading">Heading</div>
+    <div role="img">Image</div>
+    <div role="insertion">Insertion</div>
+    <div role="link">Link</div>
+    <div role="list">List</div>
+    <div role="listbox">List Box</div>
+    <div role="listitem">List Item</div>
+    <div role="log">Log</div>
+    <div role="main">Main</div>
+    <div role="mark">Mark</div>
+    <div role="marquee">Marquee</div>
+    <div role="math">Math</div>
+    <div role="meter">Meter</div>
+    <div role="menu">Menu</div>
+    <div role="menubar">Menu Bar</div>
+    <div role="menuitem">Menu Item</div>
+    <div role="menuitemcheckbox">Menu Item Checkbox</div>
+    <div role="menuitemradio">Menu Item Radio</div>
+    <div role="navigation">Navigation</div>
+    <div role="note">Note</div>
+    <div role="none">None</div>
+    <div role="option">Option</div>
+    <div role="paragraph">Paragraph</div>
+    <div role="presentation">Presentation</div>
+    <div role="progressbar">Progress Bar</div>
+    <div role="radio">Radio</div>
+    <div role="radiogroup">Radio Group</div>
+    <div role="region">Region</div>
+    <div role="row">Row</div>
+    <div role="rowgroup">Row Group</div>
+    <div role="rowheader">Row Header</div>
+    <div role="scrollbar">Scroll Bar</div>
+    <div role="search">Search</div>
+    <div role="searchbox">Search Box</div>
+    <div role="separator">Separator</div>
+    <div role="slider">Slider</div>
+    <div role="spinbutton">Spin Button</div>
+    <div role="strong">Strong</div>
+    <div role="subscript">Subscript</div>
+    <div role="superscript">Superscript</div>
+    <div role="status">Status</div>
+    <div role="switch">Switch</div>
+    <div role="tab">Tab</div>
+    <div role="tablist">Tab List</div>
+    <div role="tabpanel">Tab Panel</div>
+    <div role="table">Table</div>
+    <div role="term">Term</div>
+    <div role="textbox">Text Box</div>
+    <div role="time">Time</div>
+    <div role="timer">Timer</div>
+    <div role="toolbar">Toolbar</div>
+    <div role="tooltip">Tooltip</div>
+    <div role="tree">Tree</div>
+    <div role="treegrid">Tree Grid</div>
+    <div role="treeitem">Tree Item</div>
+  </section>
+</body>
+</html>

--- a/internal/js/modules/k6/browser/tests/static/get_by_role_implicit.html
+++ b/internal/js/modules/k6/browser/tests/static/get_by_role_implicit.html
@@ -55,7 +55,7 @@
     <!-- figure/figcaption -->
     <figure><figcaption>Caption</figcaption><img src="" alt=""></figure>
     <!-- table, thead, tbody, tfoot, tr, th, td -->
-    <table aria-label="table">
+    <table aria-label="table1">
       <thead><tr><th aria-label="th gridcell" role="gridcell">Head Gridcell</th></tr></thead>
       <thead><tr><th aria-label="th">Head Cell</th></tr></thead>
       <thead><tr><th scope="col">Head Column</th></tr></thead>

--- a/internal/js/modules/k6/browser/tests/static/get_by_role_implicit.html
+++ b/internal/js/modules/k6/browser/tests/static/get_by_role_implicit.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<head>
+  <title>Role Selector Engine Test Suite</title>
+</head>
+<body>
+  <!-- header -->
+  <header>Header</header>
+  <!-- 7. Implicit Role Coverage -->
+  <section>
+    <!-- a[href] -->
+    <a href="#">Link text</a>
+    <!-- area[href] -->
+    <map><area href="#" aria-label="Map area"></map>
+    <!-- button -->
+    <button>Click</button>
+    <!-- input type=submit -->
+    <input type="submit" value="Submit">
+    <!-- input type=image -->
+    <input type="image" src="#" alt="Image Button">
+    <!-- input type=checkbox -->
+    <input type="checkbox">
+    <!-- input type=radio -->
+    <input type="radio" name="r">
+    <!-- input type=text -->
+    <input type="text" value="Text" aria-label="Text type">
+    <!-- textarea -->
+    <textarea aria-label="Text area">Textarea</textarea>
+    <!-- input type=search -->
+    <input type="search" value="Search">
+    <!-- input type=range -->
+    <input type="range" min="0" max="100" value="50">
+    <!-- input type=number -->
+    <input type="number" value="3">
+    <!-- progress -->
+    <progress value="30" max="100">Progress</progress>
+    <!-- output -->
+    <output>Output</output>
+    <!-- details/summary -->
+    <details aria-label="details"><summary>Summary</summary><div>Details</div></details>
+    <!-- dialog -->
+    <dialog open>Dialog</dialog>
+    <!-- headings h1-h6 -->
+    <h1>Heading1</h1><h2>Heading2</h2><h3>Heading3</h3><h4>Heading4</h4><h5>Heading5</h5><h6>Heading6</h6>
+    <!-- hr -->
+    <hr>
+    <!-- img -->
+    <img src="" alt="Img" aria-label="Img">
+    <!-- ul/ol and li -->
+    <ul aria-label="ul"><li aria-label="ul-li">Item1</li></ul>
+    <ol aria-label="ol"><li aria-label="ol-li">Item2</li></ol>
+    <!-- dl dt dd -->
+    <dl><dt>Term</dt><dd>Description</dd></dl>
+    <!-- fieldset/legend -->
+    <fieldset><legend>Legend</legend><input></fieldset>
+    <!-- figure/figcaption -->
+    <figure><figcaption>Caption</figcaption><img src="" alt=""></figure>
+    <!-- table, thead, tbody, tfoot, tr, th, td -->
+    <table aria-label="table">
+      <thead><tr><th aria-label="th gridcell" role="gridcell">Head Gridcell</th></tr></thead>
+      <thead><tr><th aria-label="th">Head Cell</th></tr></thead>
+      <thead><tr><th scope="col">Head Column</th></tr></thead>
+      <thead><tr><th scope="row">Head Row</th></tr></thead>
+      <tbody aria-label="tbody"><tr><td>Cell</td></tr></tbody>
+      <tbody><tr aria-label="tr"><td>Row</td></tr></tbody>
+      <tbody><tr><td aria-label="td">Column Cell</td></tr></tbody>
+      <tbody><tr><td aria-label="td gridcell" role="gridcell">Column Gridcell</td></tr></tbody>
+      <tfoot aria-label="tfoot"><tr><td>Foot</td></tr></tfoot>
+    </table>
+    <!-- main -->
+    <main>Main</main>
+    <!-- nav -->
+    <nav>Nav</nav>
+    <!-- article -->
+    <article>Article</article>
+    <!-- aside -->
+    <aside>Aside</aside>
+    <!-- form -->
+    <form aria-label="form"><input></form>
+    <!-- section (region) -->
+    <section aria-label="Region Section">Region content</section>
+    <blockquote>Blockquote text</blockquote>
+    <!-- caption -->
+    <table><caption>Table Caption</caption><tr><td>Cell</td></tr></table>
+    <!-- code -->
+    <code>Code sample</code>
+    <!-- del -->
+    <del>Deleted text</del>
+    <!-- dfn -->
+    <dfn>Definition term</dfn>
+    <!-- em -->
+    <em>Emphasized text</em>
+    <!-- ins -->
+    <ins>Inserted text</ins>
+    <!-- mark -->
+    <mark>Marked text</mark>
+    <!-- math -->
+    <math><mi>x</mi><mo>=</mo><mn>1</mn></math>
+    <!-- menu -->
+    <menu aria-label="menu"><li>Menu item</li></menu>
+    <!-- meter -->
+    <meter value="0.5">50%</meter>
+    <!-- p -->
+    <p>Paragraph text</p>
+    <!-- strong -->
+    <strong>Strong text</strong>
+    <!-- sub -->
+    <sub>Subscript</sub>
+    <!-- sup -->
+    <sup>Superscript</sup>
+    <!-- svg -->
+    <svg aria-label="svg"><circle cx="10" cy="10" r="5"></circle></svg>
+    <!-- time -->
+    <time datetime="2025-06-09">June 9, 2025</time>
+    <!-- select (combobox) -->
+    <select aria-label="select">
+        <option>A</option>
+    </select>
+    <!-- select (listbox) -->
+    <select aria-label="select multiple" multiple>
+      <option>A</option>
+      <option>B</option>
+    </select>
+    <!-- select (optgroup) -->
+    <select>
+      <optgroup label="optgroup">
+        <option>A</option>
+        <option>B</option>
+      </optgroup>
+    </select>
+    <!-- datalist -->
+    <datalist id="dl2"><option>One</option></datalist><input list="dl2">
+  </section>
+  <!-- footer -->
+  <footer>Footer</footer>
+</body>
+</html>

--- a/internal/js/modules/k6/browser/tests/test_browser.go
+++ b/internal/js/modules/k6/browser/tests/test_browser.go
@@ -378,3 +378,8 @@ func asString(tb testing.TB, v any) string {
 	require.True(tb, ok)
 	return s
 }
+
+// toPtr is a helper function to convert a value to a pointer.
+func toPtr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
## What?

This PR adds a long awaited feature which is `page.getByRole`. It makes working with selectors slightly simpler. More `getBy*` APIs are in the works.

## Why?

It is a lot simpler to work with `getByRole` instead of XPath or CSS selectors in most cases.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/issues/4764
https://github.com/grafana/k6/issues/4320
https://github.com/grafana/k6/issues/4248