### PR TITLE
remove enable community extensions flag

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/signal"
@@ -27,9 +26,6 @@ import (
 const (
 	// AutoExtensionResolution defines the environment variable that enables using extensions natively
 	AutoExtensionResolution = "K6_AUTO_EXTENSION_RESOLUTION"
-
-	// communityExtensionsCatalog defines the catalog for community extensions
-	communityExtensionsCatalog = "oss"
 
 	// defaultBuildServiceURL defines the URL to the default (grafana hosted) build service
 	defaultBuildServiceURL = "https://ingest.k6.io/builder/api/v1"
@@ -181,23 +177,21 @@ type GlobalFlags struct {
 	LogFormat        string
 	Verbose          bool
 
-	AutoExtensionResolution   bool
-	BuildServiceURL           string
-	BinaryCache               string
-	EnableCommunityExtensions bool
+	AutoExtensionResolution bool
+	BuildServiceURL         string
+	BinaryCache             string
 }
 
 // GetDefaultFlags returns the default global flags.
 func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 	return GlobalFlags{
-		Address:                   "localhost:6565",
-		ProfilingEnabled:          false,
-		ConfigFilePath:            filepath.Join(homeDir, "k6", defaultConfigFileName),
-		LogOutput:                 "stderr",
-		AutoExtensionResolution:   true,
-		BuildServiceURL:           defaultBuildServiceURL,
-		EnableCommunityExtensions: false,
-		BinaryCache:               filepath.Join(cacheDir, "k6", defaultBinaryCacheDir),
+		Address:                 "localhost:6565",
+		ProfilingEnabled:        false,
+		ConfigFilePath:          filepath.Join(homeDir, "k6", defaultConfigFileName),
+		LogOutput:               "stderr",
+		AutoExtensionResolution: true,
+		BuildServiceURL:         defaultBuildServiceURL,
+		BinaryCache:             filepath.Join(cacheDir, "k6", defaultBinaryCacheDir),
 	}
 }
 
@@ -243,19 +237,6 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 	}
 	if val, ok := env["K6_BUILD_SERVICE_URL"]; ok {
 		result.BuildServiceURL = val
-	}
-	if v, ok := env["K6_ENABLE_COMMUNITY_EXTENSIONS"]; ok {
-		vb, err := strconv.ParseBool(v)
-		if err == nil {
-			result.EnableCommunityExtensions = vb
-		}
-	}
-
-	// adjust BuildServiceURL if community extensions are enable
-	// community extensions flag only takes effect if the default build service is used
-	// for custom build service URLs it has no effect (because the /oss path may not be implemented)
-	if result.EnableCommunityExtensions && result.BuildServiceURL == defaultBuildServiceURL {
-		result.BuildServiceURL = fmt.Sprintf("%s/%s", defaultBuildServiceURL, communityExtensionsCatalog)
 	}
 
 	// check if verbose flag is set


### PR DESCRIPTION
## What?

Removes the enable community extensions flag and the need to adjust the build service's URL to select the `oss` catalog when they were enabled.

## Why?

After alll extensions were integrated into a single catalog that includes both official and community extensions, and all these extensions are supported in GCK6, there's no need to explicitly enable community extensions.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
