### PR TITLE
k6packager: Update to the latest Debian LTS and adjust the createrepo variant

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-20240612
+FROM debian:bullseye-20250811
 
 LABEL maintainer="k6 Developers <developers@k6.io>"
 
@@ -8,7 +8,7 @@ RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /
     sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \
     echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
     apt-get update -y && \
-    apt-get install -y apt-utils createrepo curl git gnupg2 python3-pip unzip
+    apt-get install -y apt-utils createrepo-c curl git gnupg2 python3-pip unzip
 
 RUN pip3 install "s3cmd==2.4.0"
 

--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -4,10 +4,7 @@ LABEL maintainer="k6 Developers <developers@k6.io>"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list && \
-    sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list && \
-    echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until && \
-    apt-get update -y && \
+RUN apt-get update -y && \
     apt-get install -y apt-utils createrepo-c curl git gnupg2 python3-pip unzip
 
 RUN pip3 install "s3cmd==2.4.0"

--- a/packaging/bin/create-rpm-repo.sh
+++ b/packaging/bin/create-rpm-repo.sh
@@ -2,7 +2,7 @@
 set -eEuo pipefail
 
 # External dependencies:
-# - https://github.com/rpm-software-management/createrepo
+# - https://github.com/rpm-software-management/createrepo_c
 # - https://github.com/s3tools/s3cmd
 #   s3cmd expects AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to be set in the
 #   environment.


### PR DESCRIPTION
## What?

It updates the k6packager base image to the latest Debian LTS release.

It also replaces `createrepo` with its variant implemented in C, named `createrepo_c`.

## Why?

Because the Debian version in-use is more than one year old and no longer under LTS guarantees.

Because `createrepo` (the old one, written in Python) is no longer available in newer Debian repositories, and its variant implemented in C is the way to go, as mentioned in https://github.com/grafana/k6/issues/4947#issuecomment-3161112089.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #4947 

<!-- Thanks for your contribution! 🙏🏼 -->
