### PR TITLE
Update tests to use getBy* where it make sense

### DIFF
--- a/examples/browser/dispatch.js
+++ b/examples/browser/dispatch.js
@@ -24,7 +24,7 @@ export default async function() {
   try {
     await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
 
-    const contacts = page.locator('a[href="/contacts.php"]');
+    const contacts = page.getByRole('link', { name: '/contacts.php' });
     await contacts.dispatchEvent("click");
 
     await check(page.locator('h3'), {

--- a/examples/browser/fillform.js
+++ b/examples/browser/fillform.js
@@ -26,7 +26,7 @@ export default async function() {
     await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
     await Promise.all([
       page.waitForNavigation(),
-      page.locator('a[href="/my_messages.php"]').click(),
+      page.getByRole('link', {name: '/my_messages.php'}).click(),
     ]);
 
     // Enter login credentials and login
@@ -38,7 +38,7 @@ export default async function() {
     // to resolve.
     await Promise.all([
       page.waitForNavigation(),
-      page.locator('input[type="submit"]').click(),
+      page.getByText('Go!').click(),
     ]);
 
     await check(page.locator('h2'), {

--- a/examples/browser/locator.js
+++ b/examples/browser/locator.js
@@ -39,10 +39,10 @@ export default async function() {
     locator across frame navigations. Let's create two locators;
     each locates a button on the page.
     */
-    const heads = page.locator("input[value='Bet on heads!']");
-    const tails = page.locator("input[value='Bet on tails!']");
+    const heads = page.getByRole("button", { name: "Bet on heads!" });
+    const tails = page.getByRole("button", { name: "Bet on tails!" });
 
-    const currentBet = page.locator("//p[starts-with(text(),'Your bet: ')]");
+    const currentBet = page.getByText(/Your bet\: .*/);
 
     // In the following Promise.all the tails locator clicks
     // on the tails button by using the locator's selector.

--- a/examples/browser/locator_pom.js
+++ b/examples/browser/locator_pom.js
@@ -28,9 +28,9 @@ the Page Object Model pattern in locator.js.
 export class Bet {
   constructor(page) {
     this.page = page;
-    this.headsButton = page.locator("input[value='Bet on heads!']");
-    this.tailsButton = page.locator("input[value='Bet on tails!']");
-    this.currentBet = page.locator("//p[starts-with(text(),'Your bet: ')]");
+    this.headsButton = page.getByRole("button", { name: "Bet on heads!" });
+    this.tailsButton = page.getByRole("button", { name: "Bet on tails!" });
+    this.currentBet = page.getByText(/Your bet\: .*/);
   }
 
   goto() {


### PR DESCRIPTION
## What?

This is updating the browser tests to work with the `getBy*` APIs where it makes sense to do so.

## Why?

To align with trying to get users to work with these instead of raw/naked selectors.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
