### PR TITLE
Use `crypto/rand` instead of insecure `math/rand`

### DIFF
--- a/internal/js/modules/k6/browser/chromium/browser_type.go
+++ b/internal/js/modules/k6/browser/chromium/browser_type.go
@@ -86,8 +86,10 @@ func (b *BrowserType) initContext(ctx context.Context) context.Context {
 	ctx = k6ext.WithCustomMetrics(ctx, b.k6Metrics)
 	ctx = common.WithHooks(ctx, b.hooks)
 	var buf [8]byte
-	rand.Read(buf[:])
-	ctx = common.WithIterationID(ctx, fmt.Sprintf("%x", buf[:]))
+	_, err := rand.Read(buf[:])
+	if err == nil {
+		ctx = common.WithIterationID(ctx, fmt.Sprintf("%x", buf[:]))
+	}
 	return ctx
 }
 


### PR DESCRIPTION
## What?

This is using `crypto/rand` instead of `math/rand`.

## Why?

`math/rand` raises a gosec issue.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
