### PR TITLE
Deprecate experimental/redis module

### DIFF
--- a/internal/js/jsmodules.go
+++ b/internal/js/jsmodules.go
@@ -57,7 +57,7 @@ func getInternalJSModules() map[string]interface{} {
 		"k6/experimental/redis": newWarnExperimentalModule(redis.New(),
 			"k6/experimental/redis has been deprecated and will be removed in future versions."+
 				" Please migrate to the new version by changing your import to 'k6/x/redis'."+
-				" Read more here: https://grafana.com/docs/k6/latest/javascript-api/k6-x/redis"),
+				" Read more here: https://grafana.com/docs/k6/latest/javascript-api/k6-x-redis"),
 
 		// Removed modules
 		"k6/experimental/browser": newRemovedModule(
@@ -118,7 +118,6 @@ func newWarnExperimentalModule(base modules.Module, msg string) modules.Module {
 	return &warnExperimentalModule{
 		msg:  msg,
 		base: base,
-		once: sync.Once{},
 	}
 }
 


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

It deprecates the `k6/experiemental/redis`, and it encourages to migrate to `k6/x/redis` resolved via automatic extension resolution.

The intention is to remove fully the module in one of the future releases. It has to be defined if it will be directly in v1.x or in v2.x.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

As part of the experimental process we decided to not keep redis client builtin in the k6 core binary. Instead, we want to keep it as an official extension and benefit of automatic extension resolution.


Closes #5236 