### PR TITLE
Browser: add route.continue

### DIFF
--- a/examples/browser/route_continue.js
+++ b/examples/browser/route_continue.js
@@ -1,13 +1,13 @@
-import { check, sleep } from "k6";
-import { browser } from "k6/browser";
+import { check, sleep } from 'k6';
+import { browser } from 'k6/browser';
 
 export const options = {
   scenarios: {
     ui: {
-      executor: "shared-iterations",
+      executor: 'shared-iterations',
       options: {
         browser: {
-          type: "chromium",
+          type: 'chromium',
         },
       },
     },
@@ -17,25 +17,27 @@ export const options = {
 export default async function () {
   const page = await browser.newPage();
 
-  await page.route(/.*\/api\/pizza/, function (route) {
-    route.continue({
-      postData: JSON.stringify({
-        customName: "My Pizza",
-      }),
+  try {
+    await page.route(/.*\/api\/pizza/, function (route) {
+      route.continue({
+        postData: JSON.stringify({
+          customName: 'My Pizza',
+        }),
+      });
     });
-  });
 
-  await page.goto("https://quickpizza.grafana.com/");
+    await page.goto('https://quickpizza.grafana.com/');
 
-  await page.getByRole("button", { name: "pizza, please" }).click();
-  sleep(1);
+    await page.getByRole('button', { name: 'pizza, please' }).click();
+    sleep(1);
 
-  const checkData = await page
-    .locator('//p[text()[contains(., "Name:")]]')
-    .innerText();
-  check(page, {
-    pizzaName: checkData === "Name: My Pizza",
-  });
-
-  await page.close();
+    const checkData = await page
+      .locator('//p[text()[contains(., "Name:")]]')
+      .innerText();
+    check(page, {
+      pizzaName: checkData === 'Name: My Pizza',
+    });
+  } finally {
+    await page.close();
+  }
 }

--- a/examples/browser/route_continue.js
+++ b/examples/browser/route_continue.js
@@ -1,0 +1,41 @@
+import { check, sleep } from "k6";
+import { browser } from "k6/browser";
+
+export const options = {
+  scenarios: {
+    ui: {
+      executor: "shared-iterations",
+      options: {
+        browser: {
+          type: "chromium",
+        },
+      },
+    },
+  },
+};
+
+export default async function () {
+  const page = await browser.newPage();
+
+  await page.route(/.*\/api\/pizza/, function (route) {
+    route.continue({
+      postData: JSON.stringify({
+        customName: "My Pizza",
+      }),
+    });
+  });
+
+  await page.goto("https://quickpizza.grafana.com/");
+
+  await page.getByRole("button", { name: "pizza, please" }).click();
+  sleep(1);
+
+  const checkData = await page
+    .locator('//p[text()[contains(., "Name:")]]')
+    .innerText();
+  check(page, {
+    pizzaName: checkData === "Name: My Pizza",
+  });
+
+  await page.close();
+}

--- a/examples/browser/route_continue.js
+++ b/examples/browser/route_continue.js
@@ -1,5 +1,7 @@
-import { check, sleep } from 'k6';
+import { sleep } from 'k6';
 import { browser } from 'k6/browser';
+import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
+
 
 export const options = {
   scenarios: {
@@ -31,11 +33,9 @@ export default async function () {
     await page.getByRole('button', { name: 'pizza, please' }).click();
     sleep(1);
 
-    const checkData = await page
-      .locator('//p[text()[contains(., "Name:")]]')
-      .innerText();
-    check(page, {
-      pizzaName: checkData === 'Name: My Pizza',
+    const e = page.getByText('Name:')
+    check(null, {
+      pizzaName: await e.innerText() === 'Name: My Pizza',
     });
   } finally {
     await page.close();

--- a/internal/js/modules/k6/browser/browser/route_mapping.go
+++ b/internal/js/modules/k6/browser/browser/route_mapping.go
@@ -20,8 +20,8 @@ func mapRoute(vu moduleVU, route *common.Route) mapping {
 			})
 		},
 		"continue": func(opts sobek.Value) *sobek.Promise {
+			copts := parseContinueOptions(vu.Context(), opts)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				copts := parseContinueOptions(vu.Context(), opts)
 				return nil, route.Continue(copts)
 			})
 		},
@@ -40,14 +40,13 @@ func mapRoute(vu moduleVU, route *common.Route) mapping {
 	}
 }
 
-func parseContinueOptions(ctx context.Context, opts sobek.Value) *common.ContinueOptions {
+func parseContinueOptions(ctx context.Context, opts sobek.Value) common.ContinueOptions {
+	copts := common.ContinueOptions{}
 	if !sobekValueExists(opts) {
-		return nil
+		return copts
 	}
 
 	rt := k6ext.Runtime(ctx)
-	copts := &common.ContinueOptions{}
-
 	obj := opts.ToObject(rt)
 	for _, k := range obj.Keys() {
 		switch k {

--- a/internal/js/modules/k6/browser/browser/route_mapping.go
+++ b/internal/js/modules/k6/browser/browser/route_mapping.go
@@ -19,6 +19,12 @@ func mapRoute(vu moduleVU, route *common.Route) mapping {
 				return nil, route.Abort(reason)
 			})
 		},
+		"continue": func(opts sobek.Value) *sobek.Promise {
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				copts := parseContinueOptions(vu.Context(), opts)
+				return nil, route.Continue(copts)
+			})
+		},
 		"fulfill": func(opts sobek.Value) *sobek.Promise {
 			fopts, err := parseFulfillOptions(vu.Context(), opts)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
@@ -32,6 +38,31 @@ func mapRoute(vu moduleVU, route *common.Route) mapping {
 			return mapRequest(vu, route.Request())
 		},
 	}
+}
+
+func parseContinueOptions(ctx context.Context, opts sobek.Value) *common.ContinueOptions {
+	if !sobekValueExists(opts) {
+		return nil
+	}
+
+	rt := k6ext.Runtime(ctx)
+	copts := &common.ContinueOptions{}
+
+	obj := opts.ToObject(rt)
+	for _, k := range obj.Keys() {
+		switch k {
+		case "headers":
+			copts.Headers = parseHeaders(obj.Get(k).ToObject(rt))
+		case "method":
+			copts.Method = obj.Get(k).String()
+		case "postData":
+			copts.PostData = obj.Get(k).String()
+		case "url":
+			copts.URL = obj.Get(k).String()
+		}
+	}
+
+	return copts
 }
 
 func parseFulfillOptions(ctx context.Context, opts sobek.Value) (common.FulfillOptions, error) {
@@ -53,15 +84,7 @@ func parseFulfillOptions(ctx context.Context, opts sobek.Value) (common.FulfillO
 		case "contentType":
 			fopts.ContentType = obj.Get(k).String()
 		case "headers":
-			headers := obj.Get(k).ToObject(rt)
-			headersKeys := headers.Keys()
-			fopts.Headers = make([]common.HTTPHeader, len(headersKeys))
-			for i, hk := range headersKeys {
-				fopts.Headers[i] = common.HTTPHeader{
-					Name:  hk,
-					Value: headers.Get(hk).String(),
-				}
-			}
+			fopts.Headers = parseHeaders(obj.Get(k).ToObject(rt))
 		case "status":
 			fopts.Status = obj.Get(k).ToInteger()
 		// As we don't support all fields that PW supports, we return an error to inform the user
@@ -71,4 +94,16 @@ func parseFulfillOptions(ctx context.Context, opts sobek.Value) (common.FulfillO
 	}
 
 	return fopts, nil
+}
+
+func parseHeaders(headers *sobek.Object) []common.HTTPHeader {
+	headersKeys := headers.Keys()
+	result := make([]common.HTTPHeader, len(headersKeys))
+	for i, hk := range headersKeys {
+		result[i] = common.HTTPHeader{
+			Name:  hk,
+			Value: headers.Get(hk).String(),
+		}
+	}
+	return result
 }

--- a/internal/js/modules/k6/browser/common/frame_manager.go
+++ b/internal/js/modules/k6/browser/common/frame_manager.go
@@ -575,7 +575,7 @@ func (m *FrameManager) requestStarted(req *Request) {
 		return
 	}
 
-	if err := route.Continue(); err != nil {
+	if err := route.Continue(nil); err != nil {
 		m.logger.Errorf("FrameManager:requestStarted",
 			"fmid:%d rurl:%s error continuing request: %v", m.ID(), req.URL(), err)
 	}

--- a/internal/js/modules/k6/browser/common/frame_manager.go
+++ b/internal/js/modules/k6/browser/common/frame_manager.go
@@ -575,7 +575,7 @@ func (m *FrameManager) requestStarted(req *Request) {
 		return
 	}
 
-	if err := route.Continue(nil); err != nil {
+	if err := route.Continue(ContinueOptions{}); err != nil {
 		m.logger.Errorf("FrameManager:requestStarted",
 			"fmid:%d rurl:%s error continuing request: %v", m.ID(), req.URL(), err)
 	}

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -722,7 +722,7 @@ type Route struct {
 type ContinueOptions struct {
 	Headers  []HTTPHeader
 	Method   string
-	PostData string
+	PostData []byte
 	URL      string
 }
 

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -762,7 +762,7 @@ func (r *Route) Abort(errorCode string) error {
 }
 
 // Continue continues the request.
-func (r *Route) Continue(opts *ContinueOptions) error {
+func (r *Route) Continue(opts ContinueOptions) error {
 	err := r.startHandling()
 	if err != nil {
 		return err

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -718,6 +718,14 @@ type Route struct {
 	handled bool
 }
 
+// ContinueOptions are request fields that can be overridden when continuing a request.
+type ContinueOptions struct {
+	Headers  []HTTPHeader
+	Method   string
+	PostData string
+	URL      string
+}
+
 // FulfillOptions are response fields that can be set when fulfilling a request.
 type FulfillOptions struct {
 	Body        []byte
@@ -754,13 +762,13 @@ func (r *Route) Abort(errorCode string) error {
 }
 
 // Continue continues the request.
-func (r *Route) Continue() error {
+func (r *Route) Continue(opts *ContinueOptions) error {
 	err := r.startHandling()
 	if err != nil {
 		return err
 	}
 
-	return r.networkManager.ContinueRequest(r.request.interceptionID)
+	return r.networkManager.ContinueRequest(r.request.interceptionID, opts, r.request.HeadersArray())
 }
 
 // Fulfill fulfills the request with the given options for the response.

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -898,8 +898,8 @@ func (m *NetworkManager) ContinueRequest(
 	if opts.Method != "" {
 		action = action.WithMethod(opts.Method)
 	}
-	if opts.PostData != "" {
-		b64PostData := base64.StdEncoding.EncodeToString([]byte(opts.PostData))
+	if len(opts.PostData) > 0 {
+		b64PostData := base64.StdEncoding.EncodeToString(opts.PostData)
 		action = action.WithPostData(b64PostData)
 	}
 

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -890,8 +890,7 @@ func (m *NetworkManager) ContinueRequest(
 	action := fetch.ContinueRequest(requestID)
 
 	if len(opts.Headers) > 0 {
-		allHeaders := mergeHeaders(originalHeaders, opts.Headers)
-		action = action.WithHeaders(allHeaders)
+		action = action.WithHeaders(toFetchHeaders(opts.Headers))
 	}
 	if opts.URL != "" {
 		action = action.WithURL(opts.URL)
@@ -983,36 +982,6 @@ func toFetchHeaders(headers []HTTPHeader) []*fetch.HeaderEntry {
 		}
 	}
 	return fetchHeaders
-}
-
-func mergeHeaders(originalHeaders []HTTPHeader, extraHeaders []HTTPHeader) []*fetch.HeaderEntry {
-	if len(originalHeaders) == 0 {
-		return toFetchHeaders(extraHeaders)
-	}
-	if len(extraHeaders) == 0 {
-		return toFetchHeaders(originalHeaders)
-	}
-
-	headers := make([]*fetch.HeaderEntry, 0, len(originalHeaders)+len(extraHeaders))
-	existingHeaders := make(map[string]bool, len(extraHeaders))
-	for _, header := range extraHeaders {
-		headers = append(headers, &fetch.HeaderEntry{
-			Name:  header.Name,
-			Value: header.Value,
-		})
-		existingHeaders[header.Name] = true
-	}
-
-	for _, header := range originalHeaders {
-		if !existingHeaders[header.Name] {
-			headers = append(headers, &fetch.HeaderEntry{
-				Name:  header.Name,
-				Value: header.Value,
-			})
-		}
-	}
-
-	return headers
 }
 
 // SetExtraHTTPHeaders sets extra HTTP request headers to be sent with every request.

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -644,7 +644,7 @@ func (m *NetworkManager) onRequestPaused(event *fetch.EventRequestPaused) {
 
 		// If no route was added, continue all requests
 		if m.frameManager.page == nil || !m.frameManager.page.hasRoutes() {
-			err := m.ContinueRequest(event.RequestID)
+			err := m.ContinueRequest(event.RequestID, nil, nil)
 			if err != nil {
 				m.logger.Errorf("NetworkManager:onRequestPaused",
 					"continuing request %s %s: %s", event.Request.Method, event.Request.URL, err)
@@ -881,10 +881,33 @@ func (m *NetworkManager) AbortRequest(requestID fetch.RequestID, errorReason str
 	return nil
 }
 
-func (m *NetworkManager) ContinueRequest(requestID fetch.RequestID) error {
+func (m *NetworkManager) ContinueRequest(
+	requestID fetch.RequestID,
+	opts *ContinueOptions,
+	originalHeaders []HTTPHeader,
+) error {
 	m.logger.Debugf("NetworkManager:ContinueRequest", "continuing request (id: %s)", requestID)
-
 	action := fetch.ContinueRequest(requestID)
+
+	if opts != nil {
+		m.logger.Infof("NetworkManager:ContinueRequest", "continuing request (id: %s) with options: %+v; and headers %+v",
+			requestID, opts, originalHeaders)
+		allHeaders := mergeHeaders(originalHeaders, opts.Headers)
+		if len(allHeaders) > 0 {
+			action = action.WithHeaders(allHeaders)
+		}
+		if opts.URL != "" {
+			action = action.WithURL(opts.URL)
+		}
+		if opts.Method != "" {
+			action = action.WithMethod(opts.Method)
+		}
+		if opts.PostData != "" {
+			b64PostData := base64.StdEncoding.EncodeToString([]byte(opts.PostData))
+			action = action.WithPostData(b64PostData)
+		}
+	}
+
 	if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
 		// Avoid logging as error when context is canceled.
 		// Most probably this happens when trying to fail a site's background request
@@ -964,6 +987,36 @@ func toFetchHeaders(headers []HTTPHeader) []*fetch.HeaderEntry {
 		}
 	}
 	return fetchHeaders
+}
+
+func mergeHeaders(originalHeaders []HTTPHeader, extraHeaders []HTTPHeader) []*fetch.HeaderEntry {
+	if len(originalHeaders) == 0 {
+		return toFetchHeaders(extraHeaders)
+	}
+	if len(extraHeaders) == 0 {
+		return toFetchHeaders(originalHeaders)
+	}
+
+	headers := make([]*fetch.HeaderEntry, 0, len(originalHeaders)+len(extraHeaders))
+	existingHeaders := make(map[string]bool, len(extraHeaders))
+	for _, header := range extraHeaders {
+		headers = append(headers, &fetch.HeaderEntry{
+			Name:  header.Name,
+			Value: header.Value,
+		})
+		existingHeaders[header.Name] = true
+	}
+
+	for _, header := range originalHeaders {
+		if !existingHeaders[header.Name] {
+			headers = append(headers, &fetch.HeaderEntry{
+				Name:  header.Name,
+				Value: header.Value,
+			})
+		}
+	}
+
+	return headers
 }
 
 // SetExtraHTTPHeaders sets extra HTTP request headers to be sent with every request.

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -891,9 +891,7 @@ func (m *NetworkManager) ContinueRequest(
 
 	if len(opts.Headers) > 0 {
 		allHeaders := mergeHeaders(originalHeaders, opts.Headers)
-		if len(allHeaders) > 0 {
-			action = action.WithHeaders(allHeaders)
-		}
+		action = action.WithHeaders(allHeaders)
 	}
 	if opts.URL != "" {
 		action = action.WithURL(opts.URL)

--- a/internal/js/modules/k6/browser/tests/frame_manager_test.go
+++ b/internal/js/modules/k6/browser/tests/frame_manager_test.go
@@ -156,7 +156,7 @@ func TestFrameManagerRequestStartedWithRoutes(t *testing.T) {
 			name:      "continue_request_with_matching_string_route",
 			routePath: "/data/first",
 			routeHandler: func(route *common.Route) {
-				err := route.Continue(nil)
+				err := route.Continue(common.ContinueOptions{})
 				assert.NoError(t, err)
 			},
 			callsCount: callsCount{
@@ -169,7 +169,7 @@ func TestFrameManagerRequestStartedWithRoutes(t *testing.T) {
 			name:      "continue_request_with_non_matching_string_route",
 			routePath: "/data/third",
 			routeHandler: func(route *common.Route) {
-				err := route.Continue(nil)
+				err := route.Continue(common.ContinueOptions{})
 				assert.NoError(t, err)
 			},
 			callsCount: callsCount{
@@ -182,7 +182,7 @@ func TestFrameManagerRequestStartedWithRoutes(t *testing.T) {
 			name:      "continue_request_with_multiple_matching_regex_route",
 			routePath: "/data/.*",
 			routeHandler: func(route *common.Route) {
-				err := route.Continue(nil)
+				err := route.Continue(common.ContinueOptions{})
 				assert.NoError(t, err)
 			},
 			callsCount: callsCount{
@@ -196,7 +196,7 @@ func TestFrameManagerRequestStartedWithRoutes(t *testing.T) {
 			routePath: "/data/first",
 			routeHandler: func(route *common.Route) {
 				newURL := strings.Replace(route.Request().URL(), "/data/first", "/data/second", 1)
-				err := route.Continue(&common.ContinueOptions{
+				err := route.Continue(common.ContinueOptions{
 					URL: newURL,
 				})
 				assert.NoError(t, err)


### PR DESCRIPTION
## What?

This PR adds the `route.continue` function. Used in `page.route`, it allows to continue a request with modified: header, body, method or URL. 

## Why?

This helps with Playwright compatibility and allow to add headers to specific request (especially useful when dealing with CORS or authentication issues).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
