### PR TITLE
Potential fix for code scanning alert no. 91: Incorrect conversion between integer types

### DIFF
--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -829,6 +829,9 @@ func (h *ElementHandle) count(apiCtx context.Context, selector string) (int, err
 	}
 	switch r := result.(type) {
 	case float64:
+		if r < float64(math.MinInt) || r > float64(math.MaxInt) {
+			return 0, fmt.Errorf("value %v out of range for int type", r)
+		}
 		return int(r), nil
 	default:
 		return 0, fmt.Errorf("unexpected value %v of type %T", r, r)


### PR DESCRIPTION
Potential fix for [https://github.com/grafana/k6/security/code-scanning/91](https://github.com/grafana/k6/security/code-scanning/91)

To address the issue, we need to ensure that the conversion from `float64` to `int` is safe and does not result in unexpected values. This can be achieved by:
1. Adding bounds checks to ensure the `float64` value is within the valid range for the `int` type.
2. Returning an error or a default value if the bounds are violated.

The fix involves modifying the `count` function in `internal/js/modules/k6/browser/common/element_handle.go` to include bounds checks using constants from the `math` package (`math.MinInt32` and `math.MaxInt32` for 32-bit systems, or equivalent for 64-bit systems).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
