### PR TITLE
Disable usage reporting in CI jobs

### DIFF
--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -65,6 +65,7 @@ jobs:
             export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
           fi
           export K6_BROWSER_HEADLESS=true
+          export K6_NO_USAGE_REPORT=true
           for f in examples/browser/*.js; do
             if [ "$f" == "examples/browser/hosts.js" ] && [ "$RUNNER_OS" == "Windows" ]; then
               echo "skipping $f on Windows"

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -79,6 +79,7 @@ jobs:
             --output ./k6ext \
             --with github.com/grafana/xk6-js-test="$(pwd)/xk6-js-test" \
             --with github.com/grafana/xk6-output-test="$(pwd)/xk6-output-test"
+          export K6_NO_USAGE_REPORT=true
           ./k6ext version
           ./k6ext run --out outputtest=output-results.txt xk6-test.js
 


### PR DESCRIPTION
## What?

Explicitly disable usage reporting in CI jobs

## Why?
There is no need for this to report anything.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
