### PR TITLE
Feature/remove event listener

### DIFF
--- a/internal/js/modules/k6/ws/ws.go
+++ b/internal/js/modules/k6/ws/ws.go
@@ -69,13 +69,14 @@ var ErrWSInInitContext = common.NewInitContextError("using websockets in the ini
 
 // Socket is the representation of the websocket returned to the js.
 type Socket struct {
-	rt            *sobek.Runtime
-	ctx           context.Context //nolint:containedctx
-	conn          *websocket.Conn
-	eventHandlers map[string][]sobek.Callable
-	scheduled     chan sobek.Callable
-	done          chan struct{}
-	shutdownOnce  sync.Once
+	rt               *sobek.Runtime
+	ctx              context.Context //nolint:containedctx
+	conn             *websocket.Conn
+	eventHandlers    map[string][]sobek.Callable
+	eventHandlerVals map[string][]sobek.Value
+	scheduled        chan sobek.Callable
+	done             chan struct{}
+	shutdownOnce     sync.Once
 
 	pingSendTimestamps map[string]time.Time
 	pingSendCounter    int
@@ -295,6 +296,7 @@ func (mi *WS) dial(
 		rt:                 rt,
 		conn:               conn,
 		eventHandlers:      make(map[string][]sobek.Callable),
+		eventHandlerVals:   make(map[string][]sobek.Value),
 		pingSendTimestamps: make(map[string]time.Time),
 		scheduled:          make(chan sobek.Callable),
 		done:               make(chan struct{}),
@@ -310,8 +312,9 @@ func (mi *WS) dial(
 
 // On is used to configure what the websocket should do on each event.
 func (s *Socket) On(event string, handler sobek.Value) {
-	if handler, ok := sobek.AssertFunction(handler); ok {
-		s.eventHandlers[event] = append(s.eventHandlers[event], handler)
+	if handlerCallable, ok := sobek.AssertFunction(handler); ok {
+		s.eventHandlers[event] = append(s.eventHandlers[event], handlerCallable)
+		s.eventHandlerVals[event] = append(s.eventHandlerVals[event], handler)
 	}
 }
 


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

This PR adds `Off` function which remove registered event-listener function mapped to user specified event.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

As Issue #4823 describes, k6 doesn't have interface for removing event-listener of websocket.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
#4823 
<!-- Thanks for your contribution! 🙏🏼 -->
