### PR TITLE
Update, add and refactor `waitForURL` and `waitForNavigation` tests

### DIFF
--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -987,13 +987,7 @@ func waitForURLBodyImpl(vu moduleVU, target interface {
 		return nil, fmt.Errorf("parsing waitForURL options: %w", err)
 	}
 
-	var val string
-	switch url.ExportType() {
-	case reflect.TypeOf(string("")):
-		val = fmt.Sprintf("'%s'", url.String()) // Strings require quotes
-	default: // JS Regex, CSS, numbers or booleans
-		val = url.String() // No quotes
-	}
+	val := parseStringOrRegex(url, false)
 
 	// Inject JS regex checker for URL pattern matching
 	ctx, stopTaskqueue := context.WithCancel(vu.Context())

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2860,25 +2860,15 @@ func TestWaitForNavigationWithURL(t *testing.T) {
 	`,
 	)
 	assert.Equal(t, tb.staticURL("page2.html"), got.Result().String())
-}
 
-func TestWaitForNavigationWithURL_RegexFailure(t *testing.T) {
-	t.Parallel()
-
-	tb := newTestBrowser(t, withFileServer())
-	tb.vu.ActivateVU()
-	tb.vu.StartIteration(t)
-
-	_, err := tb.vu.RunAsync(t, `
-		const page = await browser.newPage();
-		await page.goto('%s');
+	_, err = tb.vu.RunAsync(t, `
+		await page.goto(testURL);
 
 		await Promise.all([
 			page.waitForNavigation({ url: /^.*/my_messages.*$/ }),
 			page.locator('#page2').click()
 		]);
 	`,
-		tb.staticURL("waitfornavigation_test.html"),
 	)
 	assert.ErrorContains(t, err, "Unexpected token *")
 }

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2810,65 +2810,56 @@ func TestWaitForNavigationWithURL(t *testing.T) {
 		`)
 	require.NoError(t, err)
 
+	// Test exact URL match
 	got := tb.vu.RunPromise(t, `
 		await page.goto(testURL);
 
-		// Test exact URL match
 		await Promise.all([
 			page.waitForNavigation({ url: page1URL }),
 			page.locator('#page1').click()
 		]);
-		let currentURL = page.url();
-		if (!currentURL.endsWith('page1.html')) {
-			throw new Error('Expected to navigate to page1.html but got ' + currentURL);
-		}
+		return page.url();
+	`,
+	)
+	assert.Equal(t, tb.staticURL("page1.html"), got.Result().String())
 
+	// Test regex pattern - matches any page with .html extension
+	got = tb.vu.RunPromise(t, `
 		await page.goto(testURL);
 
-		// Test regex pattern - matches any page with .html extension
 		await Promise.all([
 			page.waitForNavigation({ url: /.*\.html$/ }),
 			page.locator('#page2').click()
 		]);
-		currentURL = page.url();
-		if (!currentURL.endsWith('.html')) {
-			throw new Error('Expected URL to end with .html but got ' + currentURL);
-		}
+		return page.url();
+	`,
+	)
+	assert.Equal(t, tb.staticURL("page2.html"), got.Result().String())
 
+	// Test timeout when URL doesn't match
+	_, err = tb.vu.RunAsync(t, `
 		await page.goto(testURL);
 
-		// Test timeout when URL doesn't match
-		let timedOut = false;
-		try {
-			await Promise.all([
-				page.waitForNavigation({ url: /.*nonexistent.html$/, timeout: 500 }),
-				page.locator('#page1').click()  // This goes to page1.html, not nonexistent.html
-			]);
-		} catch (error) {
-			if (error.toString().includes('waiting for navigation')) {
-				timedOut = true;
-			} else {
-				throw error;
-			}
-		}
-		if (!timedOut) {
-			throw new Error('Expected timeout error when URL does not match');
-		}
+		await Promise.all([
+			page.waitForNavigation({ url: /.*nonexistent.html$/, timeout: 500 }),
+			page.locator('#page1').click()  // This goes to page1.html, not nonexistent.html
+		]);
+	`,
+	)
+	assert.ErrorContains(t, err, "timed out after 500ms")
 
+	// Test empty pattern (matches any navigation)
+	got = tb.vu.RunPromise(t, `
 		await page.goto(testURL);
 
-		// Test empty pattern (matches any navigation)
 		await Promise.all([
 			page.waitForNavigation({ url: '' }),
 			page.locator('#page2').click()
 		]);
-		currentURL = page.url();
-		if (!currentURL.endsWith('page2.html')) {
-			throw new Error('Expected empty pattern to match any navigation but got ' + currentURL);
-		}
+		return page.url();
 	`,
 	)
-	assert.Equal(t, sobek.Undefined(), got.Result())
+	assert.Equal(t, tb.staticURL("page2.html"), got.Result().String())
 }
 
 func TestWaitForNavigationWithURL_RegexFailure(t *testing.T) {
@@ -2912,88 +2903,95 @@ func TestWaitForURL(t *testing.T) {
 		`)
 	require.NoError(t, err)
 
+	// Test when already at matching URL (should just wait for load state)
 	got := tb.vu.RunPromise(t, `
-		// Test when already at matching URL (should just wait for load state)
 		await page.goto(page1URL);
-		await page.waitForURL(/.*page1\.html$/);
-		let currentURL = page.url();
-		if (!currentURL.endsWith('page1.html')) {
-			throw new Error('Expected to stay at page1.html but got ' + currentURL);
-		}
 
-		// Test exact URL match with navigation
+		await page.waitForURL(/.*page1\.html$/);
+		return page.url();
+	`,
+	)
+	assert.Equal(t, tb.staticURL("page1.html"), got.Result().String())
+
+	// Test exact URL match with navigation
+	got = tb.vu.RunPromise(t, `
 		await page.goto(testURL);
+
 		await Promise.all([
 			page.waitForURL(page1URL),
 			page.locator('#page1').click()
 		]);
-		currentURL = page.url();
-		if (!currentURL.endsWith('page1.html')) {
-			throw new Error('Expected to navigate to page1.html but got ' + currentURL);
-		}
+		return page.url();
+	`,
+	)
+	assert.Equal(t, tb.staticURL("page1.html"), got.Result().String())
 
-		// Test regex pattern - matches any page with .html extension
+	// Test regex pattern - matches any page with .html extension
+	got = tb.vu.RunPromise(t, `
 		await page.goto(testURL);
+
 		await Promise.all([
 			page.waitForURL(/.*\.html$/),
 			page.locator('#page2').click()
 		]);
-		currentURL = page.url();
-		if (!currentURL.endsWith('.html')) {
-			throw new Error('Expected URL to end with .html but got ' + currentURL);
-		}
+		return page.url();
+	`,
+	)
+	assert.Equal(t, tb.staticURL("page2.html"), got.Result().String())
 
-		// Test timeout when URL doesn't match
+	// Test timeout when URL doesn't match
+	_, err = tb.vu.RunAsync(t, `
 		await page.goto(testURL);
-		let timedOut = false;
-		try {
-			await Promise.all([
-				page.waitForURL(/.*nonexistent\.html$/, { timeout: 500 }),
-				page.locator('#page1').click()  // This goes to page1.html, not nonexistent.html
-			]);
-		} catch (error) {
-			if (error.toString().includes('waiting for navigation')) {
-				timedOut = true;
-			} else {
-				throw error;
-			}
-		}
-		if (!timedOut) {
-			throw new Error('Expected timeout error when URL does not match');
-		}
 
-		// Test empty pattern (matches any navigation)
+		await Promise.all([
+			page.waitForURL(/.*nonexistent\.html$/, { timeout: 500 }),
+			page.locator('#page1').click()  // This goes to page1.html, not nonexistent.html
+		]);
+	`,
+	)
+	assert.ErrorContains(t, err, "timed out after 500ms")
+
+	// Test empty pattern (matches any navigation)
+	got = tb.vu.RunPromise(t, `
 		await page.goto(testURL);
 		await Promise.all([
 			page.waitForURL(''),
 			page.locator('#page2').click()
 		]);
-		currentURL = page.url();
-		if (!currentURL.endsWith('page2.html') && !currentURL.endsWith('waitfornavigation_test.html')) {
-			throw new Error('Expected empty pattern to match any navigation but got ' + currentURL);
-		}
+		return page.url();
+	`,
+	)
+	assert.Equal(t, tb.staticURL("page2.html"), got.Result().String())
 
-		// Test waitUntil option
+	// Test waitUntil option
+	got = tb.vu.RunPromise(t, `
 		await page.goto(testURL);
 		await Promise.all([
 			page.waitForURL(/.*page1\.html$/, { waitUntil: 'domcontentloaded' }),
 			page.locator('#page1').click()
 		]);
-		currentURL = page.url();
-		if (!currentURL.endsWith('page1.html')) {
-			throw new Error('Expected to navigate to page1.html with domcontentloaded but got ' + currentURL);
-		}
-
-		// Test when already at URL with regex pattern
-		await page.goto(testURL);
-		await page.waitForURL(/.*\/waitfornavigation_test\.html$/);
-		currentURL = page.url();
-		if (!currentURL.endsWith('waitfornavigation_test.html')) {
-			throw new Error('Expected to stay at waitfornavigation_test.html but got ' + currentURL);
-		}
+		return page.url();
 	`,
 	)
-	assert.Equal(t, sobek.Undefined(), got.Result())
+	assert.Equal(t, tb.staticURL("page1.html"), got.Result().String())
+
+	// Test when already at URL with regex pattern
+	got = tb.vu.RunPromise(t, `
+		await page.goto(testURL);
+		await page.waitForURL(/.*\/waitfornavigation_test\.html$/);
+		return page.url();
+	`,
+	)
+	assert.Equal(t, tb.staticURL("waitfornavigation_test.html"), got.Result().String())
+
+	// Expect error on null/undefined URL
+	_, err = tb.vu.RunAsync(t, `
+		await page.goto(testURL);
+
+		await page.waitForURL();
+	`,
+	)
+	assert.ErrorContains(t, err, "missing required argument 'url'")
 }
 
 func TestPageWaitForResponse(t *testing.T) {

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2828,7 +2828,7 @@ func TestWaitForNavigationWithURL(t *testing.T) {
 		await page.goto(testURL);
 
 		await Promise.all([
-			page.waitForNavigation({ url: /.*\.html$/ }),
+			page.waitForNavigation({ url: /.*2\.html$/ }),
 			page.locator('#page2').click()
 		]);
 		return page.url();
@@ -2861,6 +2861,7 @@ func TestWaitForNavigationWithURL(t *testing.T) {
 	)
 	assert.Equal(t, tb.staticURL("page2.html"), got.Result().String())
 
+	// Test regex pattern with invalid regex
 	_, err = tb.vu.RunAsync(t, `
 		await page.goto(testURL);
 
@@ -2873,7 +2874,7 @@ func TestWaitForNavigationWithURL(t *testing.T) {
 	assert.ErrorContains(t, err, "Unexpected token *")
 }
 
-func TestWaitForURL(t *testing.T) {
+func TestPageWaitForURL(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipped due to https://github.com/grafana/k6/issues/4937")
 	}
@@ -2921,7 +2922,7 @@ func TestWaitForURL(t *testing.T) {
 		await page.goto(testURL);
 
 		await Promise.all([
-			page.waitForURL(/.*\.html$/),
+			page.waitForURL(/.*2\.html$/),
 			page.locator('#page2').click()
 		]);
 		return page.url();
@@ -2951,7 +2952,8 @@ func TestWaitForURL(t *testing.T) {
 		return page.url();
 	`,
 	)
-	assert.Equal(t, tb.staticURL("page2.html"), got.Result().String())
+	assert.True(t, strings.Contains(got.Result().String(), "page2.html") ||
+		strings.Contains(got.Result().String(), "waitfornavigation_test.html"))
 
 	// Test waitUntil option
 	got = tb.vu.RunPromise(t, `

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2801,15 +2801,21 @@ func TestWaitForNavigationWithURL(t *testing.T) {
 	tb.vu.ActivateVU()
 	tb.vu.StartIteration(t)
 
-	got := tb.vu.RunPromise(t, `
-		const page = await browser.newPage();
-		const testURL = '%s';
+	// Setup
+	tb.vu.SetVar(t, "page", &sobek.Object{})
+	tb.vu.SetVar(t, "testURL", tb.staticURL("waitfornavigation_test.html"))
+	tb.vu.SetVar(t, "page1URL", tb.staticURL("page1.html"))
+	_, err := tb.vu.RunAsync(t, `
+			page = await browser.newPage();
+		`)
+	require.NoError(t, err)
 
+	got := tb.vu.RunPromise(t, `
 		await page.goto(testURL);
 
 		// Test exact URL match
 		await Promise.all([
-			page.waitForNavigation({ url: '%s' }),
+			page.waitForNavigation({ url: page1URL }),
 			page.locator('#page1').click()
 		]);
 		let currentURL = page.url();
@@ -2861,8 +2867,6 @@ func TestWaitForNavigationWithURL(t *testing.T) {
 			throw new Error('Expected empty pattern to match any navigation but got ' + currentURL);
 		}
 	`,
-		tb.staticURL("waitfornavigation_test.html"),
-		tb.staticURL("page1.html"),
 	)
 	assert.Equal(t, sobek.Undefined(), got.Result())
 }
@@ -2899,12 +2903,18 @@ func TestWaitForURL(t *testing.T) {
 	tb.vu.ActivateVU()
 	tb.vu.StartIteration(t)
 
-	got := tb.vu.RunPromise(t, `
-		const page = await browser.newPage();
-		const testURL = '%s';
+	// Setup
+	tb.vu.SetVar(t, "page", &sobek.Object{})
+	tb.vu.SetVar(t, "testURL", tb.staticURL("waitfornavigation_test.html"))
+	tb.vu.SetVar(t, "page1URL", tb.staticURL("page1.html"))
+	_, err := tb.vu.RunAsync(t, `
+			page = await browser.newPage();
+		`)
+	require.NoError(t, err)
 
+	got := tb.vu.RunPromise(t, `
 		// Test when already at matching URL (should just wait for load state)
-		await page.goto('%s');
+		await page.goto(page1URL);
 		await page.waitForURL(/.*page1\.html$/);
 		let currentURL = page.url();
 		if (!currentURL.endsWith('page1.html')) {
@@ -2914,7 +2924,7 @@ func TestWaitForURL(t *testing.T) {
 		// Test exact URL match with navigation
 		await page.goto(testURL);
 		await Promise.all([
-			page.waitForURL('%s'),
+			page.waitForURL(page1URL),
 			page.locator('#page1').click()
 		]);
 		currentURL = page.url();
@@ -2982,9 +2992,6 @@ func TestWaitForURL(t *testing.T) {
 			throw new Error('Expected to stay at waitfornavigation_test.html but got ' + currentURL);
 		}
 	`,
-		tb.staticURL("waitfornavigation_test.html"),
-		tb.staticURL("page1.html"),
-		tb.staticURL("page1.html"),
 	)
 	assert.Equal(t, sobek.Undefined(), got.Result())
 }


### PR DESCRIPTION
## What?

This PR aims to tidy up the tests and add new ones where necessary including a refactor in the implementation for `waitForURL`:

1. Refactor to work with `parseStringOrRegex` in `waitForURL`;
2. Refactor tests so that they're easier to maintain and fix when/if they fail;
3. Refactor tests so that they're not flakey;
4. Add `waitForURL` tests to `frame`.

## Why?

Refactors based on comments made in this PR: https://github.com/grafana/k6/pull/4920
- https://github.com/grafana/k6/pull/4920#discussion_r2215746887
- https://github.com/grafana/k6/pull/4920#discussion_r2238980488

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/pull/4920