### PR TITLE
Fix sobek usage in evaluate and evaluateHandle

### DIFF
--- a/internal/js/modules/k6/browser/browser/frame_mapping.go
+++ b/internal/js/modules/k6/browser/browser/frame_mapping.go
@@ -87,16 +87,20 @@ func mapFrame(vu moduleVU, f *common.Frame) mapping {
 			if sobekEmptyString(pageFunc) {
 				return nil, fmt.Errorf("evaluate requires a page function")
 			}
+			funcString := pageFunc.String()
+			gopts := exportArgs(gargs)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				return f.Evaluate(pageFunc.String(), exportArgs(gargs)...)
+				return f.Evaluate(funcString, gopts...)
 			}), nil
 		},
 		"evaluateHandle": func(pageFunc sobek.Value, gargs ...sobek.Value) (*sobek.Promise, error) {
 			if sobekEmptyString(pageFunc) {
 				return nil, fmt.Errorf("evaluateHandle requires a page function")
 			}
+			funcString := pageFunc.String()
+			gopts := exportArgs(gargs)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				jsh, err := f.EvaluateHandle(pageFunc.String(), exportArgs(gargs)...)
+				jsh, err := f.EvaluateHandle(funcString, gopts...)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}

--- a/internal/js/modules/k6/browser/browser/js_handle_mapping.go
+++ b/internal/js/modules/k6/browser/browser/js_handle_mapping.go
@@ -24,20 +24,20 @@ func mapJSHandle(vu moduleVU, jsh common.JSHandleAPI) mapping {
 			if sobekEmptyString(pageFunc) {
 				return nil, fmt.Errorf("evaluate requires a page function")
 			}
+			funcString := pageFunc.String()
+			gopts := exportArgs(gargs)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				args := make([]any, 0, len(gargs))
-				for _, a := range gargs {
-					args = append(args, exportArg(a))
-				}
-				return jsh.Evaluate(pageFunc.String(), args...)
+				return jsh.Evaluate(funcString, gopts...)
 			}), nil
 		},
 		"evaluateHandle": func(pageFunc sobek.Value, gargs ...sobek.Value) (*sobek.Promise, error) {
 			if sobekEmptyString(pageFunc) {
 				return nil, fmt.Errorf("evaluateHandle requires a page function")
 			}
+			funcString := pageFunc.String()
+			gopts := exportArgs(gargs)
 			return k6ext.Promise(vu.Context(), func() (any, error) {
-				h, err := jsh.EvaluateHandle(pageFunc.String(), exportArgs(gargs)...)
+				h, err := jsh.EvaluateHandle(funcString, gopts...)
 				if err != nil {
 					return nil, err //nolint:wrapcheck
 				}


### PR DESCRIPTION
## What?

Fix sobek usage in `frame.evaluate`, `frame.evaluateHandle`, `jsHandle.evaluate` and `jsHandle.evaluateHandle`.

## Why?

The work with the `sobek.Object` and `sobek` in general should be done before we start doing anything a goroutine. We got one test on Cloud that ran into this issue and generated an alert. 

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
