### PR TITLE
Added link to documentation in k6 --help output

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -64,7 +64,7 @@ func newRootWithLauncher(gs *state.GlobalState, l *launcher) *rootCommand {
 		Use:   gs.BinaryName,
 		Short: "a next-generation load generator",
 		Long: "\n" + getBanner(gs.Flags.NoColor || !gs.Stdout.IsTTY, isTrueColor(gs.Env)) +
-			"\n\nFull CLI documentation is available at: https://grafana.com/docs/k6",
+			"\n\nFull CLI documentation is available at: https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/",
 		SilenceUsage:      true,
 		SilenceErrors:     true,
 		PersistentPreRunE: c.persistentPreRunE,


### PR DESCRIPTION
Added "Full CLI documentation available at https://docs.k6.io/docs/options" in the output of k6 --help command.

Related to #1154

## What?

The current  output from k6 --help does not provides a link to the documentation while a man page for k6 --help would be a better option this provides a temporary fix to the issue.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
