### PR TITLE
`TestPageOnResponse`: Fail fast on error

### DIFF
--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2553,7 +2553,7 @@ func TestPageOnResponse(t *testing.T) {
 
 		return JSON.stringify(returnValue, null, 2);
 	`, tb.url("/home"))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	got := k6test.ToPromise(t, gv)
 


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

Use `require` instead of `assert` to fail fast.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

In case of any error on `RunAsync()`, `gv` may be `nil`. It defeats `ToPromise()`'s input assumption,  leading to a panic.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)


<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Close #5124 

<!-- Thanks for your contribution! 🙏🏼 -->
