### PR TITLE
feat: remove deprecated direct execution from k6 cloud command

### DIFF
--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -388,15 +388,7 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 	cloudCmd := &cobra.Command{
 		Use:   "cloud",
 		Short: "Run a test on the cloud",
-		Long: `Manage Grafana Cloud k6 tests.
-
-This command provides subcommands for interacting with Grafana Cloud k6:
-- "run": Run a test in Grafana Cloud k6
-- "login": Authenticate with Grafana Cloud k6
-- "upload": Upload a test script to Grafana Cloud k6 without running it
-
-The direct usage of "k6 cloud script.js" has been removed in v2.0.0.
-Please use "k6 cloud run script.js" instead.`,
+		Long:  `Manage Grafana Cloud k6 tests.`,
 		Args:    exactCloudArgs(),
 		Example: exampleText,
 	}

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -87,20 +87,6 @@ func (c *cmdCloud) preRun(cmd *cobra.Command, _ []string) error {
 //
 //nolint:funlen,gocognit,cyclop
 func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
-	// If no args provided and called from main cloud command, show helpful error
-	if cmd.Name() == "cloud" && len(args) == 0 {
-		return errors.New("the \"k6 cloud\" command expects either a subcommand such as \"run\" or \"login\", " +
-			"or a single argument consisting in a path to a script/archive, or the `-` symbol instructing " +
-			"the command to read the test content from stdin; received no arguments")
-	}
-
-	// Show deprecation warning only when running tests directly via "k6 cloud <file>"
-	// (not when using subcommands like "k6 cloud run")
-	if cmd.Name() == "cloud" && len(args) > 0 {
-		c.gs.Logger.Warn("Running tests directly with \"k6 cloud <file>\" is deprecated. " +
-			"Use \"k6 cloud run <file>\" instead. This behavior will be removed in a future release.")
-	}
-
 	test, err := loadAndConfigureLocalTest(c.gs, cmd, args, getPartialConfig)
 	if err != nil {
 		return err
@@ -387,28 +373,32 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 	}
 
 	exampleText := getExampleText(gs, `
-  # [deprecated] Run a test script in Grafana Cloud
-  $ {{.}} cloud script.js
-
-  # [deprecated] Run a test archive in Grafana Cloud
-  $ {{.}} cloud archive.tar
-
-  # Authenticate with Grafana Cloud
+  # Authenticate with Grafana Cloud k6
   $ {{.}} cloud login
 
-  # Run a test script in Grafana Cloud
+  # Run a test script in Grafana Cloud k6
   $ {{.}} cloud run script.js
 
-  # Run a test archive in Grafana Cloud
-  $ {{.}} cloud run archive.tar`[1:])
+  # Run a k6 archive in Grafana Cloud k6
+  $ {{.}} cloud run archive.tar
+
+  # Upload a test script to Grafana Cloud k6
+  $ {{.}} cloud upload script.js`[1:])
 
 	cloudCmd := &cobra.Command{
-		Use:     "cloud",
-		Short:   "Run and manage Grafana Cloud tests",
-		Long:    "Run and manage tests in Grafana Cloud.",
+		Use:   "cloud",
+		Short: "Run a test on the cloud",
+		Long: `Manage Grafana Cloud k6 tests.
+
+This command provides subcommands for interacting with Grafana Cloud k6:
+- "run": Run a test in Grafana Cloud k6
+- "login": Authenticate with Grafana Cloud k6
+- "upload": Upload a test script to Grafana Cloud k6 without running it
+
+The direct usage of "k6 cloud script.js" has been removed in v2.0.0.
+Please use "k6 cloud run script.js" instead.`,
+		Args:    exactCloudArgs(),
 		Example: exampleText,
-		PreRunE: c.preRun,
-		RunE:    c.run,
 	}
 
 	// Register `k6 cloud` subcommands with default usage template
@@ -448,6 +438,28 @@ Use "{{.CommandPath}} [command] --help" for more information about a command.
 `)
 
 	return cloudCmd
+}
+
+func exactCloudArgs() cobra.PositionalArgs {
+	return func(_ *cobra.Command, args []string) error {
+		const baseErrMsg = `the "k6 cloud" command requires a subcommand such as "run", "login", or "upload"`
+
+		if len(args) == 0 {
+			return fmt.Errorf(baseErrMsg + "; " + "received no arguments")
+		}
+
+		hasSubcommand := args[0] == "run" || args[0] == "login" || args[0] == "upload"
+		if !hasSubcommand {
+			return fmt.Errorf(
+				baseErrMsg+"; "+
+					`direct script execution has been removed in v2.0.0. `+
+					`To run "%s", use: k6 cloud run %s`,
+				args[0], args[0],
+			)
+		}
+
+		return nil
+	}
 }
 
 func resolveDefaultProjectID(

--- a/internal/cmd/cloud_run.go
+++ b/internal/cmd/cloud_run.go
@@ -37,10 +37,10 @@ type cmdCloudRun struct {
 	// the --local-execution flag mode.
 	runCmd *cmdRun
 
-	// cloudCmd holds an instance of the k6 cloud command that we store
+	// parentCloudCmd holds an instance of the k6 cloud command that we store
 	// in order to be able to call its run method to support the cloud execution
 	// feature, and to have access to its flagSet if necessary.
-	cloudCmd *cmdCloud
+	parentCloudCmd *cmdCloud
 }
 
 func getCmdCloudRun(cloudCmd *cmdCloud) *cobra.Command {
@@ -63,8 +63,8 @@ func getCmdCloudRun(cloudCmd *cmdCloud) *cobra.Command {
 	}
 
 	cloudRunCmd := &cmdCloudRun{
-		cloudCmd: cloudCmd,
-		runCmd:   runCmd,
+		parentCloudCmd: cloudCmd,
+		runCmd:         runCmd,
 	}
 
 	exampleText := getExampleText(cloudCmd.gs, `
@@ -123,7 +123,7 @@ func (c *cmdCloudRun) preRun(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	return c.cloudCmd.preRun(cmd, args)
+	return c.parentCloudCmd.preRun(cmd, args)
 }
 
 func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
@@ -149,7 +149,7 @@ func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
 	// When running the `k6 cloud run` command explicitly disable the usage report.
 	c.noUsageReport = true
 
-	return c.cloudCmd.run(cmd, args)
+	return c.parentCloudCmd.run(cmd, args)
 }
 
 func (c *cmdCloudRun) flagSet() *pflag.FlagSet {

--- a/internal/cmd/cloud_run.go
+++ b/internal/cmd/cloud_run.go
@@ -37,10 +37,10 @@ type cmdCloudRun struct {
 	// the --local-execution flag mode.
 	runCmd *cmdRun
 
-	// deprecatedCloudCmd holds an instance of the k6 cloud command that we store
+	// cloudCmd holds an instance of the k6 cloud command that we store
 	// in order to be able to call its run method to support the cloud execution
 	// feature, and to have access to its flagSet if necessary.
-	deprecatedCloudCmd *cmdCloud
+	cloudCmd *cmdCloud
 }
 
 func getCmdCloudRun(cloudCmd *cmdCloud) *cobra.Command {
@@ -63,8 +63,8 @@ func getCmdCloudRun(cloudCmd *cmdCloud) *cobra.Command {
 	}
 
 	cloudRunCmd := &cmdCloudRun{
-		deprecatedCloudCmd: cloudCmd,
-		runCmd:             runCmd,
+		cloudCmd: cloudCmd,
+		runCmd:   runCmd,
 	}
 
 	exampleText := getExampleText(cloudCmd.gs, `
@@ -123,7 +123,7 @@ func (c *cmdCloudRun) preRun(cmd *cobra.Command, args []string) error {
 		)
 	}
 
-	return c.deprecatedCloudCmd.preRun(cmd, args)
+	return c.cloudCmd.preRun(cmd, args)
 }
 
 func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
@@ -149,7 +149,7 @@ func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
 	// When running the `k6 cloud run` command explicitly disable the usage report.
 	c.noUsageReport = true
 
-	return c.deprecatedCloudCmd.run(cmd, args)
+	return c.cloudCmd.run(cmd, args)
 }
 
 func (c *cmdCloudRun) flagSet() *pflag.FlagSet {

--- a/internal/cmd/cloud_upload.go
+++ b/internal/cmd/cloud_upload.go
@@ -12,16 +12,16 @@ const cloudUploadCommandName = "upload"
 type cmdCloudUpload struct {
 	globalState *state.GlobalState
 
-	// deprecatedCloudCmd holds an instance of the k6 cloud command that we store
+	// cloudCmd holds an instance of the k6 cloud command that we store
 	// in order to be able to call its run method to support the cloud upload
 	// feature
-	deprecatedCloudCmd *cmdCloud
+	cloudCmd *cmdCloud
 }
 
 func getCmdCloudUpload(cloudCmd *cmdCloud) *cobra.Command {
 	c := &cmdCloudUpload{
-		globalState:        cloudCmd.gs,
-		deprecatedCloudCmd: cloudCmd,
+		globalState: cloudCmd.gs,
+		cloudCmd:    cloudCmd,
 	}
 
 	// uploadCloudCommand represents the 'cloud upload' command
@@ -45,13 +45,13 @@ func getCmdCloudUpload(cloudCmd *cmdCloud) *cobra.Command {
 }
 
 func (c *cmdCloudUpload) preRun(cmd *cobra.Command, args []string) error {
-	return c.deprecatedCloudCmd.preRun(cmd, args)
+	return c.cloudCmd.preRun(cmd, args)
 }
 
 // run is the code that runs when the user executes `k6 cloud upload`
 func (c *cmdCloudUpload) run(cmd *cobra.Command, args []string) error {
-	c.deprecatedCloudCmd.uploadOnly = true
-	return c.deprecatedCloudCmd.run(cmd, args)
+	c.cloudCmd.uploadOnly = true
+	return c.cloudCmd.run(cmd, args)
 }
 
 func (c *cmdCloudUpload) flagSet() *pflag.FlagSet {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -26,7 +26,7 @@ func TestRootCommandHelpDisplayCommands(t *testing.T) {
 		},
 		{
 			name:               "should have cloud command",
-			wantStdoutContains: "  cloud       Run and manage Grafana Cloud tests",
+			wantStdoutContains: "  cloud       Run a test on the cloud",
 		},
 		{
 			name:               "should have completion command",

--- a/internal/cmd/tests/cmd_cloud_test.go
+++ b/internal/cmd/tests/cmd_cloud_test.go
@@ -26,7 +26,7 @@ func TestK6Cloud(t *testing.T) {
 }
 
 func setupK6CloudCmd(cliFlags []string) []string {
-	return append([]string{"k6", "cloud"}, append(cliFlags, "test.js")...)
+	return append([]string{"k6", "cloud", "run"}, append(cliFlags, "test.js")...)
 }
 
 type setupCommandFunc func(cliFlags []string) []string
@@ -215,7 +215,7 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 
 		require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "archive.tar"), data, 0o644))
 
-		ts.CmdArgs = []string{"k6", "cloud", "--verbose", "--log-output=stdout", "archive.tar"}
+		ts.CmdArgs = []string{"k6", "cloud", "run", "--verbose", "--log-output=stdout", "archive.tar"}
 		ts.Env["K6_SHOW_CLOUD_LOGS"] = "false" // no mock for the logs yet
 		ts.Env["K6_CLOUD_HOST"] = srv.URL
 		ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -109,7 +109,7 @@ func TestBinaryNameHelpStdout(t *testing.T) {
 		},
 		{
 			cmdName:        "cloud",
-			containsOutput: fmt.Sprintf("%s cloud script.js", ts.BinaryName),
+			containsOutput: fmt.Sprintf("%s cloud run script.js", ts.BinaryName),
 		},
 		{
 			cmdName:        "cloud",


### PR DESCRIPTION
## What?

Remove the deprecated `k6 cloud script.js` direct execution syntax and enforce the use of subcommands (`run`, `login`, `upload`) for all cloud operations.

**Key changes:**
- Updated `exactCloudArgs()` to reject direct script execution and require subcommands
- Modified error messages to guide users to the correct `k6 cloud run` syntax
- Updated help text and examples to reflect v2.0.0 API changes
- Cleaned up deprecated references in command descriptions
- Renamed internal variables from `deprecatedCloudCmd` to `cloudCmd` for clarity
- Updated all tests to use the new subcommand syntax

## Why?

The `k6 cloud script.js` command has been deprecated for several versions in favor of `k6 cloud run script.js`. This change:

1. **Simplifies the API** by enforcing a consistent subcommand structure
2. **Reduces confusion** between different cloud operations (run, login, upload)
3. **Aligns with planned breaking changes** for v2.0.0 as outlined in issue #5116
4. **Improves user experience** with clearer, more explicit command syntax

Users attempting to use the old syntax now receive clear guidance on how to migrate to the new commands.

## Related Issue

https://github.com/grafana/k6/issues/5116

## Migration Guide

**Before (deprecated):**
```bash
k6 cloud script.js
k6 cloud archive.tar
```

**After (v2.0.0):**
```bash
k6 cloud run script.js
k6 cloud run archive.tar
```

All other cloud functionality remains unchanged:
```bash
k6 cloud login
k6 cloud upload script.js
```