### PR TITLE
Deprecate  summary mode=legacy

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -221,8 +221,10 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 		}
 
 		switch summaryMode {
-		// TODO: Remove this code block once we stop supporting the legacy summary, and just leave the default.
+		// TODO(@joanlopez): remove by k6 v2.0, once we completely drop the support for --summary-mode=legacy.
 		case summary.ModeLegacy:
+			logger.Warn(`The --summary-mode=legacy has been deprecated, and will be removed by k6 v2.0. ` +
+				`Please, migrate to either "compact" or "full" as soon as possible.`)
 			// At the end of the test run
 			defer func() {
 				logger.Debug("Generating the end-of-test summary...")

--- a/internal/cmd/runtime_options.go
+++ b/internal/cmd/runtime_options.go
@@ -31,7 +31,11 @@ extended: base + sets "global" as alias for "globalThis"
 	flags.StringP("type", "t", "", "override test type, \"js\" or \"archive\"")
 	flags.StringArrayP("env", "e", nil, "add/override environment variable with `VAR=value`")
 	flags.Bool("no-thresholds", false, "don't run thresholds")
+	// TODO(@joanlopez): remove by k6 v2.0.
 	flags.Bool("no-summary", false, "don't show the summary at the end of the test")
+	if err := flags.MarkDeprecated("no-summary", "use --summary-mode=disabled instead"); err != nil {
+		panic(err) // Should never happen
+	}
 	flags.String("summary-mode", summary.ModeCompact.String(), "determine the summary mode,"+
 		" \"compact\", \"full\" or \"legacy\"")
 	flags.String(

--- a/internal/cmd/runtime_options.go
+++ b/internal/cmd/runtime_options.go
@@ -37,7 +37,7 @@ extended: base + sets "global" as alias for "globalThis"
 		panic(err) // Should never happen
 	}
 	flags.String("summary-mode", summary.ModeCompact.String(), "determine the summary mode,"+
-		" \"compact\", \"full\" or \"legacy\"")
+		" \"compact\", \"full\", \"disabled\" or \"legacy\"")
 	flags.String(
 		"summary-export",
 		"",

--- a/internal/cmd/runtime_options.go
+++ b/internal/cmd/runtime_options.go
@@ -124,7 +124,8 @@ func populateRuntimeOptionsFromEnv(opts lib.RuntimeOptions, environment map[stri
 	}
 
 	if _, err := summary.ValidateMode(opts.SummaryMode.String); err != nil {
-		// some early validation
+		// In the case of an invalid summary mode, we early stop
+		// the execution and return the error to the user.
 		return opts, err
 	}
 

--- a/internal/cmd/runtime_options.go
+++ b/internal/cmd/runtime_options.go
@@ -31,7 +31,7 @@ extended: base + sets "global" as alias for "globalThis"
 	flags.StringP("type", "t", "", "override test type, \"js\" or \"archive\"")
 	flags.StringArrayP("env", "e", nil, "add/override environment variable with `VAR=value`")
 	flags.Bool("no-thresholds", false, "don't run thresholds")
-	// TODO(@joanlopez): remove by k6 v2.0.
+	// TODO(@joanlopez): remove by k6 v2.0, once we completely drop the support of the deprecated --no-summary flag.
 	flags.Bool("no-summary", false, "don't show the summary at the end of the test")
 	if err := flags.MarkDeprecated("no-summary", "use --summary-mode=disabled instead"); err != nil {
 		panic(err) // Should never happen

--- a/internal/cmd/runtime_options.go
+++ b/internal/cmd/runtime_options.go
@@ -37,7 +37,7 @@ extended: base + sets "global" as alias for "globalThis"
 		panic(err) // Should never happen
 	}
 	flags.String("summary-mode", summary.ModeCompact.String(), "determine the summary mode,"+
-		" \"compact\", \"full\", \"disabled\" or \"legacy\"")
+		" \"compact\", \"full\" or \"disabled\"")
 	flags.String(
 		"summary-export",
 		"",

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -2659,6 +2659,7 @@ func TestSummaryExport(t *testing.T) {
 		})
 	}
 
+	// TODO(@joanlopez): remove by k6 v2.0, once we completely drop the support for --summary-mode=legacy.
 	t.Run("legacy", func(t *testing.T) {
 		t.Parallel()
 
@@ -2681,6 +2682,9 @@ func TestSummaryExport(t *testing.T) {
 		assert.Contains(t, stdout, "checks...............: 100.00% 1 out of 1")
 		assert.Contains(t, stdout, "custom_iterations....: 1")
 		assert.Contains(t, stdout, "iterations...........: 1")
+
+		// As of now, "legacy" has been deprecated.
+		assert.Contains(t, ts.Stderr.String(), "The --summary-mode=legacy has been deprecated, and will be removed by k6 v2.0.")
 
 		assertSummaryExport(t, ts.FS)
 	})
@@ -2706,6 +2710,7 @@ func TestHandleSummary(t *testing.T) {
 	}
 	`
 
+	// TODO(@joanlopez): remove "summary" by k6 v2.0, once we completely drop the support for --summary-mode=legacy.
 	for _, summaryMode := range []string{"compact", "full", "legacy"} {
 		t.Run(summaryMode, func(t *testing.T) {
 			t.Parallel()

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -2860,3 +2860,24 @@ func TestGroupsOrderInFullSummaryWithScenario(t *testing.T) {
 
 	assert.Regexp(t, regexp.MustCompile(expectedGroupsRegex), stdout)
 }
+
+func TestInvalidSummaryModeAbortsTheExecution(t *testing.T) {
+	t.Parallel()
+
+	ts := NewGlobalTestState(t)
+	ts.CmdArgs = []string{
+		"k6", "run", "--summary-mode=unknown", "-",
+	}
+	ts.Stdin = bytes.NewBufferString(`export default function() {};`)
+
+	// We expect the execution to be aborted by the invalid summary
+	// mode and the exit code to be non-zero.
+	ts.ExpectedExitCode = -1
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	// And the error to be shown on stderr.
+	assert.Contains(t,
+		ts.Stderr.String(),
+		`level=error msg="invalid summary mode"`,
+	)
+}

--- a/internal/lib/summary/summary.go
+++ b/internal/lib/summary/summary.go
@@ -9,13 +9,14 @@ import (
 
 // A Mode specifies the mode of the Summary,
 // which defines how the end-of-test summary will be rendered.
+// TODO(@joanlopez): remove ModeLegacy by k6 v2.0, once we completely drop the support for --summary-mode=legacy.
 type Mode int
 
 // Possible values for SummaryMode.
 const (
 	ModeCompact  = Mode(iota) // Compact mode that only displays the total results.
 	ModeFull                  // Extended mode that displays total and partial results.
-	ModeLegacy                // Legacy mode, used for backwards compatibility.
+	ModeLegacy                // Deprecated. Legacy mode, used for backwards compatibility.
 	ModeDisabled              // Disabled, formerly known as --no-summary.
 )
 

--- a/internal/lib/summary/summary.go
+++ b/internal/lib/summary/summary.go
@@ -13,18 +13,20 @@ type Mode int
 
 // Possible values for SummaryMode.
 const (
-	ModeCompact = Mode(iota) // Compact mode that only displays the total results.
-	ModeFull                 // Extended mode that displays total and  partial results.
-	ModeLegacy               // Legacy mode, used for backwards compatibility.
+	ModeCompact  = Mode(iota) // Compact mode that only displays the total results.
+	ModeFull                  // Extended mode that displays total and partial results.
+	ModeLegacy                // Legacy mode, used for backwards compatibility.
+	ModeDisabled              // Disabled, formerly known as --no-summary.
 )
 
 // ErrInvalidSummaryMode indicates the serialized summary mode is invalid.
 var ErrInvalidSummaryMode = errors.New("invalid summary mode")
 
 const (
-	compactString = "compact"
-	fullString    = "full"
-	legacyString  = "legacy"
+	compactString  = "compact"
+	fullString     = "full"
+	legacyString   = "legacy"
+	disabledString = "disabled"
 )
 
 // MarshalJSON serializes a Mode as a human-readable string.
@@ -45,6 +47,8 @@ func (m Mode) MarshalText() ([]byte, error) {
 		return []byte(fullString), nil
 	case ModeLegacy:
 		return []byte(legacyString), nil
+	case ModeDisabled:
+		return []byte(disabledString), nil
 	default:
 		return nil, ErrInvalidSummaryMode
 	}
@@ -59,6 +63,8 @@ func (m *Mode) UnmarshalText(data []byte) error {
 		*m = ModeFull
 	case legacyString:
 		*m = ModeLegacy
+	case disabledString:
+		*m = ModeDisabled
 	default:
 		return ErrInvalidSummaryMode
 	}
@@ -75,6 +81,8 @@ func (m Mode) String() string {
 		return fullString
 	case ModeLegacy:
 		return legacyString
+	case ModeDisabled:
+		return disabledString
 	default:
 		return "[INVALID]"
 	}


### PR DESCRIPTION
👋🏻  _(I have already created https://github.com/grafana/k6/issues/5137, which somehow accompanies the `TODO`s I left in the code, and will represent the effective cleanup for `--summary-mode=legacy`)_

**This is related to https://github.com/grafana/k6/pull/5118, and depends on it, as I made these changes based on those, as they impact the same pieces of code**

## What?

It marks the `--summary-mode=legacy` as deprecated, with the idea of being removed by v2.0, as described in #5137.

## Why?

Because after revamping the human-readable end-of-test summary (#4089), and as we foresee to soon deliver the new machine-readable end-of-test summary (#4872), it no longer makes sense to keep support for that "old" way of displaying the human-readable summary, which was left only to give users enough time to migrate smoothly.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes https://github.com/grafana/k6/issues/4646

<!-- Thanks for your contribution! 🙏🏼 -->
