### PR TITLE
tests: fix a race using the same sobek.Runtime in parallel

### DIFF
--- a/internal/js/console_test.go
+++ b/internal/js/console_test.go
@@ -286,7 +286,7 @@ func TestConsoleLog(t *testing.T) {
 	}
 }
 
-func TestConsoleLogWithGoValues(t *testing.T) {
+func TestConsoleLogWithGoValues(t *testing.T) { //nolint:tparallel // actually faster with parallel and also we need the rt to create some of the testdata
 	t.Parallel()
 
 	rt := sobek.New()
@@ -318,12 +318,8 @@ func TestConsoleLogWithGoValues(t *testing.T) {
 		{in: rt.NewTypeError("type error"), expected: `TypeError: type error`},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range tests { //nolint:paralleltest
 		t.Run(fmt.Sprintf("%v", tt.in), func(t *testing.T) {
-			t.Parallel()
-
-			rt.SetFieldNameMapper(common.FieldNameMapper{})
-
 			logger, hook := testutils.NewLoggerWithHook(t)
 			c := newConsole(logger)
 

--- a/internal/js/console_test.go
+++ b/internal/js/console_test.go
@@ -290,6 +290,7 @@ func TestConsoleLogWithGoValues(t *testing.T) { //nolint:tparallel // actually f
 	t.Parallel()
 
 	rt := sobek.New()
+	rt.SetFieldNameMapper(common.FieldNameMapper{})
 
 	tests := []struct {
 		in       any


### PR DESCRIPTION
## What?

Fix a race using the same sobek.Runtime in parallel in recently added tests
## Why?
It triggers the race detector, albeit requiring `-timeout` to be used by every experiment I ran
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
hat tip @ankur22 for bisecting the original commit
