### PR TITLE
Improve the communication for automatic extension resolution

### DIFF
--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -89,7 +89,7 @@ func (l *launcher) launch(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		l.gs.Logger.
 			WithError(err).
-			Error("Automatic extension resolution is enabled but it failed to analyze the dependencies." +
+			Error("Failed to analyze the extensions required." +
 				" Please, make sure to report this issue by opening a bug report.")
 		return err
 	}
@@ -103,8 +103,8 @@ func (l *launcher) launch(cmd *cobra.Command, args []string) error {
 
 	l.gs.Logger.
 		WithField("deps", deps).
-		Info("Automatic extension resolution is enabled. The current k6 binary doesn't satisfy all dependencies," +
-			" it's required to provision a custom binary.")
+		Info("Provisioning a custom binary as the current doesn't satisfy all dependencies," +
+			" may take a few seconds as it needs to download the new one.")
 
 	customBinary, err := l.provisioner.provision(deps)
 	if err != nil {


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

1. Now that automatic extension resolution is the default doesn't make sense to repeat it for each logline, this should be obvious as it is the default.
2. The current waiting time on a blinking prompt is not optimal to me, it doesn't seem obvious to me if I should wait or the program got stuck so I clarified this aspect in the message.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
