### PR TITLE
grpc: Fix usage of Any types after refactor on protobuf loading

### DIFF
--- a/internal/js/modules/k6/grpc/client.go
+++ b/internal/js/modules/k6/grpc/client.go
@@ -265,7 +265,7 @@ func (c *Client) Connect(addr string, params sobek.Value) (bool, error) {
 	}
 
 	c.addr = addr
-	c.conn, err = grpcext.Dial(ctx, addr, opts...)
+	c.conn, err = grpcext.Dial(ctx, addr, c.types, opts...)
 	if err != nil {
 		return false, err
 	}

--- a/internal/lib/netext/grpcext/conn.go
+++ b/internal/lib/netext/grpcext/conn.go
@@ -231,6 +231,7 @@ func (c *Conn) NewStream(
 		methodDescriptor:       req.MethodDescriptor,
 		discardResponseMessage: req.DiscardResponseMessage,
 		marshaler:              protojson.MarshalOptions{Resolver: c.types, EmitUnpopulated: true},
+		unmarshaler:            protojson.UnmarshalOptions{Resolver: c.types},
 	}, nil
 }
 

--- a/internal/lib/netext/grpcext/conn.go
+++ b/internal/lib/netext/grpcext/conn.go
@@ -177,7 +177,7 @@ func (c *Conn) Invoke(
 		Trailers: trailer,
 	}
 
-	marshaler := protojson.MarshalOptions{EmitUnpopulated: true}
+	marshaler := protojson.MarshalOptions{EmitUnpopulated: true, Resolver: c.types}
 
 	if err != nil {
 		sterr := status.Convert(err)

--- a/internal/lib/netext/grpcext/conn.go
+++ b/internal/lib/netext/grpcext/conn.go
@@ -230,6 +230,7 @@ func (c *Conn) NewStream(
 		method:                 req.Method,
 		methodDescriptor:       req.MethodDescriptor,
 		discardResponseMessage: req.DiscardResponseMessage,
+		marshaler:              protojson.MarshalOptions{Resolver: c.types, EmitUnpopulated: true},
 	}, nil
 }
 


### PR DESCRIPTION
## What?

After #5017 turned out that k6 does not propagate the types it loads when making gRPC calls. This means that in many of the cases the globalTypes will be used, which will lead to errors. 

This likely is not just around `Any` but is how it was reported.

This PR goes and propagates the types in each place where they will be marshaled/unmarshalled.
The added test is not perfect, but does catch the problem without needing #4981 which I would expect would've also caught this. As currently the server will load the prototypes in the global types and k6/net/grpc will load them in their local types. And then they will technically work. 
## Why?

This likely breaks loading grpc proto types for anything using `Any`, but likely more cases.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Fixes #5088
