### PR TITLE
browser: Fix linter errors and warnings

### DIFF
--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -657,6 +657,5 @@ func (c *Connection) isClosing() (s bool) {
 		s = true
 	default:
 	}
-
 	return s
 }

--- a/internal/js/modules/k6/browser/tests/frame_test.go
+++ b/internal/js/modules/k6/browser/tests/frame_test.go
@@ -5,7 +5,6 @@ package tests
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"strings"
 	"testing"
@@ -312,7 +311,6 @@ func TestFrameWaitForURLSuccess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Setup
 			tb := newTestBrowser(t, withFileServer())
 			tb.vu.ActivateVU()
 			tb.vu.StartIteration(t)
@@ -321,24 +319,20 @@ func TestFrameWaitForURLSuccess(t *testing.T) {
 			tb.vu.SetVar(t, "testURL", tb.staticURL("waitfornavigation_test.html"))
 			tb.vu.SetVar(t, "page1URL", tb.staticURL("page1.html"))
 			_, err := tb.vu.RunAsync(t, `
-					const page = await browser.newPage();
-		
-					await page.setContent('<iframe></iframe>');
-		
-					const iframeElement = await page.$('iframe');
-					frame = await iframeElement.contentFrame();
-				`)
+				const page = await browser.newPage();
+	
+				await page.setContent('<iframe></iframe>');
+	
+				const iframeElement = await page.$('iframe');
+				frame = await iframeElement.contentFrame();
+			`)
 			require.NoError(t, err)
 
-			// Test logic
-			code := fmt.Sprintf(`
-			await frame.goto(testURL);
-
-			%s
-			
-			return frame.url();`, tt.code)
-
-			result := tb.vu.RunPromise(t, code)
+			result := tb.vu.RunPromise(t, `
+				await frame.goto(testURL);
+				%s
+				return frame.url();
+			`, tt.code)
 			got := strings.ReplaceAll(result.Result().String(), tb.staticURL(""), "")
 			assert.Contains(t, tt.expected, got)
 		})
@@ -376,7 +370,6 @@ func TestFrameWaitForURLFailure(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Setup
 			tb := newTestBrowser(t, withFileServer())
 			tb.vu.ActivateVU()
 			tb.vu.StartIteration(t)
@@ -384,22 +377,19 @@ func TestFrameWaitForURLFailure(t *testing.T) {
 			tb.vu.SetVar(t, "frame", &sobek.Object{})
 			tb.vu.SetVar(t, "testURL", tb.staticURL("waitfornavigation_test.html"))
 			_, err := tb.vu.RunAsync(t, `
-					const page = await browser.newPage();
-		
-					await page.setContent('<iframe></iframe>');
-		
-					const iframeElement = await page.$('iframe');
-					frame = await iframeElement.contentFrame();
-				`)
+				const page = await browser.newPage();
+	
+				await page.setContent('<iframe></iframe>');
+	
+				const iframeElement = await page.$('iframe');
+				frame = await iframeElement.contentFrame();
+			`)
 			require.NoError(t, err)
 
-			// Test logic
-			code := fmt.Sprintf(`
-			await frame.goto(testURL);
-
-			%s`, tt.code)
-
-			_, err = tb.vu.RunAsync(t, code)
+			_, err = tb.vu.RunAsync(t, `
+				await frame.goto(testURL);
+				%s
+			`, tt.code)
 			assert.ErrorContains(t, err, tt.expected)
 		})
 	}

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2944,7 +2944,6 @@ func TestPageWaitForURLSuccess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Setup
 			tb := newTestBrowser(t, withFileServer())
 			tb.vu.ActivateVU()
 			tb.vu.StartIteration(t)
@@ -2953,19 +2952,15 @@ func TestPageWaitForURLSuccess(t *testing.T) {
 			tb.vu.SetVar(t, "testURL", tb.staticURL("waitfornavigation_test.html"))
 			tb.vu.SetVar(t, "page1URL", tb.staticURL("page1.html"))
 			_, err := tb.vu.RunAsync(t, `
-					page = await browser.newPage();
-				`)
+				page = await browser.newPage();
+			`)
 			require.NoError(t, err)
 
-			// test logic
-			code := fmt.Sprintf(`
-			await page.goto(testURL);
-
-			%s
-			
-			return page.url();`, tt.code)
-
-			result := tb.vu.RunPromise(t, code)
+			result := tb.vu.RunPromise(t, `
+				await page.goto(testURL);
+				%s
+				return page.url();
+			`, tt.code)
 			got := strings.ReplaceAll(result.Result().String(), tb.staticURL(""), "")
 			assert.Contains(t, tt.expected, got)
 		})
@@ -3010,20 +3005,17 @@ func TestPageWaitForURLFailure(t *testing.T) {
 			tb.vu.ActivateVU()
 			tb.vu.StartIteration(t)
 
-			// Setup
 			tb.vu.SetVar(t, "page", &sobek.Object{})
 			tb.vu.SetVar(t, "testURL", tb.staticURL("waitfornavigation_test.html"))
 			_, err := tb.vu.RunAsync(t, `
-					page = await browser.newPage();
-				`)
+				page = await browser.newPage();
+			`)
 			require.NoError(t, err)
 
-			code := fmt.Sprintf(`
-			await page.goto(testURL);
-
-			%s`, tt.code)
-
-			_, err = tb.vu.RunAsync(t, code)
+			_, err = tb.vu.RunAsync(t, `
+				await page.goto(testURL);
+				%s
+			`, tt.code)
 			assert.ErrorContains(t, err, tt.expected)
 		})
 	}


### PR DESCRIPTION
## What?

Fix linter errors ([example](https://github.com/grafana/k6/actions/runs/18226213967/job/51898050444?pr=5211)) and warnings.

```
internal/js/modules/k6/browser/tests/frame_test.go:341:34: non-constant format string in call to (*go.k6.io/k6/internal/js/modules/k6/browser/k6ext/k6test.VU).RunPromise
internal/js/modules/k6/browser/tests/frame_test.go:402:31: non-constant format string in call to (*go.k6.io/k6/internal/js/modules/k6/browser/k6ext/k6test.VU).RunAsync
internal/js/modules/k6/browser/tests/page_test.go:2968:34: non-constant format string in call to (*go.k6.io/k6/internal/js/modules/k6/browser/k6ext/k6test.VU).RunPromise
internal/js/modules/k6/browser/tests/page_test.go:3026:31: non-constant format string in call to (*go.k6.io/k6/internal/js/modules/k6/browser/k6ext/k6test.VU).RunAsync
internal/js/modules/k6/browser/common/connection.go:661:1: File is not properly formatted (gofumpt)
internal/js/modules/k6/browser/k6ext/panic.go:21:1: printf-like formatting function 'Abort' should be named 'Abortf' (goprintffuncname)
internal/js/modules/k6/browser/k6ext/panic.go:33:1: printf-like formatting function 'Panic' should be named 'Panicf' (goprintffuncname)
```

## Why?

Maintenance and passing the CI linter errors, [here](https://github.com/grafana/k6/actions/runs/18226213967/job/51898050444?pr=5211).

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.