### PR TITLE
ci: Lower number of test binaries run when arm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,9 @@ jobs:
             args[1]="1"
             export GOMAXPROCS=1
           fi
+          if [[ "${{ matrix.platform }}" == *arm; then
+            args[1]="1" # run only single test binary at a time on arm
+          fi
           go test "${args[@]}" -timeout 800s ./...
 
   test-tip:
@@ -98,6 +101,9 @@ jobs:
             args[1]="1"
             export GOMAXPROCS=1
           fi
+          if [[ "${{ matrix.platform }}" == *arm; then
+            args[1]="1" # run only single test binary at a time on arm
+          fi
           go test "${args[@]}" -timeout 800s ./...
 
   test-current-cov:
@@ -136,6 +142,9 @@ jobs:
             unset args[2]
             args[1]="1"
             export GOMAXPROCS=1
+          fi
+          if [[ "${{ matrix.platform }}" == *arm; then
+            args[1]="1" # run only single test binary at a time on arm
           fi
           echo "mode: set" > coverage.txt
           for pkg in $(go list ./... | grep -v vendor); do


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
