### PR TITLE
Add `frameLocator`, `frameLocator.locator` and `locator.contentFrame`

### DIFF
--- a/internal/js/modules/k6/browser/browser/frame_locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_locator_mapping.go
@@ -1,0 +1,10 @@
+package browser
+
+import (
+	"go.k6.io/k6/internal/js/modules/k6/browser/common"
+)
+
+// mapFrameLocator API to the JS module.
+func mapFrameLocator(vu moduleVU, fl *common.FrameLocator) mapping {
+	return mapping{}
+}

--- a/internal/js/modules/k6/browser/browser/frame_locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_locator_mapping.go
@@ -1,10 +1,17 @@
 package browser
 
 import (
+	"github.com/grafana/sobek"
 	"go.k6.io/k6/internal/js/modules/k6/browser/common"
 )
 
 // mapFrameLocator API to the JS module.
 func mapFrameLocator(vu moduleVU, fl *common.FrameLocator) mapping {
-	return mapping{}
+	rt := vu.Runtime()
+	return mapping{
+		"locator": func(selector string) *sobek.Object {
+			ml := mapLocator(vu, fl.Locator(selector))
+			return rt.ToValue(ml).ToObject(rt)
+		},
+	}
 }

--- a/internal/js/modules/k6/browser/browser/locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/locator_mapping.go
@@ -59,6 +59,10 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping {
 				return nil, lo.Click(popts) //nolint:wrapcheck
 			}), nil
 		},
+		"contentFrame": func() *sobek.Object {
+			ml := mapFrameLocator(vu, lo.ContentFrame())
+			return rt.ToValue(ml).ToObject(rt)
+		},
 		"count": func() *sobek.Promise {
 			return k6ext.Promise(vu.Context(), func() (any, error) {
 				return lo.Count() //nolint:wrapcheck

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -151,6 +151,12 @@ func TestMappings(t *testing.T) {
 				return mapElementHandle(moduleVU{VU: vu}, &common.ElementHandle{})
 			},
 		},
+		"frameLocator": {
+			apiInterface: (*frameLocatorAPI)(nil),
+			mapp: func() mapping {
+				return mapFrameLocator(moduleVU{VU: vu}, &common.FrameLocator{})
+			},
+		},
 		"jsHandle": {
 			apiInterface: (*common.JSHandleAPI)(nil),
 			mapp: func() mapping {
@@ -491,6 +497,10 @@ type elementHandleAPI interface { //nolint:interfacebloat
 	Uncheck(opts sobek.Value) error
 	WaitForElementState(state string, opts sobek.Value) error
 	WaitForSelector(selector string, opts sobek.Value) (*common.ElementHandle, error)
+}
+
+type frameLocatorAPI interface {
+	Locator(selector string) *common.Locator
 }
 
 // requestAPI is the interface of an HTTP request.

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -538,6 +538,7 @@ type locatorAPI interface { //nolint:interfacebloat
 	BoundingBox(opts *common.FrameBaseOptions) (*common.Rect, error)
 	Clear(opts *common.FrameFillOptions) error
 	Click(opts sobek.Value) error
+	ContentFrame() *common.FrameLocator
 	Count() (int, error)
 	Dblclick(opts sobek.Value) error
 	SetChecked(checked bool, opts sobek.Value) error

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -725,9 +725,10 @@ func (h *ElementHandle) stepIntoFrame(
 		return nil, "", fmt.Errorf("finding iframe with selector %q: %w", iframeSelector, err)
 	}
 
+	// This is a valid response from waitForSelector. It means that the element
+	// was either hidden or detached.
 	if iframeHandle == nil {
-		// TODO: Do we need to correctly handle this?
-		return nil, "", nil // No iframe found
+		return nil, "", errors.New("check if element is visible")
 	}
 
 	frame, err := iframeHandle.ContentFrame()
@@ -790,6 +791,8 @@ func (h *ElementHandle) waitForSelector(
 	case *ElementHandle:
 		return r, nil
 	default:
+		// This is a valid response, which means that the element was either
+		// hidden or detached.
 		return nil, nil //nolint:nilnil
 	}
 }

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -800,6 +800,24 @@ func (h *ElementHandle) splitSelectorAtFrame(selector *Selector, frameIndex int)
 	return beforeFrame, afterFrame
 }
 
+// reconstructSelector rebuilds a selector string from selector parts
+func (h *ElementHandle) reconstructSelector(selector *Selector) string {
+	if len(selector.Parts) == 0 {
+		return ""
+	}
+
+	parts := make([]string, len(selector.Parts))
+	for i, part := range selector.Parts {
+		if part.Name == "css" {
+			parts[i] = part.Body
+		} else {
+			parts[i] = part.Name + "=" + part.Body
+		}
+	}
+
+	return strings.Join(parts, " >> ")
+}
+
 // AsElement returns this element handle.
 func (h *ElementHandle) AsElement() *ElementHandle {
 	return h

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -783,6 +783,23 @@ func (h *ElementHandle) findFrameNavigationIndex(selector *Selector) int {
 	return -1
 }
 
+// splitSelectorAtFrame splits a selector at the frame navigation boundary
+func (h *ElementHandle) splitSelectorAtFrame(selector *Selector, frameIndex int) (*Selector, *Selector) {
+	beforeFrame := &Selector{
+		Selector: selector.Selector, // Keep original for reference
+		Parts:    selector.Parts[:frameIndex],
+		Capture:  selector.Capture,
+	}
+
+	afterFrame := &Selector{
+		Selector: selector.Selector, // Keep original for reference
+		Parts:    selector.Parts[frameIndex+1:],
+		Capture:  selector.Capture,
+	}
+
+	return beforeFrame, afterFrame
+}
+
 // AsElement returns this element handle.
 func (h *ElementHandle) AsElement() *ElementHandle {
 	return h

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -773,6 +773,16 @@ func (h *ElementHandle) count(apiCtx context.Context, selector string) (int, err
 	}
 }
 
+// findFrameNavigationIndex finds the index of the first internal:control=enter-frame directive
+func (h *ElementHandle) findFrameNavigationIndex(selector *Selector) int {
+	for i, part := range selector.Parts {
+		if part.Name == "internal:control" && part.Body == "enter-frame" {
+			return i
+		}
+	}
+	return -1
+}
+
 // AsElement returns this element handle.
 func (h *ElementHandle) AsElement() *ElementHandle {
 	return h

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -593,6 +593,9 @@ func (f *Frame) waitFor(
 		if strings.Contains(err.Error(), "Execution context was destroyed") {
 			return f.waitFor(selector, opts, retryCount)
 		}
+		if strings.Contains(err.Error(), "visible") {
+			return f.waitFor(selector, opts, retryCount)
+		}
 	}
 
 	return handle, err

--- a/internal/js/modules/k6/browser/common/frame_locator.go
+++ b/internal/js/modules/k6/browser/common/frame_locator.go
@@ -25,3 +25,10 @@ func NewFrameLocator(ctx context.Context, selector string, f *Frame, l *log.Logg
 		log:      l,
 	}
 }
+
+// Locator creates and returns a new locator chained/relative to the current FrameLocator.
+func (fl *FrameLocator) Locator(selector string) *Locator {
+	// Add frame navigation marker to indicate we need to enter the frame's contentDocument
+	frameNavSelector := fl.selector + " >> internal:control=enter-frame >> " + selector
+	return NewLocator(fl.ctx, nil, frameNavSelector, fl.frame, fl.log)
+}

--- a/internal/js/modules/k6/browser/common/frame_locator.go
+++ b/internal/js/modules/k6/browser/common/frame_locator.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"context"
+
+	"go.k6.io/k6/internal/js/modules/k6/browser/log"
+)
+
+// FrameLocator represent a way to find element(s) in an iframe.
+type FrameLocator struct {
+	selector string
+
+	frame *Frame
+
+	ctx context.Context
+	log *log.Logger
+}
+
+// NewFrameLocator creates and returns a new frame locator.
+func NewFrameLocator(ctx context.Context, selector string, f *Frame, l *log.Logger) *FrameLocator {
+	return &FrameLocator{
+		selector: selector,
+		frame:    f,
+		ctx:      ctx,
+		log:      l,
+	}
+}

--- a/internal/js/modules/k6/browser/common/locator.go
+++ b/internal/js/modules/k6/browser/common/locator.go
@@ -127,6 +127,13 @@ func (l *Locator) All() ([]*Locator, error) {
 	return locators, nil
 }
 
+// ContentFrame creates and returns a new FrameLocator, which is useful when
+// needing to interact with elements in an iframe and the current locator already
+// points to the iframe.
+func (l *Locator) ContentFrame() *FrameLocator {
+	return NewFrameLocator(l.ctx, l.selector, l.frame, l.log)
+}
+
 // Count APIs do not wait for the element to be present. It also does not set
 // strict to true, allowing it to return the total number of elements matching
 // the selector.

--- a/internal/js/modules/k6/browser/common/selectors.go
+++ b/internal/js/modules/k6/browser/common/selectors.go
@@ -115,6 +115,9 @@ func (s *Selector) parse() error {
 		case strings.HasPrefix(part, "internal:text="):
 			name = "internal:text"
 			body = part
+		case strings.HasPrefix(part, "internal:control="):
+			name = "internal:control"
+			body = part[eqIndex+1:]
 		default:
 			name = "css"
 			body = part

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -5,6 +5,8 @@ package tests
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -813,6 +815,66 @@ func TestCount(t *testing.T) {
 		return tb, p
 	}
 
+	setupCORS := func(t *testing.T) (*testBrowser, *common.Page) {
+		t.Helper()
+
+		// Origin B: intermediate frame embedding origin C + own counter (with dynamic C URL)
+		originBHTML := `<!DOCTYPE html>
+		<html>
+		<head></head>
+		<body>
+			<button id="incrementB">Increment Counter B</button>
+		</body>
+		</html>`
+
+		// Server for origin B
+		muxB := http.NewServeMux()
+		muxB.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, err := w.Write([]byte(originBHTML))
+			require.NoError(t, err)
+		})
+		srvB := httptest.NewServer(muxB)
+		t.Cleanup(func() {
+			srvB.Close()
+		})
+
+		// Origin A: main page embedding origin B and same-origin frame A (with dynamic B URL)
+		originAHTML := fmt.Sprintf(`<!DOCTYPE html>
+		<html>
+		<head></head>
+		<body>
+			<iframe id="frameB" src="%s"></iframe>
+		</body>
+		</html>`, srvB.URL)
+
+		// Server for origin A
+		muxA := http.NewServeMux()
+		muxA.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, err := w.Write([]byte(originAHTML))
+			require.NoError(t, err)
+		})
+		srvA := httptest.NewServer(muxA)
+		t.Cleanup(func() {
+			srvA.Close()
+		})
+
+		tb := newTestBrowser(t)
+
+		p := tb.NewPage(nil)
+		opts := &common.FrameGotoOptions{
+			Timeout: common.DefaultTimeout,
+		}
+		_, err := p.Goto(
+			srvA.URL,
+			opts,
+		)
+		require.NoError(t, err)
+
+		return tb, p
+	}
+
 	tests := []struct {
 		name          string
 		setup         func(*testing.T) (*testBrowser, *common.Page)
@@ -845,6 +907,15 @@ func TestCount(t *testing.T) {
 				return l.Count()
 			},
 			expectedCount: 3,
+		},
+		{
+			name:  "CORS",
+			setup: setupCORS,
+			do: func(_ *testBrowser, p *common.Page) (int, error) {
+				frameBContent := p.Locator("#frameB", nil).ContentFrame()
+				return frameBContent.Locator("#incrementB").Count()
+			},
+			expectedCount: 1,
 		},
 	}
 	for _, tt := range tests {

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -3357,4 +3357,82 @@ func TestClickInNestedFramesCORS(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, expectedCount, countD)
 	})
+
+	// This test is the same as the previous one, but uses the Locator API
+	// instead of the Frame APIs.
+	t.Run("ok/click_in_nested_frames_with_locator", func(t *testing.T) {
+		t.Parallel()
+
+		// Use srvA.URL as the entry point in the rest of the test (navigate, click, etc.).
+		page := newTestBrowser(t).NewPage(nil)
+
+		// Navigate to the page that srvA is serving.
+		opts := &common.FrameGotoOptions{
+			Timeout: common.DefaultTimeout,
+		}
+		_, err := page.Goto(srvA.URL, opts)
+		require.NoError(t, err)
+
+		var (
+			clickOpts     = common.NewFrameClickOptions(page.Timeout())
+			expectedCount = "1"
+		)
+
+		// First click on the main frame.
+		err = page.Locator("#incrementA", nil).Click(clickOpts)
+		require.NoError(t, err)
+
+		countA, ok, err := page.Locator("#countA", nil).TextContent(nil)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, expectedCount, countA)
+
+		// Now get the first nested frame.
+		frameAContent := page.Locator("#frameA", nil).ContentFrame()
+
+		// Click on the second nested frame.
+		err = frameAContent.Locator("#incrementA2").Click(clickOpts)
+		require.NoError(t, err)
+
+		countA2, ok, err := frameAContent.Locator("#countA2").TextContent(nil)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, expectedCount, countA2)
+
+		// Now get the second nested frame.
+		frameBContent := page.Locator("#frameB", nil).ContentFrame()
+
+		// Click on the third nested frame.
+		err = frameBContent.Locator("#incrementB").Click(clickOpts)
+		require.NoError(t, err)
+
+		countB, ok, err := frameBContent.Locator("#countB").TextContent(nil)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, expectedCount, countB)
+
+		// Now get the third nested frame.
+		frameCContent := frameBContent.Locator("#frameC").ContentFrame()
+
+		// Click on the fourth nested frame.
+		err = frameCContent.Locator("#increment").Click(clickOpts)
+		require.NoError(t, err)
+
+		count, ok, err := frameCContent.Locator("#count").TextContent(nil)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, expectedCount, count)
+
+		// Now get the fourth nested frame.
+		frameDContent := frameCContent.Locator("#frameD").ContentFrame()
+
+		// Click on the fifth nested frame.
+		err = frameDContent.Locator("#incrementD").Click(clickOpts)
+		require.NoError(t, err)
+
+		countD, ok, err := frameDContent.Locator("#countD").TextContent(nil)
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, expectedCount, countD)
+	})
 }


### PR DESCRIPTION
## What?

This adds a few new APIs. It would have been difficult to implement `frameLocator` on its own without the other two APIs:

1. It implements `frameLocator` which allows the user to interact with elements within `iframe`s with `locator` like APIs.
2. On top of that it implements `locator.contentFrame` which returns a `frameLocator`, allowing the user to actually retrieve a `frameLocator` to start working with elements from with an `iframe`.
3. It implements `frameLocator.locator` allowing users to actually select elements in an `iframe`.

## Why?

Working with `locator` like APIs is important for maintainable, less flakey tests. It's also a preferred way of working when interacting with `iframe`s in Playwright. We're currently on a drive to improve k6 browser's parity to make migrating from Playwright to k6 easier.

Essentially, `locator` and `frameLocator` APIs will retrieve the latest version of an element or perform an action on the latest version of an element when such APIs are called. Currently websites are very dynamic and we always want to try to work with the latest version of the DOM when trying to retrieve data or perform actions. Working with `page$` and `frame.contentFrame` are currently the only way to interact with elements in an `iframe`, but these are flakey since they work with old versions of the DOM.

The end result of this implementation also allows us to easily chain selectors. Before we used to have to do (imagine having to navigate to multiple nested `iframe`s):

```js
const frameB = await page.$('#frameB');
const frameBContent = await frameB.contentFrame(); // Takes a snapshot of the DOM

const frameC = await frameBContent.$('#frameB');
const frameCContent = await frameC.contentFrame(); // Takes a snapshot of the DOM

await frameCContent.locator("#increment", nil).click();

const count = await frameCContent.locator("#count").textContent();
```

and now we can do:

```js
const frameCContent = page.locator('#frameB').contentFrame().locator('#frameC').contentFrame();

await frameCContent.locator("#increment", nil).click(); // Works with the latest DOM and performs actionability checks.

const count = await frameCContent.locator("#count").textContent(); // Works with the latest DOM and performs actionability checks.
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/issues/5032