### PR TITLE
Fix NPD on `click` API call

### DIFF
--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/dom"
-	cdppage "github.com/chromedp/cdproto/page"
 	"github.com/grafana/sobek"
 	"go.opentelemetry.io/otel/attribute"
 
@@ -170,14 +169,12 @@ func (h *ElementHandle) clickablePoint() (*Position, error) {
 		return nil, fmt.Errorf("node is either not visible or not an HTMLElement: %w", err)
 	}
 
-	// Filter out quads that have too small area to click into.
-	var layoutViewport *cdppage.LayoutViewport
-	getLayoutMetrics := cdppage.GetLayoutMetrics()
-	if _, _, _, layoutViewport, _, _, err = getLayoutMetrics.Do(cdp.WithExecutor(h.ctx, h.session)); err != nil {
-		return nil, fmt.Errorf("getting page layout metrics %T: %w", getLayoutMetrics, err)
+	width, height, err := h.evaluateInnerWidthHeight()
+	if err != nil {
+		return nil, err
 	}
 
-	return filterQuads(layoutViewport.ClientWidth, layoutViewport.ClientHeight, quads)
+	return filterQuads(width, height, quads)
 }
 
 // We are evaluating the inner width and height of the current frame that the

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -171,10 +171,15 @@ func (h *ElementHandle) clickablePoint() (*Position, error) {
 
 	width, height, err := h.evaluateInnerWidthHeight()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("evaluating inner width and height: %w", err)
 	}
 
-	return filterQuads(width, height, quads)
+	p, err := filterQuads(width, height, quads)
+	if err != nil {
+		return nil, fmt.Errorf("filtering quads: %w", err)
+	}
+
+	return p, nil
 }
 
 // We are evaluating the inner width and height of the current frame that the
@@ -200,17 +205,17 @@ func (h *ElementHandle) evaluateInnerWidthHeight() (int64, int64, error) {
 
 	m, ok := v.(map[string]any)
 	if !ok {
-		return 0, 0, fmt.Errorf("unexpected value %v when getting inner width and height", v)
+		return 0, 0, fmt.Errorf("unexpected value %q when getting inner width and height", v)
 	}
 
 	width, ok := m["width"].(float64)
 	if !ok {
-		return 0, 0, fmt.Errorf("unexpected value %v when getting inner width", m["width"])
+		return 0, 0, fmt.Errorf("unexpected value %q when getting inner width", m["width"])
 	}
 
 	height, ok := m["height"].(float64)
 	if !ok {
-		return 0, 0, fmt.Errorf("unexpected value %v when getting inner height", m["height"])
+		return 0, 0, fmt.Errorf("unexpected value %q when getting inner height", m["height"])
 	}
 
 	return int64(width), int64(height), nil

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -180,6 +180,45 @@ func (h *ElementHandle) clickablePoint() (*Position, error) {
 	return filterQuads(layoutViewport.ClientWidth, layoutViewport.ClientHeight, quads)
 }
 
+// We are evaluating the inner width and height of the current frame that the
+// element is in in the utility context. Calculating this in the main context
+// causes NPD errors when working with the CDP API cdppage.GetLayoutMetrics.
+//
+// It returns the width and height of the current frame.
+func (h *ElementHandle) evaluateInnerWidthHeight() (int64, int64, error) {
+	h.logger.Debugf("ElementHandle:evaluateInnerWidthHeight", "fid:%s furl:%q", h.frame.ID(), h.frame.URL())
+
+	js := `() => ({ width: innerWidth, height: innerHeight })`
+
+	h.frame.waitForExecutionContext(utilityWorld)
+
+	eopts := evalOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
+	v, err := h.frame.evaluate(h.ctx, utilityWorld, eopts, js)
+	if err != nil {
+		return 0, 0, fmt.Errorf("getting inner width and height: %w", err)
+	}
+
+	m, ok := v.(map[string]any)
+	if !ok {
+		return 0, 0, fmt.Errorf("unexpected value %v when getting inner width and height", v)
+	}
+
+	width, ok := m["width"].(float64)
+	if !ok {
+		return 0, 0, fmt.Errorf("unexpected value %v when getting inner width", m["width"])
+	}
+
+	height, ok := m["height"].(float64)
+	if !ok {
+		return 0, 0, fmt.Errorf("unexpected value %v when getting inner height", m["height"])
+	}
+
+	return int64(width), int64(height), nil
+}
+
 func filterQuads(viewportWidth, viewportHeight int64, quads []dom.Quad) (*Position, error) {
 	var filteredQuads []dom.Quad
 	for _, q := range quads {


### PR DESCRIPTION
## What?

We're swapping out the use of working with `cdppage.GetLayoutMetrics` to working with a manual workaround that retrieves the current frame's width and height from the utility context.

## Why?

This should avoid NPDs that we sometimes see. More context can be found here in Playwright's PR for a similar issue: https://github.com/microsoft/playwright/pull/2669.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
Issue: https://github.com/grafana/k6/issues/4123
Comment: https://github.com/grafana/k6/issues/4123#issuecomment-2962348396