### PR TITLE
Update log to debug on "Invalid InterceptionId"

### DIFF
--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -553,6 +553,14 @@ func (m *NetworkManager) onRequestPaused(event *fetch.EventRequestPaused) {
 				m.logger.Debug("NetworkManager:onRequestPaused", "context canceled continuing request")
 				return
 			}
+			// This error message is an internal issue, rather than something that the user can
+			// action on. It's also usually ok to ignore since it means that the page has navigated
+			// away or something has occurred which means that the request is no longer needed and
+			// isn't being tracked by chromium.
+			if strings.Contains(err.Error(), "Invalid InterceptionId") {
+				m.logger.Debugf("NetworkManager:onRequestPaused", "continuing request: %s", err)
+				return
+			}
 			m.logger.Errorf("NetworkManager:onRequestPaused", "continuing request: %s", err)
 		}
 	}()


### PR DESCRIPTION
## What?

Downgrading a specific log from error to debug.

## Why?

Internal error that the user cannot action on. Occurs when the request is no longer being tracked by chromium, usually due to a navigation.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
