### PR TITLE
Fix page.url() to work with cached url

### DIFF
--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1548,17 +1548,7 @@ func (p *Page) Type(selector string, text string, popts *FrameTypeOptions) error
 func (p *Page) URL() (string, error) {
 	p.logger.Debugf("Page:URL", "sid:%v", p.sessionID())
 
-	js := `() => document.location.toString()`
-	v, err := p.Evaluate(js)
-	if err != nil {
-		return "", fmt.Errorf("getting page URL: %w", err)
-	}
-	s, ok := v.(string)
-	if !ok {
-		return "", fmt.Errorf("getting page URL: expected string, got %T", v)
-	}
-
-	return s, nil
+	return p.MainFrame().url, nil
 }
 
 // ViewportSize will return information on the viewport width and height.


### PR DESCRIPTION
## What?

Working with the cached url from `mainFrame` instead of requesting it from chromium via a CDP request.

## Why?

- This follows the same behaviour as [Playwright](https://github.com/microsoft/playwright/blob/6626bba937af513cbcf05d5e164aa20b6d390ea2/packages/playwright-core/src/client/page.ts#L359).
- It removes a CDP request to chrome in an API that is supposed to be synchronous.
- Finally, it avoids the `missing context id` errors when `page.url()` is called just after or during a navigation.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [x] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
