### PR TITLE
Fix panics in waitForURL and waitBy*

### DIFF
--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -12,6 +12,7 @@ import (
 
 	"go.k6.io/k6/internal/js/modules/k6/browser/common"
 	"go.k6.io/k6/internal/js/modules/k6/browser/k6ext"
+	k6common "go.k6.io/k6/js/common"
 )
 
 // mapPage to the JS module.
@@ -926,6 +927,9 @@ func waitForURLBodyImpl(vu moduleVU, target interface {
 	WaitForURL(urlPattern string, opts *common.FrameWaitForURLOptions, jsRegexChecker common.JSRegexChecker) error
 }, url sobek.Value, opts sobek.Value,
 ) (*sobek.Promise, error) {
+	if k6common.IsNullish(url) {
+		return nil, errors.New("missing required argument 'url'")
+	}
 	popts := common.NewFrameWaitForURLOptions(target.Timeout())
 	if err := popts.Parse(vu.Context(), opts); err != nil {
 		return nil, fmt.Errorf("parsing waitForURL options: %w", err)

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -173,36 +173,54 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			return rt.ToValue(ml).ToObject(rt), nil
 		},
 		"getByAltText": func(alt sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(alt) {
+				return nil, errors.New("missing required argument 'altText'")
+			}
 			palt, popts := parseGetByBaseOptions(vu.Context(), alt, false, opts)
 
 			ml := mapLocator(vu, p.GetByAltText(palt, popts))
 			return rt.ToValue(ml).ToObject(rt), nil
 		},
 		"getByLabel": func(label sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(label) {
+				return nil, errors.New("missing required argument 'label'")
+			}
 			plabel, popts := parseGetByBaseOptions(vu.Context(), label, true, opts)
 
 			ml := mapLocator(vu, p.GetByLabel(plabel, popts))
 			return rt.ToValue(ml).ToObject(rt), nil
 		},
 		"getByPlaceholder": func(placeholder sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(placeholder) {
+				return nil, errors.New("missing required argument 'placeholder'")
+			}
 			pplaceholder, popts := parseGetByBaseOptions(vu.Context(), placeholder, false, opts)
 
 			ml := mapLocator(vu, p.GetByPlaceholder(pplaceholder, popts))
 			return rt.ToValue(ml).ToObject(rt), nil
 		},
 		"getByTitle": func(title sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(title) {
+				return nil, errors.New("missing required argument 'title'")
+			}
 			ptitle, popts := parseGetByBaseOptions(vu.Context(), title, false, opts)
 
 			ml := mapLocator(vu, p.GetByTitle(ptitle, popts))
 			return rt.ToValue(ml).ToObject(rt), nil
 		},
 		"getByTestId": func(testID sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(testID) {
+				return nil, errors.New("missing required argument 'testId'")
+			}
 			ptestID := parseStringOrRegex(testID, false)
 
 			ml := mapLocator(vu, p.GetByTestID(ptestID))
 			return rt.ToValue(ml).ToObject(rt), nil
 		},
 		"getByText": func(text sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(text) {
+				return nil, errors.New("missing required argument 'text'")
+			}
 			ptext, popts := parseGetByBaseOptions(vu.Context(), text, true, opts)
 
 			ml := mapLocator(vu, p.GetByText(ptext, popts))


### PR DESCRIPTION
## What?

Fixes 2 panics in new APIs found during documentation creation by @ankur22 

## Why?

Panics are bad, even in new APIs. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
