### PR TITLE
Add `url` option for `waitForNavigation`

### DIFF
--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -388,7 +388,7 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 			}
 
 			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
-				resp, err := f.WaitForNavigation(popts)
+				resp, err := f.WaitForNavigation(popts, nil)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}

--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -387,8 +387,15 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return nil, fmt.Errorf("parsing frame wait for navigation options: %w", err)
 			}
 
-			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
-				resp, err := f.WaitForNavigation(popts, nil)
+			// Inject JS regex checker for URL regex pattern matching
+			ctx := vu.Context()
+			jsRegexChecker, err := injectRegexMatcherScript(ctx, vu, f.Page().TargetID())
+			if err != nil {
+				return nil, err
+			}
+
+			return k6ext.Promise(ctx, func() (result any, reason error) {
+				resp, err := f.WaitForNavigation(popts, jsRegexChecker)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -501,7 +501,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			}
 
 			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
-				resp, err := p.WaitForNavigation(popts)
+				resp, err := p.WaitForNavigation(popts, nil)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -500,8 +500,15 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return nil, fmt.Errorf("parsing page wait for navigation options: %w", err)
 			}
 
-			return k6ext.Promise(vu.Context(), func() (result any, reason error) {
-				resp, err := p.WaitForNavigation(popts, nil)
+			// Inject JS regex checker for URL regex pattern matching
+			ctx := vu.Context()
+			jsRegexChecker, err := injectRegexMatcherScript(ctx, vu, p.TargetID())
+			if err != nil {
+				return nil, err
+			}
+
+			return k6ext.Promise(ctx, func() (result any, reason error) {
+				resp, err := p.WaitForNavigation(popts, jsRegexChecker)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1902,7 +1902,7 @@ func (f *Frame) WaitForNavigation(
 	jsRegexChecker JSRegexChecker,
 ) (*Response, error) {
 	f.log.Debugf("Frame:WaitForNavigation",
-		"fid:%s furl:%s", f.ID(), f.URL())
+		"fid:%s furl:%s url:%s", f.ID(), f.URL(), opts.URL)
 	defer f.log.Debugf("Frame:WaitForNavigation:return",
 		"fid:%s furl:%s", f.ID(), f.URL())
 
@@ -1930,6 +1930,9 @@ func (f *Frame) WaitForNavigation(
 			e := &k6ext.UserFriendlyError{
 				Err:     err,
 				Timeout: opts.Timeout,
+			}
+			if opts.URL != "" {
+				return fmt.Errorf("waiting for navigation to URL matching %q: %w", opts.URL, e)
 			}
 			return fmt.Errorf("waiting for navigation: %w", e)
 		}

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -1894,7 +1894,13 @@ func (f *Frame) WaitForLoadState(state string, popts *FrameWaitForLoadStateOptio
 }
 
 // WaitForNavigation waits for the given navigation lifecycle event to happen.
-func (f *Frame) WaitForNavigation(opts *FrameWaitForNavigationOptions) (*Response, error) {
+// jsRegexChecker should be non-nil to be able to test against a URL pattern in the options.
+//
+//nolint:funlen
+func (f *Frame) WaitForNavigation(
+	opts *FrameWaitForNavigationOptions,
+	jsRegexChecker JSRegexChecker,
+) (*Response, error) {
 	f.log.Debugf("Frame:WaitForNavigation",
 		"fid:%s furl:%s", f.ID(), f.URL())
 	defer f.log.Debugf("Frame:WaitForNavigation:return",
@@ -1910,6 +1916,7 @@ func (f *Frame) WaitForNavigation(opts *FrameWaitForNavigationOptions) (*Respons
 	lifecycleEvtCh, lifecycleEvtCancel := createWaitForEventPredicateHandler(
 		timeoutCtx, f, []string{EventFrameAddLifecycle},
 		func(data any) bool {
+			// Wait for the lifecycle event to happen.
 			if le, ok := data.(FrameLifecycleEvent); ok {
 				return le.Event == opts.WaitUntil
 			}

--- a/internal/js/modules/k6/browser/common/frame_options.go
+++ b/internal/js/modules/k6/browser/common/frame_options.go
@@ -186,6 +186,9 @@ type FrameWaitForLoadStateOptions struct {
 	Timeout time.Duration `json:"timeout"`
 }
 
+// JSRegexChecker is a function that performs regex matching using JavaScript's regex engine
+type JSRegexChecker func(pattern, url string) (bool, error)
+
 type FrameWaitForNavigationOptions struct {
 	URL       string         `json:"url"`
 	WaitUntil LifecycleEvent `json:"waitUntil" js:"waitUntil"`

--- a/internal/js/modules/k6/browser/common/frame_options.go
+++ b/internal/js/modules/k6/browser/common/frame_options.go
@@ -685,7 +685,15 @@ func (o *FrameWaitForNavigationOptions) Parse(ctx context.Context, opts sobek.Va
 		for _, k := range opts.Keys() {
 			switch k {
 			case "url":
-				o.URL = opts.Get(k).String()
+				var val string
+				switch opts.Get(k).ExportType() {
+				case reflect.TypeOf(string("")):
+					val = fmt.Sprintf("'%s'", opts.Get(k).String()) // Strings require quotes
+				default: // JS Regex, CSS, numbers or booleans
+					val = opts.Get(k).String() // No quotes
+				}
+
+				o.URL = val
 			case "timeout":
 				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
 			case "waitUntil":

--- a/internal/js/modules/k6/browser/common/frame_options_test.go
+++ b/internal/js/modules/k6/browser/common/frame_options_test.go
@@ -98,7 +98,7 @@ func TestFrameWaitForNavigationOptionsParse(t *testing.T) {
 		err := navOpts.Parse(vu.Context(), opts)
 		require.NoError(t, err)
 
-		assert.Equal(t, "https://example.com/", navOpts.URL)
+		assert.Equal(t, "'https://example.com/'", navOpts.URL)
 		assert.Equal(t, time.Second, navOpts.Timeout)
 		assert.Equal(t, LifecycleEventNetworkIdle, navOpts.WaitUntil)
 	})

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1576,12 +1576,16 @@ func (p *Page) WaitForLoadState(state string, popts *FrameWaitForLoadStateOption
 }
 
 // WaitForNavigation waits for the given navigation lifecycle event to happen.
-func (p *Page) WaitForNavigation(opts *FrameWaitForNavigationOptions) (*Response, error) {
+// jsRegexChecker should be non-nil to be able to test against a URL pattern in the options.
+func (p *Page) WaitForNavigation(
+	opts *FrameWaitForNavigationOptions,
+	jsRegexChecker JSRegexChecker,
+) (*Response, error) {
 	p.logger.Debugf("Page:WaitForNavigation", "sid:%v", p.sessionID())
 	_, span := TraceAPICall(p.ctx, p.targetID.String(), "page.waitForNavigation")
 	defer span.End()
 
-	resp, err := p.frameManager.MainFrame().WaitForNavigation(opts)
+	resp, err := p.frameManager.MainFrame().WaitForNavigation(opts, jsRegexChecker)
 	if err != nil {
 		spanRecordError(span, err)
 		return nil, err

--- a/internal/js/modules/k6/browser/tests/frame_manager_test.go
+++ b/internal/js/modules/k6/browser/tests/frame_manager_test.go
@@ -45,7 +45,7 @@ func TestWaitForFrameNavigationWithinDocument(t *testing.T) {
 
 			waitForNav := func() error {
 				opts := &common.FrameWaitForNavigationOptions{Timeout: timeout}
-				_, err := p.WaitForNavigation(opts)
+				_, err := p.WaitForNavigation(opts, nil)
 				return err
 			}
 			click := func() error {
@@ -103,7 +103,7 @@ func TestWaitForFrameNavigation(t *testing.T) {
 		opts := &common.FrameWaitForNavigationOptions{
 			Timeout: 5000 * time.Millisecond,
 		}
-		_, err := p.WaitForNavigation(opts)
+		_, err := p.WaitForNavigation(opts, nil)
 		return err
 	}
 	click := func() error {

--- a/internal/js/modules/k6/browser/tests/frame_test.go
+++ b/internal/js/modules/k6/browser/tests/frame_test.go
@@ -149,7 +149,7 @@ func TestFrameNoPanicNavigateAndClickOnPageWithIFrames(t *testing.T) {
 		func() error { return p.Click(`a[href="/iframeSignIn"]`, common.NewFrameClickOptions(p.Timeout())) },
 		func() error {
 			_, err := p.WaitForNavigation(
-				common.NewFrameWaitForNavigationOptions(p.Timeout()),
+				common.NewFrameWaitForNavigationOptions(p.Timeout()), nil,
 			)
 			return err
 		},

--- a/internal/js/modules/k6/browser/tests/lifecycle_wait_test.go
+++ b/internal/js/modules/k6/browser/tests/lifecycle_wait_test.go
@@ -138,7 +138,7 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 					Timeout:   1000 * time.Millisecond,
 					WaitUntil: common.LifecycleEventNetworkIdle,
 				}
-				_, err = p.WaitForNavigation(opts)
+				_, err = p.WaitForNavigation(opts, nil)
 
 				return err
 			},
@@ -182,7 +182,7 @@ func TestLifecycleWaitForNavigation(t *testing.T) {
 						Timeout:   30000 * time.Millisecond,
 						WaitUntil: tt.waitUntil,
 					}
-					_, err := p.WaitForNavigation(opts)
+					_, err := p.WaitForNavigation(opts, nil)
 					return err
 				}
 				click := func() error {

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -950,8 +950,7 @@ func TestPageWaitForNavigationErrOnCtxDone(t *testing.T) {
 	go b.cancelContext()
 	<-b.context().Done()
 	_, err := p.WaitForNavigation(
-		common.NewFrameWaitForNavigationOptions(p.Timeout()),
-	)
+		common.NewFrameWaitForNavigationOptions(p.Timeout()), nil)
 	require.ErrorContains(t, err, "canceled")
 }
 

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2864,3 +2864,24 @@ func TestWaitForNavigationWithURL(t *testing.T) {
 	)
 	assert.Equal(t, sobek.Undefined(), got.Result())
 }
+
+func TestWaitForNavigationWithURL_RegexFailure(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	tb.vu.ActivateVU()
+	tb.vu.StartIteration(t)
+
+	_, err := tb.vu.RunAsync(t, `
+		const page = await browser.newPage();
+		await page.goto('%s');
+
+		await Promise.all([
+			page.waitForNavigation({ url: /^.*/my_messages.*$/ }),
+			page.locator('#page2').click()
+		]);
+	`,
+		tb.staticURL("waitfornavigation_test.html"),
+	)
+	assert.ErrorContains(t, err, "Unexpected token *")
+}

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2786,3 +2786,81 @@ func TestPageMustUseNativeJavaScriptObjects(t *testing.T) {
 	_, err = page.QueryAll("#textField")
 	require.NoErrorf(t, err, "page should not override the native objects, but it did")
 }
+
+func TestWaitForNavigationWithURL(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	tb.vu.ActivateVU()
+	tb.vu.StartIteration(t)
+
+	got := tb.vu.RunPromise(t, `
+		const page = await browser.newPage();
+		const testURL = '%s';
+
+		try {
+			await page.goto(testURL);
+
+			// Test exact URL match
+			await Promise.all([
+				page.waitForNavigation({ url: '%s' }),
+				page.locator('#page1').click()
+			]);
+			let currentURL = page.url();
+			if (!currentURL.endsWith('page1.html')) {
+				throw new Error('Expected to navigate to page1.html but got ' + currentURL);
+			}
+
+			await page.goto(testURL);
+
+			// Test regex pattern - matches any page with .html extension
+			await Promise.all([
+				page.waitForNavigation({ url: /.*\.html$/ }),
+				page.locator('#page2').click()
+			]);
+			currentURL = page.url();
+			if (!currentURL.endsWith('.html')) {
+				throw new Error('Expected URL to end with .html but got ' + currentURL);
+			}
+
+			await page.goto(testURL);
+
+			// Test timeout when URL doesn't match
+			let timedOut = false;
+			try {
+				await Promise.all([
+					page.waitForNavigation({ url: /.*nonexistent.html$/, timeout: 500 }),
+					page.locator('#page1').click()  // This goes to page1.html, not nonexistent.html
+				]);
+			} catch (error) {
+				if (error.toString().includes('waiting for navigation')) {
+					timedOut = true;
+				} else {
+					throw error;
+				}
+			}
+			if (!timedOut) {
+				throw new Error('Expected timeout error when URL does not match');
+			}
+
+			await page.goto(testURL);
+
+			// Test empty pattern (matches any navigation)
+			await Promise.all([
+				page.waitForNavigation({ url: '' }),
+				page.locator('#page2').click()
+			]);
+			currentURL = page.url();
+			if (!currentURL.endsWith('page2.html')) {
+				throw new Error('Expected empty pattern to match any navigation but got ' + currentURL);
+			}
+		} finally {
+			// Must call close() which will clean up the taskqueue.
+			await page.close();
+		}
+	`,
+		tb.staticURL("waitfornavigation_test.html"),
+		tb.staticURL("page1.html"),
+	)
+	assert.Equal(t, sobek.Undefined(), got.Result())
+}

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2788,6 +2788,10 @@ func TestPageMustUseNativeJavaScriptObjects(t *testing.T) {
 }
 
 func TestWaitForNavigationWithURL(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipped due to https://github.com/grafana/k6/issues/4937")
+	}
+
 	t.Parallel()
 
 	tb := newTestBrowser(t, withFileServer())

--- a/internal/js/modules/k6/browser/tests/static/waitfornavigation_test.html
+++ b/internal/js/modules/k6/browser/tests/static/waitfornavigation_test.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head></head>
+<body>
+    <a id="page1" href="page1.html">Go to Page 1</a>
+    <a id="page2" href="page2.html">Go to Page 2</a>
+</body>
+</html> 

--- a/internal/js/modules/k6/browser/tests/webvital_test.go
+++ b/internal/js/modules/k6/browser/tests/webvital_test.go
@@ -75,8 +75,7 @@ func TestWebVitalMetric(t *testing.T) {
 		func() error { return page.Click("#clickMe", common.NewFrameClickOptions(page.Timeout())) },
 		func() error {
 			_, err := page.WaitForNavigation(
-				common.NewFrameWaitForNavigationOptions(page.Timeout()),
-			)
+				common.NewFrameWaitForNavigationOptions(page.Timeout()), nil)
 			return err
 		},
 	)


### PR DESCRIPTION
## What?

This adds/uses the `url` option in `waitForNavigation`. This extends `waitForNavigation` so that k6 waits for a specific URL before continuing on.

## Why?

Many users have to work with websites which perform lots of redirects during an auth login process. They would currently have to either:

```js
    await Promise.all([
      page.waitForNavigation(),
      page.locator('a[href="/my_messages.php"]').click(),
    ]);

    // Wait for an arbitrary amount of time to make sure that any redirects during the navigation have completed entirely and we are now on the specific page.
    page.waitForTimeout(2000);
```

Or

```js
    await page.locator('a[href="/my_messages.php"]').click()

    await page.locator('//div[text()="You made it passed all the redirects!"]').waitFor()
```

Now we have another option for those who want a repeatable, consistent and deterministic way where the url doesn't change as often as the elements on the page and without arbitrary time outs, which is to do:

```js
    await Promise.all([
      page.waitForNavigation({ url:'https://quickpizza.grafana.com/my_messages.php' }),
      page.locator('a[href="/my_messages.php"]').click(),
    ]);
```

This also works for regex:

```js
    const [response3] = await Promise.all([
      page.waitForNavigation({ url: /.*\/contacts\.php.*/ }),
      page.locator('a[href^="/contacts.php"]').click()
    ]);
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/issues/4461, https://github.com/grafana/k6/issues/4385