### PR TITLE
Disable automatic resolution for custom binaries

### DIFF
--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -149,8 +149,7 @@ func (b *customBinary) run(gs *state.GlobalState) error {
 	// in `gs.Stdin` and should be passed to the command
 	cmd.Stdin = gs.Stdin
 
-	// Copy environment variables to the k6 process skipping auto extension resolution feature flag to disable it.
-	// This avoids unnecessary re-processing of dependencies in the sub-process.
+	// Copy environment variables to the k6 process skipping auto extension resolution feature flag.
 	env := []string{}
 	for k, v := range gs.Env {
 		if k == state.AutoExtensionResolution {
@@ -158,6 +157,11 @@ func (b *customBinary) run(gs *state.GlobalState) error {
 		}
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
+	// If auto extension resolution is enabled then
+	// this avoids unnecessary re-processing of dependencies in the sub-process.
+	env = append(env, state.AutoExtensionResolution+"=false")
+	// legacy envvar used in versions v1.0.x and v1.1.x
+	env = append(env, "K6_BINARY_PROVISIONING=false")
 	cmd.Env = env
 
 	// handle signals


### PR DESCRIPTION

## What?

<!-- A short (or detailed) description of what this PR does. -->

Always disable extension automatic resolution in the sub-process of custom binary.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

If the binary has been provisioned with a custom binary then the subprocess should not run with automatic resolution enabled to not join a never ending loop.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
