### PR TITLE
Add getByTitle in the browser module

### DIFF
--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -322,6 +322,7 @@ type pageAPI interface { //nolint:interfacebloat
 	GetByAltText(alt string, opts *common.GetByBaseOptions) *common.Locator
 	GetByLabel(label string, opts *common.GetByBaseOptions) *common.Locator
 	GetByPlaceholder(placeholder string, opts *common.GetByBaseOptions) *common.Locator
+	GetByTitle(title string, opts *common.GetByBaseOptions) *common.Locator
 	GetKeyboard() *common.Keyboard
 	GetMouse() *common.Mouse
 	GetTouchscreen() *common.Touchscreen

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -188,6 +188,12 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			ml := mapLocator(vu, p.GetByPlaceholder(pplaceholder, popts))
 			return rt.ToValue(ml).ToObject(rt), nil
 		},
+		"getByTitle": func(title sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			ptitle, popts := parseGetByBaseOptions(vu.Context(), title, false, opts)
+
+			ml := mapLocator(vu, p.GetByTitle(ptitle, popts))
+			return rt.ToValue(ml).ToObject(rt), nil
+		},
 		"goto": func(url string, opts sobek.Value) (*sobek.Promise, error) {
 			gopts := common.NewFrameGotoOptions(
 				p.Referrer(),

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1139,6 +1139,13 @@ func (f *Frame) GetByPlaceholder(placeholder string, opts *GetByBaseOptions) *Lo
 	return f.Locator("internal:attr="+f.buildAttributeSelector("placeholder", placeholder, opts), nil)
 }
 
+// GetByTitle creates and returns a new locator for this frame based on the title attribute.
+func (f *Frame) GetByTitle(title string, opts *GetByBaseOptions) *Locator {
+	f.log.Debugf("Frame:GetByTitle", "fid:%s furl:%q title:%q opts:%+v", f.ID(), f.URL(), title, opts)
+
+	return f.Locator("internal:attr="+f.buildAttributeSelector("title", title, opts), nil)
+}
+
 // Referrer returns the referrer of the frame from the network manager
 // of the frame's session.
 // It's an internal method not to be exposed as a JS API.

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1116,6 +1116,13 @@ func (p *Page) GetByPlaceholder(placeholder string, opts *GetByBaseOptions) *Loc
 	return p.MainFrame().GetByPlaceholder(placeholder, opts)
 }
 
+// GetByTitle creates and returns a new locator for this page (main frame) based on the title attribute.
+func (p *Page) GetByTitle(title string, opts *GetByBaseOptions) *Locator {
+	p.logger.Debugf("Page:GetByTitle", "sid:%s title: %q opts:%+v", p.sessionID(), title, opts)
+
+	return p.MainFrame().GetByTitle(title, opts)
+}
+
 // GetKeyboard returns the keyboard for the page.
 func (p *Page) GetKeyboard() *Keyboard {
 	return p.Keyboard

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -1011,3 +1011,91 @@ func TestGetByPlaceholderSuccess(t *testing.T) {
 		})
 	}
 }
+
+func TestGetByTitleSuccess(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		title    string
+		opts     *common.GetByBaseOptions
+		expected int
+	}{
+		{
+			"missing_title",
+			"",
+			nil,
+			0,
+		},
+		{
+			// matches on all the elements with a title attribute.
+			"empty_string",
+			"''",
+			nil,
+			5,
+		},
+		{
+			"no_options",
+			"'Click me'",
+			nil,
+			1,
+		},
+		{
+			"exact_match",
+			"'Link to somewhere'",
+			&common.GetByBaseOptions{Exact: toPtr(true)},
+			1,
+		},
+		{
+			"no_exact_match",
+			"'link to somewhere'",
+			&common.GetByBaseOptions{Exact: toPtr(true)},
+			0,
+		},
+		{
+			"case_insensitive_match",
+			"'link to somewhere'",
+			nil,
+			1,
+		},
+		{
+			"regex_match",
+			`/^[a-z0-9]+$/`,
+			nil,
+			1,
+		},
+		{
+			"image_title",
+			"'Placeholder image'",
+			nil,
+			1,
+		},
+		{
+			"div_title",
+			"'Information box'",
+			nil,
+			1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tb := newTestBrowser(t, withFileServer())
+			p := tb.NewPage(nil)
+			opts := &common.FrameGotoOptions{
+				Timeout: common.DefaultTimeout,
+			}
+			_, err := p.Goto(
+				tb.staticURL("get_by_title.html"),
+				opts,
+			)
+			require.NoError(t, err)
+
+			l := p.GetByTitle(tt.title, tt.opts)
+			c, err := l.Count()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, c)
+		})
+	}
+}

--- a/internal/js/modules/k6/browser/tests/static/get_by_title.html
+++ b/internal/js/modules/k6/browser/tests/static/get_by_title.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<head>
+  <title>Title Selector Engine Test Suite</title>
+</head>
+<body>
+  <button title="Click me">Button</button>
+  <a href="#" title="Link to somewhere">Link</a>
+  <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==" title="Placeholder image">
+  <div title="Information box">This is some information</div>
+  <span title="abc123">Test span</span>
+</body>
+</html> 


### PR DESCRIPTION
## What?

This adds a convenience method on `page` to be able to select on elements with the `title` attribute.

## Why?

This is part of the story of adding `getBy*`, which makes working with selectors a little easier. We used to have to work with the `page.locator` API providing either a `CSS` selector or a `XPath` selector if we wanted to get the element by the `title` attribute on an element:

```html
<div title="Information box">This is some information</div>
```

```js
const l = page.locator('div[title="Information box"]'); // CSS
const l = page.locator('//div[@title="Information box"]'); // XPath
```

Now we can use:

```js
const l = page.getByTitle('Information box');
```

Working with `getBy*` in general is an industry standard in the frontend testing world.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/issues/4793, https://github.com/grafana/k6/issues/4248