### PR TITLE
Prevent running testcov CI action on forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,14 +133,13 @@ jobs:
       # Sets CODECOV_TOKEN as an environment variable for the next step
       - name: Get Codecov token
         # Skip this step if the PR is from a fork, as we can't fetch secrets for forks.
-        # We'll be automatically passing a blank CODECOV_TOKEN in that case.
-        if: github.event.repository.fork == false && github.event.sender.login != 'dependabot[bot]'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
           repo_secrets: |
             CODECOV_TOKEN=CODECOV_TOKEN:CODECOV_TOKEN
       - name: Upload coverage to Codecov
-        if: github.event.repository.fork == false && github.event.sender.login != 'dependabot[bot]'
+        if: github.event.pull_request.head.repo.full_name == github.repository
         env:
           CODECOV_BASH_VERSION: 1.0.1
           CODECOV_BASH_SHA512SUM: d075b412a362a9a2b7aedfec3b8b9a9a927b3b99e98c7c15a2b76ef09862aeb005e91d76a5fd71b511141496d0fd23d1b42095f722ebcd509d768fba030f159e


### PR DESCRIPTION
## What?

Re-prevent running testcov CI action on forks.

## Why?

The previous approach [did not work](https://github.com/grafana/k6/actions/runs/15585456945/job/43890418996?pr=4659). 

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- #4837