### PR TITLE
k6packager: createrepo command is now createrepo_c

### DIFF
--- a/packaging/bin/create-rpm-repo.sh
+++ b/packaging/bin/create-rpm-repo.sh
@@ -77,7 +77,7 @@ for arch in $architectures; do
     cp -av "$f" "$PWD/"
     rpm --addsign "${f##*/}"
   done
-  createrepo .
+  createrepo_c .
   cd -
 
   delete_old_pkgs "$arch"


### PR DESCRIPTION
## What?

After #5072 the createrepo command is createrepo_c - apperantly as it is now implemented in c.

## Why?
Fixes the rpm repo build 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
