### PR TITLE
Binary provisioning/rename feature

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -194,6 +194,7 @@ func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 		ProfilingEnabled:          false,
 		ConfigFilePath:            filepath.Join(homeDir, "k6", defaultConfigFileName),
 		LogOutput:                 "stderr",
+		BinaryProvisioning:        true,
 		BuildServiceURL:           defaultBuildServiceURL,
 		EnableCommunityExtensions: false,
 		BinaryCache:               filepath.Join(cacheDir, "k6", defaultBinaryCacheDir),

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -25,8 +25,8 @@ import (
 )
 
 const (
-	// BinaryProvisioningFeatureFlag defines the environment variable that enables the binary provisioning
-	BinaryProvisioningFeatureFlag = "K6_BINARY_PROVISIONING"
+	// AutoExtensionResolution defines the environment variable that enables using extensions natively
+	AutoExtensionResolution = "K6_AUTO_EXTENSION_RESOLUTION"
 
 	// communityExtensionsCatalog defines the catalog for community extensions
 	communityExtensionsCatalog = "oss"
@@ -181,7 +181,7 @@ type GlobalFlags struct {
 	LogFormat        string
 	Verbose          bool
 
-	BinaryProvisioning        bool
+	AutoExtensionResolution   bool
 	BuildServiceURL           string
 	BinaryCache               string
 	EnableCommunityExtensions bool
@@ -194,7 +194,7 @@ func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 		ProfilingEnabled:          false,
 		ConfigFilePath:            filepath.Join(homeDir, "k6", defaultConfigFileName),
 		LogOutput:                 "stderr",
-		BinaryProvisioning:        true,
+		AutoExtensionResolution:   true,
 		BuildServiceURL:           defaultBuildServiceURL,
 		EnableCommunityExtensions: false,
 		BinaryCache:               filepath.Join(cacheDir, "k6", defaultBinaryCacheDir),
@@ -227,10 +227,18 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 	if _, ok := env["K6_PROFILING_ENABLED"]; ok {
 		result.ProfilingEnabled = true
 	}
+	//  old name for the K6_AUTO_EXTENSION_RESOLUTION feature flag
+	//  maintained for backward compatibility to be removed in a future release
 	if v, ok := env["K6_BINARY_PROVISIONING"]; ok {
 		vb, err := strconv.ParseBool(v)
 		if err == nil {
-			result.BinaryProvisioning = vb
+			result.AutoExtensionResolution = vb
+		}
+	}
+	if v, ok := env["K6_AUTO_EXTENSION_RESOLUTION"]; ok {
+		vb, err := strconv.ParseBool(v)
+		if err == nil {
+			result.AutoExtensionResolution = vb
 		}
 	}
 	if val, ok := env["K6_BUILD_SERVICE_URL"]; ok {

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -89,7 +89,7 @@ func (l *launcher) launch(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		l.gs.Logger.
 			WithError(err).
-			Error("Binary provisioning is enabled but it failed to analyze the dependencies." +
+			Error("Automatic extension resolution is enabled but it failed to analyze the dependencies." +
 				" Please, make sure to report this issue by opening a bug report.")
 		return err
 	}
@@ -103,9 +103,8 @@ func (l *launcher) launch(cmd *cobra.Command, args []string) error {
 
 	l.gs.Logger.
 		WithField("deps", deps).
-		Info("Binary Provisioning experimental feature is enabled." +
-			" The current k6 binary doesn't satisfy all dependencies, it's required to" +
-			" provision a custom binary.")
+		Info("Automatic extension resolution is enabled.The current k6 binary doesn't satisfy all dependencies," +
+			" it's required to provision a custom binary.")
 
 	customBinary, err := l.provisioner.provision(deps)
 	if err != nil {
@@ -150,11 +149,11 @@ func (b *customBinary) run(gs *state.GlobalState) error {
 	// in `gs.Stdin` and should be passed to the command
 	cmd.Stdin = gs.Stdin
 
-	// Copy environment variables to the k6 process and skip binary provisioning feature flag to disable it.
+	// Copy environment variables to the k6 process skipping auto extension resolution feature flag to disable it.
 	// This avoids unnecessary re-processing of dependencies in the sub-process.
 	env := []string{}
 	for k, v := range gs.Env {
-		if k == state.BinaryProvisioningFeatureFlag {
+		if k == state.AutoExtensionResolution {
 			continue
 		}
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
@@ -222,7 +221,7 @@ func isCustomBuildRequired(deps k6deps.Dependencies, k6Version string, exts []*e
 		semver, err := semver.NewVersion(version)
 		if err != nil {
 			// ignore built in module if version is not a valid sem ver (e.g. a development version)
-			// if user wants to use this built-in, must disable binary provisioning
+			// if user wants to use this built-in, must disable the automatic extension resolution
 			return true
 		}
 

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -103,7 +103,7 @@ func (l *launcher) launch(cmd *cobra.Command, args []string) error {
 
 	l.gs.Logger.
 		WithField("deps", deps).
-		Info("Automatic extension resolution is enabled.The current k6 binary doesn't satisfy all dependencies," +
+		Info("Automatic extension resolution is enabled. The current k6 binary doesn't satisfy all dependencies," +
 			" it's required to provision a custom binary.")
 
 	customBinary, err := l.provisioner.provision(deps)

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -102,7 +102,7 @@ func TestLauncherLaunch(t *testing.T) {
 	testCases := []struct {
 		name            string
 		script          string
-		disableBP       bool
+		disableAER      bool
 		k6Cmd           string
 		k6Args          []string
 		expectProvision bool
@@ -113,9 +113,9 @@ func TestLauncherLaunch(t *testing.T) {
 		expectOsExit    int
 	}{
 		{
-			name:            "disable binary provisioning",
+			name:            "disable automatic extension resolution",
 			k6Cmd:           "cloud",
-			disableBP:       true,
+			disableAER:      true,
 			script:          fakerTest,
 			expectProvision: false,
 			expectCmdRunE:   true,
@@ -151,7 +151,7 @@ func TestLauncherLaunch(t *testing.T) {
 			expectOsExit:    0,
 		},
 		{
-			name:            "script with no dependencies",
+			name:            "script with no extension dependencies",
 			k6Cmd:           "cloud",
 			script:          noDepsTest,
 			expectProvision: false,
@@ -160,7 +160,7 @@ func TestLauncherLaunch(t *testing.T) {
 			expectOsExit:    0,
 		},
 		{
-			name:            "command don't require binary provisioning",
+			name:            "command don't require automatic extension resolution",
 			k6Cmd:           "version",
 			expectProvision: false,
 			expectCmdRunE:   true,
@@ -168,7 +168,7 @@ func TestLauncherLaunch(t *testing.T) {
 			expectOsExit:    0,
 		},
 		{
-			name:            "binary provisioning is not enabled for run command",
+			name:            "automatic extension resolution not enabled for run command",
 			k6Cmd:           "run",
 			script:          noDepsTest,
 			expectProvision: false,
@@ -221,9 +221,9 @@ func TestLauncherLaunch(t *testing.T) {
 			// k6deps uses os package to access files. So we need to use it in the global state
 			ts.FS = fsext.NewOsFs()
 
-			// NewGlobalTestState does not set the Binary provisioning flag even if we set
-			// the K6_BINARY_PROVISIONING variable in the global state, so we do it manually
-			ts.Flags.BinaryProvisioning = !tc.disableBP
+			// NewGlobalTestState does not set the AutoExtensionResolution flag even if we set
+			// the K6_AUTO_EXTENSION_RESOLUTION variable in the global state, so we do it manually
+			ts.Flags.AutoExtensionResolution = !tc.disableAER
 
 			// the exit code is checked by the TestGlobalState when the test ends
 			ts.ExpectedExitCode = tc.expectOsExit
@@ -272,9 +272,9 @@ func TestLauncherViaStdin(t *testing.T) {
 	// k6deps uses os package to access files. So we need to use it in the global state
 	ts.FS = fsext.NewOsFs()
 
-	// NewGlobalTestState does not set the Binary provisioning flag even if we set
-	// the K6_BINARY_PROVISIONING variable in the global state, so we do it manually
-	ts.Flags.BinaryProvisioning = true
+	// NewGlobalTestState does not set the AutoExtensionResolution flag even if we set
+	// the K6_AUTO_EXTENSION_RESOLUTION variable in the global state, so we do it manually
+	ts.Flags.AutoExtensionResolution = true
 
 	// pass script using stdin
 	stdin := bytes.NewBuffer([]byte(requireUnsatisfiedK6Version))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -106,14 +106,14 @@ func (c *rootCommand) persistentPreRunE(cmd *cobra.Command, args []string) error
 
 	c.globalState.Logger.Debugf("k6 version: v%s", fullVersion())
 
-	// If binary provisioning is not enabled, continue with the regular k6 execution path
-	if !c.globalState.Flags.BinaryProvisioning {
-		c.globalState.Logger.Debug("Binary Provisioning feature is disabled.")
+	// If automatic extension resolution is not enabled, continue with the regular k6 execution path
+	if !c.globalState.Flags.AutoExtensionResolution {
+		c.globalState.Logger.Debug("Automatic extension resolution is disabled.")
 		return nil
 	}
 
 	c.globalState.Logger.
-		Debug("Binary Provisioning feature is enabled.")
+		Debug("Automatic extension resolution is enabled.")
 
 	return c.launcher.launch(cmd, args)
 }

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -2423,7 +2423,7 @@ func TestTypeScriptSupport(t *testing.T) {
 	`
 
 	ts := NewGlobalTestState(t)
-	ts.Flags.BinaryProvisioning = false
+	ts.Flags.AutoExtensionResolution = false
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.ts"), []byte(mainScript), 0o644))
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "bar.ts"), []byte(depScript), 0o644))
 

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -2406,7 +2406,7 @@ func TestSetupTimeout(t *testing.T) {
 	assert.Contains(t, stderr, "setup() execution timed out after 1 seconds")
 }
 
-func TestTypeScriptSupportWithoutBinaryProvisioning(t *testing.T) {
+func TestTypeScriptSupport(t *testing.T) {
 	t.Parallel()
 	depScript := `
 		export default function(): number {
@@ -2424,36 +2424,6 @@ func TestTypeScriptSupportWithoutBinaryProvisioning(t *testing.T) {
 
 	ts := NewGlobalTestState(t)
 	ts.Flags.BinaryProvisioning = false
-	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.ts"), []byte(mainScript), 0o644))
-	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "bar.ts"), []byte(depScript), 0o644))
-
-	ts.CmdArgs = []string{"k6", "run", "--quiet", "test.ts"}
-
-	cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-	stderr := ts.Stderr.String()
-	t.Log(stderr)
-	assert.Contains(t, stderr, `something 42`)
-}
-
-func TestTypeScriptSupportWithBinaryProvisioning(t *testing.T) {
-	t.Parallel()
-	depScript := `
-		export default function(): number {
-			let p: number = 42;
-			return p;
-		}
-	`
-	mainScript := `
-		import bar from "./bar.ts";
-		let s: string = "something";
-		export default function() {
-			console.log(s, bar());
-		};
-	`
-
-	ts := NewGlobalTestState(t)
-	ts.Flags.BinaryProvisioning = true
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.ts"), []byte(mainScript), 0o644))
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "bar.ts"), []byte(depScript), 0o644))
 


### PR DESCRIPTION
## What?

Update feature for binary provisioning as automatic extension resolution, and adjust comments and log messages.

## Why?

Use a name that reflects the functionality instead of the technical details of the implementation.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
