### PR TITLE
Implement the frameLocator.getBy* methods

### DIFF
--- a/internal/js/modules/k6/browser/browser/frame_locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_locator_mapping.go
@@ -1,14 +1,80 @@
 package browser
 
 import (
+	"errors"
+
 	"github.com/grafana/sobek"
 	"go.k6.io/k6/internal/js/modules/k6/browser/common"
+	k6common "go.k6.io/k6/js/common"
 )
 
 // mapFrameLocator API to the JS module.
 func mapFrameLocator(vu moduleVU, fl *common.FrameLocator) mapping {
 	rt := vu.Runtime()
 	return mapping{
+		"getByAltText": func(alt sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(alt) {
+				return nil, errors.New("missing required argument 'altText'")
+			}
+			palt, popts := parseGetByBaseOptions(vu.Context(), alt, false, opts)
+
+			ml := mapLocator(vu, fl.GetByAltText(palt, popts))
+			return rt.ToValue(ml).ToObject(rt), nil
+		},
+		"getByLabel": func(label sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(label) {
+				return nil, errors.New("missing required argument 'label'")
+			}
+			plabel, popts := parseGetByBaseOptions(vu.Context(), label, true, opts)
+
+			ml := mapLocator(vu, fl.GetByLabel(plabel, popts))
+			return rt.ToValue(ml).ToObject(rt), nil
+		},
+		"getByPlaceholder": func(placeholder sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(placeholder) {
+				return nil, errors.New("missing required argument 'placeholder'")
+			}
+			pplaceholder, popts := parseGetByBaseOptions(vu.Context(), placeholder, false, opts)
+
+			ml := mapLocator(vu, fl.GetByPlaceholder(pplaceholder, popts))
+			return rt.ToValue(ml).ToObject(rt), nil
+		},
+		"getByRole": func(role sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(role) {
+				return nil, errors.New("missing required argument 'role'")
+			}
+			popts := parseGetByRoleOptions(vu.Context(), opts)
+
+			ml := mapLocator(vu, fl.GetByRole(role.String(), popts))
+			return rt.ToValue(ml).ToObject(rt), nil
+		},
+		"getByTestId": func(testID sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(testID) {
+				return nil, errors.New("missing required argument 'testId'")
+			}
+			ptestID := parseStringOrRegex(testID, false)
+
+			ml := mapLocator(vu, fl.GetByTestID(ptestID))
+			return rt.ToValue(ml).ToObject(rt), nil
+		},
+		"getByText": func(text sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(text) {
+				return nil, errors.New("missing required argument 'text'")
+			}
+			ptext, popts := parseGetByBaseOptions(vu.Context(), text, true, opts)
+
+			ml := mapLocator(vu, fl.GetByText(ptext, popts))
+			return rt.ToValue(ml).ToObject(rt), nil
+		},
+		"getByTitle": func(title sobek.Value, opts sobek.Value) (*sobek.Object, error) {
+			if k6common.IsNullish(title) {
+				return nil, errors.New("missing required argument 'title'")
+			}
+			ptitle, popts := parseGetByBaseOptions(vu.Context(), title, false, opts)
+
+			ml := mapLocator(vu, fl.GetByTitle(ptitle, popts))
+			return rt.ToValue(ml).ToObject(rt), nil
+		},
 		"locator": func(selector string) *sobek.Object {
 			ml := mapLocator(vu, fl.Locator(selector))
 			return rt.ToValue(ml).ToObject(rt)

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -500,6 +500,13 @@ type elementHandleAPI interface { //nolint:interfacebloat
 }
 
 type frameLocatorAPI interface {
+	GetByAltText(alt string, opts *common.GetByBaseOptions) *common.Locator
+	GetByLabel(label string, opts *common.GetByBaseOptions) *common.Locator
+	GetByPlaceholder(placeholder string, opts *common.GetByBaseOptions) *common.Locator
+	GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
+	GetByTestId(testID string) *common.Locator
+	GetByText(text string, opts *common.GetByBaseOptions) *common.Locator
+	GetByTitle(title string, opts *common.GetByBaseOptions) *common.Locator
 	Locator(selector string) *common.Locator
 }
 

--- a/internal/js/modules/k6/browser/common/frame_locator.go
+++ b/internal/js/modules/k6/browser/common/frame_locator.go
@@ -26,6 +26,56 @@ func NewFrameLocator(ctx context.Context, selector string, f *Frame, l *log.Logg
 	}
 }
 
+// GetByAltText creates and returns a new locator for this frame locator
+// based on the alt attribute text.
+func (fl *FrameLocator) GetByAltText(alt string, opts *GetByBaseOptions) *Locator {
+	fl.log.Debugf("FrameLocator:GetByAltText", "selector: %q alt: %q opts:%+v", fl.selector, alt, opts)
+
+	return fl.Locator(fl.frame.buildAttributeSelector("alt", alt, opts))
+}
+
+// GetByLabel creates and returns a new locator for this frame locator based on the label text.
+func (fl *FrameLocator) GetByLabel(label string, opts *GetByBaseOptions) *Locator {
+	fl.log.Debugf("FrameLocator:GetByLabel", "selector: %q label: %q opts:%+v", fl.selector, label, opts)
+
+	return fl.Locator(fl.frame.buildLabelSelector(label, opts))
+}
+
+// GetByPlaceholder creates and returns a new locator for this frame locator based on the placeholder attribute.
+func (fl *FrameLocator) GetByPlaceholder(placeholder string, opts *GetByBaseOptions) *Locator {
+	fl.log.Debugf("FrameLocator:GetByPlaceholder", "selector: %q placeholder: %q opts:%+v", fl.selector, placeholder, opts)
+
+	return fl.Locator(fl.frame.buildAttributeSelector("placeholder", placeholder, opts))
+}
+
+// GetByRole creates and returns a new locator for this frame locator based on their ARIA role.
+func (fl *FrameLocator) GetByRole(role string, opts *GetByRoleOptions) *Locator {
+	fl.log.Debugf("FrameLocator:GetByRole", "selector: %q role: %q opts:%+v", fl.selector, role, opts)
+
+	return fl.Locator(fl.frame.buildRoleSelector(role, opts))
+}
+
+// GetByTestID creates and returns a new locator for this frame locator based on the data-testid attribute.
+func (fl *FrameLocator) GetByTestID(testID string) *Locator {
+	fl.log.Debugf("FrameLocator:GetByTestID", "selector: %q testID: %q", fl.selector, testID)
+
+	return fl.Locator(fl.frame.buildTestIDSelector(testID))
+}
+
+// GetByText creates and returns a new locator for this frame locator based on text content.
+func (fl *FrameLocator) GetByText(text string, opts *GetByBaseOptions) *Locator {
+	fl.log.Debugf("FrameLocator:GetByText", "selector: %q text: %q opts:%+v", fl.selector, text, opts)
+
+	return fl.Locator(fl.frame.buildTextSelector(text, opts))
+}
+
+// GetByTitle creates and returns a new locator for this frame locator based on the title attribute.
+func (fl *FrameLocator) GetByTitle(title string, opts *GetByBaseOptions) *Locator {
+	fl.log.Debugf("FrameLocator:GetByTitle", "selector: %q title: %q opts:%+v", fl.selector, title, opts)
+
+	return fl.Locator(fl.frame.buildAttributeSelector("title", title, opts))
+}
+
 // Locator creates and returns a new locator chained/relative to the current FrameLocator.
 func (fl *FrameLocator) Locator(selector string) *Locator {
 	// Add frame navigation marker to indicate we need to enter the frame's contentDocument

--- a/internal/js/modules/k6/browser/tests/get_by_test.go
+++ b/internal/js/modules/k6/browser/tests/get_by_test.go
@@ -11,6 +11,13 @@ import (
 	"go.k6.io/k6/internal/js/modules/k6/browser/common"
 )
 
+const (
+	frameLocatorImpl = "frameLocator"
+	locatorImpl      = "locator"
+	frameImpl        = "frame"
+	pageImpl         = "page"
+)
+
 func TestGetByRoleSuccess(t *testing.T) {
 	t.Parallel()
 
@@ -430,15 +437,9 @@ func TestGetByRoleSuccess(t *testing.T) {
 				t.Parallel()
 
 				tb := newTestBrowser(t, withFileServer())
+				staticURL := tb.staticURL("get_by_role_implicit.html")
+				tb.withIFrameURL(staticURL)
 				p := tb.NewPage(nil)
-				opts := &common.FrameGotoOptions{
-					Timeout: common.DefaultTimeout,
-				}
-				_, err := p.Goto(
-					tb.staticURL("get_by_role_implicit.html"),
-					opts,
-				)
-				require.NoError(t, err)
 
 				getByRoleImplementations := getByImplementationsOf[interface {
 					GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
@@ -446,6 +447,12 @@ func TestGetByRoleSuccess(t *testing.T) {
 
 				for implName, impl := range getByRoleImplementations {
 					t.Run(implName, func(t *testing.T) { //nolint:paralleltest
+						if implName == frameLocatorImpl {
+							tb.GoToPage(p, tb.url("/iframe"))
+						} else {
+							tb.GoToPage(p, staticURL)
+						}
+
 						l := impl.GetByRole(tt.role, tt.opts)
 						c, err := l.Count()
 						require.NoError(t, err)
@@ -562,15 +569,9 @@ func TestGetByRoleSuccess(t *testing.T) {
 				t.Parallel()
 
 				tb := newTestBrowser(t, withFileServer())
+				staticURL := tb.staticURL("get_by_role_explicit.html")
+				tb.withIFrameURL(staticURL)
 				p := tb.NewPage(nil)
-				opts := &common.FrameGotoOptions{
-					Timeout: common.DefaultTimeout,
-				}
-				_, err := p.Goto(
-					tb.staticURL("get_by_role_explicit.html"),
-					opts,
-				)
-				require.NoError(t, err)
 
 				getByRoleImplementations := getByImplementationsOf[interface {
 					GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
@@ -578,6 +579,12 @@ func TestGetByRoleSuccess(t *testing.T) {
 
 				for implName, impl := range getByRoleImplementations {
 					t.Run(implName, func(t *testing.T) { //nolint:paralleltest
+						if implName == frameLocatorImpl {
+							tb.GoToPage(p, tb.url("/iframe"))
+						} else {
+							tb.GoToPage(p, staticURL)
+						}
+
 						l := impl.GetByRole(tt.role, nil)
 						c, err := l.Count()
 						require.NoError(t, err)
@@ -599,28 +606,29 @@ func TestGetByRoleSuccess(t *testing.T) {
 			t.Parallel()
 
 			tb := newTestBrowser(t, withFileServer())
+			staticURL := tb.staticURL("get_by_role_explicit.html")
+			tb.withIFrameURL(staticURL)
 			p := tb.NewPage(nil)
-			opts := &common.FrameGotoOptions{
-				Timeout: common.DefaultTimeout,
-			}
-			_, err := p.Goto(
-				tb.staticURL("get_by_role_explicit.html"),
-				opts,
-			)
-			require.NoError(t, err)
 
 			getByRoleImplementations := getByImplementationsOf[interface {
 				GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
 			}](p)
 
 			expectedByImplementation := map[string]int{
-				"page":    2,
-				"frame":   2,
-				"locator": 1,
+				pageImpl:         2,
+				frameImpl:        2,
+				locatorImpl:      1,
+				frameLocatorImpl: 2,
 			}
 
 			for implName, impl := range getByRoleImplementations {
 				t.Run(implName, func(t *testing.T) { //nolint:paralleltest
+					if implName == frameLocatorImpl {
+						tb.GoToPage(p, tb.url("/iframe"))
+					} else {
+						tb.GoToPage(p, staticURL)
+					}
+
 					l := impl.GetByRole("document", nil)
 					c, err := l.Count()
 					require.NoError(t, err)
@@ -763,15 +771,9 @@ func TestGetByRoleSuccess(t *testing.T) {
 				t.Parallel()
 
 				tb := newTestBrowser(t, withFileServer())
+				staticURL := tb.staticURL("get_by_role_edge_cases.html")
+				tb.withIFrameURL(staticURL)
 				p := tb.NewPage(nil)
-				opts := &common.FrameGotoOptions{
-					Timeout: common.DefaultTimeout,
-				}
-				_, err := p.Goto(
-					tb.staticURL("get_by_role_edge_cases.html"),
-					opts,
-				)
-				require.NoError(t, err)
 
 				getByRoleImplementations := getByImplementationsOf[interface {
 					GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
@@ -779,6 +781,12 @@ func TestGetByRoleSuccess(t *testing.T) {
 
 				for implName, impl := range getByRoleImplementations {
 					t.Run(implName, func(t *testing.T) { //nolint:paralleltest
+						if implName == frameLocatorImpl {
+							tb.GoToPage(p, tb.url("/iframe"))
+						} else {
+							tb.GoToPage(p, staticURL)
+						}
+
 						l := impl.GetByRole(tt.role, tt.opts)
 						c, err := l.Count()
 						require.NoError(t, err)
@@ -823,15 +831,9 @@ func TestGetByRoleFailure(t *testing.T) {
 			t.Parallel()
 
 			tb := newTestBrowser(t, withFileServer())
+			staticURL := tb.staticURL("get_by_role.html")
+			tb.withIFrameURL(staticURL)
 			p := tb.NewPage(nil)
-			opts := &common.FrameGotoOptions{
-				Timeout: common.DefaultTimeout,
-			}
-			_, err := p.Goto(
-				tb.staticURL("get_by_role.html"),
-				opts,
-			)
-			require.NoError(t, err)
 
 			getByRoleImplementations := getByImplementationsOf[interface {
 				GetByRole(role string, opts *common.GetByRoleOptions) *common.Locator
@@ -839,8 +841,14 @@ func TestGetByRoleFailure(t *testing.T) {
 
 			for implName, impl := range getByRoleImplementations {
 				t.Run(implName, func(t *testing.T) {
+					if implName == frameLocatorImpl {
+						tb.GoToPage(p, tb.url("/iframe"))
+					} else {
+						tb.GoToPage(p, staticURL)
+					}
+
 					l := impl.GetByRole(tt.role, tt.opts)
-					_, err = l.Count()
+					_, err := l.Count()
 					require.ErrorContains(t, err, tt.expectedError)
 				})
 			}
@@ -900,15 +908,9 @@ func TestGetByAltTextSuccess(t *testing.T) {
 			t.Parallel()
 
 			tb := newTestBrowser(t, withFileServer())
+			staticURL := tb.staticURL("get_by_alt_text.html")
+			tb.withIFrameURL(staticURL)
 			p := tb.NewPage(nil)
-			opts := &common.FrameGotoOptions{
-				Timeout: common.DefaultTimeout,
-			}
-			_, err := p.Goto(
-				tb.staticURL("get_by_alt_text.html"),
-				opts,
-			)
-			require.NoError(t, err)
 
 			getByAltTextImplementations := getByImplementationsOf[interface {
 				GetByAltText(alt string, opts *common.GetByBaseOptions) *common.Locator
@@ -916,6 +918,12 @@ func TestGetByAltTextSuccess(t *testing.T) {
 
 			for implName, impl := range getByAltTextImplementations {
 				t.Run(implName, func(t *testing.T) {
+					if implName == frameLocatorImpl {
+						tb.GoToPage(p, tb.url("/iframe"))
+					} else {
+						tb.GoToPage(p, staticURL)
+					}
+
 					l := impl.GetByAltText(tt.alt, tt.opts)
 					c, err := l.Count()
 					require.NoError(t, err)
@@ -985,15 +993,9 @@ func TestGetByLabelSuccess(t *testing.T) {
 			t.Parallel()
 
 			tb := newTestBrowser(t, withFileServer())
+			staticURL := tb.staticURL("get_by_label.html")
+			tb.withIFrameURL(staticURL)
 			p := tb.NewPage(nil)
-			opts := &common.FrameGotoOptions{
-				Timeout: common.DefaultTimeout,
-			}
-			_, err := p.Goto(
-				tb.staticURL("get_by_label.html"),
-				opts,
-			)
-			require.NoError(t, err)
 
 			getByLabelImplementations := getByImplementationsOf[interface {
 				GetByLabel(label string, opts *common.GetByBaseOptions) *common.Locator
@@ -1001,6 +1003,12 @@ func TestGetByLabelSuccess(t *testing.T) {
 
 			for implName, impl := range getByLabelImplementations {
 				t.Run(implName, func(t *testing.T) {
+					if implName == frameLocatorImpl {
+						tb.GoToPage(p, tb.url("/iframe"))
+					} else {
+						tb.GoToPage(p, staticURL)
+					}
+
 					l := impl.GetByLabel(tt.label, tt.opts)
 					c, err := l.Count()
 					require.NoError(t, err)
@@ -1081,15 +1089,9 @@ func TestGetByPlaceholderSuccess(t *testing.T) {
 			t.Parallel()
 
 			tb := newTestBrowser(t, withFileServer())
+			staticURL := tb.staticURL("get_by_placeholder.html")
+			tb.withIFrameURL(staticURL)
 			p := tb.NewPage(nil)
-			opts := &common.FrameGotoOptions{
-				Timeout: common.DefaultTimeout,
-			}
-			_, err := p.Goto(
-				tb.staticURL("get_by_placeholder.html"),
-				opts,
-			)
-			require.NoError(t, err)
 
 			getByPlaceholderImplementations := getByImplementationsOf[interface {
 				GetByPlaceholder(placeholder string, opts *common.GetByBaseOptions) *common.Locator
@@ -1097,6 +1099,12 @@ func TestGetByPlaceholderSuccess(t *testing.T) {
 
 			for implName, impl := range getByPlaceholderImplementations {
 				t.Run(implName, func(t *testing.T) {
+					if implName == frameLocatorImpl {
+						tb.GoToPage(p, tb.url("/iframe"))
+					} else {
+						tb.GoToPage(p, staticURL)
+					}
+
 					l := impl.GetByPlaceholder(tt.placeholder, tt.opts)
 					c, err := l.Count()
 					require.NoError(t, err)
@@ -1177,21 +1185,21 @@ func TestGetByTitleSuccess(t *testing.T) {
 			t.Parallel()
 
 			tb := newTestBrowser(t, withFileServer())
+			staticURL := tb.staticURL("get_by_title.html")
+			tb.withIFrameURL(staticURL)
 			p := tb.NewPage(nil)
-			opts := &common.FrameGotoOptions{
-				Timeout: common.DefaultTimeout,
-			}
-			_, err := p.Goto(
-				tb.staticURL("get_by_title.html"),
-				opts,
-			)
-			require.NoError(t, err)
 
 			getByTitleImplementations := getByImplementationsOf[interface {
 				GetByTitle(title string, opts *common.GetByBaseOptions) *common.Locator
 			}](p)
 
 			for implName, impl := range getByTitleImplementations {
+				if implName == frameLocatorImpl {
+					tb.GoToPage(p, tb.url("/iframe"))
+				} else {
+					tb.GoToPage(p, staticURL)
+				}
+
 				t.Run(implName, func(t *testing.T) {
 					l := impl.GetByTitle(tt.title, tt.opts)
 					c, err := l.Count()
@@ -1266,15 +1274,9 @@ func TestGetByTestIDSuccess(t *testing.T) {
 			t.Parallel()
 
 			tb := newTestBrowser(t, withFileServer())
+			staticURL := tb.staticURL("get_by_testid.html")
+			tb.withIFrameURL(staticURL)
 			p := tb.NewPage(nil)
-			opts := &common.FrameGotoOptions{
-				Timeout: common.DefaultTimeout,
-			}
-			_, err := p.Goto(
-				tb.staticURL("get_by_testid.html"),
-				opts,
-			)
-			require.NoError(t, err)
 
 			getByTestIDImplementations := getByImplementationsOf[interface {
 				GetByTestID(testID string) *common.Locator
@@ -1282,6 +1284,12 @@ func TestGetByTestIDSuccess(t *testing.T) {
 
 			for implName, impl := range getByTestIDImplementations {
 				t.Run(implName, func(t *testing.T) {
+					if implName == frameLocatorImpl {
+						tb.GoToPage(p, tb.url("/iframe"))
+					} else {
+						tb.GoToPage(p, staticURL)
+					}
+
 					l := impl.GetByTestID(tt.testID)
 					c, err := l.Count()
 					require.NoError(t, err)
@@ -1384,15 +1392,9 @@ func TestGetByTextSuccess(t *testing.T) {
 			t.Parallel()
 
 			tb := newTestBrowser(t, withFileServer())
+			staticURL := tb.staticURL("get_by_text.html")
+			tb.withIFrameURL(staticURL)
 			p := tb.NewPage(nil)
-			opts := &common.FrameGotoOptions{
-				Timeout: common.DefaultTimeout,
-			}
-			_, err := p.Goto(
-				tb.staticURL("get_by_text.html"),
-				opts,
-			)
-			require.NoError(t, err)
 
 			getByTextImplementations := getByImplementationsOf[interface {
 				GetByText(text string, opts *common.GetByBaseOptions) *common.Locator
@@ -1400,6 +1402,12 @@ func TestGetByTextSuccess(t *testing.T) {
 
 			for implName, impl := range getByTextImplementations {
 				t.Run(implName, func(t *testing.T) {
+					if implName == frameLocatorImpl {
+						tb.GoToPage(p, tb.url("/iframe"))
+					} else {
+						tb.GoToPage(p, staticURL)
+					}
+
 					l := impl.GetByText(tt.text, tt.opts)
 					c, err := l.Count()
 					require.NoError(t, err)
@@ -1429,10 +1437,11 @@ func TestGetByNullHandling(t *testing.T) {
 		page = await browser.newPage();
 		frame = page.mainFrame();
 		locator = page.locator(':root');
+		frameLocator = page.locator('#frameB').contentFrame();
 	`)
 	require.NoError(t, err)
 
-	for _, getByImpl := range []string{"page", "frame", "locator"} {
+	for _, getByImpl := range []string{pageImpl, frameImpl, locatorImpl, frameLocatorImpl} {
 		_, err = tb.vu.RunAsync(t, `
 		await %s.getByRole().click();
 	`, getByImpl)
@@ -1472,8 +1481,9 @@ func TestGetByNullHandling(t *testing.T) {
 
 func getByImplementationsOf[T any](p *common.Page) map[string]T {
 	return map[string]T{
-		"page":    any(p).(T),
-		"frame":   any(p.MainFrame()).(T),
-		"locator": any(p.Locator(":root", nil)).(T),
+		pageImpl:         any(p).(T),
+		frameImpl:        any(p.MainFrame()).(T),
+		locatorImpl:      any(p.Locator(":root", nil)).(T),
+		frameLocatorImpl: any(p.Locator("#frameB", nil).ContentFrame()).(T),
 	}
 }

--- a/internal/js/modules/k6/browser/tests/test_browser.go
+++ b/internal/js/modules/k6/browser/tests/test_browser.go
@@ -219,6 +219,31 @@ func withHTTPServer() func(*testBrowser) {
 	}
 }
 
+// withIFrameURL sets up a handler for /iframe that serves a page embedding
+// an iframe with the given URL.
+func (tb *testBrowser) withIFrameURL(iframeURL string) {
+	tb.t.Helper()
+
+	if tb.http == nil {
+		tb.t.Fatalf("You should enable HTTP test server, see: withHTTPServer option")
+	}
+
+	// Origin A: main page embedding origin B and same-origin frame A (with dynamic B URL)
+	originAHTML := fmt.Sprintf(`<!DOCTYPE html>
+		<html>
+		<head></head>
+		<body>
+			<iframe id="frameB" src="%s"></iframe>
+		</body>
+		</html>`, iframeURL)
+
+	tb.withHandler("/iframe", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, err := w.Write([]byte(originAHTML))
+		require.NoError(tb.t, err)
+	})
+}
+
 // withLogCache enables the log cache.
 //
 // example:
@@ -248,6 +273,39 @@ func withSamples(sc chan k6metrics.SampleContainer) func(*testBrowser) {
 //	b := TestBrowser(t, withSkipClose())
 func withSkipClose() func(*testBrowser) {
 	return func(tb *testBrowser) { tb.skipClose = true }
+}
+
+// GoToNewPage is a wrapper around testBrowser.NewPage and Page.Goto that fails
+// the test if an error occurs. Added this helper to avoid boilerplate code in tests.
+func (b *testBrowser) GoToNewPage(url string) *common.Page {
+	b.t.Helper()
+
+	p := b.NewPage(nil)
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	_, err := p.Goto(
+		url,
+		opts,
+	)
+	require.NoError(b.t, err)
+
+	return p
+}
+
+// GoToPage is a wrapper around Page.Goto that fails the test if an error occurs.
+// Added this helper to avoid boilerplate code in tests.
+func (b *testBrowser) GoToPage(p *common.Page, url string) {
+	b.t.Helper()
+
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+	_, err := p.Goto(
+		url,
+		opts,
+	)
+	require.NoError(b.t, err)
 }
 
 // NewPage is a wrapper around Browser.NewPage that fails the test if an


### PR DESCRIPTION
## What?

Implement the following `frameLocator.getBy*` APIs which are the preferred way of working with selectors:
- frameLocator.getByAltText
- frameLocator.getByLabel
- frameLocator.getByPlaceholder
- frameLocator.getByRole
- frameLocator.getByTestId
- frameLocator.getByText
- frameLocator.getByTitle

## Why?

Because we have already implemented all those methods for `page`, `frame`, and `locator`, and we want to implement them as well for `frameLocator` as a way to increase our compatibility with Playwright, as described in https://github.com/grafana/k6/issues/5036.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

Closes https://github.com/grafana/k6/issues/5036
