### PR TITLE
Drop some gosec comments

### DIFF
--- a/internal/js/modules/k6/browser/browser/module.go
+++ b/internal/js/modules/k6/browser/browser/module.go
@@ -9,9 +9,6 @@ package browser
 import (
 	"context"
 	"io"
-	"log"
-	"net/http"
-	_ "net/http/pprof" //nolint:gosec
 	"sync"
 
 	"github.com/grafana/sobek"
@@ -122,9 +119,6 @@ func (m *RootModule) initialize(vu k6modules.VU) {
 	if err != nil {
 		k6ext.Abort(vu.Context(), "parsing browser traces metadata: %v", err)
 	}
-	if _, ok := initEnv.LookupEnv(env.EnableProfiling); ok {
-		go startDebugServer()
-	}
 	m.filePersister, err = newScreenshotPersister(initEnv.LookupEnv)
 	if err != nil {
 		k6ext.Abort(vu.Context(), "failed to create file persister: %v", err)
@@ -132,10 +126,4 @@ func (m *RootModule) initialize(vu k6modules.VU) {
 	if e, ok := initEnv.LookupEnv(env.K6TestRunID); ok && e != "" {
 		m.testRunID = e
 	}
-}
-
-func startDebugServer() {
-	log.Println("Starting http debug server", env.ProfilingServerAddr)
-	log.Println(http.ListenAndServe(env.ProfilingServerAddr, nil)) //nolint:gosec
-	// no linted because we don't need to set timeouts for the debug server.
 }

--- a/internal/js/modules/k6/browser/env/env.go
+++ b/internal/js/modules/k6/browser/env/env.go
@@ -43,14 +43,6 @@ const (
 
 // Logging and debugging.
 const (
-	// EnableProfiling is an environment variable that can be used to
-	// enable profiling for the browser. It will start up a debugging
-	// server on ProfilingServerAddr.
-	EnableProfiling = "K6_BROWSER_ENABLE_PPROF"
-
-	// ProfilingServerAddr is the address of the profiling server.
-	ProfilingServerAddr = "localhost:6060"
-
 	// LogCaller is an environment variable that can be used to enable
 	// the caller function information in the browser logs.
 	LogCaller = "K6_BROWSER_LOG_CALLER"

--- a/internal/lib/testutils/untar.go
+++ b/internal/lib/testutils/untar.go
@@ -61,9 +61,7 @@ func Untar(t *testing.T, fileSystem fsext.Fs, fileName string, destination strin
 			}
 			defer func() { _ = f.Close() }()
 
-			// as long as this code in a test helper, we can safely
-			// omit G110: Potential DoS vulnerability via decompression bomb
-			if _, err := io.Copy(f, tr); err != nil { //nolint:gosec
+			if _, err := io.CopyN(f, tr, header.Size); err != nil {
 				return err
 			}
 		}

--- a/internal/output/opentelemetry/tls.go
+++ b/internal/output/opentelemetry/tls.go
@@ -15,7 +15,9 @@ func buildTLSConfig(
 	certPath, clientCertPath, clientKeyPath null.String,
 ) (*tls.Config, error) {
 	set := false
-	tlsConfig := &tls.Config{} //nolint:gosec // it's up to the caller
+	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+	}
 
 	if insecureSkipVerify.Valid {
 		tlsConfig.InsecureSkipVerify = insecureSkipVerify.Bool

--- a/internal/output/prometheusrw/remotewrite/config.go
+++ b/internal/output/prometheusrw/remotewrite/config.go
@@ -12,9 +12,10 @@ import (
 
 	"go.k6.io/k6/internal/output/prometheusrw/sigv4"
 
+	"gopkg.in/guregu/null.v3"
+
 	"go.k6.io/k6/internal/output/prometheusrw/remote"
 	"go.k6.io/k6/lib/types"
-	"gopkg.in/guregu/null.v3"
 )
 
 const (
@@ -115,6 +116,7 @@ func (conf Config) RemoteConfig() (*remote.HTTPConfig, error) {
 
 	hc.TLSConfig = &tls.Config{
 		InsecureSkipVerify: conf.InsecureSkipTLSVerify.Bool, //nolint:gosec
+		MinVersion:         tls.VersionTLS13,
 	}
 
 	if conf.ClientCertificate.Valid && conf.ClientCertificateKey.Valid {

--- a/internal/output/prometheusrw/remotewrite/config_test.go
+++ b/internal/output/prometheusrw/remotewrite/config_test.go
@@ -11,9 +11,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v3"
+
 	"go.k6.io/k6/internal/output/prometheusrw/remote"
 	"go.k6.io/k6/lib/types"
-	"gopkg.in/guregu/null.v3"
 )
 
 func TestConfigApply(t *testing.T) {
@@ -74,6 +75,7 @@ func TestConfigRemoteConfig(t *testing.T) {
 		Timeout: 5 * time.Second,
 		TLSConfig: &tls.Config{
 			InsecureSkipVerify: true, //nolint:gosec
+			MinVersion:         tls.VersionTLS13,
 		},
 		BasicAuth: &remote.BasicAuth{
 			Username: "myuser",


### PR DESCRIPTION
## What?

Remove some `gosec` nolint warnings

## Why?

Reducing potential security issues, especially where there is no need for the small issues to be fixed.

This is marked as breaking change due to Prometheus and opentelemetry outputs now requiring TLS 1.3 - which seems just like the correct thing to do. I can't imagine there are any implementations that do not support 1.3 for the last many years now. Yet it still changes the version so I am marking it as a breaking change.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
