### PR TITLE
Move codecov analysis to a dedicated workflow

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,73 @@
+name: Code coverage
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+permissions: {}
+
+jobs:
+  codecov:
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: [1.24.x]
+        platform: [ubuntu-22.04]
+    permissions: 
+      id-token: write # required for Vault
+      contents: read
+    runs-on: ${{ matrix.platform }}
+    if: ${{ github.ref == 'refs/heads/master' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+          check-latest: true
+      - name: Run tests with code coverage
+        run: |
+          go version
+          export GOMAXPROCS=2
+          echo "mode: set" > coverage.txt
+          for pkg in $(go list ./... | grep -v vendor); do
+              list=$(go list -test -f  '{{ join .Deps  "\n"}}' $pkg | grep go.k6.io/k6 | grep -v vendor || true)
+              if [ -n "$list" ]; then
+                  list=$(echo "$list" | cut -f1 -d ' ' | sort -u | paste -sd, -)
+              fi
+              go test -p 2 -timeout 800s --coverpkg="$list" -coverprofile=$(echo $pkg | tr / -).coverage $pkg
+          done
+          grep -h -v "^mode:" *.coverage >> coverage.txt
+          rm -f *.coverage
+      # Sets CODECOV_TOKEN as an environment variable for the next step
+      - name: Get Codecov token
+        # Skip this step if the PR is from a fork, as we can't fetch secrets for forks.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+        with:
+          repo_secrets: |
+            CODECOV_TOKEN=CODECOV_TOKEN:CODECOV_TOKEN
+      - name: Upload coverage to Codecov
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          CODECOV_BASH_VERSION: 1.0.1
+          CODECOV_BASH_SHA512SUM: d075b412a362a9a2b7aedfec3b8b9a9a927b3b99e98c7c15a2b76ef09862aeb005e91d76a5fd71b511141496d0fd23d1b42095f722ebcd509d768fba030f159e
+        run: |
+          curl -fsSLO "https://raw.githubusercontent.com/codecov/codecov-bash/${CODECOV_BASH_VERSION}/codecov"
+          echo "$CODECOV_BASH_SHA512SUM  codecov" | sha512sum -c -
+          bash ./codecov
+      - name: Generate coverage HTML report
+        run: go tool cover -html=coverage.txt -o coverage.html
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-coverage-report-${{ matrix.platform }}
+          path: coverage.html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Unit Tests
 on:
   push:
     branches:
@@ -9,17 +9,18 @@ defaults:
   run:
     shell: bash
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
-  test-prev:
+  tests:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.23.x, 1.24.x]
         platform: [ubuntu-22.04, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.platform }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -62,6 +63,8 @@ jobs:
         platform: [ubuntu-22.04, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.platform }}
     continue-on-error: true
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -99,81 +102,3 @@ jobs:
             export GOMAXPROCS=1
           fi
           go test "${args[@]}" -timeout 800s ./...
-
-  test-current-cov:
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: [1.24.x]
-        platform: [ubuntu-22.04, ubuntu-24.04-arm, windows-latest]
-    permissions: # required for Vault
-      id-token: write
-      contents: read
-    runs-on: ${{ matrix.platform }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - name: Install Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: ${{ matrix.go-version }}
-          check-latest: true
-      - name: Install chromium
-        # This is only needed on arm images, chromium comes preinstalled on amd64 runner images.
-        if: contains(matrix.platform, 'arm')
-        run: |
-          sudo apt update && sudo apt install chromium-browser
-          chromium --version
-      - name: Run tests with code coverage
-        run: |
-          go version
-          export GOMAXPROCS=2
-          args=("-p" "2" "-race")
-          # Run with less concurrency on Windows/MacOS to minimize flakiness.
-          if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos* ]]; then
-            unset args[2]
-            args[1]="1"
-            export GOMAXPROCS=1
-          fi
-          echo "mode: set" > coverage.txt
-          for pkg in $(go list ./... | grep -v vendor); do
-              list=$(go list -test -f  '{{ join .Deps  "\n"}}' $pkg | grep go.k6.io/k6 | grep -v vendor || true)
-              if [ -n "$list" ]; then
-                  list=$(echo "$list" | cut -f1 -d ' ' | sort -u | paste -sd, -)
-              fi
-
-              go test "${args[@]}" -timeout 800s --coverpkg="$list" -coverprofile=$(echo $pkg | tr / -).coverage $pkg
-          done
-          grep -h -v "^mode:" *.coverage >> coverage.txt
-          rm -f *.coverage
-      # Sets CODECOV_TOKEN as an environment variable for the next step
-      - name: Get Codecov token
-        # Skip this step if the PR is from a fork, as we can't fetch secrets for forks.
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
-        with:
-          repo_secrets: |
-            CODECOV_TOKEN=CODECOV_TOKEN:CODECOV_TOKEN
-      - name: Upload coverage to Codecov
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        env:
-          CODECOV_BASH_VERSION: 1.0.1
-          CODECOV_BASH_SHA512SUM: d075b412a362a9a2b7aedfec3b8b9a9a927b3b99e98c7c15a2b76ef09862aeb005e91d76a5fd71b511141496d0fd23d1b42095f722ebcd509d768fba030f159e
-        run: |
-          if [[ "${{ matrix.platform }}" == macos* ]]; then
-            shopt -s expand_aliases
-            alias sha512sum='shasum -a 512'
-          fi
-          curl -fsSLO "https://raw.githubusercontent.com/codecov/codecov-bash/${CODECOV_BASH_VERSION}/codecov"
-          echo "$CODECOV_BASH_SHA512SUM  codecov" | sha512sum -c -
-          platform="${{ matrix.platform }}"
-          bash ./codecov -F "${platform%%-*}"
-      - name: Generate coverage HTML report
-        run: go tool cover -html=coverage.txt -o coverage.html
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-coverage-report-${{ matrix.platform }}
-          path: coverage.html


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

It moves the code coverage analysis to run on a dedicated workflow.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

- We can limit the run to only `master` as these days we're not really observing it from each pull request.
- We can simplify our testing workflow.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
