### PR TITLE
Deps: upgrade go to 1.25 in workflows and Dockerfile

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.24.x
+        go-version: 1.25.x
         check-latest: true
     - name: Get golangci-lint version and download rules
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ env:
   APP_NAME: "k6"
   DOCKER_IMAGE_ID: "grafana/k6"
   GHCR_IMAGE_ID: ${{ github.repository }}
-  DEFAULT_GO_VERSION: "1.24.x"
+  DEFAULT_GO_VERSION: "1.25.x"
 
 jobs:
   configure:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           check-latest: true
       - name: Check dependencies
         run: |

--- a/.github/workflows/tc39.yml
+++ b/.github/workflows/tc39.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           check-latest: true
       - name: Run tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.x]
+        go-version: [1.24.x]
         platform: [ubuntu-22.04, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.25.x]
         platform: [ubuntu-22.04, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           check-latest: true
       # TODO: combine WebPlatform tests checkout & patch into the single step
       - name: Run Streams Tests

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -31,7 +31,7 @@ jobs:
         if: matrix.go != 'tip'
         uses: actions/setup-go@v5
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
           check-latest: true
       - name: Download Go tip
         if: matrix.go == 'tip'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.24-alpine3.22 as builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine3.22 as builder
 WORKDIR $GOPATH/src/go.k6.io/k6
 COPY . .
 ARG TARGETOS TARGETARCH


### PR DESCRIPTION
## What?

Update k6 to use go 1.24 and 1.25 instead of 1.23 and 1.24.

## Why?

1.25.1 contains bug fixes and security fixes.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.