### PR TITLE
Revert "Update sobek and goja respectfully"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/grafana/k6deps v0.2.6
 	github.com/grafana/k6provider v0.1.15
-	github.com/grafana/sobek v0.0.0-20250617123252-8dce75eadcb6
+	github.com/grafana/sobek v0.0.0-20250320150027-203dc85b6d98
 	github.com/grafana/xk6-dashboard v0.7.6
 	github.com/grafana/xk6-redis v0.3.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/grafana/k6foundry v0.4.6 h1:fFgR72Pw0dzo8wVWyggu35SGGjdt31Dktil1bDE1M
 github.com/grafana/k6foundry v0.4.6/go.mod h1:eLsr0whhH+5Y1y7YpDxJi3Jv5wHMuf+80vdRyMH10pg=
 github.com/grafana/k6provider v0.1.15 h1:aUStpqDMEnEL9aGCcSKmpcreHRZsr8IELna+ttKMOYI=
 github.com/grafana/k6provider v0.1.15/go.mod h1:tnyPNxenfF0G5JWVXQixk7QUJIn2FbZneDfvgocttNs=
-github.com/grafana/sobek v0.0.0-20250617123252-8dce75eadcb6 h1:fMY/DjNakxYQU7DHm/LE52JaN79k6SBkenbMmE5wrIM=
-github.com/grafana/sobek v0.0.0-20250617123252-8dce75eadcb6/go.mod h1:FmcutBFPLiGgroH42I4/HBahv7GxVjODcVWFTw1ISes=
+github.com/grafana/sobek v0.0.0-20250320150027-203dc85b6d98 h1:DqWI8D/A8GABIIjukZVNr0Sj4sBeewK2TmbTyiqUAZk=
+github.com/grafana/sobek v0.0.0-20250320150027-203dc85b6d98/go.mod h1:FmcutBFPLiGgroH42I4/HBahv7GxVjODcVWFTw1ISes=
 github.com/grafana/xk6-dashboard v0.7.6 h1:7MNk87R6ZUcBdyoIkaOkLsor4hrIT1F57X77Z83oE68=
 github.com/grafana/xk6-dashboard v0.7.6/go.mod h1:ofJsxGG4TTuzSUvTU8BroyCBy6A44/ksi4x/hUNeiYA=
 github.com/grafana/xk6-redis v0.3.3 h1:9QiS4OUjYMzvriGzbqrhCn9i/kENmCkibZE+xCJSdPk=

--- a/vendor/github.com/grafana/sobek/compiler.go
+++ b/vendor/github.com/grafana/sobek/compiler.go
@@ -672,8 +672,6 @@ func (s *scope) finaliseVarAlloc(stackOffset int) (stashSize, stackSize int) {
 								*ap = loadThisStash(idx)
 							case initStack:
 								*ap = initStash(idx)
-							case initStackP:
-								*ap = initStashP(idx)
 							case resolveThisStack:
 								*ap = resolveThisStash(idx)
 							case _ret:
@@ -690,8 +688,6 @@ func (s *scope) finaliseVarAlloc(stackOffset int) (stashSize, stackSize int) {
 								*ap = loadStash(idx)
 							case initStack:
 								*ap = initStash(idx)
-							case initStackP:
-								*ap = initStashP(idx)
 							default:
 								s.c.assert(false, s.c.p.sourceOffset(pc), "Unsupported instruction for 'this'")
 							}
@@ -774,8 +770,6 @@ func (s *scope) finaliseVarAlloc(stackOffset int) (stashSize, stackSize int) {
 							case loadStack:
 								*ap = loadThisStack{}
 							case initStack:
-								// no-op
-							case initStackP:
 								// no-op
 							case resolveThisStack:
 								// no-op

--- a/vendor/github.com/grafana/sobek/compiler_expr.go
+++ b/vendor/github.com/grafana/sobek/compiler_expr.go
@@ -1693,7 +1693,6 @@ func (e *compiledFunctionLiteral) compile() (prg *Program, name unistring.String
 		}
 	}
 
-	needInitThis := false
 	if thisBinding != nil {
 		if !s.isDynamic() && thisBinding.useCount() == 0 {
 			s.deleteBinding(thisBinding)
@@ -1702,15 +1701,13 @@ func (e *compiledFunctionLiteral) compile() (prg *Program, name unistring.String
 			if thisBinding.inStash || s.isDynamic() {
 				delta++
 				thisBinding.emitInitAtScope(s, preambleLen-delta)
-				needInitThis = true
 			}
 		}
 	}
 
 	stashSize, stackSize := s.finaliseVarAlloc(0)
 
-	if needInitThis && (s.numArgs > 0 && !s.argsInStash || stackSize > 0) {
-		code[preambleLen-delta] = initStashP(code[preambleLen-delta].(initStash))
+	if thisBinding != nil && thisBinding.inStash && (!s.argsInStash || stackSize > 0) {
 		delta++
 		code[preambleLen-delta] = loadStack(0)
 	} // otherwise, 'this' will be at stack[sp-1], no need to load

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -196,7 +196,7 @@ github.com/grafana/k6deps/internal/pack/plugins/k6
 # github.com/grafana/k6provider v0.1.15
 ## explicit; go 1.23.0
 github.com/grafana/k6provider
-# github.com/grafana/sobek v0.0.0-20250617123252-8dce75eadcb6
+# github.com/grafana/sobek v0.0.0-20250320150027-203dc85b6d98
 ## explicit; go 1.20
 github.com/grafana/sobek
 github.com/grafana/sobek/ast


### PR DESCRIPTION
## What?

This reverts commit 34c2dc9490cd54e7ecf4c1706c1186cb05237e23.

## Why?

This seems to have introduced a bug with `this` when calling classses (still looking into the exact problems).

Given that the original issue fixed seems to have to not have been hit or had problems with, reverting this for now seems better. Especially as v1.1.0 is planned for release soon. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
