### PR TITLE
fix: add throw exception for rsa salt

### DIFF
--- a/internal/js/modules/k6/webcrypto/rsa.go
+++ b/internal/js/modules/k6/webcrypto/rsa.go
@@ -387,6 +387,9 @@ func (rsasv *RSAPssParams) Sign(key CryptoKey, data []byte) ([]byte, error) {
 	hashedData := hash.New()
 	hashedData.Write(data)
 
+	if rsasv.SaltLength == 0 {
+		return nil, NewError(ImplementationError, "K6 RSA-PSS use standard Golang SDK, doesn't support salt length=0. Sign result might be different!")
+	}
 	signature, err := rsa.SignPSS(rand.Reader, rsaKey, hash, hashedData.Sum(nil), &rsa.PSSOptions{
 		SaltLength: rsasv.SaltLength,
 	})
@@ -412,6 +415,9 @@ func (rsasv *RSAPssParams) Verify(key CryptoKey, signature []byte, data []byte) 
 	hashedData := hash.New()
 	hashedData.Write(data)
 
+	if rsasv.SaltLength == 0 {
+		return false, NewError(ImplementationError, "K6 RSA-PSS use standard Golang SDK, doesn't support salt length=0. Verify result might be different!")
+	}
 	err = rsa.VerifyPSS(rsaKey, hash, hashedData.Sum(nil), signature, &rsa.PSSOptions{
 		SaltLength: rsasv.SaltLength,
 	})


### PR DESCRIPTION
## What?

Implement throw exception in RSA PSS, when given salt length = 0, in Sign / Verify function
## Why?

It improves UX and makes implementation predictable.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Issues https://github.com/grafana/k6/issues/4265 
Previous PR https://github.com/grafana/k6/pull/4659