### PR TITLE
fix clearTimeout running next timer if first is removed

### DIFF
--- a/internal/js/tc55/timers/timers.go
+++ b/internal/js/tc55/timers/timers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/grafana/sobek"
+
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
 )
@@ -91,6 +92,13 @@ func (e *timers) clearTimeout(id uint64) {
 	}
 	delete(e.timers, id)
 
+	first := e.queue.first()
+	if first != nil && first.id == id && e.queue.length() > 1 {
+		// if this is the first in queue we need to reset the first timer
+		// but only if there are more tasks in the queue
+		// and we need to do it after we remove this one, so we are deferring it
+		defer e.setupTaskTimeout()
+	}
 	e.queue.remove(id)
 	e.freeEventLoopIfPossible()
 }


### PR DESCRIPTION
## What?

clearTimeout was not clearing the first timer if it was removing it. Leading to it executing and pulling the next queued item. Which potentially can run a much later queued item.

Now the clearTimeout specifically checks and if it is removing the first timer it will also reset so it will correctly run the remaining ones when they should be.


## Why?
setTimeout should not run its queued items before they are meant to. 
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Fixes #5199
