### PR TITLE
chore: format Go Doc comments

### DIFF
--- a/internal/js/timeout_error.go
+++ b/internal/js/timeout_error.go
@@ -27,7 +27,7 @@ func newTimeoutError(place string, d time.Duration) timeoutError {
 	return timeoutError{place: place, d: d}
 }
 
-// String returns the timeout error in human readable format.
+// Error returns the timeout error in human readable format.
 func (t timeoutError) Error() string {
 	return fmt.Sprintf("%s() execution timed out after %.f seconds", t.place, t.d.Seconds())
 }

--- a/js/common/bridge.go
+++ b/js/common/bridge.go
@@ -15,7 +15,7 @@ var fieldNameExceptions = map[string]string{
 	"OCSP": "ocsp",
 }
 
-// FieldName Returns the JS name for an exported struct field. The name is snake_cased, with respect for
+// FieldName returns the JS name for an exported struct field. The name is snake_cased, with respect for
 // certain common initialisms (URL, ID, HTTP, etc).
 func FieldName(_ reflect.Type, f reflect.StructField) string {
 	// PkgPath is non-empty for unexported fields.
@@ -51,7 +51,7 @@ var methodNameExceptions = map[string]string{
 	"OCSP": "ocsp",
 }
 
-// MethodName Returns the JS name for an exported method. The first letter of the method's name is
+// MethodName returns the JS name for an exported method. The first letter of the method's name is
 // lowercased, otherwise it is unaltered.
 func MethodName(_ reflect.Type, m reflect.Method) string {
 	// A field with a name beginning with an X is a constructor, and just gets the prefix stripped.

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -27,7 +27,7 @@ type HTTPRequestCookie struct {
 	Replace     bool
 }
 
-// Request represent an http request
+// Request represents an HTTP request.
 type Request struct {
 	Method  string                          `json:"method"`
 	URL     string                          `json:"url"`
@@ -36,7 +36,7 @@ type Request struct {
 	Cookies map[string][]*HTTPRequestCookie `json:"cookies"`
 }
 
-// ParsedHTTPRequest a represantion of a request after it has been parsed from a user script
+// ParsedHTTPRequest is a representation of a request after it has been parsed from a user script.
 type ParsedHTTPRequest struct {
 	URL              *URL
 	Body             *bytes.Buffer
@@ -53,7 +53,7 @@ type ParsedHTTPRequest struct {
 	TagsAndMeta      metrics.TagsAndMeta
 }
 
-// Matches non-compliant io.Closer implementations (e.g. zstd.Decoder)
+// ncloser matches non-compliant io.Closer implementations (e.g. zstd.Decoder).
 type ncloser interface {
 	Close()
 }
@@ -62,7 +62,7 @@ type readCloser struct {
 	io.Reader
 }
 
-// Close readers with differing Close() implementations
+// Close closes readers with differing Close() implementations.
 func (r readCloser) Close() error {
 	var err error
 	switch v := r.Reader.(type) {
@@ -106,7 +106,7 @@ func updateK6Response(k6Response *Response, finishedReq *finishedRequest) {
 	}
 }
 
-// MakeRequest makes http request for tor the provided ParsedHTTPRequest.
+// MakeRequest makes an HTTP request for the provided ParsedHTTPRequest.
 //
 // TODO: split apart...
 //

--- a/lib/types/hostnametrie.go
+++ b/lib/types/hostnametrie.go
@@ -50,7 +50,7 @@ func (d *NullHostnameTrie) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// Source return source hostnames that were used diring the construction
+// Source returns source hostnames that were used during construction.
 func (d *NullHostnameTrie) Source() []string {
 	if d.Trie == nil {
 		return []string{}
@@ -119,8 +119,8 @@ func isValidHostnamePattern(s string) error {
 	return nil
 }
 
-// insert a hostname pattern into the given HostnameTrie. Returns an error
-// if hostname pattern is invalid.
+// insert inserts a hostname pattern into the HostnameTrie. It returns an error
+// if the hostname pattern is invalid.
 func (t *HostnameTrie) insert(s string) error {
 	s = strings.ToLower(s)
 	if err := isValidHostnamePattern(s); err != nil {


### PR DESCRIPTION
## What?

fix some obvious misspells and format Go Doc comments.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
