### PR TITLE
Backport grpc: Fix usage of Any types after refactor on protobuf loading

### DIFF
--- a/internal/js/modules/k6/grpc/client.go
+++ b/internal/js/modules/k6/grpc/client.go
@@ -265,7 +265,7 @@ func (c *Client) Connect(addr string, params sobek.Value) (bool, error) {
 	}
 
 	c.addr = addr
-	c.conn, err = grpcext.Dial(ctx, addr, opts...)
+	c.conn, err = grpcext.Dial(ctx, addr, c.types, opts...)
 	if err != nil {
 		return false, err
 	}

--- a/internal/lib/netext/grpcext/conn.go
+++ b/internal/lib/netext/grpcext/conn.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
 
@@ -25,6 +26,7 @@ import (
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/dynamicpb"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -72,7 +74,8 @@ type clientConnCloser interface {
 
 // Conn is a gRPC client connection.
 type Conn struct {
-	raw clientConnCloser
+	raw   clientConnCloser
+	types *protoregistry.Types
 }
 
 // DefaultOptions generates an option set
@@ -93,14 +96,15 @@ func DefaultOptions(getState func() *lib.State) []grpc.DialOption {
 }
 
 // Dial establish a gRPC connection.
-func Dial(ctx context.Context, addr string, options ...grpc.DialOption) (*Conn, error) {
+func Dial(ctx context.Context, addr string, types *protoregistry.Types, options ...grpc.DialOption) (*Conn, error) {
 	//nolint:staticcheck // see https://github.com/grafana/k6/issues/3699
 	conn, err := grpc.DialContext(ctx, addr, options...)
 	if err != nil {
 		return nil, err
 	}
 	return &Conn{
-		raw: conn,
+		raw:   conn,
+		types: types,
 	}, nil
 }
 
@@ -147,7 +151,7 @@ func (c *Conn) Invoke(
 	ctx = metadata.NewOutgoingContext(ctx, req.Metadata)
 
 	reqdm := dynamicpb.NewMessage(req.MethodDescriptor.Input())
-	if err := protojson.Unmarshal(req.Message, reqdm); err != nil {
+	if err := (protojson.UnmarshalOptions{Resolver: c.types}).Unmarshal(req.Message, reqdm); err != nil {
 		return nil, fmt.Errorf("unable to serialise request object to protocol buffer: %w", err)
 	}
 
@@ -173,7 +177,7 @@ func (c *Conn) Invoke(
 		Trailers: trailer,
 	}
 
-	marshaler := protojson.MarshalOptions{EmitUnpopulated: true}
+	marshaler := protojson.MarshalOptions{EmitUnpopulated: true, Resolver: c.types}
 
 	if err != nil {
 		sterr := status.Convert(err)
@@ -226,6 +230,8 @@ func (c *Conn) NewStream(
 		method:                 req.Method,
 		methodDescriptor:       req.MethodDescriptor,
 		discardResponseMessage: req.DiscardResponseMessage,
+		marshaler:              protojson.MarshalOptions{Resolver: c.types, EmitUnpopulated: true},
+		unmarshaler:            protojson.UnmarshalOptions{Resolver: c.types},
 	}, nil
 }
 


### PR DESCRIPTION
## What?

Fix very likely most usage of gRPC module. 

## Why?

The bug makes a lot of gRPC usage practically impossible, making this a bigger issue than it might first seem.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
