### PR TITLE
Backport fix: better detection of root command for auto extension resolution

### DIFF
--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -332,25 +332,25 @@ func analyze(gs *state.GlobalState, args []string) (k6deps.Dependencies, error) 
 
 // isAnalysisRequired returns a boolean indicating if dependency analysis is required for the command
 func isAnalysisRequired(cmd *cobra.Command) bool {
-	switch cmd.Name() {
-	case "run":
-		if parent := cmd.Parent(); parent != nil {
-			switch parent.Name() {
-			case "k6", "cloud":
-				return true
-			}
-		}
-	case "upload":
-		if parent := cmd.Parent(); parent != nil {
-			return parent.Name() == "cloud"
-		}
-	case "cloud", "archive", "inspect":
-		if parent := cmd.Parent(); parent != nil {
-			return parent.Name() == "k6"
-		}
+	switch stringifyCommand(cmd) {
+	case "k6 run",
+		"k6 cloud",
+		"k6 cloud run",
+		"k6 cloud upload",
+		"k6 upload",
+		"k6 archive",
+		"k6 inspect":
+		return true
 	}
 
 	return false
+}
+
+func stringifyCommand(cmd *cobra.Command) string {
+	if cmd.Parent() == nil {
+		return "k6"
+	}
+	return stringifyCommand(cmd.Parent()) + " " + cmd.Name()
 }
 
 // extractToken gets the cloud token required to access the build service

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/ext"
 
@@ -386,6 +387,10 @@ func TestIsAnalysisRequired(t *testing.T) {
 
 			args := append([]string{"k6"}, tc.args...)
 			ts := tests.NewGlobalTestState(t)
+			// Specifically set to not be the default k6 name.
+			// It asserts the scenario where a user has a custom name for the binary,
+			// such as k6v1.2.2, which is useful for managing multiple installed versions.
+			ts.BinaryName = "somethingelse"
 			ts.CmdArgs = args
 			rootCommand := newRootCommand(ts.GlobalState)
 


### PR DESCRIPTION
## What?

The original PR is fixing auto resolution not working if the k6 binary is not called `k6` as if it is called `k6.v1.2.2`.

## Why?

Auto extension resolution should not depend on what the binary is called.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
