### PR TITLE
Add getByText in the browser module

### DIFF
--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -324,6 +324,7 @@ type pageAPI interface { //nolint:interfacebloat
 	GetByPlaceholder(placeholder string, opts *common.GetByBaseOptions) *common.Locator
 	GetByTitle(title string, opts *common.GetByBaseOptions) *common.Locator
 	GetByTestId(testID string) *common.Locator
+	GetByText(text string, opts *common.GetByBaseOptions) *common.Locator
 	GetKeyboard() *common.Keyboard
 	GetMouse() *common.Mouse
 	GetTouchscreen() *common.Touchscreen

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -200,6 +200,12 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			ml := mapLocator(vu, p.GetByTestID(ptestID))
 			return rt.ToValue(ml).ToObject(rt), nil
 		},
+		"getByText": func(text sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			ptext, popts := parseGetByBaseOptions(vu.Context(), text, true, opts)
+
+			ml := mapLocator(vu, p.GetByText(ptext, popts))
+			return rt.ToValue(ml).ToObject(rt), nil
+		},
 		"goto": func(url string, opts sobek.Value) (*sobek.Promise, error) {
 			gopts := common.NewFrameGotoOptions(
 				p.Referrer(),

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1153,6 +1153,22 @@ func (f *Frame) GetByTestID(testID string) *Locator {
 	return f.Locator("internal:attr=[data-testid="+testID+"]", nil)
 }
 
+// GetByText creates and returns a new locator for this frame based on text content.
+func (f *Frame) GetByText(text string, opts *GetByBaseOptions) *Locator {
+	f.log.Debugf("Frame:GetByText", "fid:%s furl:%q text:%q opts:%+v", f.ID(), f.URL(), text, opts)
+
+	l := "internal:text=" + text
+	if isQuotedText(text) {
+		if opts != nil && opts.Exact != nil && *opts.Exact {
+			l = "internal:text=" + text + "s"
+		} else {
+			l = "internal:text=" + text + "i"
+		}
+	}
+
+	return f.Locator(l, nil)
+}
+
 // Referrer returns the referrer of the frame from the network manager
 // of the frame's session.
 // It's an internal method not to be exposed as a JS API.

--- a/internal/js/modules/k6/browser/common/js/injected_script.js
+++ b/internal/js/modules/k6/browser/common/js/injected_script.js
@@ -1842,6 +1842,19 @@ function getElementLabels(textCache, element) {
   }
   return [];
 }
+function elementMatchesText(cache, element, matcher) {
+  if (shouldSkipForTextMatching(element))
+    return "none";
+  if (!matcher(elementText(cache, element)))
+    return "none";
+  for (let child = element.firstChild; child; child = child.nextSibling) {
+    if (child.nodeType === Node.ELEMENT_NODE && matcher(elementText(cache, child)))
+      return "selfAndChildren";
+  }
+  if (element.shadowRoot && matcher(elementText(cache, element.shadowRoot)))
+    return "selfAndChildren";
+  return "self";
+}
 
 // packages/injected/src/injectedScript.ts
 function cssUnquote(s) {
@@ -2082,6 +2095,40 @@ class LabelEngine {
   }
 }
 
+class TextEngine {
+  constructor(shadow, internal) {
+    this._evaluator = new SelectorEvaluatorImpl();
+    this._shadow = shadow;
+    this._internal = internal;
+  }
+  queryAll(root, selector) {
+    try {
+      this._evaluator.begin();
+
+      const { matcher, kind } = createTextMatcher(selector, this._internal);
+      const result = [];
+      let lastDidNotMatchSelf = null;
+      const appendElement = (element) => {
+        if (kind === "lax" && lastDidNotMatchSelf && lastDidNotMatchSelf.contains(element))
+          return false;
+        const matches = elementMatchesText(this._evaluator._cacheText, element, matcher);
+        if (matches === "none")
+          lastDidNotMatchSelf = element;
+        if (matches === "self" || matches === "selfAndChildren" && kind === "strict" && !this._internal)
+          result.push(element);
+      };
+      if (root.nodeType === Node.ELEMENT_NODE)
+        appendElement(root);
+      const elements = this._evaluator._queryCSS({ scope: root, pierceShadow: this._shadow }, "*");
+      for (const element of elements)
+        appendElement(element);
+      return result;
+    } finally {
+      this._evaluator.end();
+    }
+  }
+}
+
 // convertToDocument will convert a DocumentFragment into a Document. It does
 // this by creating a new Document and copying the elements from the
 // DocumentFragment to the Document.
@@ -2130,6 +2177,7 @@ class InjectedScript {
       'internal:role': createRoleEngine(true),
       'internal:attr': new AttributeEngine(),
       'internal:label': new LabelEngine(),
+      'internal:text': new TextEngine(true, true),
     };
   }
 

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1130,6 +1130,13 @@ func (p *Page) GetByTestID(testID string) *Locator {
 	return p.MainFrame().GetByTestID(testID)
 }
 
+// GetByText creates and returns a new locator for this page (main frame) based on text content.
+func (p *Page) GetByText(text string, opts *GetByBaseOptions) *Locator {
+	p.logger.Debugf("Page:GetByText", "sid:%s text: %q opts:%+v", p.sessionID(), text, opts)
+
+	return p.MainFrame().GetByText(text, opts)
+}
+
 // GetKeyboard returns the keyboard for the page.
 func (p *Page) GetKeyboard() *Keyboard {
 	return p.Keyboard

--- a/internal/js/modules/k6/browser/common/selectors.go
+++ b/internal/js/modules/k6/browser/common/selectors.go
@@ -100,6 +100,9 @@ func (s *Selector) parse() error {
 		case strings.HasPrefix(part, "internal:label="):
 			name = "internal:label"
 			body = part
+		case strings.HasPrefix(part, "internal:text="):
+			name = "internal:text"
+			body = part
 		default:
 			name = "css"
 			body = part

--- a/internal/js/modules/k6/browser/tests/static/get_by_text.html
+++ b/internal/js/modules/k6/browser/tests/static/get_by_text.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<head>
+  <title>Text Selector Engine Test Suite</title>
+</head>
+<body>
+  <div>Hello World</div>
+  <button>Click me</button>
+  <a href="#">Learn more</a>
+  <span>abc123</span>
+  <p>This is a longer text with multiple words</p>
+  <div>  Spaced  text  </div>
+  <label>Email address</label>
+</body>
+</html> 


### PR DESCRIPTION
## What?

This adds a convenience method on `page` to be able to select on elements with the `text` in the element.

## Why?

This is part of the story of adding `getBy*`, which makes working with selectors a little easier. We used to have to work with the `page.locator` API providing either a `CSS` selector or a `XPath` selector if we wanted to get the element by the `text` in the element:

```html
<div>Hello World</div>
```

```js
// Not available in CSS
const l = page.locator('//div[text()="Hello World"]'); // XPath
```

Now we can use:

```js
const l = page.getByText('Hello World');
```

Working with `getBy*` in general is an industry standard in the frontend testing world.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/issues/4792, https://github.com/grafana/k6/issues/4248