### PR TITLE
Use new expect() syntax in script templates

### DIFF
--- a/internal/cmd/templates/minimal.js
+++ b/internal/cmd/templates/minimal.js
@@ -1,5 +1,6 @@
 import http from 'k6/http';
-import { sleep, check } from 'k6';
+import { sleep } from 'k6';
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 export const options = {
   vus: 10,
@@ -12,6 +13,6 @@ export const options = {
 
 export default function() {
   let res = http.get('https://quickpizza.grafana.com');
-  check(res, { "status is 200": (res) => res.status === 200 });
+  expect.soft(res.status).toBe(200);
   sleep(1);
 }

--- a/internal/cmd/templates/protocol.js
+++ b/internal/cmd/templates/protocol.js
@@ -1,6 +1,7 @@
 import http from "k6/http";
 import exec from 'k6/execution';
-import { check, sleep } from "k6";
+import { sleep } from "k6";
+import { expect } from "https://jslib.k6.io/k6-testing/0.5.0/index.js";
 
 const BASE_URL = __ENV.BASE_URL || 'https://quickpizza.grafana.com';
 
@@ -22,9 +23,7 @@ export const options = {
 
 export function setup() {
   let res = http.get(BASE_URL);
-  if (res.status !== 200) {
-    exec.test.abort(`Got unexpected status code ${res.status} when trying to setup. Exiting.`);
-  }
+  expect(res.status, `Got unexpected status code ${res.status} when trying to setup. Exiting.`).toBe(200);
 }
 
 export default function() {
@@ -44,7 +43,7 @@ export default function() {
     },
   });
 
-  check(res, { "status is 200": (res) => res.status === 200 });
+  expect.soft(res.status).toBe(200);
   console.log(res.json().pizza.name + " (" + res.json().pizza.ingredients.length + " ingredients)");
   sleep(1);
 }


### PR DESCRIPTION
## What?
Update script templates used by `k6 new` to use the new `expect()` syntax introduced in [k6-jslib-testing](https://github.com/grafana/k6-jslib-testing)

## Why?
`k6-jslib-testing` aims to replace the old `check()` API with a flexible and user-friendly set o matchers. This PR updates the templates used by `k6 new` to use this API.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.
- [x] I have added the correct milestone and labels to the PR.