### PR TITLE
Backport: fix: do not panic on k6 login cloud

### DIFF
--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -333,8 +333,21 @@ func analyze(gs *state.GlobalState, args []string) (k6deps.Dependencies, error) 
 // isAnalysisRequired returns a boolean indicating if dependency analysis is required for the command
 func isAnalysisRequired(cmd *cobra.Command) bool {
 	switch cmd.Name() {
-	case "run", "archive", "inspect", "upload", "cloud":
-		return true
+	case "run":
+		if parent := cmd.Parent(); parent != nil {
+			switch parent.Name() {
+			case "k6", "cloud":
+				return true
+			}
+		}
+	case "upload":
+		if parent := cmd.Parent(); parent != nil {
+			return parent.Name() == "cloud"
+		}
+	case "cloud", "archive", "inspect":
+		if parent := cmd.Parent(); parent != nil {
+			return parent.Name() == "k6"
+		}
 	}
 
 	return false

--- a/internal/cmd/tests/tests_test.go
+++ b/internal/cmd/tests/tests_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.k6.io/k6/internal/cmd"
 )
 
@@ -31,4 +32,14 @@ func TestRootCommand(t *testing.T) {
 			assert.Contains(t, ts.Stdout.String(), helptxt)
 		})
 	}
+}
+
+func TestLoginCloudNotPanicking(t *testing.T) {
+	t.Parallel()
+
+	ts := NewGlobalTestState(t)
+	ts.CmdArgs = []string{"k6", "login", "cloud"}
+	ts.ExpectedExitCode = -1
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	assert.Contains(t, ts.Stderr.String(), "Stdin is not a terminal, falling back to plain text input")
 }


### PR DESCRIPTION
## What?

This is backporting #5057 to 1.2.x 

## Why?
So we can release a 1.2.2 with this fixed.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
