### PR TITLE
chore: add nosemgrep comments for false positives

### DIFF
--- a/cloudapi/logs.go
+++ b/cloudapi/logs.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand" // nosemgrep: math-random-used // This is being used retry jitter
 	"net/http"
 	"net/url"
 	"strconv"

--- a/internal/js/modules/k6/browser/chromium/browser_type.go
+++ b/internal/js/modules/k6/browser/chromium/browser_type.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand" // nosemgrep: math-random-used // This is used to generate id for easier debugging
 	"os/exec"
 	"path/filepath"
 	"sort"

--- a/internal/js/modules/k6/crypto/x509/x509.go
+++ b/internal/js/modules/k6/crypto/x509/x509.go
@@ -275,6 +275,6 @@ func signatureAlgorithm(value x509.SignatureAlgorithm) string {
 }
 
 func fingerPrint(parsed *x509.Certificate) []byte {
-	bytes := sha1.Sum(parsed.Raw) // #nosec G401
+	bytes := sha1.Sum(parsed.Raw) // #nosec G401 nosemgrep: use-of-sha1
 	return bytes[:]
 }

--- a/internal/js/modules/k6/k6.go
+++ b/internal/js/modules/k6/k6.go
@@ -3,7 +3,7 @@ package k6
 
 import (
 	"errors"
-	"math/rand"
+	"math/rand" // nosemgrep: math-random-used // used to seed the Marh.random of the JS VM that is pseudo random by specification
 	"strings"
 	"time"
 

--- a/internal/lib/testutils/grpcservice/service.go
+++ b/internal/lib/testutils/grpcservice/service.go
@@ -9,7 +9,7 @@ import (
 	"io"
 	"log"
 	"math"
-	"math/rand"
+	"math/rand" // nosemgrep: math-random-used // used to add random delay in calls
 	"os"
 	sync "sync"
 	"time"

--- a/js/common/randsource.go
+++ b/js/common/randsource.go
@@ -4,7 +4,7 @@ import (
 	crand "crypto/rand"
 	"encoding/binary"
 	"fmt"
-	"math/rand"
+	"math/rand" // nosemgrep: math-random-used // used to seed the Marh.random of the JS VM that is pseudo random by specification
 
 	"github.com/grafana/sobek"
 )

--- a/lib/models.go
+++ b/lib/models.go
@@ -127,7 +127,7 @@ func NewGroup(name string, parent *Group) (*Group, error) {
 		return nil, err
 	}
 
-	hash := md5.Sum([]byte(path)) //nolint:gosec
+	hash := md5.Sum([]byte(path)) //nolint:gosec // nosemgrep: use-of-md5 // this ID is just for correlation
 	id := hex.EncodeToString(hash[:])
 
 	return &Group{
@@ -223,7 +223,7 @@ func NewCheck(name string, group *Group) (*Check, error) {
 	}
 
 	path := group.Path + GroupSeparator + name
-	hash := md5.Sum([]byte(path)) //nolint:gosec
+	hash := md5.Sum([]byte(path)) //nolint:gosec // nosemgrep: use-of-md5 // this ID is just for correlation
 	id := hex.EncodeToString(hash[:])
 
 	return &Check{

--- a/lib/netext/httpext/transport.go
+++ b/lib/netext/httpext/transport.go
@@ -201,6 +201,7 @@ func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	ctx := req.Context()
 	tracer := &Tracer{}
+	// nosemgrep: dynamic-httptrace-clienttrace // this is a false possitive
 	reqWithTracer := req.WithContext(httptrace.WithClientTrace(ctx, tracer.Trace()))
 	resp, err := t.state.Transport.RoundTrip(reqWithTracer)
 

--- a/lib/netext/resolver.go
+++ b/lib/netext/resolver.go
@@ -1,7 +1,7 @@
 package netext
 
 import (
-	"math/rand"
+	"math/rand" // nosemgrep: math-random-used // used for random TTL on DNS resolve
 	"net"
 	"sync"
 	"time"


### PR DESCRIPTION
## What?

Add nosemgrep comments to disable reporting on false possitives.

## Why?

Using semgrep currently reports issues that aren't really there. This marks those as not issues.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
