### PR TITLE
feat: Enable web dashboard by default

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -42,10 +42,10 @@ func configFlagSet() *pflag.FlagSet {
 type Config struct {
 	lib.Options
 
-	Out           []string  `json:"out" envconfig:"K6_OUT"`
-	Linger        null.Bool `json:"linger" envconfig:"K6_LINGER"`
-	NoUsageReport null.Bool `json:"noUsageReport" envconfig:"K6_NO_USAGE_REPORT"`
-	WebDashboard  null.Bool `json:"webDashboard" envconfig:"K6_WEB_DASHBOARD"`
+	Out            []string  `json:"out" envconfig:"K6_OUT"`
+	Linger         null.Bool `json:"linger" envconfig:"K6_LINGER"`
+	NoUsageReport  null.Bool `json:"noUsageReport" envconfig:"K6_NO_USAGE_REPORT"`
+	NoWebDashboard null.Bool `json:"noWebDashboard" envconfig:"K6_NO_WEB_DASHBOARD"`
 
 	// NoArchiveUpload is an option that is only used when running in local-execution mode with the cloud run
 	// command.
@@ -79,8 +79,8 @@ func (c Config) Apply(cfg Config) Config {
 	if cfg.NoUsageReport.Valid {
 		c.NoUsageReport = cfg.NoUsageReport
 	}
-	if cfg.WebDashboard.Valid {
-		c.WebDashboard = cfg.WebDashboard
+	if cfg.NoWebDashboard.Valid {
+		c.NoWebDashboard = cfg.NoWebDashboard
 	}
 	if cfg.NoArchiveUpload.Valid {
 		c.NoArchiveUpload = cfg.NoArchiveUpload

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -91,10 +91,10 @@ func TestConfigEnv(t *testing.T) {
 			"true":  func(c Config) { assert.Equal(t, null.BoolFrom(true), c.NoUsageReport) },
 			"false": func(c Config) { assert.Equal(t, null.BoolFrom(false), c.NoUsageReport) },
 		},
-		{"WebDashboard", "K6_WEB_DASHBOARD"}: {
-			"":      func(c Config) { assert.Equal(t, null.Bool{}, c.WebDashboard) },
-			"true":  func(c Config) { assert.Equal(t, null.BoolFrom(true), c.WebDashboard) },
-			"false": func(c Config) { assert.Equal(t, null.BoolFrom(false), c.WebDashboard) },
+		{"NoWebDashboard", "K6_NO_WEB_DASHBOARD"}: {
+			"":      func(c Config) { assert.Equal(t, null.Bool{}, c.NoWebDashboard) },
+			"true":  func(c Config) { assert.Equal(t, null.BoolFrom(true), c.NoWebDashboard) },
+			"false": func(c Config) { assert.Equal(t, null.BoolFrom(false), c.NoWebDashboard) },
 		},
 		{"Out", "K6_OUT"}: {
 			"":         func(c Config) { assert.Equal(t, []string{}, c.Out) },
@@ -335,7 +335,7 @@ func TestWriteDiskConfigWithDefaultFlags(t *testing.T) {
 		DefaultFlags: defaultFlags,
 	}
 
-	c := Config{WebDashboard: null.BoolFrom(true)}
+	c := Config{NoWebDashboard: null.BoolFrom(true)}
 	err := writeDiskConfig(gs, c)
 	require.NoError(t, err)
 
@@ -359,7 +359,7 @@ func TestWriteDiskConfigOverwrite(t *testing.T) {
 		DefaultFlags: defaultFlags,
 	}
 
-	c := Config{WebDashboard: null.BoolFrom(true)}
+	c := Config{NoWebDashboard: null.BoolFrom(true)}
 	err := writeDiskConfig(gs, c)
 	require.NoError(t, err)
 }
@@ -376,7 +376,7 @@ func TestWriteDiskConfigCustomPath(t *testing.T) {
 	}
 	gs.Flags.ConfigFilePath = "my-custom-path/config.json"
 
-	c := Config{WebDashboard: null.BoolFrom(true)}
+	c := Config{NoWebDashboard: null.BoolFrom(true)}
 	err := writeDiskConfig(gs, c)
 	require.NoError(t, err)
 }
@@ -393,7 +393,7 @@ func TestWriteDiskConfigNoJSONContentError(t *testing.T) {
 	}
 
 	c := Config{
-		WebDashboard: null.BoolFrom(true),
+		NoWebDashboard: null.BoolFrom(true),
 		Options: lib.Options{
 			Cloud: []byte(`invalid-json`),
 		},

--- a/internal/cmd/outputs.go
+++ b/internal/cmd/outputs.go
@@ -121,7 +121,7 @@ func createOutputs(
 	}
 
 	outputs := test.derivedConfig.Out
-	if test.derivedConfig.WebDashboard.Bool {
+	if !test.derivedConfig.NoWebDashboard.Bool {
 		outputs = append(outputs, dashboard.OutputName)
 	}
 

--- a/internal/cmd/tests/cmd_run_grpc_test.go
+++ b/internal/cmd/tests/cmd_run_grpc_test.go
@@ -103,10 +103,8 @@ func TestGRPCInputOutput(t *testing.T) {
 			require.NoError(t, err)
 
 			ts := getSingleFileTestState(t, string(script), []string{"-v", "--log-output=stdout", "--no-usage-report"}, 0)
-			ts.Env = map[string]string{
-				"GRPC_ADDR":       tb.Addr,
-				"GRPC_PROTO_PATH": "./proto.proto",
-			}
+			ts.Env["GRPC_ADDR"] = tb.Addr
+			ts.Env["GRPC_PROTO_PATH"] = "./proto.proto"
 			require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "proto.proto"), proto, 0o644))
 
 			cmd.ExecuteWithGlobalState(ts.GlobalState)

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -1952,9 +1952,9 @@ func TestUIRenderWebDashboard(t *testing.T) {
 		active    bool
 		expRender string
 	}{
-		{expRender: "web dashboard:"},
-		{env: "false", expRender: "web dashboard:"},
-		{env: "true", active: true, expRender: "web dashboard: http://127.0.0.1:"},
+		{active: true, expRender: "web dashboard: http://127.0.0.1:"},
+		{env: "false", active: true, expRender: "web dashboard: http://127.0.0.1:"},
+		{env: "true", expRender: "web dashboard:"},
 	}
 
 	for _, tc := range tests {
@@ -1963,7 +1963,7 @@ func TestUIRenderWebDashboard(t *testing.T) {
 
 			ts := NewGlobalTestState(t)
 			if tc.env != "" {
-				ts.Env["K6_WEB_DASHBOARD"] = tc.env
+				ts.Env["K6_NO_WEB_DASHBOARD"] = tc.env
 			}
 			ts.Env["K6_WEB_DASHBOARD_PORT"] = "0"
 			ts.CmdArgs = []string{"k6", "run", "--log-output=stdout"}

--- a/internal/cmd/tests/test_state.go
+++ b/internal/cmd/tests/test_state.go
@@ -93,7 +93,7 @@ func NewGlobalTestState(tb testing.TB) *GlobalTestState {
 		Getwd:        func() (string, error) { return ts.Cwd, nil },
 		BinaryName:   "k6",
 		CmdArgs:      []string{},
-		Env:          map[string]string{"K6_NO_USAGE_REPORT": "true"},
+		Env:          map[string]string{"K6_NO_USAGE_REPORT": "true", "K6_WEB_DASHBOARD_PORT": "0"},
 		Events:       event.NewEventSystem(100, logger),
 		DefaultFlags: defaultFlags,
 		Flags:        defaultFlags,


### PR DESCRIPTION
### What

This PR changes the behavior of the built-in web dashboard to be enabled by default.

  * The dashboard now starts automatically with `k6 run`.
  * The opt-in `K6_WEB_DASHBOARD` environment variable and `webDashboard` JSON property have been removed.
  * New opt-out mechanisms have been introduced to disable the dashboard:
      * Environment variable: `K6_NO_WEB_DASHBOARD=true`
      * JSON config property: `noWebDashboard: true`

**BREAKING CHANGE:**

The `webDashboard` property and `K6_WEB_DASHBOARD` environment variable are no longer supported. Users who explicitly set these to `true` will now have the dashboard enabled by default and should remove the old settings. To disable the dashboard, they must migrate to the new `noWebDashboard` or `K6_NO_WEB_DASHBOARD` options.

### Why

The primary motivation is to improve the out-of-the-box user experience. By enabling the dashboard by default, we provide immediate, real-time visual feedback for test runs without requiring manual configuration. This makes a powerful feature more discoverable and provides instant value to both new and existing users. The opt-out mechanism ensures that users who run k6 in environments where a web server is not desired (e.g., CI/CD) retain full control.

-----

Closes #4903