### PR TITLE
Implement the `frame.getBy*` methods

### DIFF
--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -406,6 +406,13 @@ type frameAPI interface { //nolint:interfacebloat
 	Focus(selector string, opts sobek.Value) error
 	FrameElement() (*common.ElementHandle, error)
 	GetAttribute(selector string, name string, opts sobek.Value) (string, bool, error)
+	GetByAltText(alt string, opts *common.GetByBaseOptions) *common.Locator
+	GetByLabel(label string, opts *common.GetByBaseOptions) *common.Locator
+	GetByPlaceholder(placeholder string, opts *common.GetByBaseOptions) *common.Locator
+	GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
+	GetByTestId(testID string) *common.Locator
+	GetByText(text string, opts *common.GetByBaseOptions) *common.Locator
+	GetByTitle(title string, opts *common.GetByBaseOptions) *common.Locator
 	Goto(url string, opts sobek.Value) (*common.Response, error)
 	Hover(selector string, opts sobek.Value) error
 	InnerHTML(selector string, opts sobek.Value) (string, error)

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -440,12 +440,9 @@ func TestGetByRoleSuccess(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				getByRoleImplementations := map[string]interface {
+				getByRoleImplementations := getByImplementationsOf[interface {
 					GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
-				}{
-					"page":  p,
-					"frame": p.MainFrame(),
-				}
+				}](p)
 
 				for implName, impl := range getByRoleImplementations {
 					t.Run(implName, func(t *testing.T) { //nolint:paralleltest
@@ -577,12 +574,9 @@ func TestGetByRoleSuccess(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				getByRoleImplementations := map[string]interface {
+				getByRoleImplementations := getByImplementationsOf[interface {
 					GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
-				}{
-					"page":  p,
-					"frame": p.MainFrame(),
-				}
+				}](p)
 
 				for implName, impl := range getByRoleImplementations {
 					t.Run(implName, func(t *testing.T) { //nolint:paralleltest
@@ -745,12 +739,9 @@ func TestGetByRoleSuccess(t *testing.T) {
 				)
 				require.NoError(t, err)
 
-				getByRoleImplementations := map[string]interface {
+				getByRoleImplementations := getByImplementationsOf[interface {
 					GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
-				}{
-					"page":  p,
-					"frame": p.MainFrame(),
-				}
+				}](p)
 
 				for implName, impl := range getByRoleImplementations {
 					t.Run(implName, func(t *testing.T) { //nolint:paralleltest
@@ -808,12 +799,9 @@ func TestGetByRoleFailure(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			getByRoleImplementations := map[string]interface {
+			getByRoleImplementations := getByImplementationsOf[interface {
 				GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
-			}{
-				"page":  p,
-				"frame": p.MainFrame(),
-			}
+			}](p)
 
 			for implName, impl := range getByRoleImplementations {
 				t.Run(implName, func(t *testing.T) {
@@ -888,12 +876,9 @@ func TestGetByAltTextSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			getByAltTextImplementations := map[string]interface {
+			getByAltTextImplementations := getByImplementationsOf[interface {
 				GetByAltText(alt string, opts *common.GetByBaseOptions) *common.Locator
-			}{
-				"page":  p,
-				"frame": p.MainFrame(),
-			}
+			}](p)
 
 			for implName, impl := range getByAltTextImplementations {
 				t.Run(implName, func(t *testing.T) {
@@ -976,12 +961,9 @@ func TestGetByLabelSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			getByLabelImplementations := map[string]interface {
+			getByLabelImplementations := getByImplementationsOf[interface {
 				GetByLabel(label string, opts *common.GetByBaseOptions) *common.Locator
-			}{
-				"page":  p,
-				"frame": p.MainFrame(),
-			}
+			}](p)
 
 			for implName, impl := range getByLabelImplementations {
 				t.Run(implName, func(t *testing.T) {
@@ -1075,12 +1057,9 @@ func TestGetByPlaceholderSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			getByPlaceholderImplementations := map[string]interface {
+			getByPlaceholderImplementations := getByImplementationsOf[interface {
 				GetByPlaceholder(placeholder string, opts *common.GetByBaseOptions) *common.Locator
-			}{
-				"page":  p,
-				"frame": p.MainFrame(),
-			}
+			}](p)
 
 			for implName, impl := range getByPlaceholderImplementations {
 				t.Run(implName, func(t *testing.T) {
@@ -1174,12 +1153,9 @@ func TestGetByTitleSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			getByTitleImplementations := map[string]interface {
+			getByTitleImplementations := getByImplementationsOf[interface {
 				GetByTitle(title string, opts *common.GetByBaseOptions) *common.Locator
-			}{
-				"page":  p,
-				"frame": p.MainFrame(),
-			}
+			}](p)
 
 			for implName, impl := range getByTitleImplementations {
 				t.Run(implName, func(t *testing.T) {
@@ -1266,12 +1242,9 @@ func TestGetByTestIDSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			getByTestIDImplementations := map[string]interface {
+			getByTestIDImplementations := getByImplementationsOf[interface {
 				GetByTestID(testID string) *common.Locator
-			}{
-				"page":  p,
-				"frame": p.MainFrame(),
-			}
+			}](p)
 
 			for implName, impl := range getByTestIDImplementations {
 				t.Run(implName, func(t *testing.T) {
@@ -1387,12 +1360,9 @@ func TestGetByTextSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			getByTextImplementations := map[string]interface {
+			getByTextImplementations := getByImplementationsOf[interface {
 				GetByText(text string, opts *common.GetByBaseOptions) *common.Locator
-			}{
-				"page":  p,
-				"frame": p.MainFrame(),
-			}
+			}](p)
 
 			for implName, impl := range getByTextImplementations {
 				t.Run(implName, func(t *testing.T) {
@@ -1462,5 +1432,12 @@ func TestGetByNullHandling(t *testing.T) {
 		await %s.getByText().click();
 	`, getByImpl)
 		require.ErrorContains(t, err, "missing required argument 'text'")
+	}
+}
+
+func getByImplementationsOf[T any](p *common.Page) map[string]T {
+	return map[string]T{
+		"page":  any(p).(T),
+		"frame": any(p.MainFrame()).(T),
 	}
 }

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -448,7 +448,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 				}
 
 				for implName, impl := range getByRoleImplementations {
-					t.Run(implName, func(t *testing.T) {
+					t.Run(implName, func(t *testing.T) { //nolint:paralleltest
 						l := impl.GetByRole(tt.role, tt.opts)
 						c, err := l.Count()
 						require.NoError(t, err)
@@ -585,7 +585,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 				}
 
 				for implName, impl := range getByRoleImplementations {
-					t.Run(implName, func(t *testing.T) {
+					t.Run(implName, func(t *testing.T) { //nolint:paralleltest
 						l := impl.GetByRole(tt.role, nil)
 						c, err := l.Count()
 						require.NoError(t, err)
@@ -753,7 +753,7 @@ func TestGetByRoleSuccess(t *testing.T) {
 				}
 
 				for implName, impl := range getByRoleImplementations {
-					t.Run(implName, func(t *testing.T) {
+					t.Run(implName, func(t *testing.T) { //nolint:paralleltest
 						l := impl.GetByRole(tt.role, tt.opts)
 						c, err := l.Count()
 						require.NoError(t, err)

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -14,23 +14,12 @@ import (
 func TestGetByRoleSuccess(t *testing.T) {
 	t.Parallel()
 
-	// This test all the implicit roles that are valid for the role based
-	// selector engine that is in the injectd_script.js file. Implicit roles
+	// This test all the implicit roles that are valid for the role-based
+	// selector engine that is in the injected_script.js file. Implicit roles
 	// are roles that are not explicitly defined in the HTML, but are
 	// implied by the context of the element.
 	t.Run("implicit", func(t *testing.T) {
 		t.Parallel()
-
-		tb := newTestBrowser(t, withFileServer())
-		p := tb.NewPage(nil)
-		opts := &common.FrameGotoOptions{
-			Timeout: common.DefaultTimeout,
-		}
-		_, err := p.Goto(
-			tb.staticURL("get_by_role_implicit.html"),
-			opts,
-		)
-		require.NoError(t, err)
 
 		tests := []struct {
 			name         string
@@ -440,37 +429,48 @@ func TestGetByRoleSuccess(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				l := p.GetByRole(tt.role, tt.opts)
-				c, err := l.Count()
+				tb := newTestBrowser(t, withFileServer())
+				p := tb.NewPage(nil)
+				opts := &common.FrameGotoOptions{
+					Timeout: common.DefaultTimeout,
+				}
+				_, err := p.Goto(
+					tb.staticURL("get_by_role_implicit.html"),
+					opts,
+				)
 				require.NoError(t, err)
-				require.Equal(t, tt.expected, c)
 
-				if tt.expectedText != "" {
-					text, _, err := l.TextContent(sobek.Undefined())
-					require.NoError(t, err)
-					require.Equal(t, tt.expectedText, text)
+				getByRoleImplementations := map[string]interface {
+					GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
+				}{
+					"page":  p,
+					"frame": p.MainFrame(),
+				}
+
+				for implName, impl := range getByRoleImplementations {
+					t.Run(implName, func(t *testing.T) {
+						l := impl.GetByRole(tt.role, tt.opts)
+						c, err := l.Count()
+						require.NoError(t, err)
+						require.Equal(t, tt.expected, c)
+
+						if tt.expectedText != "" {
+							text, _, err := l.TextContent(sobek.Undefined())
+							require.NoError(t, err)
+							require.Equal(t, tt.expectedText, text)
+						}
+					})
 				}
 			})
 		}
 	})
 
-	// This test all the explicit roles that are valid for the role based
-	// selector engine that is in the injectd_script.js file. Explicit roles
+	// This test all the explicit roles that are valid for the role-based
+	// selector engine that is in the injected_script.js file. Explicit roles
 	// are roles that are explicitly defined in the HTML using the correct
 	// role attribute.
 	t.Run("explicit", func(t *testing.T) {
 		t.Parallel()
-
-		tb := newTestBrowser(t, withFileServer())
-		p := tb.NewPage(nil)
-		opts := &common.FrameGotoOptions{
-			Timeout: common.DefaultTimeout,
-		}
-		_, err := p.Goto(
-			tb.staticURL("get_by_role_explicit.html"),
-			opts,
-		)
-		require.NoError(t, err)
 
 		tests := []struct {
 			role         string
@@ -566,36 +566,47 @@ func TestGetByRoleSuccess(t *testing.T) {
 			t.Run(tt.role, func(t *testing.T) {
 				t.Parallel()
 
-				l := p.GetByRole(tt.role, nil)
-				c, err := l.Count()
+				tb := newTestBrowser(t, withFileServer())
+				p := tb.NewPage(nil)
+				opts := &common.FrameGotoOptions{
+					Timeout: common.DefaultTimeout,
+				}
+				_, err := p.Goto(
+					tb.staticURL("get_by_role_explicit.html"),
+					opts,
+				)
 				require.NoError(t, err)
-				require.Equal(t, tt.expected, c)
 
-				if tt.expectedText != "" {
-					text, err := l.InnerText(sobek.Undefined())
-					require.NoError(t, err)
-					require.Equal(t, tt.expectedText, text)
+				getByRoleImplementations := map[string]interface {
+					GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
+				}{
+					"page":  p,
+					"frame": p.MainFrame(),
+				}
+
+				for implName, impl := range getByRoleImplementations {
+					t.Run(implName, func(t *testing.T) {
+						l := impl.GetByRole(tt.role, nil)
+						c, err := l.Count()
+						require.NoError(t, err)
+						require.Equal(t, tt.expected, c)
+
+						if tt.expectedText != "" {
+							text, err := l.InnerText(sobek.Undefined())
+							require.NoError(t, err)
+							require.Equal(t, tt.expectedText, text)
+						}
+					})
 				}
 			})
 		}
 	})
 
-	// This tests all the options, and different attributes (such as explicit
+	// This tests all the options and different attributes (such as explicit
 	// aria attributes vs the text value of an element) that can be used in
 	// the DOM with the same role.
 	t.Run("edge_cases", func(t *testing.T) {
 		t.Parallel()
-
-		tb := newTestBrowser(t, withFileServer())
-		p := tb.NewPage(nil)
-		opts := &common.FrameGotoOptions{
-			Timeout: common.DefaultTimeout,
-		}
-		_, err := p.Goto(
-			tb.staticURL("get_by_role_edge_cases.html"),
-			opts,
-		)
-		require.NoError(t, err)
 
 		tests := []struct {
 			name         string
@@ -723,15 +734,37 @@ func TestGetByRoleSuccess(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
-				l := p.GetByRole(tt.role, tt.opts)
-				c, err := l.Count()
+				tb := newTestBrowser(t, withFileServer())
+				p := tb.NewPage(nil)
+				opts := &common.FrameGotoOptions{
+					Timeout: common.DefaultTimeout,
+				}
+				_, err := p.Goto(
+					tb.staticURL("get_by_role_edge_cases.html"),
+					opts,
+				)
 				require.NoError(t, err)
-				require.Equal(t, tt.expected, c)
 
-				if tt.expectedText != "" {
-					text, err := l.InnerText(sobek.Undefined())
-					require.NoError(t, err)
-					require.Equal(t, tt.expectedText, text)
+				getByRoleImplementations := map[string]interface {
+					GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
+				}{
+					"page":  p,
+					"frame": p.MainFrame(),
+				}
+
+				for implName, impl := range getByRoleImplementations {
+					t.Run(implName, func(t *testing.T) {
+						l := impl.GetByRole(tt.role, tt.opts)
+						c, err := l.Count()
+						require.NoError(t, err)
+						require.Equal(t, tt.expected, c)
+
+						if tt.expectedText != "" {
+							text, err := l.InnerText(sobek.Undefined())
+							require.NoError(t, err)
+							require.Equal(t, tt.expectedText, text)
+						}
+					})
 				}
 			})
 		}
@@ -775,9 +808,20 @@ func TestGetByRoleFailure(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			l := p.GetByRole(tt.role, tt.opts)
-			_, err = l.Count()
-			require.ErrorContains(t, err, tt.expectedError)
+			getByRoleImplementations := map[string]interface {
+				GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
+			}{
+				"page":  p,
+				"frame": p.MainFrame(),
+			}
+
+			for implName, impl := range getByRoleImplementations {
+				t.Run(implName, func(t *testing.T) {
+					l := impl.GetByRole(tt.role, tt.opts)
+					_, err = l.Count()
+					require.ErrorContains(t, err, tt.expectedError)
+				})
+			}
 		})
 	}
 }
@@ -844,10 +888,21 @@ func TestGetByAltTextSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			l := p.GetByAltText(tt.alt, tt.opts)
-			c, err := l.Count()
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, c)
+			getByAltTextImplementations := map[string]interface {
+				GetByAltText(alt string, opts *common.GetByBaseOptions) *common.Locator
+			}{
+				"page":  p,
+				"frame": p.MainFrame(),
+			}
+
+			for implName, impl := range getByAltTextImplementations {
+				t.Run(implName, func(t *testing.T) {
+					l := impl.GetByAltText(tt.alt, tt.opts)
+					c, err := l.Count()
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, c)
+				})
+			}
 		})
 	}
 }
@@ -921,10 +976,21 @@ func TestGetByLabelSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			l := p.GetByLabel(tt.label, tt.opts)
-			c, err := l.Count()
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, c)
+			getByLabelImplementations := map[string]interface {
+				GetByLabel(label string, opts *common.GetByBaseOptions) *common.Locator
+			}{
+				"page":  p,
+				"frame": p.MainFrame(),
+			}
+
+			for implName, impl := range getByLabelImplementations {
+				t.Run(implName, func(t *testing.T) {
+					l := impl.GetByLabel(tt.label, tt.opts)
+					c, err := l.Count()
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, c)
+				})
+			}
 		})
 	}
 }
@@ -1009,10 +1075,21 @@ func TestGetByPlaceholderSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			l := p.GetByPlaceholder(tt.placeholder, tt.opts)
-			c, err := l.Count()
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, c)
+			getByPlaceholderImplementations := map[string]interface {
+				GetByPlaceholder(placeholder string, opts *common.GetByBaseOptions) *common.Locator
+			}{
+				"page":  p,
+				"frame": p.MainFrame(),
+			}
+
+			for implName, impl := range getByPlaceholderImplementations {
+				t.Run(implName, func(t *testing.T) {
+					l := impl.GetByPlaceholder(tt.placeholder, tt.opts)
+					c, err := l.Count()
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, c)
+				})
+			}
 		})
 	}
 }
@@ -1097,10 +1174,21 @@ func TestGetByTitleSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			l := p.GetByTitle(tt.title, tt.opts)
-			c, err := l.Count()
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, c)
+			getByTitleImplementations := map[string]interface {
+				GetByTitle(title string, opts *common.GetByBaseOptions) *common.Locator
+			}{
+				"page":  p,
+				"frame": p.MainFrame(),
+			}
+
+			for implName, impl := range getByTitleImplementations {
+				t.Run(implName, func(t *testing.T) {
+					l := impl.GetByTitle(tt.title, tt.opts)
+					c, err := l.Count()
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, c)
+				})
+			}
 		})
 	}
 }
@@ -1178,15 +1266,26 @@ func TestGetByTestIDSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			l := p.GetByTestID(tt.testID)
-			c, err := l.Count()
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, c)
+			getByTestIDImplementations := map[string]interface {
+				GetByTestID(testID string) *common.Locator
+			}{
+				"page":  p,
+				"frame": p.MainFrame(),
+			}
 
-			if tt.expected > 0 && tt.expectedText != "" {
-				text, err := l.InnerText(sobek.Undefined())
-				require.NoError(t, err)
-				require.Equal(t, tt.expectedText, text)
+			for implName, impl := range getByTestIDImplementations {
+				t.Run(implName, func(t *testing.T) {
+					l := impl.GetByTestID(tt.testID)
+					c, err := l.Count()
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, c)
+
+					if tt.expected > 0 && tt.expectedText != "" {
+						text, err := l.InnerText(sobek.Undefined())
+						require.NoError(t, err)
+						require.Equal(t, tt.expectedText, text)
+					}
+				})
 			}
 		})
 	}
@@ -1288,15 +1387,26 @@ func TestGetByTextSuccess(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			l := p.GetByText(tt.text, tt.opts)
-			c, err := l.Count()
-			require.NoError(t, err)
-			require.Equal(t, tt.expected, c)
+			getByTextImplementations := map[string]interface {
+				GetByText(text string, opts *common.GetByBaseOptions) *common.Locator
+			}{
+				"page":  p,
+				"frame": p.MainFrame(),
+			}
 
-			if tt.expected > 0 && tt.expectedText != "" {
-				text, err := l.InnerText(sobek.Undefined())
-				require.NoError(t, err)
-				require.Equal(t, tt.expectedText, text)
+			for implName, impl := range getByTextImplementations {
+				t.Run(implName, func(t *testing.T) {
+					l := impl.GetByText(tt.text, tt.opts)
+					c, err := l.Count()
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, c)
+
+					if tt.expected > 0 && tt.expectedText != "" {
+						text, err := l.InnerText(sobek.Undefined())
+						require.NoError(t, err)
+						require.Equal(t, tt.expectedText, text)
+					}
+				})
 			}
 		})
 	}
@@ -1313,41 +1423,44 @@ func TestGetByNullHandling(t *testing.T) {
 	tb.vu.SetVar(t, "page", &sobek.Object{})
 	_, err := tb.vu.RunAsync(t, `
 		page = await browser.newPage();
+		frame = page.mainFrame()
 	`)
 	require.NoError(t, err)
 
-	_, err = tb.vu.RunAsync(t, `
-		await page.getByRole().click();
-	`)
-	require.ErrorContains(t, err, "missing required argument 'role'")
+	for _, getByImpl := range []string{"page", "frame"} {
+		_, err = tb.vu.RunAsync(t, `
+		await %s.getByRole().click();
+	`, getByImpl)
+		require.ErrorContains(t, err, "missing required argument 'role'")
 
-	_, err = tb.vu.RunAsync(t, `
-		await page.getByAltText().click();
-	`)
-	require.ErrorContains(t, err, "missing required argument 'altText'")
+		_, err = tb.vu.RunAsync(t, `
+		await %s.getByAltText().click();
+	`, getByImpl)
+		require.ErrorContains(t, err, "missing required argument 'altText'")
 
-	_, err = tb.vu.RunAsync(t, `
-		await page.getByLabel().click();
-	`)
-	require.ErrorContains(t, err, "missing required argument 'label'")
+		_, err = tb.vu.RunAsync(t, `
+		await %s.getByLabel().click();
+	`, getByImpl)
+		require.ErrorContains(t, err, "missing required argument 'label'")
 
-	_, err = tb.vu.RunAsync(t, `
-		await page.getByPlaceholder().click();
-	`)
-	require.ErrorContains(t, err, "missing required argument 'placeholder'")
+		_, err = tb.vu.RunAsync(t, `
+		await %s.getByPlaceholder().click();
+	`, getByImpl)
+		require.ErrorContains(t, err, "missing required argument 'placeholder'")
 
-	_, err = tb.vu.RunAsync(t, `
-		await page.getByTitle().click();
-	`)
-	require.ErrorContains(t, err, "missing required argument 'title'")
+		_, err = tb.vu.RunAsync(t, `
+		await %s.getByTitle().click();
+	`, getByImpl)
+		require.ErrorContains(t, err, "missing required argument 'title'")
 
-	_, err = tb.vu.RunAsync(t, `
-		await page.getByTestId().click();
-	`)
-	require.ErrorContains(t, err, "missing required argument 'testId'")
+		_, err = tb.vu.RunAsync(t, `
+		await %s.getByTestId().click();
+	`, getByImpl)
+		require.ErrorContains(t, err, "missing required argument 'testId'")
 
-	_, err = tb.vu.RunAsync(t, `
-		await page.getByText().click();
-	`)
-	require.ErrorContains(t, err, "missing required argument 'text'")
+		_, err = tb.vu.RunAsync(t, `
+		await %s.getByText().click();
+	`, getByImpl)
+		require.ErrorContains(t, err, "missing required argument 'text'")
+	}
 }


### PR DESCRIPTION
## What?

It adds the mapping for all the `getBy*` methods for the `frame` API.

## Why?

Because we have already implemented all those methods, and we want to expose them as a way to increase our compatibility with Playwright, as described in #5037.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes  #5037

<!-- Thanks for your contribution! 🙏🏼 -->
