### PR TITLE
add k6 Studio mention in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,11 @@ export default function () {
 
 You can run scripts like this on the CLI, or in your CI, or across a Kubernetes cluster.
 
+> [!NOTE]
+> Don't want to write code ?
+> 
+> We got you! Meet [k6 Studio](https://github.com/grafana/k6-studio), a desktop application made to help you generate k6 scripts without having to touch code!
+
 ## Documentation
 
 The docs cover all aspects of using k6. Some highlights include:


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->
This PR adds a note under the first example script before the Documentation section to mention k6 Studio is available for users that don't want to write scripts themselves.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->
This change is made to increase visibility of the k6 Studio application.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
