### PR TITLE
Browser: Support string-labels in locator.selectOption

### DIFF
--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -550,9 +550,12 @@ func ConvertSelectOptionValues(rt *sobek.Runtime, values sobek.Value) ([]any, er
 		for _, item := range sl {
 			switch item := item.(type) {
 			case string:
-				opt := SelectOption{Value: new(string)}
-				*opt.Value = item
-				opts = append(opts, &opt)
+				// Strings will match values or labels
+				valOpt := SelectOption{Value: new(string)}
+				*valOpt.Value = item
+				labelOpt := SelectOption{Label: new(string)}
+				*labelOpt.Label = item
+				opts = append(opts, &valOpt, &labelOpt)
 			case map[string]interface{}:
 				opt, err := extractSelectOptionFromMap(item)
 				if err != nil {
@@ -596,9 +599,12 @@ func ConvertSelectOptionValues(rt *sobek.Runtime, values sobek.Value) ([]any, er
 		}
 		opts = append(opts, &opt)
 	case reflect.String:
-		opt := SelectOption{Value: new(string)}
-		*opt.Value = t.(string) //nolint:forcetypeassert
-		opts = append(opts, &opt)
+		// Strings will match values or labels
+		valOpt := SelectOption{Value: new(string)}
+		*valOpt.Value = t.(string) //nolint:forcetypeassert
+		labelOpt := SelectOption{Label: new(string)}
+		*labelOpt.Label = t.(string) //nolint:forcetypeassert
+		opts = append(opts, &valOpt, &labelOpt)
 	default:
 		return nil, fmt.Errorf("options: unsupported type %T", values)
 	}

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -734,6 +734,23 @@ func TestSelectOption(t *testing.T) {
 		if (selectedValue !== 'five') {
 			throw new Error('Expected "five" but got ' + selectedValue);
 		}
+
+		await options.selectOption(['Three']); // Label
+		selectedValue = await options.inputValue();
+		if (selectedValue !== 'three') {
+			throw new Error('Expected "three" but got ' + selectedValue);
+		}
+
+		await options.selectOption('Five'); // Label
+		selectedValue = await options.inputValue();
+		if (selectedValue !== 'five') {
+			throw new Error('Expected "five" but got ' + selectedValue);
+		}
+
+		const results = await options.selectOption(['One', 'two']); // Both label and value
+		if (results.length !== 2 || results[0] !== 'one' || results[1] !== 'two') {
+			throw new Error('Expected "one,two" but got ' + results);
+		}
 	`, tb.staticURL("select_options.html"))
 	assert.Equal(t, sobek.Undefined(), got.Result())
 }

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -748,7 +748,7 @@ func TestSelectOption(t *testing.T) {
 		}
 
 		const results = await options.selectOption(['One', 'two']); // Both label and value
-		if (results.length !== 2 || results[0] !== 'one' || results[1] !== 'two') {
+		if (results.length !== 2 || !results.includes('one') || !results.includes('two')) {
 			throw new Error('Expected "one,two" but got ' + results);
 		}
 	`, tb.staticURL("select_options.html"))


### PR DESCRIPTION
## What?
Add [locator.selectOption](https://grafana.com/docs/k6/next/javascript-api/k6-browser/locator/selectoption/) support for label matching if it's a string input, cases like:
```
<select name="numbers" id="numbers-options" multiple>
	<option value="zero">Zero</option>
	<option value="one">One</option>
	<option value="two">Two</option>
	<option value="three">Three</option>
	<option value="four">Four</option>
	<option value="five">Five</option>
</select>

await options.selectOption(['Two', 'Four']); // labels
await options.selectOption('Five'); // label
```
## Why?

Playwright does support that https://playwright.dev/docs/api/class-locator#locator-select-option

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [x] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): https://github.com/grafana/k6-docs/pull/1983
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes https://github.com/grafana/k6/issues/4111