### PR TITLE
fix: Avoid NAN check results

### DIFF
--- a/internal/output/summary/data.go
+++ b/internal/output/summary/data.go
@@ -306,7 +306,11 @@ func populateSummaryChecks(
 
 	summaryGroup.Checks.Metrics.Fail.Values["passes"] = totalChecks - successChecks
 	summaryGroup.Checks.Metrics.Fail.Values["fails"] = successChecks
-	summaryGroup.Checks.Metrics.Fail.Values["rate"] = (totalChecks - successChecks) / totalChecks
+	if totalChecks > 0 {
+		summaryGroup.Checks.Metrics.Fail.Values["rate"] = (totalChecks - successChecks) / totalChecks
+	} else {
+		summaryGroup.Checks.Metrics.Fail.Values["rate"] = 0
+	}
 
 	summaryGroup.Checks.OrderedChecks = groupData.checks.orderedChecks
 }


### PR DESCRIPTION
## What?

This pr fixes a bug that generated check_failed results with NAN, this error occurred when an exception was thrown before the test was called, resulting in a division by 0 when checking the failed tests.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Closes #4842

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
