### PR TITLE
Add `locator.boundingbox`

### DIFF
--- a/internal/js/modules/k6/browser/browser/locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/locator_mapping.go
@@ -29,6 +29,15 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
 				return res, nil
 			})
 		},
+		"boundingBox": func(opts sobek.Value) (*sobek.Promise, error) {
+			popts := common.NewFrameBaseOptions(lo.Timeout())
+			if err := popts.Parse(vu.Context(), opts); err != nil {
+				return nil, fmt.Errorf("parsing locator bounding box options: %w", err)
+			}
+			return k6ext.Promise(vu.Context(), func() (any, error) {
+				return lo.BoundingBox(popts) //nolint:wrapcheck
+			}), nil
+		},
 		"clear": func(opts sobek.Value) (*sobek.Promise, error) {
 			copts := common.NewFrameFillOptions(lo.Timeout())
 			if err := copts.Parse(vu.Context(), opts); err != nil {

--- a/internal/js/modules/k6/browser/browser/locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/locator_mapping.go
@@ -11,8 +11,8 @@ import (
 
 // mapLocator API to the JS module.
 //
-//nolint:gocognit
-func mapLocator(vu moduleVU, lo *common.Locator) mapping { //nolint:funlen
+//nolint:gocognit,funlen
+func mapLocator(vu moduleVU, lo *common.Locator) mapping {
 	rt := vu.Runtime()
 	return mapping{
 		"all": func() *sobek.Promise {

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -528,6 +528,7 @@ type responseAPI interface { //nolint:interfacebloat
 // locatorAPI represents a way to find element(s) on a page at any moment.
 type locatorAPI interface { //nolint:interfacebloat
 	All() ([]*common.Locator, error)
+	BoundingBox(opts *common.FrameBaseOptions) (*common.Rect, error)
 	Clear(opts *common.FrameFillOptions) error
 	Click(opts sobek.Value) error
 	Count() (int, error)

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -592,6 +592,26 @@ func (f *Frame) waitFor(
 	return handle, err
 }
 
+func (f *Frame) boundingBox(selector string, opts *FrameBaseOptions) (*Rect, error) {
+	getBoundingBox := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
+		return handle.boundingBox()
+	}
+	act := f.newAction(
+		selector, DOMElementStateAttached, opts.Strict, getBoundingBox, []string{}, false, true, opts.Timeout,
+	)
+	v, err := call(f.ctx, act, opts.Timeout)
+	if err != nil {
+		return nil, errorFromDOMError(err)
+	}
+
+	bv, ok := v.(*Rect)
+	if !ok {
+		return nil, fmt.Errorf("getting bounding box of %q: unexpected type %T", selector, v)
+	}
+
+	return bv, nil
+}
+
 // ChildFrames returns a list of child frames.
 func (f *Frame) ChildFrames() []*Frame {
 	f.childFramesMu.RLock()

--- a/internal/js/modules/k6/browser/common/locator.go
+++ b/internal/js/modules/k6/browser/common/locator.go
@@ -37,6 +37,12 @@ func NewLocator(ctx context.Context, selector string, f *Frame, l *log.Logger) *
 	}
 }
 
+// BoundingBox will return the bounding box of the element.
+func (l *Locator) BoundingBox(opts *FrameBaseOptions) (*Rect, error) {
+	opts.Strict = true
+	return l.frame.boundingBox(l.selector, opts)
+}
+
 // Clear will clear the input field.
 // This works with the Fill API and fills the input field with an empty string.
 func (l *Locator) Clear(opts *FrameFillOptions) error {

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -55,6 +55,18 @@ func TestLocator(t *testing.T) {
 			},
 		},
 		{
+			"BoundingBox", func(_ *testBrowser, p *common.Page) {
+				rect, err := p.Locator("#divHello", nil).BoundingBox(&common.FrameBaseOptions{
+					Timeout: p.Timeout(),
+				})
+				require.NoError(t, err)
+				assert.GreaterOrEqual(t, rect.X, 0.0)
+				assert.GreaterOrEqual(t, rect.Y, 0.0)
+				assert.GreaterOrEqual(t, rect.Width, 0.0)
+				assert.GreaterOrEqual(t, rect.Height, 0.0)
+			},
+		},
+		{
 			"Check", func(_ *testBrowser, p *common.Page) {
 				check := func() bool {
 					v, err := p.Evaluate(`() => window.check`)
@@ -380,6 +392,12 @@ func TestLocator(t *testing.T) {
 		name string
 		do   func(*common.Locator, *testBrowser) error
 	}{
+		{
+			"BoundingBox", func(l *common.Locator, tb *testBrowser) error {
+				_, err := l.BoundingBox(common.NewFrameBaseOptions(100 * time.Millisecond))
+				return err
+			},
+		},
 		{
 			"Check", func(l *common.Locator, tb *testBrowser) error {
 				return l.Check(timeout(tb))


### PR DESCRIPTION
## What?

This change adds `boundingBox` to `locator`.

## Why?

When working on another issue (https://github.com/grafana/k6/pull/5071) I found it useful to work with this API. It's also part of Playwright, so bringing this in will give us better parity with Playwright.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/issues/4490