### PR TITLE
Add expect to goto calls in examples

### DIFF
--- a/examples/browser/colorscheme.js
+++ b/examples/browser/colorscheme.js
@@ -1,5 +1,6 @@
 import { browser } from 'k6/browser';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -25,10 +26,12 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto(
+    const response = await page.goto(
       'https://quickpizza.grafana.com/test.k6.io',
       { waitUntil: 'load' },
     )
+    expect(response.status()).toBe(200);
+
     await check(page, {
       'isDarkColorScheme':
         p => p.evaluate(() => window.matchMedia('(prefers-color-scheme: dark)').matches)

--- a/examples/browser/device_emulation.js
+++ b/examples/browser/device_emulation.js
@@ -1,5 +1,6 @@
 import { browser, devices } from 'k6/browser';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -27,7 +28,9 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
+    const response = await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
+    expect(response.status()).toBe(200);
+
     const dimensions = await page.evaluate(() => {
       return {
         width: document.documentElement.clientWidth,

--- a/examples/browser/dispatch.js
+++ b/examples/browser/dispatch.js
@@ -1,5 +1,6 @@
 import { browser } from 'k6/browser';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -22,7 +23,8 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
+    const response = await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
+    expect(response.status()).toBe(200);
 
     const contacts = page.locator('a[href="/contacts.php"]');
     await contacts.dispatchEvent("click");

--- a/examples/browser/grant_permission.js
+++ b/examples/browser/grant_permission.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -26,7 +27,8 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://quickpizza.grafana.com/test.k6.io/');
+    const response = await page.goto('https://quickpizza.grafana.com/test.k6.io/');
+    expect(response.status()).toBe(200);
     await page.screenshot({ path: `example-chromium.png` });
     await context.clearPermissions();
   } finally {

--- a/examples/browser/keyboard.js
+++ b/examples/browser/keyboard.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -16,18 +17,21 @@ export const options = {
 export default async function () {
   const page = await browser.newPage();
 
-  await page.goto('https://quickpizza.grafana.com/my_messages.php', { waitUntil: 'networkidle' });
+  try {
+    const response = await page.goto('https://quickpizza.grafana.com/my_messages.php', { waitUntil: 'networkidle' });
+    expect(response.status()).toBe(200);
 
-  const userInput = page.locator('input[name="login"]');
-  await userInput.click();
-  await page.keyboard.type("admin");
+    const userInput = page.locator('input[name="login"]');
+    await userInput.click();
+    await page.keyboard.type("admin");
 
-  const pwdInput = page.locator('input[name="password"]');
-  await pwdInput.click();
-  await page.keyboard.type("123");
+    const pwdInput = page.locator('input[name="password"]');
+    await pwdInput.click();
+    await page.keyboard.type("123");
 
-  await page.keyboard.press('Enter'); // submit
-  await page.waitForNavigation();
-
-  await page.close();
+    await page.keyboard.press('Enter'); // submit
+    await page.waitForNavigation();
+  } finally {
+    await page.close();
+  }
 }

--- a/examples/browser/locator.js
+++ b/examples/browser/locator.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -21,9 +22,10 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto("https://quickpizza.grafana.com/flip_coin.php", {
+    const response = await page.goto("https://quickpizza.grafana.com/flip_coin.php", {
       waitUntil: "networkidle",
-    })
+    });
+    expect(response.status()).toBe(200);
 
     /*
     In this example, we will use two locators, matching a

--- a/examples/browser/locator_pom.js
+++ b/examples/browser/locator_pom.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -33,8 +34,10 @@ export class Bet {
     this.currentBet = page.locator("//p[starts-with(text(),'Your bet: ')]");
   }
 
-  goto() {
-    return this.page.goto("https://quickpizza.grafana.com/flip_coin.php", { waitUntil: "networkidle" });
+  async goto() {
+    const response = await this.page.goto("https://quickpizza.grafana.com/flip_coin.php", { waitUntil: "networkidle" });
+    expect(response.status()).toBe(200);
+    return response;
   }
 
   heads() {

--- a/examples/browser/multiple-scenario.js
+++ b/examples/browser/multiple-scenario.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -36,7 +37,8 @@ export async function messages() {
   const page = await browser.newPage();
 
   try {
-    await page.goto('https://quickpizza.grafana.com/my_messages.php', { waitUntil: 'networkidle' });
+    const response = await page.goto('https://quickpizza.grafana.com/my_messages.php', { waitUntil: 'networkidle' });
+    expect(response.status()).toBe(200);
   } finally {
     await page.close();
   }

--- a/examples/browser/querying.js
+++ b/examples/browser/querying.js
@@ -1,5 +1,6 @@
 import { browser } from 'k6/browser';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 export const options = {
   scenarios: {
@@ -22,7 +23,8 @@ export default async function() {
   const page = await context.newPage();
 
   try {
-    await page.goto('https://quickpizza.grafana.com/test.k6.io/');
+    const response = await page.goto('https://quickpizza.grafana.com/test.k6.io/');
+    expect(response.status()).toBe(200);
 
     await check(page, {
       'Title with CSS selector': async p => {

--- a/examples/browser/shadowdom.js
+++ b/examples/browser/shadowdom.js
@@ -20,22 +20,24 @@ export const options = {
 export default async function() {
   const page = await browser.newPage();
   
-  await page.setContent("<html><head><style></style></head><body>hello!</body></html>")
+  try {
+    await page.setContent("<html><head><style></style></head><body>hello!</body></html>")
 
-  await page.evaluate(() => {
-    const shadowRoot = document.createElement('div');
-    shadowRoot.id = 'shadow-root';
-    shadowRoot.attachShadow({mode: 'open'});
-    shadowRoot.shadowRoot.innerHTML = '<p id="shadow-dom">Shadow DOM</p>';
-    document.body.appendChild(shadowRoot);
-  });
+    await page.evaluate(() => {
+      const shadowRoot = document.createElement('div');
+      shadowRoot.id = 'shadow-root';
+      shadowRoot.attachShadow({mode: 'open'});
+      shadowRoot.shadowRoot.innerHTML = '<p id="shadow-dom">Shadow DOM</p>';
+      document.body.appendChild(shadowRoot);
+    });
 
-  await check(page.locator('#shadow-dom'), {
-    'shadow element exists': e => e !== null,
-    'shadow element text is correct': async e => {
-      return await e.innerText() === 'Shadow DOM';
-    }
-  });
-
-  await page.close();
+    await check(page.locator('#shadow-dom'), {
+      'shadow element exists': e => e !== null,
+      'shadow element text is correct': async e => {
+        return await e.innerText() === 'Shadow DOM';
+      }
+    });
+  } finally {
+    await page.close();
+  }
 }

--- a/examples/browser/touchscreen.js
+++ b/examples/browser/touchscreen.js
@@ -16,19 +16,21 @@ export const options = {
 export default async function () {
   const page = await browser.newPage();
 
-  await page.goto("https://quickpizza.grafana.com/test.k6.io/", { waitUntil: "networkidle" });
+  try {
+    await page.goto("https://quickpizza.grafana.com/test.k6.io/", { waitUntil: "networkidle" });
 
-  // Obtain ElementHandle for news link and navigate to it
-  // by tapping in the 'a' element's bounding box
-  const newsLinkBox = await page.$('a[href="/news.php"]').then((e) => e.boundingBox());
+    // Obtain ElementHandle for news link and navigate to it
+    // by tapping in the 'a' element's bounding box
+    const newsLinkBox = await page.$('a[href="/news.php"]').then((e) => e.boundingBox());
 
-  // Wait until the navigation is done before closing the page.
-  // Otherwise, there will be a race condition between the page closing
-  // and the navigation.
-  await Promise.all([
-    page.waitForNavigation(),
-    page.touchscreen.tap(newsLinkBox.x + newsLinkBox.width / 2, newsLinkBox.y),
-  ]);
-
-  await page.close();
+    // Wait until the navigation is done before closing the page.
+    // Otherwise, there will be a race condition between the page closing
+    // and the navigation.
+    await Promise.all([
+      page.waitForNavigation(),
+      page.touchscreen.tap(newsLinkBox.x + newsLinkBox.width / 2, newsLinkBox.y),
+    ]);
+  } finally {
+    await page.close();
+  }
 }

--- a/examples/browser/useragent.js
+++ b/examples/browser/useragent.js
@@ -22,14 +22,18 @@ export default async function() {
     userAgent: 'k6 test user agent',
   })
   let page = await context.newPage();
-  await check(page, {
-    'user agent is set': async p => {
-        const userAgent = await p.evaluate(() => navigator.userAgent);
-        return userAgent.includes('k6 test user agent');
-    }
-  });
-  await page.close();
-  await context.close();
+
+  try {
+    await check(page, {
+      'user agent is set': async p => {
+          const userAgent = await p.evaluate(() => navigator.userAgent);
+          return userAgent.includes('k6 test user agent');
+      }
+    });
+  } finally {
+    await page.close();
+    await context.close();
+  }
 
   context = await browser.newContext();
   check(context.browser(), {
@@ -39,11 +43,14 @@ export default async function() {
   });
 
   page = await context.newPage();
-  await check(page, {
-    'chromium user agent does not contain headless': async p => {
-        const userAgent = await p.evaluate(() => navigator.userAgent);
-        return userAgent.includes('Headless') === false;
-    }
-  });
-  await page.close();
+  try {
+    await check(page, {
+      'chromium user agent does not contain headless': async p => {
+          const userAgent = await p.evaluate(() => navigator.userAgent);
+          return userAgent.includes('Headless') === false;
+      }
+    });
+  } finally {
+    await page.close();
+  }
 }

--- a/examples/browser/waitForEvent.js
+++ b/examples/browser/waitForEvent.js
@@ -29,11 +29,13 @@ export default async function() {
   const page = await context.newPage();
   const page2 = await context.newPage();
 
-  // We await for the page creation events to be processed and the predicate
-  // to pass.
-  await promise
-  console.log('predicate passed')
-
-  await page.close()
-  await page2.close();
+  try {
+    // We await for the page creation events to be processed and the predicate
+    // to pass.
+    await promise
+    console.log('predicate passed')
+  } finally {
+    await page.close()
+    await page2.close();
+  }
 };


### PR DESCRIPTION
## What?

1. Use `expect` to check for status code 200 on all `goto` calls.
2. Standardise the tests so that they all use try and finally.

## Why?

This will help us avoid issues where we ignore HTTP errors and continue the test. In some cases it doesn't seem to matter that we get something other than a 200.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
