### PR TITLE
Simplify warning message for legacy config file

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -226,7 +226,7 @@ func loadConfigFile(gs *state.GlobalState) (Config, error) {
 		// a legacy file has been found
 		if legacyErr == nil {
 			gs.Logger.Warnf("The configuration file has been found on the old default path (%q). "+
-				"Please, run again `k6 cloud login` or `k6 login` commands to migrate to the new default path.\n\n",
+				"Please, run `k6 cloud login` or `k6 login` to migrate to the new default path.\n\n",
 				legacyConfigFilePath(gs))
 			return legacyConf, nil
 		}


### PR DESCRIPTION
## What?

Small edit to the warning message about a configuration file being found in the old path.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
