### PR TITLE
chore: fix examples/browser to use the correct domains in some cases

### DIFF
--- a/examples/browser/keyboard.js
+++ b/examples/browser/keyboard.js
@@ -16,7 +16,7 @@ export const options = {
 export default async function () {
   const page = await browser.newPage();
 
-  await page.goto('https://quickpizza.grafana.com/test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
+  await page.goto('https://quickpizza.grafana.com/my_messages.php', { waitUntil: 'networkidle' });
 
   const userInput = page.locator('input[name="login"]');
   await userInput.click();

--- a/examples/browser/locator.js
+++ b/examples/browser/locator.js
@@ -19,9 +19,9 @@ export const options = {
 export default async function() {
   const context = await browser.newContext();
   const page = await context.newPage();
-  
+
   try {
-    await page.goto("https://quickpizza.grafana.com/test.k6.io/flip_coin.php", {
+    await page.goto("https://quickpizza.grafana.com/flip_coin.php", {
       waitUntil: "networkidle",
     })
 
@@ -30,10 +30,10 @@ export default async function() {
     different betting button on the page. If you were to query
     the buttons once and save them as below, you would see an
     error after the initial navigation. Try it!
-  
+
       const heads = page.$("input[value='Bet on heads!']");
       const tails = page.$("input[value='Bet on tails!']");
-  
+
     The Locator API allows you to get a fresh element handle each
     time you use one of the locator methods. And, you can carry a
     locator across frame navigations. Let's create two locators;

--- a/examples/browser/locator_pom.js
+++ b/examples/browser/locator_pom.js
@@ -34,7 +34,7 @@ export class Bet {
   }
 
   goto() {
-    return this.page.goto("https://quickpizza.grafana.com/test.k6.io/flip_coin.php", { waitUntil: "networkidle" });
+    return this.page.goto("https://quickpizza.grafana.com/flip_coin.php", { waitUntil: "networkidle" });
   }
 
   heads() {

--- a/examples/browser/multiple-scenario.js
+++ b/examples/browser/multiple-scenario.js
@@ -36,7 +36,7 @@ export async function messages() {
   const page = await browser.newPage();
 
   try {
-    await page.goto('https://quickpizza.grafana.com/test.k6.io/my_messages.php', { waitUntil: 'networkidle' });
+    await page.goto('https://quickpizza.grafana.com/my_messages.php', { waitUntil: 'networkidle' });
   } finally {
     await page.close();
   }
@@ -46,7 +46,7 @@ export async function news() {
   const page = await browser.newPage();
 
   try {
-    await page.goto('https://quickpizza.grafana.com/test.k6.io/news.php', { waitUntil: 'networkidle' });
+    await page.goto('https://quickpizza.grafana.com/news.php', { waitUntil: 'networkidle' });
   } finally {
     await page.close();
   }


### PR DESCRIPTION
## What?

It seems as part of #4754 I didn't change the URLs exactly correct in some cases.

## Why?

Examples should actually be testing something instead of hitting a 404 page. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Continues #4754
<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
