### PR TITLE
Fix Prometheus RW trend stats metric transformation

### DIFF
--- a/internal/output/prometheusrw/remotewrite/prometheus.go
+++ b/internal/output/prometheusrw/remotewrite/prometheus.go
@@ -1,7 +1,8 @@
 package remotewrite
 
 import (
-	"sort"
+	"cmp"
+	"slices"
 
 	prompb "buf.build/gen/go/prometheus/prometheus/protocolbuffers/go"
 	"github.com/mstoykov/atlas"
@@ -45,8 +46,8 @@ func MapSeries(series metrics.TimeSeries, suffix string) []*prompb.Label {
 		Name:  namelbl,
 		Value: v,
 	})
-	sort.Slice(lbls, func(i int, j int) bool {
-		return lbls[i].Name < lbls[j].Name
+	slices.SortStableFunc(lbls, func(i, j *prompb.Label) int {
+		return cmp.Compare(i.Name, j.Name)
 	})
 	return lbls
 }

--- a/internal/output/prometheusrw/remotewrite/trend.go
+++ b/internal/output/prometheusrw/remotewrite/trend.go
@@ -1,8 +1,9 @@
 package remotewrite
 
 import (
+	"cmp"
 	"fmt"
-	"sort"
+	"slices"
 	"time"
 
 	prompb "buf.build/gen/go/prometheus/prometheus/protocolbuffers/go"
@@ -108,12 +109,10 @@ func (tg *trendAsGauges) CacheNameIndex() {
 
 	// in the case __name__ is not the first
 	// then search for its position
-
-	i := sort.Search(len(tg.labels), func(i int) bool {
-		return tg.labels[i].Name == namelbl
+	i, found := slices.BinarySearchFunc(tg.labels, namelbl, func(lbl *prompb.Label, key string) int {
+		return cmp.Compare(lbl.Name, key)
 	})
-
-	if i < len(tg.labels) && tg.labels[i].Name == namelbl {
+	if found {
 		tg.ixname = uint16(i) //nolint:gosec
 	}
 }


### PR DESCRIPTION
## What?

It changes the way we look for the `__name__` label in order to transform trend stats metrics, according to our docs.

## Why?

Because the current code doesn't always find the label, as expected, and thus it doesn't produce the expected outcome.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [X] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes https://github.com/grafana/k6/issues/5175

<!-- Thanks for your contribution! 🙏🏼 -->

Thanks for your contribution @cuelebreorg! 🙏🏼 
