### PR TITLE
Add ability to send application data with WebSocket ping frames

### DIFF
--- a/examples/websocket.js
+++ b/examples/websocket.js
@@ -10,6 +10,14 @@ export default function () {
             console.log('connected');
             socket.send(Date.now());
 
+            // Send a regular ping
+            socket.ping();
+            console.log("Sent a ping without application data");
+
+            // Send a ping with application data
+            socket.ping("application-data");
+            console.log("Sent a ping with application data");
+
             socket.setInterval(function timeout() {
                 socket.ping();
                 console.log("Pinging every 1sec (setInterval test)");


### PR DESCRIPTION
Closes #4593

## What?

This PR adds support for sending WebSocket ping frames with application data, as specified in RFC 6455 section 5.5.2. The implementation updates both:
- Standard WebSocket implementation (`k6/ws`)
- Experimental WebSocket implementation (`k6/experimental/websockets`)

The WebSocket `ping()` method now accepts an optional string parameter for application data. Examples:
```javascript
// Send a regular ping without application data
socket.ping();

// Send a ping with application data
socket.ping("application-data");
```

## Why?

RFC 6455 section 5.5.2 states that ping frames MAY include application data. This implementation:

- Enhances the WebSocket API to fully comply with the WebSocket protocol specification
- Allows users to leverage ping frames for custom application-level keep-alive mechanisms
- Maintains backward compatibility with existing code while adding new functionality
- Properly handles both RTT metrics tracking and application data separation

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

[Issue #4593: Add ability to ping send Application data per RFC 6455](https://github.com/grafana/k6/issues/4593)
