### PR TITLE
Add a temporary skip on TestURLSkipRequest

### DIFF
--- a/internal/js/modules/k6/browser/tests/network_manager_test.go
+++ b/internal/js/modules/k6/browser/tests/network_manager_test.go
@@ -19,7 +19,7 @@ import (
 func TestURLSkipRequest(t *testing.T) {
 	t.Parallel()
 
-	// Today's date: 2025-09-09
+t.Skip("Temporary skip while we work out why test is failing with the latest version of chromium; TODO: https://github.com/grafana/k6/issues/5162")
 	t.Skip("temporary skip while we work out why test is failing with the latest version of chromium")
 
 	tb := newTestBrowser(t, withLogCache())

--- a/internal/js/modules/k6/browser/tests/network_manager_test.go
+++ b/internal/js/modules/k6/browser/tests/network_manager_test.go
@@ -19,8 +19,7 @@ import (
 func TestURLSkipRequest(t *testing.T) {
 	t.Parallel()
 
-t.Skip("Temporary skip while we work out why test is failing with the latest version of chromium; TODO: https://github.com/grafana/k6/issues/5162")
-	t.Skip("temporary skip while we work out why test is failing with the latest version of chromium")
+	t.Skip(`Temporary skip while we work out why test is failing with the latest version of chromium; FIXME: https://github.com/grafana/k6/issues/5162`)
 
 	tb := newTestBrowser(t, withLogCache())
 	p := tb.NewPage(nil)

--- a/internal/js/modules/k6/browser/tests/network_manager_test.go
+++ b/internal/js/modules/k6/browser/tests/network_manager_test.go
@@ -19,6 +19,9 @@ import (
 func TestURLSkipRequest(t *testing.T) {
 	t.Parallel()
 
+	// Today's date: 2025-09-09
+	t.Skip("temporary skip while we work out why test is failing with the latest version of chromium")
+
 	tb := newTestBrowser(t, withLogCache())
 	p := tb.NewPage(nil)
 


### PR DESCRIPTION
## What?

We're adding a temporary skip on `TestURLSkipRequest`.

## Why?

Only until we work out why this test is failing against the latest version of chromium.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
