### PR TITLE
Fix early context cancellation in browser tests

### DIFF
--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -616,7 +616,7 @@ func (c *Connection) Execute(
 					case <-evCancelCtx.Done():
 						c.logger.Debugf("connection:Execute:<-evCancelCtx.Done()#2", "wsURL:%q err:%v", c.wsURL, evCancelCtx.Err())
 					case ch <- msg:
-						// Stopping goroutine as we expect only one response with the matching message ID,
+						// Stopping goroutine as we expect only one response with the matching message ID
 						return
 					}
 				}


### PR DESCRIPTION
## What?

Fix early context cancellation issue in browser tests, recent examples:
- https://github.com/grafana/k6/actions/runs/18380409959/job/52365216823?pr=5234
- https://github.com/grafana/k6/actions/runs/18351497019/job/52272403299

This is reproducible locally running `go test ./internal/js/modules/k6/browser/tests/ -race -count=2` (it almost always happen with count=2 but if you want to be sure to run into the issue, you can increase it).

## Why?

My understanding of the issue is that:
1. In `connection.Execute`, we [cancel the context](https://github.com/grafana/k6/blob/master/internal/js/modules/k6/browser/common/connection.go#L620) right after [sending the message](https://github.com/grafana/k6/blob/master/internal/js/modules/k6/browser/common/connection.go#L617).
2. In `connection.send` method, we have a select that wait on different event (like [receiving the message](https://github.com/grafana/k6/blob/master/internal/js/modules/k6/browser/common/connection.go#L499) or [receiving a context cancelled event](https://github.com/grafana/k6/blob/master/internal/js/modules/k6/browser/common/connection.go#L526)). In most cases, the message is received before and everything goes right. In some cases, the two events are received at the same time and in this case, the Golang doc states `It chooses one at random if multiple are ready.`.

My change ensures this doesn't happen by not immediately cancelling the context but making sure we return from the `send` function when we receive the message and then relying on the existing [`defer evCancelFn()`](https://github.com/grafana/k6/blob/master/internal/js/modules/k6/browser/common/connection.go#L628) to cancel the context when we're done. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes https://github.com/grafana/k6/issues/4311
