### PR TITLE
Add Dependabot rule for the main Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,12 @@ updates:
       - dependency-name: "github.com/stretchr/testify"
       - dependency-name: "go.opentelemetry.io/*"
 
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      # We don't update immediately. We usually wait for `vX.Y.1` to be out.
+      interval: "quarterly"
+
   # Update k6packager dependencies
   - package-ecosystem: "docker"
     directory: "/packaging"


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

It adds a rule to keep up to date of the main Dockerfile. It uses a very relaxed interval, as we usually don't update immediately on Alpine releases. I didn't find the possibility to define a condition based on SemVer for Docker.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

If we forget to update the image, then Dependabot will remind it.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
