### PR TITLE
Browser: Add locator.all

### DIFF
--- a/internal/js/modules/k6/browser/browser/locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/locator_mapping.go
@@ -13,6 +13,11 @@ import (
 func mapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
 	rt := vu.Runtime()
 	return mapping{
+		"all": func() *sobek.Promise {
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return lo.All() //nolint:wrapcheck
+			})
+		},
 		"clear": func(opts sobek.Value) (*sobek.Promise, error) {
 			copts := common.NewFrameFillOptions(lo.Timeout())
 			if err := copts.Parse(vu.Context(), opts); err != nil {

--- a/internal/js/modules/k6/browser/browser/locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/locator_mapping.go
@@ -15,7 +15,16 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
 	return mapping{
 		"all": func() *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return lo.All() //nolint:wrapcheck
+				all, err := lo.All()
+				if err != nil {
+					return nil, err
+				}
+
+				res := make([]mapping, len(all))
+				for i, el := range all {
+					res[i] = mapLocator(vu, el)
+				}
+				return res, nil
 			})
 		},
 		"clear": func(opts sobek.Value) (*sobek.Promise, error) {

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -516,6 +516,7 @@ type responseAPI interface { //nolint:interfacebloat
 
 // locatorAPI represents a way to find element(s) on a page at any moment.
 type locatorAPI interface { //nolint:interfacebloat
+	All() ([]*common.Locator, error)
 	Clear(opts *common.FrameFillOptions) error
 	Click(opts sobek.Value) error
 	Count() (int, error)

--- a/internal/js/modules/k6/browser/common/locator.go
+++ b/internal/js/modules/k6/browser/common/locator.go
@@ -81,6 +81,22 @@ func (l *Locator) click(opts *FrameClickOptions) error {
 	return l.frame.click(l.selector, opts)
 }
 
+func (l *Locator) All() ([]*Locator, error) {
+	l.log.Debugf("Locator:All", "fid:%s furl:%q sel:%q", l.frame.ID(), l.frame.URL(), l.selector)
+
+	count, err := l.Count()
+	if err != nil {
+		return nil, err
+	}
+
+	locators := make([]*Locator, count)
+	for i := 0; i < count; i++ {
+		locators[i] = l.Nth(i)
+	}
+
+	return locators, nil
+}
+
 // Count APIs do not wait for the element to be present. It also does not set
 // strict to true, allowing it to return the total number of elements matching
 // the selector.

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -36,6 +36,25 @@ func TestLocator(t *testing.T) {
 		do   func(*testBrowser, *common.Page)
 	}{
 		{
+			"All", func(_ *testBrowser, p *common.Page) {
+				locators, err := p.Locator("a", nil).All()
+				require.NoError(t, err)
+				require.Len(t, locators, 3)
+
+				firstText, err := locators[0].InnerText(nil)
+				assert.NoError(t, err)
+				assert.Equal(t, `Click`, firstText)
+
+				secondText, err := locators[1].InnerText(nil)
+				assert.NoError(t, err)
+				assert.Equal(t, `Dblclick`, secondText)
+
+				thirdText, err := locators[2].InnerText(nil)
+				assert.NoError(t, err)
+				assert.Equal(t, `Click`, thirdText)
+			},
+		},
+		{
 			"Check", func(_ *testBrowser, p *common.Page) {
 				check := func() bool {
 					v, err := p.Evaluate(`() => window.check`)


### PR DESCRIPTION
## What?

Adds support for locator.all() function to get an array of locators (see https://playwright.dev/docs/api/class-locator#locator-all).

## Why?

This is a useful function of the Playwright API to work with multiple elements.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [x] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): https://github.com/grafana/k6-docs/pull/1986
- [x] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): https://github.com/grafana/k6-DefinitelyTyped/pull/87

## Related PR(s)/Issue(s)