### PR TITLE
ci: Run tests with `-race` always

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,6 @@ jobs:
           args=("-p" "2" "-race")
           # Run with less concurrency on Windows/MacOS/ARM to minimize flakiness.
           if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos*  || "${{ matrix.platform }}" == *arm ]]; then
-            unset args[2]
             args[1]="1"
             export GOMAXPROCS=1
           fi
@@ -94,7 +93,6 @@ jobs:
           args=("-p" "2" "-race")
           # Run with less concurrency on Windows/MacOS/ARM to minimize flakiness.
           if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos*  || "${{ matrix.platform }}" == *arm ]]; then
-            unset args[2]
             args[1]="1"
             export GOMAXPROCS=1
           fi
@@ -133,7 +131,6 @@ jobs:
           args=("-p" "2" "-race")
           # Run with less concurrency on Windows/MacOS/ARM to minimize flakiness.
           if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos* || "${{ matrix.platform }}" == *arm ]]; then
-            unset args[2]
             args[1]="1"
             export GOMAXPROCS=1
           fi


### PR DESCRIPTION
## What?

Tests in the CI were not run with `-race` for some cases (except on x86_64 linux machines). This was due to them being flaky, but me running test 10 times on GHA seems to have no more flakiness.

I do expect this is in big parts golang making the race detector lighter and in some parts our tests being less flaky.

Actually it does fix a timeout on a test within cloud that I can't understand or figure out, that only happens on arm64 runners. It will be nice if we know if this is a bug, but it only happens on arm runners and only if we do not have `-race`. 

## Why?

The arm runners failing is quite distracting especially as it truly seems like a not real issue, just some test problem. 
It also is nice if we catch race conditions earlier, and as it seems that we do not hit flakiness with this it seems fine.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
