### PR TITLE
Skip running winsign on public forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,20 +273,21 @@ jobs:
           cd .\packaging
           candle.exe -arch x64 "-dVERSION=$env:VERSION" k6.wxs
           light.exe -ext WixUIExtension k6.wixobj
-
-      - uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
+      
+      # GH secrets are unavailable when building from project forks, so this
+      # will fail for external PRs, even if we wanted to do it. And we don't.
+      # We are only going to sign packages that are built from master or a
+      # version tag, or manually triggered dev builds, so we have enough
+      # assurance that package signing works, but don't sign every PR build.
+      - if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets/v1.2.1
         with:
           repo_secrets: |
             WIN_SIGN_CERT=winsign:WIN_SIGN_CERT
             WIN_SIGN_PASS=winsign:WIN_SIGN_PASS
 
       - name: Sign Windows binary and .msi package
-        # GH secrets are unavailable when building from project forks, so this
-        # will fail for external PRs, even if we wanted to do it. And we don't.
-        # We are only going to sign packages that are built from master or a
-        # version tag, or manually triggered dev builds, so we have enough
-        # assurance that package signing works, but don't sign every PR build.
-        if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        if: ${{ env.WIN_SIGN_CERT != '' && env.WIN_SIGN_PASS != '' }}
         run: |
           # Convert base64 certificate to PFX
           $bytes = [Convert]::FromBase64String("${{ env.WIN_SIGN_CERT }}")


### PR DESCRIPTION
## What?

Skips running winsign on public forks.

It should be safe not to sign binaries for public fork test runs.

## Why?

Runs on public forks [fail](https://github.com/grafana/k6/actions/runs/15902153259/job/44847948943?pr=4659).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#4659
