### PR TITLE
Update log from warn to debug

### DIFF
--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -370,7 +370,7 @@ func (b *Browser) isAttachedPageValid(ev *target.EventAttachedToTarget, browserC
 	}
 	pageType := targetPage.Type
 	if pageType != "page" && pageType != "background_page" {
-		b.logger.Warnf(
+		b.logger.Debugf(
 			"Browser:isAttachedPageValid", "sid:%v tid:%v bctxid:%v bctx nil:%t, unknown target type: %q",
 			ev.SessionID, targetPage.TargetID, targetPage.BrowserContextID, browserCtx == nil, targetPage.Type)
 		return false


### PR DESCRIPTION
## What?

There's nothing that the user can do with this warning, so lets change it to debug to avoid confusion. It's an internal issue that we should look into when users want to work with other types. At the moment we support page and background_page. We might need to work with service_worker in the future when the use case is clearer, and maybe other types.

# Why?

When i was creating the migration doc from PW to k6, the PW example test script in k6 was logging this warning. Not a great first start to a migration doc with confusing logs that can't be actioned on.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
