### PR TITLE
experimental/websockets: support code and reason for close() and close event

### DIFF
--- a/internal/js/modules/k6/experimental/websockets/websockets.go
+++ b/internal/js/modules/k6/experimental/websockets/websockets.go
@@ -96,6 +96,10 @@ type webSocket struct {
 	binaryType     string
 	protocol       string
 	extensions     []string
+
+	// fields for `close` event
+	closeCode   int
+	closeReason string
 }
 
 type ping struct {
@@ -493,27 +497,23 @@ func (w *webSocket) readPump(wg *sync.WaitGroup) {
 				data:  data,
 				t:     time.Now(),
 			})
-
 			continue
 		}
 
-		if !websocket.IsUnexpectedCloseError(
-			err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
-			// maybe still log it with debug level?
+		var closeErr *websocket.CloseError
+		if errors.As(err, &closeErr) {
+			w.closeCode = closeErr.Code
+			w.closeReason = closeErr.Text
+		}
+
+		if !websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway) {
 			err = nil
 		}
 
-		if err != nil {
-			w.tq.Queue(func() error {
-				_ = w.conn.Close() // TODO fix this
-				return nil
-			})
-		}
-
 		w.tq.Queue(func() error {
+			_ = w.conn.Close()
 			return w.connectionClosedWithError(err)
 		})
-
 		return
 	}
 }
@@ -726,15 +726,41 @@ func (w *webSocket) assertStateOpen() {
 	common.Throw(w.vu.Runtime(), errors.New("InvalidStateError"))
 }
 
-// TODO support code and reason
+func isValidClientCloseCode(code int) bool {
+	return code == 1000 || (code >= 3000 && code <= 4999)
+}
+
+func isValidCloseReason(reason string) bool {
+	return len([]byte(reason)) <= 123
+}
+
 func (w *webSocket) close(code int, reason string) {
 	if w.readyState == CLOSED || w.readyState == CLOSING {
 		return
 	}
-	w.readyState = CLOSING
+
+	rt := w.vu.Runtime()
+
+	if code != 0 && !isValidClientCloseCode(code) {
+		common.Throw(rt, fmt.Errorf(
+			`InvalidAccessError: Failed to execute 'close' on 'WebSocket': The close code must be either 1000, or between 3000 and 4999. %d is neither`,
+			code,
+		))
+	}
+
+	if !isValidCloseReason(reason) {
+		common.Throw(rt, errors.New(
+			`SyntaxError: Failed to execute 'close' on 'WebSocket': The message must not be greater than 123 bytes`,
+		))
+	}
+
 	if code == 0 {
 		code = websocket.CloseNormalClosure
 	}
+
+	w.readyState = CLOSING
+	w.closeCode = code
+
 	w.writeQueueCh <- message{
 		mtype: websocket.CloseMessage,
 		data:  websocket.FormatCloseMessage(code, reason),
@@ -768,8 +794,11 @@ func (w *webSocket) connectionClosedWithError(err error) error {
 	close(w.done)
 
 	if err != nil {
-		if errList := w.callErrorListeners(err); errList != nil {
-			return errList // TODO ... still call the close listeners ?!?
+		var closeError *websocket.CloseError
+		if !errors.As(err, &closeError) || closeError.Code != websocket.CloseNormalClosure {
+			if errList := w.callErrorListeners(err); errList != nil {
+				return errList
+			}
 		}
 	}
 	return w.callEventListeners(events.CLOSE)
@@ -778,7 +807,7 @@ func (w *webSocket) connectionClosedWithError(err error) error {
 // newEvent return an event implementing "implements" https://dom.spec.whatwg.org/#event
 // needs to be called on the event loop
 // TODO: move to events
-func (w *webSocket) newEvent(eventType string, t time.Time) *sobek.Object {
+func (w *webSocket) newEvent(eventType string, t time.Time, extras ...func(*sobek.Object)) *sobek.Object {
 	rt := w.vu.Runtime()
 	o := rt.NewObject()
 
@@ -800,6 +829,10 @@ func (w *webSocket) newEvent(eventType string, t time.Time) *sobek.Object {
 		return float64(t.UnixNano()) / 1_000_000 // milliseconds as double as per the spec
 		// https://w3c.github.io/hr-time/#dom-domhighrestimestamp
 	}), nil, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+
+	for _, extra := range extras {
+		extra(o)
+	}
 
 	return o
 }
@@ -831,9 +864,21 @@ func (w *webSocket) callErrorListeners(e error) error { // TODO use the error ev
 }
 
 func (w *webSocket) callEventListeners(eventType string) error {
+	var event *sobek.Object
+	if eventType == events.CLOSE {
+		event = w.newEvent(eventType, time.Now(), func(o *sobek.Object) {
+			rt := w.vu.Runtime()
+			if w.closeCode != 0 {
+				must(rt, o.DefineDataProperty("code", rt.ToValue(w.closeCode), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+			}
+			must(rt, o.DefineDataProperty("reason", rt.ToValue(w.closeReason), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+		})
+	} else {
+		event = w.newEvent(eventType, time.Now())
+	}
+
 	for _, listener := range w.eventListeners.all(eventType) {
-		// TODO the event here needs to be different and have an error (figure out it was for the close listeners)
-		if _, err := listener(w.newEvent(eventType, time.Now())); err != nil { // TODO fix timestamp
+		if _, err := listener(event); err != nil {
 			return err
 		}
 	}

--- a/internal/js/modules/k6/experimental/websockets/websockets_test.go
+++ b/internal/js/modules/k6/experimental/websockets/websockets_test.go
@@ -1050,7 +1050,7 @@ func TestCookiesDefaultJar(t *testing.T) {
 
 	ts.runtime.VU.StateField.CookieJar, _ = cookiejar.New(nil)
 	_, err = ts.runtime.RunOnEventLoop(sr(`
-		http.cookieJar().set("HTTPBIN_URL/ws-echo-someheader", "someheader", "defaultjar")		
+		http.cookieJar().set("HTTPBIN_URL/ws-echo-someheader", "someheader", "defaultjar")
 
 		var ws = new WebSocket("WSBIN_URL/ws-echo-someheader", null)
 		ws.onopen = () => {
@@ -1372,7 +1372,7 @@ func TestSessionPingAdd(t *testing.T) {
 	ts := newTestState(t)
 
 	_, err := ts.runtime.RunOnEventLoop(sr(`
-			var ws = new WebSocket("WSBIN_URL/ws-echo")			
+			var ws = new WebSocket("WSBIN_URL/ws-echo")
 			ws.addEventListener("open", () => {
 				ws.ping()
 			})
@@ -1545,4 +1545,110 @@ func TestReadyStateSwitch(t *testing.T) {
 	require.NoError(t, err)
 	logs := hook.Drain()
 	require.Len(t, logs, 0)
+}
+
+func TestCloseWithCode(t *testing.T) {
+	t.Parallel()
+	ts := newTestState(t)
+	sr := ts.tb.Replacer.Replace
+	_, err := ts.runtime.RunOnEventLoop(sr(`
+		var ws = new WebSocket("WSBIN_URL/ws-echo")
+		ws.addEventListener("open", () => {
+			ws.send("something")
+			ws.close(1000)
+		})
+		ws.addEventListener("close", (event) => {
+			if (event.code !== 1000) {
+				throw "Expected code 1000, instead got: " + event.code
+			}
+		})
+	`))
+	require.NoError(t, err)
+	samples := metrics.GetBufferedSamples(ts.samples)
+	assertSessionMetricsEmitted(t, samples, "", sr("WSBIN_URL/ws-echo"), http.StatusSwitchingProtocols, "")
+}
+
+func TestCloseWithCodeAndReason(t *testing.T) {
+	t.Parallel()
+	ts := newTestState(t)
+	sr := ts.tb.Replacer.Replace
+	_, err := ts.runtime.RunOnEventLoop(sr(`
+		var ws = new WebSocket("WSBIN_URL/ws-echo")
+		ws.addEventListener("open", () => {
+			ws.send("something")
+			ws.close(1000, "a really good reason")
+		})
+		ws.addEventListener("close", (event) => {
+			if (event.code !== 1000) {
+				throw "Expected code 1000, instead got: " + event.code
+			}
+
+			if (event.reason !== "") {
+				throw "Expected empty reason when calling close from client, instead got: " + event.reason
+			}
+		})
+	`))
+	require.NoError(t, err)
+	samples := metrics.GetBufferedSamples(ts.samples)
+	assertSessionMetricsEmitted(t, samples, "", sr("WSBIN_URL/ws-echo"), http.StatusSwitchingProtocols, "")
+}
+
+func TestCloseWithDisallowedCode(t *testing.T) {
+	t.Parallel()
+	ts := newTestState(t)
+	sr := ts.tb.Replacer.Replace
+	_, err := ts.runtime.RunOnEventLoop(sr(`
+		var ws = new WebSocket("WSBIN_URL/ws-echo")
+		ws.addEventListener("open", () => {
+			ws.send("something")
+			ws.close(1001)
+		})
+	`))
+	require.ErrorContains(t, err, "InvalidAccessError: Failed to execute 'close' on 'WebSocket': The close code must be either 1000, or between 3000 and 4999")
+	samples := metrics.GetBufferedSamples(ts.samples)
+	assertSessionMetricsEmitted(t, samples, "", sr("WSBIN_URL/ws-echo"), http.StatusSwitchingProtocols, "")
+}
+
+func TestCloseWithReasonTooLong(t *testing.T) {
+	t.Parallel()
+	ts := newTestState(t)
+	sr := ts.tb.Replacer.Replace
+	_, err := ts.runtime.RunOnEventLoop(sr(`
+		var ws = new WebSocket("WSBIN_URL/ws-echo")
+		ws.addEventListener("open", () => {
+			ws.send("something")
+			ws.close(1000, "a really really long reason about why we are closing this connection, which is clearly over the top and too long, long enough to be longer than the allowed amount of 123 bytes")
+		})
+	`))
+	require.ErrorContains(t, err, "SyntaxError: Failed to execute 'close' on 'WebSocket': The message must not be greater than 123 bytes")
+	samples := metrics.GetBufferedSamples(ts.samples)
+	assertSessionMetricsEmitted(t, samples, "", sr("WSBIN_URL/ws-echo"), http.StatusSwitchingProtocols, "")
+}
+
+func TestRemoteCloseWithCodeAndReason(t *testing.T) {
+	t.Parallel()
+	ts := newTestState(t)
+	sr := ts.tb.Replacer.Replace
+
+	ts.addHandler("/ws-remote-close", nil, &testMessage{
+		kind: websocket.CloseMessage,
+		data: websocket.FormatCloseMessage(1001, "closed by server"),
+	})
+
+	_, err := ts.runtime.RunOnEventLoop(sr(`
+		var ws = new WebSocket("WSBIN_URL/ws-remote-close");
+		ws.onclose = (event) => {
+			if (event.code !== 1001) {
+				throw new Error("Expected code 1001, got: " + event.code);
+			}
+			if (event.reason !== "closed by server") {
+				throw new Error("Expected reason 'closed by server', got: " + event.reason);
+			}
+			call("remote closed");
+		};
+	`))
+	require.NoError(t, err)
+	samples := metrics.GetBufferedSamples(ts.samples)
+	assertSessionMetricsEmitted(t, samples, "", sr("WSBIN_URL/ws-remote-close"), http.StatusSwitchingProtocols, "")
+	assert.Equal(t, []string{"remote closed"}, ts.callRecorder.Recorded())
 }


### PR DESCRIPTION
## What?

Closes https://github.com/grafana/k6/issues/4972

With a small caveat: I wasn't sure the proper implementation for `wasClean` and prefer to contribute it as a second later PR, after I get to read the RFC spec about it a bit more in depth.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.


