### PR TITLE
Fix for code scanning alert no. 102: Incorrect conversion between integer types

### DIFF
--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -847,8 +847,8 @@ func (h *ElementHandle) count(apiCtx context.Context, selector string) (int, err
 	}
 	switch r := result.(type) {
 	case float64:
-		if r < float64(math.MinInt) || r > float64(math.MaxInt) {
-			return 0, fmt.Errorf("value %v out of range for int type", r)
+		if r < float64(math.MinInt32) || r > float64(math.MaxInt32) {
+			return 0, fmt.Errorf("value %v out of range for int32 type", r)
 		}
 		return int(r), nil
 	default:


### PR DESCRIPTION
Potential fix for [https://github.com/grafana/k6/security/code-scanning/102](https://github.com/grafana/k6/security/code-scanning/102)

The best way to fix the problem is to ensure that before converting a `float64` value (originally from a 64-bit integer) to a Go `int` type, you verify that the `float64` value actually fits in the Go `int` type for your target platform, regardless of whether Go is compiled with 32-bit or 64-bit `int`. To do this, use the constants `math.MinInt` and `math.MaxInt` (already present), but ensure they always match the expected `int` type used in the codebase.  
If the intent is to guarantee compatibility and cover all platforms, perform a bounds check that matches the size of `int` on both 32- and 64-bit systems.  
If more precise bounds are needed, add a comment clarifying the expected range.  
Alternatively, to be more robust, use Go's `strconv.ParseInt` with the correct bit size if the original value is a parsed integer; and ensure downstream code cannot receive an out-of-bounds value.

For platforms with 32-bit `int`, `math.MinInt == math.MinInt32`, so the current code already uses platform-specific bounds; but for absolute safety and clarity, you should use `math.MinInt32` and `math.MaxInt32` if the function always expects a 32-bit value (i.e., for element counts, which are rarely expected to exceed `2^31-1`).  

So, check the intended range and platform type; if users expect `int` to be 32-bit, then use `math.MinInt32` and `math.MaxInt32`.  
If users expect 64-bit, then the current code suffices.

Assuming cross-compilation and maximum robustness (since element counts almost never exceed max 32-bit int), use `math.MinInt32` and `math.MaxInt32`.

On line 850, change:
```go
if r < float64(math.MinInt) || r > float64(math.MaxInt) {
```
to:
```go
if r < float64(math.MinInt32) || r > float64(math.MaxInt32) {
```
Also update the error message to say "int32 type" for clarity.

No new imports are required: `math` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
