### PR TITLE
Fix actionability retry

### DIFF
--- a/internal/js/modules/k6/browser/browser/element_handle_mapping.go
+++ b/internal/js/modules/k6/browser/browser/element_handle_mapping.go
@@ -1,8 +1,8 @@
 package browser
 
 import (
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/grafana/sobek"
 
@@ -19,7 +19,7 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 				box, err := eh.BoundingBox()
 				// We want to avoid errors when an element is not visible and instead
 				// opt to return a nil rectangle -- this matches Playwright's behaviour.
-				if err != nil && strings.Contains(err.Error(), "check if element is visible") {
+				if errors.Is(err, common.ErrElementNotVisible) {
 					return nil, nil
 				}
 				return box, err

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -20,6 +20,12 @@ import (
 	k6common "go.k6.io/k6/js/common"
 )
 
+// Common error types for element visibility.
+var (
+	// ErrElementNotVisible is returned when an element is not visible for an operation.
+	ErrElementNotVisible = errors.New("element is not visible")
+)
+
 const (
 	resultDone       = "done"
 	resultNeedsInput = "needsinput"
@@ -776,7 +782,7 @@ func (h *ElementHandle) AsElement() *ElementHandle {
 func (h *ElementHandle) BoundingBox() (*Rect, error) {
 	bbox, err := h.boundingBox()
 	if err != nil && strings.Contains(err.Error(), "Could not compute box model") {
-		return nil, fmt.Errorf("check if element is visible: %w", err)
+		return nil, fmt.Errorf("%w: %w", ErrElementNotVisible, err)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("getting bounding box: %w", err)
@@ -1709,7 +1715,7 @@ func retryPointerAction(
 			}
 		}
 
-		if !strings.Contains(err.Error(), "check if element is visible") &&
+		if !errors.Is(err, ErrElementNotVisible) &&
 			!strings.Contains(err.Error(), "error:notvisible") {
 			return res, err
 		}

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -416,7 +416,10 @@ func (f *Frame) position() (*Position, error) {
 		return nil, err
 	}
 
-	box := element.BoundingBox()
+	box, err := element.BoundingBox()
+	if err != nil {
+		return nil, err
+	}
 
 	return &Position{X: box.X, Y: box.Y}, nil
 }

--- a/internal/js/modules/k6/browser/common/js/injected_script.js
+++ b/internal/js/modules/k6/browser/common/js/injected_script.js
@@ -2445,7 +2445,6 @@ class InjectedScript {
     let lastRect = undefined;
     let counter = 0;
     let samePositionCounter = 0;
-    let lastTime = 0;
 
     const predicate = () => {
       if (states.includes("stable")) {
@@ -2460,13 +2459,6 @@ class InjectedScript {
         if (++counter === 1) {
           return continuePolling;
         }
-
-        // Drop frames that are shorter than 16ms - WebKit Win bug.
-        const time = performance.now();
-        if (this._stableRafCount > 1 && time - lastTime < 15) {
-          return continuePolling;
-        }
-        lastTime = time;
 
         const clientRect = element.getBoundingClientRect();
         const rect = {

--- a/internal/js/modules/k6/browser/common/js/injected_script.js
+++ b/internal/js/modules/k6/browser/common/js/injected_script.js
@@ -2448,18 +2448,7 @@ class InjectedScript {
     let lastTime = 0;
 
     const predicate = () => {
-      for (const state of states) {
-        if (state !== "stable") {
-          const result = this.checkElementState(node, state);
-          if (typeof result !== "boolean") {
-            return result;
-          }
-          if (!result) {
-            return continuePolling;
-          }
-          continue;
-        }
-
+      if (states.includes("stable")) {
         const element = this._retarget(node, "no-follow-label");
         if (!element) {
           return "error:notconnected";
@@ -2504,6 +2493,20 @@ class InjectedScript {
           return continuePolling;
         }
       }
+
+      for (const state of states) {
+        if (state !== "stable") {
+          const result = this.checkElementState(node, state);
+          if (typeof result !== "boolean") {
+            return result;
+          }
+          if (!result) {
+            return continuePolling;
+          }
+          continue;
+        }
+      }
+
       return true; // All states are good!
     };
 

--- a/internal/js/modules/k6/browser/tests/element_handle_test.go
+++ b/internal/js/modules/k6/browser/tests/element_handle_test.go
@@ -68,7 +68,7 @@ func TestElementHandleBoundingBoxInvisibleElement(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = element.BoundingBox()
-	require.ErrorContains(t, err, "check if element is visible: getting bounding box model of DOM node: Could not compute box model.")
+	require.ErrorIs(t, err, common.ErrElementNotVisible)
 }
 
 // This test is the same as TestElementHandleBoundingBoxInvisibleElement, but

--- a/internal/js/modules/k6/browser/tests/element_handle_test.go
+++ b/internal/js/modules/k6/browser/tests/element_handle_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/sobek"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -65,7 +66,32 @@ func TestElementHandleBoundingBoxInvisibleElement(t *testing.T) {
 	require.NoError(t, err)
 	element, err := p.Query("div")
 	require.NoError(t, err)
-	require.Nil(t, element.BoundingBox())
+
+	_, err = element.BoundingBox()
+	require.ErrorContains(t, err, "check if element is visible: getting bounding box model of DOM node: Could not compute box model.")
+}
+
+// This test is the same as TestElementHandleBoundingBoxInvisibleElement, but
+// uses the mapper to test the behaviour to ensure we get a null result when
+// an element is not visible.
+func TestElementHandleBoundingBoxInvisibleElementWithMapper(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	tb.vu.ActivateVU()
+	tb.vu.StartIteration(t)
+
+	got := tb.vu.RunPromise(t, `
+		const p = await browser.newPage();
+		
+		await p.setContent('<div style="display:none">hello</div>');
+
+		const element = await p.$("div");
+
+		return await element.boundingBox();
+	`,
+	)
+	assert.Equal(t, sobek.Null(), got.Result())
 }
 
 func TestElementHandleBoundingBoxSVG(t *testing.T) {
@@ -84,7 +110,9 @@ func TestElementHandleBoundingBoxSVG(t *testing.T) {
 	element, err := p.Query("#therect")
 	require.NoError(t, err)
 
-	bbox := element.BoundingBox()
+	bbox, err := element.BoundingBox()
+	require.NoError(t, err)
+
 	pageFn := `e => {
         const rect = e.getBoundingClientRect();
         return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };

--- a/internal/js/modules/k6/browser/tests/mouse_test.go
+++ b/internal/js/modules/k6/browser/tests/mouse_test.go
@@ -28,7 +28,8 @@ func TestMouseActions(t *testing.T) {
 		require.NoError(t, err)
 
 		// Simulate a click at the button coordinates
-		box := button.BoundingBox()
+		box, err := button.BoundingBox()
+		require.NoError(t, err)
 		require.NoError(t, m.Click(box.X, box.Y, common.NewMouseClickOptions()))
 
 		// Verify the button's text changed
@@ -59,7 +60,8 @@ func TestMouseActions(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get the button's bounding box for accurate clicking
-		box := button.BoundingBox()
+		box, err := button.BoundingBox()
+		require.NoError(t, err)
 
 		// Simulate a double click at the button coordinates
 		require.NoError(t, m.DblClick(box.X, box.Y, common.NewMouseDblClickOptions()))
@@ -99,7 +101,8 @@ func TestMouseActions(t *testing.T) {
 		require.NoError(t, err)
 
 		// Simulate mouse move within the div
-		box := area.BoundingBox()
+		box, err := area.BoundingBox()
+		require.NoError(t, err)
 		require.NoError(t, m.Move(box.X+50, box.Y+50, common.NewMouseMoveOptions())) // Move to the center of the div
 		text, ok, err := area.TextContent()
 		require.NoError(t, err)
@@ -126,7 +129,8 @@ func TestMouseActions(t *testing.T) {
 		button, err := p.Query("button")
 		require.NoError(t, err)
 
-		box := button.BoundingBox()
+		box, err := button.BoundingBox()
+		require.NoError(t, err)
 		require.NoError(t, m.Move(box.X, box.Y, common.NewMouseMoveOptions()))
 		require.NoError(t, m.Down(common.NewMouseDownUpOptions()))
 		text, ok, err := button.TextContent()

--- a/internal/js/modules/k6/browser/tests/static/hide_unhide.html
+++ b/internal/js/modules/k6/browser/tests/static/hide_unhide.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>RAF-Toggling Counter Button</title>
+</head>
+<body>
+  <p>Count: <span id="value">0</span></p>
+
+  <button id="incBtn" type="button">+1</button>
+
+  <script>
+    let count = 0;
+    const valueEl = document.getElementById('value');
+    const incBtn = document.getElementById('incBtn');
+
+    incBtn.addEventListener('click', function () {
+      count += 1;
+      valueEl.textContent = count;
+      console.log('click', count);
+    });
+
+    function loop() {
+      // Flip visibility every animation frame (~60 times per second)
+      incBtn.hidden = !incBtn.hidden;
+      requestAnimationFrame(loop);
+    }
+
+    requestAnimationFrame(loop);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## What

This fixes an issue that was long standing but was made evident after a recent fix for CORS and `click` (https://github.com/grafana/k6/pull/5071). It does three things:

1. Calling `BoundingBox` in `ElementHandle` now returns an error to the caller. It wasn't obvious that the bounding box could be `nil` which caused the NPD in the first place. There is a valid reason for the bounding box being `nil` when returned back to the caller if it was called in a script, which is why we keep that behaviour but move it to the mapping layer.
2. We automatically retry when chrome returns us an error indicating that the element is not visible and therefore it can't retrieve data on it (such as the bounding box). The retry will keep retrying until it hits the default timeout or a timeout set by the user -- this now matches the expected behaviour of `locator` based APIs.
3. In the injected script, it now checks the `stable` state first before trying to continue onto trying to see if the element is `visible` and `enabled`. This ensures that the stability counter is reset back to 0 as soon as the stability check fails, which was being skipped previously -- this is also how Playwright handles the same situation.

## Why

This fixes an NPD. The NPD was due to a race condition:

1. A `locator.click` is called on an element;
2. The element is initially visible, and therefore we can [focus](https://github.com/grafana/k6/blob/47514286136f67e9c297bdddf92317e818677587/internal/js/modules/k6/browser/common/element_handle.go#L1574) on it and all the actionability checks [pass](https://github.com/grafana/k6/blob/47514286136f67e9c297bdddf92317e818677587/internal/js/modules/k6/browser/common/element_handle.go#L1585);
3. However, in between the previous checks and getting the rect for the element, the element is hidden or detached which then [returns `nil`](https://github.com/grafana/k6/blob/47514286136f67e9c297bdddf92317e818677587/internal/js/modules/k6/browser/common/element_handle.go#L60) when getting the bounding box;
4. The error is [ignored](https://github.com/grafana/k6/blob/47514286136f67e9c297bdddf92317e818677587/internal/js/modules/k6/browser/common/element_handle.go#L766-L769) since the behaviour is valid (only when `boundingBox` is called from the user script directly) since it means that the element is hidden or detached;
5. A [NPD panic](https://github.com/grafana/k6/blob/47514286136f67e9c297bdddf92317e818677587/internal/js/modules/k6/browser/common/element_handle.go#L202) occurs since I didn't expect that behaviour.

## Test

Reproducing the NPD panic is tricky. I tried with the following test which helped identify where the possible race could occur. This test is likely to cause an error to do with the visibility of the element being the issue. It is still helpful to validate that we do indeed correctly wait for stability and retry on visibility errors.

You can test the change with this:

```js
import { browser } from "k6/browser";

export const options = {
    scenarios: {
      ui: {
        executor: 'shared-iterations',
        options: {
          browser: {
            type: 'chromium',
          },
        },
      },
    },
  }

export default async function () {
  const page = await browser.newPage();

  // We shouldn't see any console messages from chrome being written to the terminal.
  page.on('console', (msg) => {
    // Should assert here and fail the iteration.
    console.log(`PAGE LOG: ${msg.text()}`);
  });

  page.setContent(`
<!doctype html>
<html>
<head>
  <meta charset="utf-8">
  <title>RAF-Toggling Counter Button</title>
</head>
<body>
  <p>Count: <span id="value">0</span></p>

  <button id="incBtn" type="button">+1</button>

  <script>
    let count = 0;
    const valueEl = document.getElementById('value');
    const incBtn = document.getElementById('incBtn');

    incBtn.addEventListener('click', function () {
      count += 1;
      valueEl.textContent = count;
      console.log('click', count);
    });

    function loop() {
      // Flip visibility every animation frame (~60 times per second)
      incBtn.hidden = !incBtn.hidden;
      requestAnimationFrame(loop);
    }

    requestAnimationFrame(loop);
  </script>
</body>
</html>
  `)

  // This should throw a timeout error.
  for (let i = 0; i < 10; i++) {
    await page.locator('button').click();
  }

  // Should assert here to make sure that the counter hasn't increased.

  await page.close();
}
```

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/issues/5110