### PR TITLE
Binary provisioning/pass fs to k6deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/golang/protobuf v1.5.4
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/grafana/k6deps v0.3.0
+	github.com/grafana/k6deps v0.4.0
 	github.com/grafana/k6provider v0.1.15
 	github.com/grafana/sobek v0.0.0-20250320150027-203dc85b6d98
 	github.com/grafana/xk6-dashboard v0.7.10

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/k6build v0.5.11 h1:nuYV5DOMz5PEU8/XFRcDcfgzxUlLujeYNkU7NVEbdfc=
 github.com/grafana/k6build v0.5.11/go.mod h1:SA6/5cnnCLQ99IpFrqVfcuO+SxCRo/yLGtcnj3bfpII=
-github.com/grafana/k6deps v0.3.0 h1:jmI+miMW28hfteRhLvtzERbjJ1+JVK/b3V3spo3dghY=
-github.com/grafana/k6deps v0.3.0/go.mod h1:31pACKFJApQMMcu4hb4N3ti+Kz4s6PomUR63Y6S0bWM=
+github.com/grafana/k6deps v0.4.0 h1:YJ2xJyy3VM8/YWmCeX2vyoWzuq9dwdDTA5qCXIsnS0w=
+github.com/grafana/k6deps v0.4.0/go.mod h1:31pACKFJApQMMcu4hb4N3ti+Kz4s6PomUR63Y6S0bWM=
 github.com/grafana/k6foundry v0.4.6 h1:fFgR72Pw0dzo8wVWyggu35SGGjdt31Dktil1bDE1MCM=
 github.com/grafana/k6foundry v0.4.6/go.mod h1:eLsr0whhH+5Y1y7YpDxJi3Jv5wHMuf+80vdRyMH10pg=
 github.com/grafana/k6provider v0.1.15 h1:aUStpqDMEnEL9aGCcSKmpcreHRZsr8IELna+ttKMOYI=

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -326,7 +326,7 @@ func analyze(gs *state.GlobalState, args []string) (k6deps.Dependencies, error) 
 		}
 		dopts.Script.Name = sourceRootPath
 		dopts.Script.Contents = src.Data
-		dopts.Fs = gs.FS
+		dopts.Fs = newIofsBridge(gs.FS)
 	}
 
 	return k6deps.Analyze(dopts)

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -21,23 +21,23 @@ import (
 	"go.k6.io/k6/lib/fsext"
 )
 
-// OFSBridge allows an afero.Fs to implement the Go standard library io/fs.FS.
-type iofSBridge struct {
+// ioFSBridge allows an afero.Fs to implement the Go standard library io/fs.FS.
+type ioFSBridge struct {
 	fsext fsext.Fs
 }
 
 // newIofsBridge returns an IOFSBridge from a Fs
-func newIofsBridge(fs fsext.Fs) fs.FS {
-	return &iofSBridge{
+func newIOFSBridge(fs fsext.Fs) fs.FS {
+	return &ioFSBridge{
 		fsext: fs,
 	}
 }
 
 // Open implements fs.Fs Open
-func (b *iofSBridge) Open(name string) (fs.File, error) {
+func (b *ioFSBridge) Open(name string) (fs.File, error) {
 	f, err := b.fsext.Open(name)
 	if err != nil {
-		return nil, fmt.Errorf("opening file: %w", err)
+		return nil, fmt.Errorf("opening file via launcher's bridge: %w", err)
 	}
 	return f, nil
 }
@@ -326,7 +326,7 @@ func analyze(gs *state.GlobalState, args []string) (k6deps.Dependencies, error) 
 		}
 		dopts.Script.Name = sourceRootPath
 		dopts.Script.Contents = src.Data
-		dopts.Fs = newIofsBridge(gs.FS)
+		dopts.Fs = newIOFSBridge(gs.FS)
 	}
 
 	return k6deps.Analyze(dopts)

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -405,9 +405,9 @@ func TestBridgeOpen(t *testing.T) {
 	testfs := afero.NewMemMapFs()
 	require.NoError(t, fsext.WriteFile(testfs, "abasicpath/onetwo.txt", []byte(`test123`), 0o644))
 
-	bridge := &iofSBridge{fsext: testfs}
+	bridge := &ioFSBridge{fsext: testfs}
 
-	// it asserts that bridge implements io/fs.FS
+	// It asserts that the bridge implements io/fs.FS
 	goiofs := fs.FS(bridge)
 	f, err := goiofs.Open("abasicpath/onetwo.txt")
 	require.NoError(t, err)

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -4,13 +4,17 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/grafana/k6deps"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/cmd/state"
 
 	"go.k6.io/k6/errext"
@@ -393,4 +397,24 @@ func TestIsAnalysisRequired(t *testing.T) {
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
+}
+
+func TestBridgeOpen(t *testing.T) {
+	t.Parallel()
+
+	testfs := afero.NewMemMapFs()
+	require.NoError(t, fsext.WriteFile(testfs, "abasicpath/onetwo.txt", []byte(`test123`), 0o644))
+
+	bridge := &iofSBridge{fsext: testfs}
+
+	// it asserts that bridge implements io/fs.FS
+	goiofs := fs.FS(bridge)
+	f, err := goiofs.Open("abasicpath/onetwo.txt")
+	require.NoError(t, err)
+	require.NotNil(t, f)
+
+	content, err := io.ReadAll(f)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test123", string(content))
 }

--- a/vendor/github.com/grafana/k6deps/README.md
+++ b/vendor/github.com/grafana/k6deps/README.md
@@ -15,19 +15,10 @@ k6deps is primarily used as a [go library](https://pkg.go.dev/github.com/grafana
 
 The command line tool can be integrated into other command line tools as a subcommand. For this purpose, the library also contains the functionality of the command line tool as a factrory function that returns [cobra.Command](https://pkg.go.dev/github.com/spf13/cobra#Command).
 
-## Install
 
-Precompiled binaries can be downloaded and installed from the [Releases](https://github.com/grafana/k6deps/releases) page.
+## Library Usage
 
-If you have a go development environment, the installation can also be done with the following command:
-
-```
-go install github.com/grafana/k6deps/cmd/k6deps@latest
-```
-
-## Usage
-
-Dependencies can come from three [sources](#sources): k6 test script, manifest file, `K6_DEPENDENCIES` environment variable. Instead of these three sources, a k6 archive can also be specified, which can contain all three sources (currently two actually, because the manifest file is not yet included in the k6 archive).
+Dependencies come from [sources](#sources): k6 test script or k6 archive files. These dependencies are combined with overrides from a manifest file and the `K6_DEPENDENCIES` environment variable. Only dependencies that do not specify a constrain or specify a general "*" constrain are overriden from those sources.
 
 In the simplest use, we only extract the dependencies from the script source.
 
@@ -123,6 +114,16 @@ func ExampleAnalyze_without_pragma() {
 
 ## CLI
 
+## Install
+
+Precompiled binaries can be downloaded and installed from the [Releases](https://github.com/grafana/k6deps/releases) page.
+
+If you have a go development environment, the installation can also be done with the following command:
+
+```
+go install github.com/grafana/k6deps/cmd/k6deps@latest
+```
+
 <!-- #region cli -->
 ## k6deps
 
@@ -134,7 +135,7 @@ Analyze the k6 test script and extract the extensions that the script depends on
 
 ### Sources
 
-Dependencies can come from three sources: k6 test script, manifest file, `K6_DEPENDENCIES` environment variable. Instead of these three sources, a k6 archive can also be specified, which can contain all three sources (currently two actually, because the manifest file is not yet included in the k6 archive). An archive is a tar file, which can be created using the k6 archive command.
+Dependencies come from [sources](#sources): k6 test script or k6 archive files. These dependencies are combined with overrides from a manifest file and the `K6_DEPENDENCIES` environment variable. Only dependencies that do not specify a constrain or specify a general "*" constrain are overriden from those sources.
 
 > *NOTE*: It is assumed that the script and all dependencies are in the archive. No external dependencies are analyzed.
 
@@ -157,6 +158,8 @@ Dependencies and version constraints can also be specified in the so-called mani
 Dependencies and version constraints can also be specified in the `K6_DEPENDENCIES` environment variable. The value of the variable is a list of dependencies in a one-line text format.
 
     k6>0.54;k6/x/faker>0.4.0;k6/x/sql>=v1.0.1
+
+> *NOTE*: dependencies specied in the manifest or environment variables are used only to override the constrains of the dependencies found in the script or achive. If they are not referenced in the source, they are ignored.
 
 ### Format
 
@@ -191,7 +194,6 @@ k6deps [flags] [script-file]
       --format json|text|js   output format, possible values: json,env,script (default json)
   -h, --help                  help for k6deps
       --ignore-manifest       disable package.json detection and processing
-      --ignore-script         disable script processing
       --ingnore-env           ignore K6_DEPENDENCIES environment variable processing
   -i, --input string          input format ('js', 'ts' or 'tar' for archives)
       --manifest string       manifest file to analyze (default 'package.json' nearest to script-file)
@@ -202,5 +204,5 @@ k6deps [flags] [script-file]
 
 ## Contribute
 
-If you want to contribute or help with the development of **k6pack**, start by 
+If you want to contribute or help with the development of **k6deps**, start by 
 reading [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/vendor/github.com/grafana/k6deps/analyze.go
+++ b/vendor/github.com/grafana/k6deps/analyze.go
@@ -118,24 +118,20 @@ func (a *archiveAnalizer) analyze() (Dependencies, error) {
 	return processArchive(a.src)
 }
 
-type mergeAnalyzer struct {
-	analyzers []analyzer
-}
+// resolve the overides of the dependencies from multiple analyzers
+func resolveOverrides(src analyzer, overrides ...analyzer) (Dependencies, error) {
+	deps, err := src.analyze()
+	if err != nil {
+		return nil, err
+	}
 
-func newMergeAnalyzer(analyzers ...analyzer) analyzer {
-	return &mergeAnalyzer{analyzers: analyzers}
-}
-
-func (m *mergeAnalyzer) analyze() (Dependencies, error) {
-	deps := make(Dependencies)
-
-	for _, a := range m.analyzers {
+	for _, a := range overrides {
 		dep, err := a.analyze()
 		if err != nil {
 			return nil, err
 		}
 
-		err = deps.Merge(dep)
+		err = deps.Override(dep)
 		if err != nil {
 			return nil, err
 		}

--- a/vendor/github.com/grafana/k6deps/dependencies.go
+++ b/vendor/github.com/grafana/k6deps/dependencies.go
@@ -52,17 +52,38 @@ func (deps Dependencies) update(from *Dependency) error {
 	return dep.update(from)
 }
 
-// Merge updates deps dependencies based on from dependencies.
-// Adds a dependency that doesn't exist yet.
+// Merge combines two sets of dependencies.
 // If the dependency exists in both collections, but one of them does not have version constraints,
 // then the dependency with version constraints is placed in deps.
-// Otherwise, i.e. if the dependency is included in both collections and in both with version constraints,
+// If the dependency is included in both collections and in both with version constraints,
 // an error is generated.
 func (deps Dependencies) Merge(from Dependencies) error {
 	for _, dep := range from {
 		if err := deps.update(dep); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// Override updates dependencies without constrains.
+func (deps Dependencies) Override(from Dependencies) error {
+	if len(from) == 0 {
+		return nil
+	}
+
+	for _, dep := range deps {
+		over, found := from[dep.Name]
+		if !found {
+			continue
+		}
+
+		if dep.GetConstraints().String() != defaultConstraintsString {
+			continue
+		}
+
+		dep.Constraints = over.Constraints
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -184,7 +184,7 @@ github.com/gorilla/websocket
 github.com/grafana/k6build
 github.com/grafana/k6build/pkg/api
 github.com/grafana/k6build/pkg/client
-# github.com/grafana/k6deps v0.3.0
+# github.com/grafana/k6deps v0.4.0
 ## explicit; go 1.23.0
 github.com/grafana/k6deps
 github.com/grafana/k6deps/internal/pack


### PR DESCRIPTION
## What?

Creates a bridge between the internally used `afero.Fs` library and golang's standard `fs.FS` and use it in the `k6deps` library.

## Why?

`afero.FS` will eventually be removed from `k6`. Therefore, we want to prevent creating more dependencies from this library


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
