### PR TITLE
Changes for `Locator.Filter` reviews

### DIFF
--- a/internal/js/modules/k6/browser/common/locator.go
+++ b/internal/js/modules/k6/browser/common/locator.go
@@ -40,21 +40,18 @@ type LocatorOptions struct {
 
 // NewLocator creates and returns a new locator.
 func NewLocator(ctx context.Context, opts *LocatorOptions, selector string, f *Frame, l *log.Logger) *Locator {
-	// We can create a locator from another. We clone the options
-	// to avoid surprising aliasing effects between locators.
-	var copts LocatorOptions
-	if opts != nil {
-		copts = *opts
+	if opts == nil {
+		opts = new(LocatorOptions)
 	}
-	if copts.HasText != "" {
-		selector += " >> internal:has-text=" + copts.HasText
+	if opts.HasText != "" {
+		selector += " >> internal:has-text=" + opts.HasText
 	}
-	if copts.HasNotText != "" {
-		selector += " >> internal:has-not-text=" + copts.HasNotText
+	if opts.HasNotText != "" {
+		selector += " >> internal:has-not-text=" + opts.HasNotText
 	}
 	return &Locator{
 		selector: selector,
-		opts:     &copts,
+		opts:     opts,
 		frame:    f,
 		ctx:      ctx,
 		log:      l,

--- a/internal/js/modules/k6/browser/common/selectors.go
+++ b/internal/js/modules/k6/browser/common/selectors.go
@@ -22,12 +22,6 @@ import (
 	"strings"
 )
 
-// TODO: Reimplement this by looking at:
-// https://github.com/microsoft/playwright/blob/
-// 		35cd6fb279ccf4c91eae4b8094697eceb61426cc/
-// 		packages/playwright-core/src/utils/isomorphic/selectorParser.ts#L154
-// Current implementation is a simplified version of the above and cannot handle all edge cases.
-
 // Matches `name:body`, a query engine name and selector for that engine.
 var reQueryEngine *regexp.Regexp = regexp.MustCompile(`^[a-zA-Z_0-9-+:*]+$`)
 
@@ -71,6 +65,10 @@ func (s *Selector) appendPart(p *SelectorPart, capture bool) error {
 	return nil
 }
 
+// parse splits the selector into parts, separated by `>>`, and identifies
+// the query engine for each part. This implementation is a simplified version
+// of the one in Playwright and don't handle all edge cases (see Issue #5130).
+//
 //nolint:cyclop,funlen
 func (s *Selector) parse() error {
 	parsePart := func(selector string, start, index int) (*SelectorPart, bool) {

--- a/internal/js/modules/k6/browser/common/selectors.go
+++ b/internal/js/modules/k6/browser/common/selectors.go
@@ -79,6 +79,20 @@ func (s *Selector) parse() error {
 		var name, body string
 
 		switch {
+		// Using TrimQuote prevents issues with selectors like:
+		//
+		//       page.getByRole("listitem >> internal:has-text='Product 2'")
+		//
+		// We'd receive the following error because of the quotes:
+		//
+		//       Uncaught (in promise) getting text content of
+		//       "internal:role=listitem >> internal:has-text='Product 2'
+		//       >> nth=0": SyntaxError: Unexpected token ''', "'Product 2'"
+		//       is not valid JSON
+		//
+		// Selectors, such as, internal:has-text, by their nature, are
+		// exposed to users, even if we don't document it. So, we need to
+		// be able to handle quoted text with internal selectors.
 		case strings.HasPrefix(part, "internal:has-text="):
 			name = "internal:has-text"
 			body = TrimQuotes(part[eqIndex+1:])

--- a/internal/js/modules/k6/browser/common/selectors.go
+++ b/internal/js/modules/k6/browser/common/selectors.go
@@ -79,7 +79,8 @@ func (s *Selector) parse() error {
 		var name, body string
 
 		switch {
-		// Using TrimQuote prevents issues with selectors like:
+		// Using TrimQuote prevents issues with selectors, allowing us to
+		// handle quoted text with internal selectors, such as:
 		//
 		//       page.getByRole("listitem >> internal:has-text='Product 2'")
 		//
@@ -91,8 +92,7 @@ func (s *Selector) parse() error {
 		//       is not valid JSON
 		//
 		// Selectors, such as, internal:has-text, by their nature, are
-		// exposed to users, even if we don't document it. So, we need to
-		// be able to handle quoted text with internal selectors.
+		// exposed to users, even if we don't document their use.
 		case strings.HasPrefix(part, "internal:has-text="):
 			name = "internal:has-text"
 			body = TrimQuotes(part[eqIndex+1:])


### PR DESCRIPTION
## What?

Changes for `Locator.Filter` reviews.

## Why?

See #5033 tasks.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_

## Related PR(s)/Issue(s)

#5114