### PR TITLE
Add comment on why we use element's session

### DIFF
--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -823,6 +823,13 @@ func (p *Page) getOwnerFrame(apiCtx context.Context, h *ElementHandle) (cdp.Fram
 	}
 
 	action := dom.DescribeNode().WithObjectID(documentElement.remoteObject.ObjectID)
+	// If the element is in an iframe, then using the page's session will not
+	// contain the element that we're looking for since frames do not
+	// share context between each other due to CORS.
+	//
+	// Instead here we use the element's session to retrieve the description of
+	// itself, which works even when we're handling elements that are not in
+	// an iframe.
 	node, err := action.Do(cdp.WithExecutor(p.ctx, h.session))
 	if err != nil {
 		p.logger.Debugf("Page:getOwnerFrame:DescribeNode:return", "sid:%v err:%v", p.sessionID(), err)


### PR DESCRIPTION
## What?

Adding a comment to help others know why we use the element's session to get the description of itself.

## Why?

NA

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/pull/5071/commits/38a49a8ac468118ff77ed82f9a249e66636fe908