### PR TITLE
Update golangci-lint to v2.5.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -115,6 +115,9 @@ linters:
       - linters:
           - forbidigo
         text: use of `os\.(SyscallError|Signal|Interrupt)` forbidden
+      - linters:
+          - revive
+        text: avoid meaningless package names
     paths:
       - third_party$
       - builtin$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
-# v2.1.6
+# v2.5.0
 # Please don't remove the first line. It uses in CI to determine the golangci version
 version: "2"
 linters:

--- a/cloudapi/logs.go
+++ b/cloudapi/logs.go
@@ -244,5 +244,5 @@ func retry(s sleeper, attempts int, interval, maxDuration time.Duration, do func
 			return nil
 		}
 	}
-	return
+	return err
 }

--- a/cloudapi/logs_test.go
+++ b/cloudapi/logs_test.go
@@ -223,7 +223,7 @@ func TestStreamLogsToLogger(t *testing.T) {
 		for _, e := range hook.Drain() {
 			lines = append(lines, e.Message)
 		}
-		return
+		return lines
 	}
 
 	generateLogline := func(key string, ts uint64, msg string) string {
@@ -276,7 +276,7 @@ func TestStreamLogsToLogger(t *testing.T) {
 			}
 
 			start = time.Unix(0, rawstart)
-			return
+			return start, err
 		}
 
 		var requestsCount uint64
@@ -355,7 +355,7 @@ func TestStreamLogsToLogger(t *testing.T) {
 			}
 
 			start = time.Unix(0, rawstart)
-			return
+			return start, err
 		}
 
 		var requestsCount uint64

--- a/ext/ext.go
+++ b/ext/ext.go
@@ -136,12 +136,12 @@ func extractModuleInfo(mod interface{}) (path, version string) {
 	case reflect.Func:
 		path = runtime.FuncForPC(reflect.ValueOf(mod).Pointer()).Name()
 	default:
-		return
+		return path, version
 	}
 
 	buildInfo, ok := debug.ReadBuildInfo()
 	if !ok {
-		return
+		return path, version
 	}
 
 	for _, dep := range buildInfo.Deps {
@@ -154,7 +154,7 @@ func extractModuleInfo(mod interface{}) (path, version string) {
 		}
 	}
 
-	return
+	return path, version
 }
 
 func init() {

--- a/internal/cmd/tests/grpc.go
+++ b/internal/cmd/tests/grpc.go
@@ -24,7 +24,7 @@ func NewGRPC(t testing.TB) *GRPC {
 
 	addr := getFreeBindAddr(t)
 
-	lis, err := net.Listen("tcp", addr)
+	lis, err := (&net.ListenConfig{}).Listen(t.Context(), "tcp", addr)
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}

--- a/internal/cmd/tests/test_state.go
+++ b/internal/cmd/tests/test_state.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/internal/event"
 	"go.k6.io/k6/internal/lib/testutils"
@@ -128,7 +129,7 @@ func getFreeBindAddr(tb testing.TB) string {
 		port := atomic.AddUint64(&portRangeStart, 1)
 		addr := net.JoinHostPort("localhost", strconv.FormatUint(port, 10))
 
-		listener, err := net.Listen("tcp", addr)
+		listener, err := (&net.ListenConfig{}).Listen(tb.Context(), "tcp", addr)
 		if err != nil {
 			continue // port was busy for some reason
 		}

--- a/internal/js/eventloop/eventloop.go
+++ b/internal/js/eventloop/eventloop.go
@@ -149,7 +149,7 @@ func (e *EventLoop) popAll() (queue []func() error, awaiting bool) {
 	e.queue = make([]func() error, 0, len(queue))
 	awaiting = e.registeredCallbacks != 0
 	e.lock.Unlock()
-	return
+	return queue, awaiting
 }
 
 func (e *EventLoop) putInfront(queue []func() error) {

--- a/internal/js/modules/k6/browser/browser/helpers.go
+++ b/internal/js/modules/k6/browser/browser/helpers.go
@@ -14,7 +14,7 @@ import (
 
 func panicIfFatalError(ctx context.Context, err error) {
 	if errors.Is(err, k6error.ErrFatal) {
-		k6ext.Abort(ctx, err.Error())
+		k6ext.Abortf(ctx, err.Error())
 	}
 }
 

--- a/internal/js/modules/k6/browser/browser/module.go
+++ b/internal/js/modules/k6/browser/browser/module.go
@@ -113,15 +113,15 @@ func (m *RootModule) initialize(vu k6modules.VU) {
 	)
 	m.remoteRegistry, err = newRemoteRegistry(initEnv.LookupEnv)
 	if err != nil {
-		k6ext.Abort(vu.Context(), "failed to create remote registry: %v", err)
+		k6ext.Abortf(vu.Context(), "failed to create remote registry: %v", err)
 	}
 	m.tracesMetadata, err = parseTracesMetadata(initEnv.LookupEnv)
 	if err != nil {
-		k6ext.Abort(vu.Context(), "parsing browser traces metadata: %v", err)
+		k6ext.Abortf(vu.Context(), "parsing browser traces metadata: %v", err)
 	}
 	m.filePersister, err = newScreenshotPersister(initEnv.LookupEnv)
 	if err != nil {
-		k6ext.Abort(vu.Context(), "failed to create file persister: %v", err)
+		k6ext.Abortf(vu.Context(), "failed to create file persister: %v", err)
 	}
 	if e, ok := initEnv.LookupEnv(env.K6TestRunID); ok && e != "" {
 		m.testRunID = e

--- a/internal/js/modules/k6/browser/browser/registry.go
+++ b/internal/js/modules/k6/browser/browser/registry.go
@@ -281,7 +281,7 @@ func (r *browserRegistry) handleIterEvents(
 
 		if data, ok = e.Data.(k6event.IterData); !ok {
 			e.Done()
-			k6ext.Abort(vuCtx, "unexpected iteration event data format: %v", e.Data)
+			k6ext.Abortf(vuCtx, "unexpected iteration event data format: %v", e.Data)
 			// Continue so we don't block the k6 event system producer.
 			// Test will be aborted by k6, which will previously send the
 			// 'Exit' event so browser resources cleanup can be guaranteed.
@@ -306,7 +306,7 @@ func (r *browserRegistry) handleIterEvents(
 			b, err := r.buildFn(ctx, tracedCtx)
 			if err != nil {
 				e.Done()
-				k6ext.Abort(vuCtx, "error building browser on IterStart: %v", err)
+				k6ext.Abortf(vuCtx, "error building browser on IterStart: %v", err)
 				// Continue so we don't block the k6 event system producer.
 				// Test will be aborted by k6, which will previously send the
 				// 'Exit' event so browser resources cleanup can be guaranteed.

--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -235,7 +235,7 @@ func (b *Browser) initEvents() error {
 				if ev, ok := event.data.(*target.EventAttachedToTarget); ok {
 					b.logger.Debugf("Browser:initEvents:onAttachedToTarget", "sid:%v tid:%v", ev.SessionID, ev.TargetInfo.TargetID)
 					if err := b.onAttachedToTarget(ev); err != nil {
-						k6ext.Panic(b.vuCtx, "browser is attaching to target: %w", err)
+						k6ext.Panicf(b.vuCtx, "browser is attaching to target: %w", err)
 					}
 				} else if ev, ok := event.data.(*target.EventDetachedFromTarget); ok {
 					b.logger.Debugf("Browser:initEvents:onDetachedFromTarget", "sid:%v", ev.SessionID)

--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -658,5 +658,5 @@ func (c *Connection) isClosing() (s bool) {
 	default:
 	}
 
-	return
+	return s
 }

--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -682,7 +682,7 @@ func (fs *FrameSession) onExecutionContextCreated(event *cdpruntime.EventExecuti
 		Type      string      `json:"type"`
 	}
 	if err := json.Unmarshal(auxData, &i); err != nil {
-		k6ext.Panic(fs.ctx, "unmarshaling executionContextCreated event JSON: %w", err)
+		k6ext.Panicf(fs.ctx, "unmarshaling executionContextCreated event JSON: %w", err)
 	}
 
 	frame, ok := fs.manager.getFrameByID(i.FrameID)
@@ -767,7 +767,7 @@ func (fs *FrameSession) onFrameDetached(frameID cdp.FrameID, reason cdppage.Fram
 		fs.session.ID(), fs.targetID, frameID, reason)
 
 	if err := fs.manager.frameDetached(frameID, reason); err != nil {
-		k6ext.Panic(fs.ctx, "handling frameDetached event: %w", err)
+		k6ext.Panicf(fs.ctx, "handling frameDetached event: %w", err)
 	}
 }
 
@@ -780,7 +780,7 @@ func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
 		frame.ID, frame.ParentID, frame.LoaderID.String(),
 		frame.Name, frame.URL+frame.URLFragment, initial)
 	if err != nil {
-		k6ext.Panic(fs.ctx, "handling frameNavigated event to %q: %w",
+		k6ext.Panicf(fs.ctx, "handling frameNavigated event to %q: %w",
 			frame.URL+frame.URLFragment, err)
 	}
 
@@ -855,7 +855,7 @@ func (fs *FrameSession) onFrameRequestedNavigation(event *cdppage.EventFrameRequ
 	if event.Disposition == "currentTab" {
 		err := fs.manager.frameRequestedNavigation(event.FrameID, event.URL, "")
 		if err != nil {
-			k6ext.Panic(fs.ctx, "handling frameRequestedNavigation event to %q: %w", event.URL, err)
+			k6ext.Panicf(fs.ctx, "handling frameRequestedNavigation event to %q: %w", event.URL, err)
 		}
 	}
 }
@@ -995,7 +995,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 			return // ignore
 		}
 		reason = "fatal"
-		k6ext.Panic(fs.ctx, "attaching %v: %w", ti.Type, err)
+		k6ext.Panicf(fs.ctx, "attaching %v: %w", ti.Type, err)
 	}
 }
 
@@ -1064,7 +1064,7 @@ func (fs *FrameSession) onTargetCrashed() {
 	// TODO:?
 	s, ok := fs.session.(*Session)
 	if !ok {
-		k6ext.Panic(fs.ctx, "unexpected type %T", fs.session)
+		k6ext.Panicf(fs.ctx, "unexpected type %T", fs.session)
 	}
 	s.markAsCrashed()
 }

--- a/internal/js/modules/k6/browser/common/helpers.go
+++ b/internal/js/modules/k6/browser/common/helpers.go
@@ -210,7 +210,7 @@ func createWaitForEventPredicateHandler(
 //nolint:unused
 func panicOrSlowMo(ctx context.Context, err error) {
 	if err != nil {
-		k6ext.Panic(ctx, "%w", err)
+		k6ext.Panicf(ctx, "%w", err)
 	}
 	applySlowMo(ctx)
 }

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -1041,7 +1041,7 @@ func (m *NetworkManager) ThrottleNetwork(networkProfile NetworkProfile) error {
 func (m *NetworkManager) SetUserAgent(userAgent string) {
 	action := emulation.SetUserAgentOverride(userAgent)
 	if err := action.Do(cdp.WithExecutor(m.ctx, m.session)); err != nil {
-		k6ext.Panic(m.ctx, "setting user agent: %w", err)
+		k6ext.Panicf(m.ctx, "setting user agent: %w", err)
 	}
 }
 
@@ -1049,6 +1049,6 @@ func (m *NetworkManager) SetUserAgent(userAgent string) {
 func (m *NetworkManager) SetCacheEnabled(enabled bool) {
 	m.userCacheDisabled = !enabled
 	if err := m.updateProtocolCacheDisabled(); err != nil {
-		k6ext.Panic(m.ctx, "%v", err)
+		k6ext.Panicf(m.ctx, "%v", err)
 	}
 }

--- a/internal/js/modules/k6/browser/k6ext/panic.go
+++ b/internal/js/modules/k6/browser/k6ext/panic.go
@@ -14,11 +14,11 @@ import (
 	k6common "go.k6.io/k6/js/common"
 )
 
-// Abort will shutdown the whole test run. This should
+// Abortf will shutdown the whole test run. This should
 // only be used from the sobek mapping layer. It is only
 // to be used when an error will occur in all iterations,
 // so it's permanent.
-func Abort(ctx context.Context, format string, a ...any) {
+func Abortf(ctx context.Context, format string, a ...any) {
 	failFunc := func(rt *sobek.Runtime, a ...any) {
 		reason := fmt.Errorf(format, a...).Error()
 		rt.Interrupt(&errext.InterruptError{Reason: reason})
@@ -26,11 +26,11 @@ func Abort(ctx context.Context, format string, a ...any) {
 	sharedPanic(ctx, failFunc, a...)
 }
 
-// Panic will cause a panic with the given error which will stop
+// Panicf will cause a panic with the given error which will stop
 // the current iteration. Before panicking, it will find the
 // browser process from the context and kill it if it still exists.
 // TODO: test.
-func Panic(ctx context.Context, format string, a ...any) {
+func Panicf(ctx context.Context, format string, a ...any) {
 	failFunc := func(rt *sobek.Runtime, a ...any) {
 		k6common.Throw(rt, fmt.Errorf(format, a...))
 	}

--- a/internal/js/modules/k6/browser/tests/browser_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_test.go
@@ -282,7 +282,7 @@ func TestMultiBrowserPanic(t *testing.T) {
 
 		func() {
 			defer func() { _ = recover() }()
-			k6ext.Panic(b1.ctx, "forcing a panic")
+			k6ext.Panicf(b1.ctx, "forcing a panic")
 		}()
 	})
 

--- a/internal/js/runner_test.go
+++ b/internal/js/runner_test.go
@@ -865,7 +865,7 @@ func getTestServerWithCertificate(t *testing.T, certPem, key []byte) *httptest.S
 		},
 		ForceAttemptHTTP2: s.EnableHTTP2,
 	}
-	s.Listener, err = net.Listen("tcp", "")
+	s.Listener, err = (&net.ListenConfig{}).Listen(context.Background(), "tcp", "")
 	require.NoError(t, err)
 	s.Listener = tls.NewListener(s.Listener, s.TLS)
 	s.URL = "https://" + s.Listener.Addr().String()

--- a/internal/lib/summary/summary.go
+++ b/internal/lib/summary/summary.go
@@ -97,7 +97,7 @@ func ValidateMode(val string) (m Mode, err error) {
 	if err = m.UnmarshalText([]byte(val)); err != nil {
 		return 0, err
 	}
-	return
+	return m, err
 }
 
 // Summary is the data structure that holds all the summary data (thresholds, metrics, checks, etc)

--- a/internal/lib/testutils/minirunner/minirunner.go
+++ b/internal/lib/testutils/minirunner/minirunner.go
@@ -64,7 +64,7 @@ func (r *MiniRunner) Setup(ctx context.Context, out chan<- metrics.SampleContain
 	if fn := r.SetupFn; fn != nil {
 		r.SetupData, err = fn(ctx, out)
 	}
-	return
+	return err
 }
 
 // GetSetupData returns json representation of the setup data if setup() is

--- a/internal/output/influxdb/output_test.go
+++ b/internal/output/influxdb/output_test.go
@@ -60,7 +60,7 @@ func testOutputCycle(t testing.TB, handler http.HandlerFunc, body func(testing.T
 		MaxHeaderBytes:    1 << 20,
 		ReadHeaderTimeout: time.Second,
 	}
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer func() {
 		_ = l.Close()

--- a/internal/output/opentelemetry/output_test.go
+++ b/internal/output/opentelemetry/output_test.go
@@ -13,14 +13,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.k6.io/k6/internal/lib/testutils"
-	"go.k6.io/k6/metrics"
-	"go.k6.io/k6/output"
 	collectormetrics "go.opentelemetry.io/proto/otlp/collector/metrics/v1"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 	metricpb "go.opentelemetry.io/proto/otlp/metrics/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
+
+	"go.k6.io/k6/internal/lib/testutils"
+	"go.k6.io/k6/metrics"
+	"go.k6.io/k6/output"
 )
 
 type MetricsServer interface {
@@ -82,7 +83,7 @@ type grpcMetricsServer struct {
 }
 
 func newGRPCServer() (*grpcMetricsServer, error) {
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "localhost:0")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create listener: %w", err)
 	}

--- a/internal/output/summary/data.go
+++ b/internal/output/summary/data.go
@@ -441,7 +441,7 @@ func extractPercentileThresholdSource(source string) (agg string, percentile flo
 
 		agg = "p(" + matches[1] + ")"
 		isPercentile = true
-		return
+		return agg, percentile, isPercentile
 	}
 
 	return "", 0, false

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -2373,7 +2373,7 @@ func GetTestServerWithCertificate(t *testing.T, certPem, key []byte, suitesIDs .
 		ResponseHeaderTimeout: time.Second,
 		IdleConnTimeout:       time.Second,
 	}
-	s.Listener, err = net.Listen("tcp", "")
+	s.Listener, err = (&net.ListenConfig{}).Listen(context.Background(), "tcp", "")
 	require.NoError(t, err)
 	s.Listener = tls.NewListener(s.Listener, s.TLS)
 	return s, client

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -26,7 +26,7 @@ func sumStagesDuration(stages []Stage) (result time.Duration) {
 	for _, s := range stages {
 		result += s.Duration.TimeDuration()
 	}
-	return
+	return result
 }
 
 func getStagesUnscaledMaxTarget(unscaledStartValue int64, stages []Stage) int64 {

--- a/lib/netext/httpext/error_codes_test.go
+++ b/lib/netext/httpext/error_codes_test.go
@@ -126,7 +126,7 @@ func testMapOfErrorCodes(t *testing.T, testTable map[errCode]error) {
 func TestConnReset(t *testing.T) {
 	t.Parallel()
 	// based on https://gist.github.com/jpittis/4357d817dc425ae99fbf719828ab1800
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -261,7 +261,7 @@ func TestX509UnknownAuthorityError(t *testing.T) {
 func TestDefaultTLSError(t *testing.T) {
 	t.Parallel()
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
+	l, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	go func() {
 		conn, err := l.Accept()

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -18,10 +18,11 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.k6.io/k6/lib"
-	"go.k6.io/k6/metrics"
 	"golang.org/x/time/rate"
 	"gopkg.in/guregu/null.v3"
+
+	"go.k6.io/k6/lib"
+	"go.k6.io/k6/metrics"
 )
 
 type reader func([]byte) (int, error)
@@ -86,7 +87,7 @@ func TestMakeRequestError(t *testing.T) {
 
 	t.Run("bad compression algorithm body", func(t *testing.T) {
 		t.Parallel()
-		req, err := http.NewRequest(http.MethodGet, "https://wont.be.used", nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://wont.be.used", nil)
 
 		require.NoError(t, err)
 		badCompressionType := CompressionType(13)
@@ -123,7 +124,7 @@ func TestMakeRequestError(t *testing.T) {
 			Logger:    logger,
 			Tags:      lib.NewVUStateTags(metrics.NewRegistry().RootTagSet()),
 		}
-		req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
 		preq := &ParsedHTTPRequest{
 			Req:         req,
 			URL:         &URL{u: req.URL},
@@ -175,7 +176,7 @@ func TestResponseStatus(t *testing.T) {
 					BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 					Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 				}
-				req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+				req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, nil)
 				require.NoError(t, err)
 
 				preq := &ParsedHTTPRequest{
@@ -256,7 +257,7 @@ func TestMakeRequestTimeoutInTheMiddle(t *testing.T) {
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
-	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	preq := &ParsedHTTPRequest{
 		Req:              req,
 		URL:              &URL{u: req.URL, URL: srv.URL},
@@ -334,7 +335,7 @@ func TestTrailFailed(t *testing.T) {
 				BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 				Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 			}
-			req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 			preq := &ParsedHTTPRequest{
 				Req:              req,
 				URL:              &URL{u: req.URL, URL: srv.URL},
@@ -374,7 +375,7 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 		t.Skipf("dial timeout doesn't get returned on windows") // or we don't match it correctly
 	}
 	t.Parallel()
-	ln, err := net.Listen("tcp", "localhost:0")
+	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "localhost:0")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -404,7 +405,7 @@ func TestMakeRequestDialTimeout(t *testing.T) {
 		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
 
-	req, _ := http.NewRequest(http.MethodGet, "http://"+addr.String(), nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://"+addr.String(), nil)
 	preq := &ParsedHTTPRequest{
 		Req:              req,
 		URL:              &URL{u: req.URL, URL: req.URL.String()},
@@ -459,7 +460,7 @@ func TestMakeRequestTimeoutInTheBegining(t *testing.T) {
 		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
 		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
 	}
-	req, _ := http.NewRequest(http.MethodGet, srv.URL, nil)
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
 	preq := &ParsedHTTPRequest{
 		Req:              req,
 		URL:              &URL{u: req.URL, URL: srv.URL},
@@ -540,7 +541,7 @@ func TestMakeRequestRPSLimit(t *testing.T) {
 			assert.InDelta(t, val, 3, 3)
 			return
 		default:
-			req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL, nil)
 			preq := &ParsedHTTPRequest{
 				Req:         req,
 				URL:         &URL{u: req.URL, URL: ts.URL, Name: ts.URL},

--- a/lib/netext/httpext/tracer_test.go
+++ b/lib/netext/httpext/tracer_test.go
@@ -115,11 +115,12 @@ func TestTracer(t *testing.T) { //nolint:tparallel
 	for tnum, isReuse := range []bool{false, true, true} { //nolint:paralleltest
 		t.Run(fmt.Sprintf("Test #%d", tnum), func(t *testing.T) {
 			// Do not enable parallel testing, test relies on sequential execution
-			req, err := http.NewRequest(http.MethodGet, srv.URL+"/get", nil)
+			tracer, ct := getTestTracer(t)
+			ctx := httptrace.WithClientTrace(context.Background(), ct)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/get", nil)
 			require.NoError(t, err)
 
-			tracer, ct := getTestTracer(t)
-			res, err := transport.RoundTrip(req.WithContext(httptrace.WithClientTrace(context.Background(), ct)))
+			res, err := transport.RoundTrip(req)
 			require.NoError(t, err)
 
 			_, err = io.Copy(io.Discard, res.Body)
@@ -204,12 +205,12 @@ func TestTracerNegativeHttpSendingValues(t *testing.T) {
 		return connection, err
 	}
 
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/get", nil)
-	require.NoError(t, err)
-
 	{
 		tracer := &Tracer{}
-		res, err := transport.RoundTrip(req.WithContext(httptrace.WithClientTrace(context.Background(), tracer.Trace())))
+		ctx := httptrace.WithClientTrace(context.Background(), tracer.Trace())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/get", nil)
+		require.NoError(t, err)
+		res, err := transport.RoundTrip(req)
 		require.NoError(t, err)
 		_, err = io.Copy(io.Discard, res.Body)
 		assert.NoError(t, err)
@@ -222,7 +223,10 @@ func TestTracerNegativeHttpSendingValues(t *testing.T) {
 
 	{
 		tracer := &Tracer{}
-		res, err := transport.RoundTrip(req.WithContext(httptrace.WithClientTrace(context.Background(), tracer.Trace())))
+		ctx := httptrace.WithClientTrace(context.Background(), tracer.Trace())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/get", nil)
+		require.NoError(t, err)
+		res, err := transport.RoundTrip(req)
 		require.NoError(t, err)
 		_, err = io.Copy(io.Discard, res.Body)
 		assert.NoError(t, err)
@@ -242,14 +246,11 @@ func TestTracerError(t *testing.T) {
 	defer srv.Close()
 
 	tracer := &Tracer{}
-	req, err := http.NewRequest(http.MethodGet, srv.URL+"/get", nil)
+	ctx := httptrace.WithClientTrace(context.Background(), tracer.Trace())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL+"/get", nil)
 	require.NoError(t, err)
 
-	_, err = http.DefaultTransport.RoundTrip( //nolint:bodyclose
-		req.WithContext(
-			httptrace.WithClientTrace(
-				context.Background(),
-				tracer.Trace())))
+	_, err = http.DefaultTransport.RoundTrip(req) //nolint:bodyclose
 
 	assert.Error(t, err)
 }

--- a/lib/netext/resolver.go
+++ b/lib/netext/resolver.go
@@ -154,7 +154,7 @@ func (r *resolver) applyPolicy(ips []net.IP) (retIPs []net.IP) {
 		retIPs = ips
 	}
 
-	return
+	return retIPs
 }
 
 func groupByVersion(ips []net.IP) (ip4 []net.IP, ip6 []net.IP) {
@@ -166,5 +166,5 @@ func groupByVersion(ips []net.IP) (ip4 []net.IP, ip6 []net.IP) {
 		}
 	}
 
-	return
+	return ip4, ip6
 }

--- a/lib/runtime_options.go
+++ b/lib/runtime_options.go
@@ -60,5 +60,5 @@ func ValidateCompatibilityMode(val string) (cm CompatibilityMode, err error) {
 		err = fmt.Errorf(`invalid compatibility mode "%s". Use: "%s"`,
 			val, strings.Join(compatValues, `", "`))
 	}
-	return
+	return cm, err
 }

--- a/lib/types/types.go
+++ b/lib/types/types.go
@@ -39,7 +39,7 @@ func ParseExtendedDuration(data string) (result time.Duration, err error) {
 	if dPos+1 < len(data) { // case "12d"
 		hours, err = time.ParseDuration(data[dPos+1:])
 		if err != nil {
-			return
+			return result, err
 		}
 		if hours < 0 {
 			return 0, fmt.Errorf("invalid time format '%s'", data[dPos+1:])
@@ -48,7 +48,7 @@ func ParseExtendedDuration(data string) (result time.Duration, err error) {
 
 	days, err := strconv.ParseInt(data[:dPos], 10, 64)
 	if err != nil {
-		return
+		return result, err
 	}
 	if days < 0 {
 		hours = -hours

--- a/metrics/sample.go
+++ b/metrics/sample.go
@@ -117,11 +117,11 @@ func GetBufferedSamples(input <-chan SampleContainer) (result []SampleContainer)
 		select {
 		case val, ok := <-input:
 			if !ok {
-				return
+				return result
 			}
 			result = append(result, val)
 		default:
-			return
+			return result
 		}
 	}
 }


### PR DESCRIPTION
## What?

Update to latet golangci-lint v2.5.0

## Why?
Both to update the version and fix issues earlier, but also because we need newer version to work with go 1.25, and not have local issues that do not happen in CI. 
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
