### PR TITLE
Make k6 get it version entirely from the build info

### DIFF
--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -66,6 +66,10 @@ func versionDetails() map[string]any {
 
 	if buildInfo.Main.Path == mainK6Path {
 		details["version"] = buildInfo.Main.Version
+		if buildInfo.Main.Version == "(devel)" {
+			details["version"] = v
+			details[commitKey] = "devel"
+		}
 		for _, s := range buildInfo.Settings {
 			switch s.Key {
 			case "vcs.revision":

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/ext"
 	"go.k6.io/k6/internal/build"
@@ -16,6 +17,7 @@ import (
 const (
 	commitKey      = "commit"
 	commitDirtyKey = "commit_dirty"
+	mainK6Path     = "go.k6.io/k6"
 )
 
 // fullVersion returns the maximally full version and build information for
@@ -44,13 +46,13 @@ func fullVersion() string {
 }
 
 // versionDetails returns the structured details about version
-func versionDetails() map[string]interface{} {
+func versionDetails() map[string]any {
 	v := build.Version
 	if !strings.HasPrefix(v, "v") {
 		v = "v" + v
 	}
 
-	details := map[string]interface{}{
+	details := map[string]any{
 		"version":    v,
 		"go_version": runtime.Version(),
 		"go_os":      runtime.GOOS,
@@ -62,6 +64,16 @@ func versionDetails() map[string]interface{} {
 		return details
 	}
 
+	if buildInfo.Main.Path == mainK6Path {
+		details["version"] = buildInfo.Main.Version
+	} else {
+		for _, dep := range buildInfo.Deps {
+			if dep.Path == mainK6Path {
+				details["version"] = dep.Version
+			}
+		}
+	}
+
 	var (
 		commit string
 		dirty  bool
@@ -69,10 +81,7 @@ func versionDetails() map[string]interface{} {
 	for _, s := range buildInfo.Settings {
 		switch s.Key {
 		case "vcs.revision":
-			commitLen := 10
-			if len(s.Value) < commitLen {
-				commitLen = len(s.Value)
-			}
+			commitLen := min(len(s.Value), 10)
 			commit = s.Value[:commitLen]
 		case "vcs.modified":
 			if s.Value == "true" {

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -66,38 +66,25 @@ func versionDetails() map[string]any {
 
 	if buildInfo.Main.Path == mainK6Path {
 		details["version"] = buildInfo.Main.Version
+		for _, s := range buildInfo.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				commitLen := min(len(s.Value), 10)
+				details[commitKey] = s.Value[:commitLen]
+			case "vcs.modified":
+				if s.Value == "true" {
+					details[commitDirtyKey] = true
+				}
+			default:
+			}
+		}
 	} else {
 		for _, dep := range buildInfo.Deps {
 			if dep.Path == mainK6Path {
 				details["version"] = dep.Version
+				break
 			}
 		}
-	}
-
-	var (
-		commit string
-		dirty  bool
-	)
-	for _, s := range buildInfo.Settings {
-		switch s.Key {
-		case "vcs.revision":
-			commitLen := min(len(s.Value), 10)
-			commit = s.Value[:commitLen]
-		case "vcs.modified":
-			if s.Value == "true" {
-				dirty = true
-			}
-		default:
-		}
-	}
-
-	if commit == "" {
-		return details
-	}
-
-	details[commitKey] = commit
-	if dirty {
-		details[commitDirtyKey] = true
 	}
 
 	return details

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"go.k6.io/k6/internal/build"
 	"go.k6.io/k6/internal/cmd/tests"
 )
@@ -79,4 +80,5 @@ func TestVersionJSONSubCommand(t *testing.T) {
 	assert.Equal(t, runtime.Version(), details["go_version"])
 	assert.Equal(t, runtime.GOOS, details["go_os"])
 	assert.Equal(t, runtime.GOARCH, details["go_arch"])
+	assert.Equal(t, "devel", details[commitKey])
 }


### PR DESCRIPTION
## What?

Try to more accurately asses the version of k6 also in cases where it is build with xk6.

This should remove the need to bumpd the constatnt with the version.

## Why?

When using xk6, k6 is a dependancy instead of the main version which leads to `k6 version` just returning the constant, irregardless if k6 is build from a later commit.

Before with `xk6 build e2181aa00` - previous commit from before this changes:
<img width="350" height="37" alt="image" src="https://github.com/user-attachments/assets/c6b0f124-f663-4dca-88c8-9072ff31065d" />
vs wiuth latest commit here
<img width="591" height="44" alt="image" src="https://github.com/user-attachments/assets/f67a06cf-d4a5-4d41-91a6-0e89e14573ff" />
and vs `go build` from the latest commit here again
<img width="752" height="63" alt="image" src="https://github.com/user-attachments/assets/bf4d051a-2e65-4fa2-b0cc-7bd987a0c563" />



## Notes:

Some of this functionality seems to be dependant on go 1.24.x as discussed in https://github.com/grafana/k6build/pull/197 

I am not removing the constant for now, probably after 1.3.0 we can consider removing it.



## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
