### PR TITLE
test for binary provisioning disabled

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -194,6 +194,7 @@ func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 		ProfilingEnabled:          false,
 		ConfigFilePath:            filepath.Join(homeDir, "k6", defaultConfigFileName),
 		LogOutput:                 "stderr",
+		BinaryProvisioning:        true,
 		BuildServiceURL:           defaultBuildServiceURL,
 		EnableCommunityExtensions: false,
 		BinaryCache:               filepath.Join(cacheDir, "k6", defaultBinaryCacheDir),

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -2435,7 +2435,7 @@ func TestTypeScriptSupport(t *testing.T) {
 	assert.Contains(t, stderr, `something 42`)
 }
 
-func TestTypeScriptSupportWithoutBinaryProvisioning(t *testing.T) {
+func TestTypeScriptSupportWithoutAutomaticExtensionResolution(t *testing.T) {
 	t.Parallel()
 	depScript := `
 		export default function(): number {

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -2423,6 +2423,35 @@ func TestTypeScriptSupport(t *testing.T) {
 	`
 
 	ts := NewGlobalTestState(t)
+	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.ts"), []byte(mainScript), 0o644))
+	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "bar.ts"), []byte(depScript), 0o644))
+
+	ts.CmdArgs = []string{"k6", "run", "--quiet", "test.ts"}
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stderr := ts.Stderr.String()
+	t.Log(stderr)
+	assert.Contains(t, stderr, `something 42`)
+}
+
+func TestTypeScriptSupportWithoutBinaryProvisioning(t *testing.T) {
+	t.Parallel()
+	depScript := `
+		export default function(): number {
+			let p: number = 42;
+			return p;
+		}
+	`
+	mainScript := `
+		import bar from "./bar.ts";
+		let s: string = "something";
+		export default function() {
+			console.log(s, bar());
+		};
+	`
+
+	ts := NewGlobalTestState(t)
 	ts.Flags.BinaryProvisioning = false
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.ts"), []byte(mainScript), 0o644))
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "bar.ts"), []byte(depScript), 0o644))

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -2406,7 +2406,7 @@ func TestSetupTimeout(t *testing.T) {
 	assert.Contains(t, stderr, "setup() execution timed out after 1 seconds")
 }
 
-func TestTypeScriptSupportWithoutBinaryProvisioning(t *testing.T) {
+func TestTypeScriptSupport(t *testing.T) {
 	t.Parallel()
 	depScript := `
 		export default function(): number {
@@ -2424,36 +2424,6 @@ func TestTypeScriptSupportWithoutBinaryProvisioning(t *testing.T) {
 
 	ts := NewGlobalTestState(t)
 	ts.Flags.BinaryProvisioning = false
-	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.ts"), []byte(mainScript), 0o644))
-	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "bar.ts"), []byte(depScript), 0o644))
-
-	ts.CmdArgs = []string{"k6", "run", "--quiet", "test.ts"}
-
-	cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-	stderr := ts.Stderr.String()
-	t.Log(stderr)
-	assert.Contains(t, stderr, `something 42`)
-}
-
-func TestTypeScriptSupportWithBinaryProvisioning(t *testing.T) {
-	t.Parallel()
-	depScript := `
-		export default function(): number {
-			let p: number = 42;
-			return p;
-		}
-	`
-	mainScript := `
-		import bar from "./bar.ts";
-		let s: string = "something";
-		export default function() {
-			console.log(s, bar());
-		};
-	`
-
-	ts := NewGlobalTestState(t)
-	ts.Flags.BinaryProvisioning = true
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.ts"), []byte(mainScript), 0o644))
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "bar.ts"), []byte(depScript), 0o644))
 


### PR DESCRIPTION
## What?

Adds a smoke test for running k6 with the automatic extension resolution (formerly known as binary provisioning) disabled.

## Why?

This feature is now enabled by default, so all tests in the k6 test suite will go through the binary provisioning path. It is important to have a test that goes through the other path (binary provisioning disabled)

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
