### PR TITLE
renovate: Force the updates immediately

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "schedule:weekly"
-  ],
   "prConcurrentLimit": 50,
   "packageRules": [
     {
@@ -86,9 +83,6 @@
       ],
       "ignorePaths": [
         "packaging/**"
-      ],
-      "extends": [
-        "schedule:monthly"
       ]
     },
     {
@@ -98,9 +92,6 @@
       ],
       "matchPaths": [
         "packaging/**"
-      ],
-      "extends": [
-        "schedule:quarterly"
       ]
     }
   ]


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

It removes the schedules config.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

As we want to run a first cycle immediately, we remove the slow set frequency. We will rollback it as soon as we have the pull requests open.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
