### PR TITLE
ci: Again run windows tests with -race and MacOs cleanup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,10 +47,13 @@ jobs:
           go version
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
-          # Run with less concurrency on Windows/MacOS/ARM to minimize flakiness.
+          # Run with less concurrency on Windows/ARM to minimize flakiness.
           if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos*  || "${{ matrix.platform }}" == *arm ]]; then
             args[1]="1"
             export GOMAXPROCS=1
+            if [[ "${{ matrix.platform }}" == windows* ]]; then
+              unset args[2]
+            fi
           fi
           go test "${args[@]}" -timeout 800s ./...
 
@@ -91,10 +94,13 @@ jobs:
           go version
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
-          # Run with less concurrency on Windows/MacOS/ARM to minimize flakiness.
-          if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos*  || "${{ matrix.platform }}" == *arm ]]; then
+          # Run with less concurrency on Windows/ARM to minimize flakiness.
+          if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == *arm ]]; then
             args[1]="1"
             export GOMAXPROCS=1
+            if [[ "${{ matrix.platform }}" == windows* ]]; then
+              unset args[2]
+            fi
           fi
           go test "${args[@]}" -timeout 800s ./...
 
@@ -129,10 +135,13 @@ jobs:
           go version
           export GOMAXPROCS=2
           args=("-p" "2" "-race")
-          # Run with less concurrency on Windows/MacOS/ARM to minimize flakiness.
-          if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == macos* || "${{ matrix.platform }}" == *arm ]]; then
+          # Run with less concurrency on Windows/ARM to minimize flakiness.
+          if [[ "${{ matrix.platform }}" == windows* || "${{ matrix.platform }}" == *arm ]]; then
             args[1]="1"
             export GOMAXPROCS=1
+            if [[ "${{ matrix.platform }}" == windows* ]]; then
+              unset args[2]
+            fi
           fi
           echo "mode: set" > coverage.txt
           for pkg in $(go list ./... | grep -v vendor); do
@@ -159,10 +168,6 @@ jobs:
           CODECOV_BASH_VERSION: 1.0.1
           CODECOV_BASH_SHA512SUM: d075b412a362a9a2b7aedfec3b8b9a9a927b3b99e98c7c15a2b76ef09862aeb005e91d76a5fd71b511141496d0fd23d1b42095f722ebcd509d768fba030f159e
         run: |
-          if [[ "${{ matrix.platform }}" == macos* ]]; then
-            shopt -s expand_aliases
-            alias sha512sum='shasum -a 512'
-          fi
           curl -fsSLO "https://raw.githubusercontent.com/codecov/codecov-bash/${CODECOV_BASH_VERSION}/codecov"
           echo "$CODECOV_BASH_SHA512SUM  codecov" | sha512sum -c -
           platform="${{ matrix.platform }}"


### PR DESCRIPTION
## What?

Revert partially 45a99b7e9 on windows and cleanup MacOS 

## Why?

Windows CI is failing a bit more it seems (hard to judge really) and while the failure isn't around race it seems reasonable that it might be provoked by it.

Also there are some macos stuff - but it doesn't seem likely we will run CI on MacOS. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
