### PR TITLE
Backport: fix: order groups in summary by execution also in scenario

### DIFF
--- a/internal/js/summary.go
+++ b/internal/js/summary.go
@@ -72,13 +72,24 @@ func summarizeReportToObject(rt *sobek.Runtime, s *summary.Summary) (map[string]
 	if err != nil {
 		return nil, err
 	}
+	scenarios := make(map[string]any, len(s.Scenarios))
+	for name, scenario := range s.Scenarios {
+		scenarioObject := make(map[string]any, len(s.Scenarios))
+		scenarioObject["groups"], err = mapGroups(scenario.Groups, scenario.GroupsOrder)
+		if err != nil {
+			return nil, err
+		}
+		scenarioObject["checks"] = scenario.Checks
+		scenarioObject["metrics"] = scenario.Metrics
+		scenarios[name] = scenarioObject
+	}
 
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	m["thresholds"] = s.Thresholds
 	m["checks"] = s.Checks
 	m["metrics"] = s.Metrics
 	m["groups"] = groups
-	m["scenarios"] = s.Scenarios
+	m["scenarios"] = scenarios
 	return m, nil
 }
 


### PR DESCRIPTION
## What?

Backport #5059

## Why?

It is a bugfix we can make part of v1.2.2

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
