### PR TITLE
Add/wait for response

### DIFF
--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -448,6 +448,31 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 				return nil, f.WaitForURL(val, popts, jsRegexChecker)
 			}), nil
 		},
+		"waitForResponse": func(url sobek.Value, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameWaitForResponseOptions(f.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing waitForResponse options: %w", err)
+			}
+
+			var val string
+			switch url.ExportType() {
+			case reflect.TypeOf(string("")):
+				val = fmt.Sprintf("'%s'", url.String()) // Strings require quotes
+			default: // JS Regex, CSS, numbers or booleans
+				val = url.String() // No quotes
+			}
+
+			// Inject JS regex checker for URL pattern matching
+			ctx := vu.Context()
+			jsRegexChecker, err := injectRegexMatcherScript(ctx, vu, f.Page().TargetID())
+			if err != nil {
+				return nil, err
+			}
+
+			return k6ext.Promise(ctx, func() (result any, reason error) {
+				return f.WaitForResponse(val, popts, jsRegexChecker)
+			}), nil
+		},
 	}
 	maps["$"] = func(selector string) *sobek.Promise {
 		return k6ext.Promise(vu.Context(), func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -373,6 +373,7 @@ type pageAPI interface { //nolint:interfacebloat
 	WaitForSelector(selector string, opts sobek.Value) (*common.ElementHandle, error)
 	WaitForTimeout(timeout int64)
 	WaitForURL(url string, opts sobek.Value) (*sobek.Promise, error)
+	WaitForResponse(url string, opts sobek.Value) (*sobek.Promise, error)
 	Workers() []*common.Worker
 }
 
@@ -442,6 +443,7 @@ type frameAPI interface { //nolint:interfacebloat
 	WaitForSelector(selector string, opts sobek.Value) (*common.ElementHandle, error)
 	WaitForTimeout(timeout int64)
 	WaitForURL(url string, opts sobek.Value) (*sobek.Promise, error)
+	WaitForResponse(url string, opts sobek.Value) (*sobek.Promise, error)
 }
 
 // elementHandleAPI is the interface of an in-page DOM element.

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -597,6 +597,31 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return nil, p.WaitForURL(val, popts, jsRegexChecker)
 			}), nil
 		},
+		"waitForResponse": func(url sobek.Value, opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameWaitForResponseOptions(p.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing waitForResponse options: %w", err)
+			}
+
+			var val string
+			switch url.ExportType() {
+			case reflect.TypeOf(string("")):
+				val = fmt.Sprintf("'%s'", url.String()) // Strings require quotes
+			default: // JS Regex, CSS, numbers or booleans
+				val = url.String() // No quotes
+			}
+
+			// Inject JS regex checker for URL pattern matching
+			ctx := vu.Context()
+			jsRegexChecker, err := injectRegexMatcherScript(ctx, vu, p.TargetID())
+			if err != nil {
+				return nil, err
+			}
+
+			return k6ext.Promise(ctx, func() (result any, reason error) {
+				return p.WaitForResponse(val, popts, jsRegexChecker)
+			}), nil
+		},
 		"workers": func() *sobek.Object {
 			var mws []mapping
 			for _, w := range p.Workers() {

--- a/internal/js/modules/k6/browser/common/frame_options.go
+++ b/internal/js/modules/k6/browser/common/frame_options.go
@@ -802,3 +802,30 @@ func (o *FrameWaitForURLOptions) Parse(ctx context.Context, opts sobek.Value) er
 	}
 	return nil
 }
+
+// FrameWaitForResponseOptions are options for Frame.waitForResponse and Page.waitForResponse.
+type FrameWaitForResponseOptions struct {
+	Timeout time.Duration
+}
+
+// NewFrameWaitForResponseOptions returns a new FrameWaitForResponseOptions.
+func NewFrameWaitForResponseOptions(defaultTimeout time.Duration) *FrameWaitForResponseOptions {
+	return &FrameWaitForResponseOptions{
+		Timeout: defaultTimeout,
+	}
+}
+
+// Parse parses the frame waitForResponse options.
+func (o *FrameWaitForResponseOptions) Parse(ctx context.Context, opts sobek.Value) error {
+	rt := k6ext.Runtime(ctx)
+	if opts != nil && !sobek.IsUndefined(opts) && !sobek.IsNull(opts) {
+		opts := opts.ToObject(rt)
+		for _, k := range opts.Keys() {
+			switch k {
+			case "timeout":
+				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
+			}
+		}
+	}
+	return nil
+}

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1728,6 +1728,22 @@ func (p *Page) WaitForURL(urlPattern string, opts *FrameWaitForURLOptions, jsReg
 	return nil
 }
 
+// WaitForResponse waits for a response that matches the given URL pattern.
+// jsRegexChecker should be non-nil to be able to test against a URL pattern.
+func (p *Page) WaitForResponse(urlPattern string, opts *FrameWaitForResponseOptions, jsRegexChecker JSRegexChecker) (*Response, error) {
+	p.logger.Debugf("Page:WaitForResponse", "sid:%v pattern:%s", p.sessionID(), urlPattern)
+	_, span := TraceAPICall(p.ctx, p.targetID.String(), "page.waitForResponse")
+	defer span.End()
+
+	resp, err := p.frameManager.MainFrame().WaitForResponse(urlPattern, opts, jsRegexChecker)
+	if err != nil {
+		spanRecordError(span, err)
+		return nil, err
+	}
+
+	return resp, nil
+}
+
 // Workers returns all WebWorkers of page.
 func (p *Page) Workers() []*Worker {
 	p.workersMu.Lock()


### PR DESCRIPTION
Based on the implementation and testing we've done, here's a complete PR description:

## What?

This PR adds the `waitForResponse` method to the k6 browser module, allowing users to wait for HTTP responses that match specific URL patterns during browser automation.

The implementation includes:
- Core `waitForResponse` functionality in Frame and Page classes
- JavaScript API bindings with sobek.Promise support
- Support for exact URL matching, regex patterns, and empty patterns (match any response)
- Proper timeout handling and event cleanup
- Integration tests following existing repository patterns

## Why?

Browser automation often requires waiting for specific network responses before proceeding with test actions. This is particularly important for:
- **API Testing**: Waiting for AJAX/fetch requests to complete
- **Performance Testing**: Measuring response times for critical resources
- **E2E Testing**: Ensuring data loading is complete before assertions
- **Playwright Compatibility**: Matching Playwright's `page.waitForResponse()` API for easier migration

This feature complements the existing `waitForURL` method by focusing on HTTP responses rather than navigation events.

## Implementation Details

**URL Pattern Matching:**
```javascript
// Exact URL match
await page.waitForResponse('https://api.example.com/data');

// Regex pattern
await page.waitForResponse(/\/api\/.*\.json$/);

// Match any response
await page.waitForResponse('');
```

**Note:** This PR implements URL pattern matching for `waitForResponse`. A future PR will add support for predicate functions (e.g., `await page.waitForResponse(response => response.status() === 200)`) as the current implementation is already quite substantial.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

This implements similar functionality to Playwright's `page.waitForResponse()` method, enhancing k6's browser automation capabilities for modern web application testing.

<!-- Future work: Add predicate function support in a follow-up PR -->

---

This PR description highlights the key functionality while noting that predicate functions (JavaScript functions as response matchers) will come in a future PR, keeping the scope manageable for reviewers.

## Summary by Sourcery

Add waitForResponse API to k6 browser module to enable waiting for HTTP responses matching URL patterns (string, regex, or wildcard) with timeout support and event handler cleanup

New Features:
- Implement Frame.waitForResponse and Page.waitForResponse methods to await HTTP responses by URL pattern
- Support exact URL, regex, and empty-pattern matching with injected JS regex checker
- Add FrameWaitForResponseOptions for configurable timeouts and proper timeout error handling
- Expose JavaScript API bindings for page.waitForResponse and frame.waitForResponse

Tests:
- Add integration tests for waitForResponse covering exact match, regex, wildcard, and timeout scenarios
- Extend mapping tests to include waitForResponse API bindings on Page and Frame

## Related PR(s)/Issue(s)
Closes #4339

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
