### PR TITLE
fix logic for getting the build service URL

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -27,8 +27,8 @@ const (
 	// BinaryProvisioningFeatureFlag defines the environment variable that enables the binary provisioning
 	BinaryProvisioningFeatureFlag = "K6_BINARY_PROVISIONING"
 
-	// defaultBuildServiceURL defines the URL to the default (grafana hosted) build service
-	defaultBuildServiceURL = "https://ingest.k6.io/builder/api/v1"
+	// DefaultBuildServiceURL defines the URL to the default (grafana hosted) build service
+	DefaultBuildServiceURL = "https://ingest.k6.io/builder/api/v1"
 
 	defaultConfigFileName = "config.json"
 	defaultBinaryCacheDir = "builds"
@@ -190,7 +190,7 @@ func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 		ProfilingEnabled:          false,
 		ConfigFilePath:            filepath.Join(homeDir, "k6", defaultConfigFileName),
 		LogOutput:                 "stderr",
-		BuildServiceURL:           defaultBuildServiceURL,
+		BuildServiceURL:           DefaultBuildServiceURL,
 		EnableCommunityExtensions: false,
 		BinaryCache:               filepath.Join(cacheDir, "k6", defaultBinaryCacheDir),
 	}

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -522,17 +522,31 @@ func TestGetBuildServiceURL(t *testing.T) {
 	}{
 		{
 			name:                      "default build service url",
+			buildSrvURL:               state.DefaultBuildServiceURL,
+			enableCommunityExtensions: false,
+			expectErr:                 false,
+			expectedURL:               state.DefaultBuildServiceURL,
+		},
+		{
+			name:                      "custom build service URL",
 			buildSrvURL:               "https://build.srv",
 			enableCommunityExtensions: false,
 			expectErr:                 false,
-			expectedURL:               "https://build.srv/cloud",
+			expectedURL:               "https://build.srv",
 		},
 		{
 			name:                      "enable community extensions",
+			buildSrvURL:               state.DefaultBuildServiceURL,
+			enableCommunityExtensions: true,
+			expectErr:                 false,
+			expectedURL:               fmt.Sprintf("%s/%s", state.DefaultBuildServiceURL, communityExtensionsCatalog),
+		},
+		{
+			name:                      "enable community extensions for custom build service URL",
 			buildSrvURL:               "https://build.srv",
 			enableCommunityExtensions: true,
 			expectErr:                 false,
-			expectedURL:               "https://build.srv/oss",
+			expectedURL:               "https://build.srv",
 		},
 		{
 			name:                      "invalid buildServiceURL",

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/grafana/k6deps"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -508,74 +507,4 @@ func TestIOFSBridgeOpen(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "test123", string(content))
-}
-
-func TestGetBuildServiceURL(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name                      string
-		buildSrvURL               string
-		enableCommunityExtensions bool
-		expectErr                 bool
-		expectedURL               string
-	}{
-		{
-			name:                      "default build service url",
-			buildSrvURL:               state.DefaultBuildServiceURL,
-			enableCommunityExtensions: false,
-			expectErr:                 false,
-			expectedURL:               state.DefaultBuildServiceURL,
-		},
-		{
-			name:                      "custom build service URL",
-			buildSrvURL:               "https://build.srv",
-			enableCommunityExtensions: false,
-			expectErr:                 false,
-			expectedURL:               "https://build.srv",
-		},
-		{
-			name:                      "enable community extensions",
-			buildSrvURL:               state.DefaultBuildServiceURL,
-			enableCommunityExtensions: true,
-			expectErr:                 false,
-			expectedURL:               fmt.Sprintf("%s/%s", state.DefaultBuildServiceURL, communityExtensionsCatalog),
-		},
-		{
-			name:                      "enable community extensions for custom build service URL",
-			buildSrvURL:               "https://build.srv",
-			enableCommunityExtensions: true,
-			expectErr:                 false,
-			expectedURL:               "https://build.srv",
-		},
-		{
-			name:                      "invalid buildServiceURL",
-			buildSrvURL:               "https://host:port",
-			enableCommunityExtensions: false,
-			expectErr:                 true,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			logger := &logrus.Logger{ //nolint:forbidigo
-				Out: io.Discard,
-			}
-
-			flags := state.GlobalFlags{
-				BinaryProvisioning:        true,
-				BuildServiceURL:           tc.buildSrvURL,
-				EnableCommunityExtensions: tc.enableCommunityExtensions,
-			}
-
-			buildSrvURL, err := getBuildServiceURL(flags, logger)
-			if tc.expectErr {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tc.expectedURL, buildSrvURL)
-			}
-		})
-	}
 }


### PR DESCRIPTION
## What?

Modifies the logic for using the community extensions catalog to prevent changing the URL for custom build service deployments.

## Why?

The changes introduced in [support community extensions #4922](https://github.com/grafana/k6/pull/4922) added the `/cloud` path to the build service URL by default and added `/oss` when community extensions are enabled.

This is correct for the default build services, but not for custom build services that don't implement either of these paths.

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->
Closes #4995 

<!-- Thanks for your contribution! 🙏🏼 -->
