### PR TITLE
Fix metric results alignment in end of test summary

### DIFF
--- a/internal/js/summary.js
+++ b/internal/js/summary.js
@@ -882,9 +882,9 @@ function renderMetricLine(
 	const fmtIndent = renderContext.indentLevel();
 
 	// Compute the trailing dots:
-	// Use `3` as a spacing offset as per original code.
-	const dotsCount =
-		maxNameWidth - strWidth(displayedName) - strWidth(fmtIndent) + 3;
+	// Ensure longest metric name gets exactly 3 dots, shorter names get more for alignment
+	const currentNameWidth = strWidth(displayedName) + strWidth(fmtIndent);
+	const dotsCount = Math.max(3, maxNameWidth - currentNameWidth + 3);
 	const dottedName =
 		displayedName +
 		formatter.decorate('.'.repeat(dotsCount) + ':', 'white', 'faint');
@@ -1083,7 +1083,7 @@ function computeSummaryInfo(metrics, renderContext, options) {
 	for (const name of metricNames) {
 		const metric = metrics[name];
 		const displayName = renderContext.indent(
-			name + renderMetricDisplayName(name),
+			renderMetricDisplayName(name),
 		);
 		maxNameWidth = Math.max(maxNameWidth, strWidth(displayName));
 


### PR DESCRIPTION
## What?

This Pull Request makes sure the metric results of the end of test summary follow a global, shortest possible, alignment to reduce the horizontal space consumed, and make reading the results easier.

<img width="1597" height="1330" alt="CleanShot 2025-07-28 at 11 45 54" src="https://github.com/user-attachments/assets/ca0c0207-f056-49b3-86a3-50bfad7eb688" />

This was done by computing the alignment value (how many dots should be printed before the `: {results}`) globally, and cascading it down to each specific renderers. The minimum number of dot separators has been set to 3, which by my testing "feels" the best and most liable option.

Importantly, the human-readable end of test summary is explicitly excluded from verisioning policy, and **this is not considered a breaking change**. Tentatively putting this in the v1.2.0 roadmap, as it is a rather small change, but happy to drop it if reviews uncover more work 🙇🏻 

## Why?

It was reported to us recently, that the end of test summary would sometimes now keep the metric results properly aligned, and would use more horizontal spacing than necessary.

<img width="1918" height="1080" alt="unaligned-eot" src="https://github.com/user-attachments/assets/1423b2a2-b61d-4ed6-837a-8e8b4850a3fa" />

We noticed that in certain more advanced cases, including using `summary-mode=full`, this would lead to unexpected alignment patterns, when using groups and scenarios. Most of them caused by alignment being computed locally to each section rather than globally.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.
- [X] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
