### PR TITLE
Update cdproto and fix changes in syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/PuerkitoBio/goquery v1.9.2
 	github.com/Soontao/goHttpDigestClient v0.0.0-20170320082612-6d28bb1415c5
 	github.com/andybalholm/brotli v1.2.0
-	github.com/chromedp/cdproto v0.0.0-20250509201441-70372ae9ef75
+	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d
 	github.com/evanw/esbuild v0.25.10
 	github.com/fatih/color v1.18.0
 	github.com/go-json-experiment/json v0.0.0-20250211171154-1ae217ad3535

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,8 @@ github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F9
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
-github.com/chromedp/cdproto v0.0.0-20250509201441-70372ae9ef75 h1:vJWnG5KwxY99SrdFqcniGdFPxZJHxk4lIHPxU96f7t4=
-github.com/chromedp/cdproto v0.0.0-20250509201441-70372ae9ef75/go.mod h1:NItd7aLkcfOA/dcMXvl8p1u+lQqioRMq/SqDp71Pb/k=
+github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d h1:ZtA1sedVbEW7EW80Iz2GR3Ye6PwbJAJXjv7D74xG6HU=
+github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d/go.mod h1:NItd7aLkcfOA/dcMXvl8p1u+lQqioRMq/SqDp71Pb/k=
 github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipwM=
 github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -621,7 +621,7 @@ func (fs *FrameSession) navigateFrame(frame *Frame, url, referrer string) (strin
 		fs.session.ID(), frame.ID(), fs.targetID, url, referrer)
 
 	action := cdppage.Navigate(url).WithReferrer(referrer).WithFrameID(cdp.FrameID(frame.ID()))
-	_, documentID, errorText, err := action.Do(cdp.WithExecutor(fs.ctx, fs.session))
+	_, documentID, errorText, _, err := action.Do(cdp.WithExecutor(fs.ctx, fs.session))
 	if err != nil {
 		if errorText == "" {
 			err = fmt.Errorf("%w", err)

--- a/vendor/github.com/chromedp/cdproto/audits/types.go
+++ b/vendor/github.com/chromedp/cdproto/audits/types.go
@@ -970,6 +970,44 @@ func (t *SRIMessageSignatureError) UnmarshalJSON(buf []byte) error {
 	return nil
 }
 
+// UnencodedDigestError [no description].
+//
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Audits#type-UnencodedDigestError
+type UnencodedDigestError string
+
+// String returns the UnencodedDigestError as string value.
+func (t UnencodedDigestError) String() string {
+	return string(t)
+}
+
+// UnencodedDigestError values.
+const (
+	UnencodedDigestErrorMalformedDictionary   UnencodedDigestError = "MalformedDictionary"
+	UnencodedDigestErrorUnknownAlgorithm      UnencodedDigestError = "UnknownAlgorithm"
+	UnencodedDigestErrorIncorrectDigestType   UnencodedDigestError = "IncorrectDigestType"
+	UnencodedDigestErrorIncorrectDigestLength UnencodedDigestError = "IncorrectDigestLength"
+)
+
+// UnmarshalJSON satisfies [json.Unmarshaler].
+func (t *UnencodedDigestError) UnmarshalJSON(buf []byte) error {
+	s := string(buf)
+	s = strings.TrimSuffix(strings.TrimPrefix(s, `"`), `"`)
+
+	switch UnencodedDigestError(s) {
+	case UnencodedDigestErrorMalformedDictionary:
+		*t = UnencodedDigestErrorMalformedDictionary
+	case UnencodedDigestErrorUnknownAlgorithm:
+		*t = UnencodedDigestErrorUnknownAlgorithm
+	case UnencodedDigestErrorIncorrectDigestType:
+		*t = UnencodedDigestErrorIncorrectDigestType
+	case UnencodedDigestErrorIncorrectDigestLength:
+		*t = UnencodedDigestErrorIncorrectDigestLength
+	default:
+		return fmt.Errorf("unknown UnencodedDigestError value: %v", s)
+	}
+	return nil
+}
+
 // AttributionReportingIssueDetails details for issues around "Attribution
 // Reporting API" usage. Explainer:
 // https://github.com/WICG/attribution-reporting-api.
@@ -1010,6 +1048,14 @@ type SRIMessageSignatureIssueDetails struct {
 	SignatureBase       string                   `json:"signatureBase"`
 	IntegrityAssertions []string                 `json:"integrityAssertions"`
 	Request             *AffectedRequest         `json:"request"`
+}
+
+// UnencodedDigestIssueDetails [no description].
+//
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Audits#type-UnencodedDigestIssueDetails
+type UnencodedDigestIssueDetails struct {
+	Error   UnencodedDigestError `json:"error"`
+	Request *AffectedRequest     `json:"request"`
 }
 
 // GenericIssueErrorType [no description].
@@ -1455,55 +1501,58 @@ type PartitioningBlobURLIssueDetails struct {
 	PartitioningBlobURLInfo PartitioningBlobURLInfo `json:"partitioningBlobURLInfo"` // Additional information about the Partitioning Blob URL issue.
 }
 
-// SelectElementAccessibilityIssueReason [no description].
+// ElementAccessibilityIssueReason [no description].
 //
-// See: https://chromedevtools.github.io/devtools-protocol/tot/Audits#type-SelectElementAccessibilityIssueReason
-type SelectElementAccessibilityIssueReason string
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Audits#type-ElementAccessibilityIssueReason
+type ElementAccessibilityIssueReason string
 
-// String returns the SelectElementAccessibilityIssueReason as string value.
-func (t SelectElementAccessibilityIssueReason) String() string {
+// String returns the ElementAccessibilityIssueReason as string value.
+func (t ElementAccessibilityIssueReason) String() string {
 	return string(t)
 }
 
-// SelectElementAccessibilityIssueReason values.
+// ElementAccessibilityIssueReason values.
 const (
-	SelectElementAccessibilityIssueReasonDisallowedSelectChild         SelectElementAccessibilityIssueReason = "DisallowedSelectChild"
-	SelectElementAccessibilityIssueReasonDisallowedOptGroupChild       SelectElementAccessibilityIssueReason = "DisallowedOptGroupChild"
-	SelectElementAccessibilityIssueReasonNonPhrasingContentOptionChild SelectElementAccessibilityIssueReason = "NonPhrasingContentOptionChild"
-	SelectElementAccessibilityIssueReasonInteractiveContentOptionChild SelectElementAccessibilityIssueReason = "InteractiveContentOptionChild"
-	SelectElementAccessibilityIssueReasonInteractiveContentLegendChild SelectElementAccessibilityIssueReason = "InteractiveContentLegendChild"
+	ElementAccessibilityIssueReasonDisallowedSelectChild               ElementAccessibilityIssueReason = "DisallowedSelectChild"
+	ElementAccessibilityIssueReasonDisallowedOptGroupChild             ElementAccessibilityIssueReason = "DisallowedOptGroupChild"
+	ElementAccessibilityIssueReasonNonPhrasingContentOptionChild       ElementAccessibilityIssueReason = "NonPhrasingContentOptionChild"
+	ElementAccessibilityIssueReasonInteractiveContentOptionChild       ElementAccessibilityIssueReason = "InteractiveContentOptionChild"
+	ElementAccessibilityIssueReasonInteractiveContentLegendChild       ElementAccessibilityIssueReason = "InteractiveContentLegendChild"
+	ElementAccessibilityIssueReasonInteractiveContentSummaryDescendant ElementAccessibilityIssueReason = "InteractiveContentSummaryDescendant"
 )
 
 // UnmarshalJSON satisfies [json.Unmarshaler].
-func (t *SelectElementAccessibilityIssueReason) UnmarshalJSON(buf []byte) error {
+func (t *ElementAccessibilityIssueReason) UnmarshalJSON(buf []byte) error {
 	s := string(buf)
 	s = strings.TrimSuffix(strings.TrimPrefix(s, `"`), `"`)
 
-	switch SelectElementAccessibilityIssueReason(s) {
-	case SelectElementAccessibilityIssueReasonDisallowedSelectChild:
-		*t = SelectElementAccessibilityIssueReasonDisallowedSelectChild
-	case SelectElementAccessibilityIssueReasonDisallowedOptGroupChild:
-		*t = SelectElementAccessibilityIssueReasonDisallowedOptGroupChild
-	case SelectElementAccessibilityIssueReasonNonPhrasingContentOptionChild:
-		*t = SelectElementAccessibilityIssueReasonNonPhrasingContentOptionChild
-	case SelectElementAccessibilityIssueReasonInteractiveContentOptionChild:
-		*t = SelectElementAccessibilityIssueReasonInteractiveContentOptionChild
-	case SelectElementAccessibilityIssueReasonInteractiveContentLegendChild:
-		*t = SelectElementAccessibilityIssueReasonInteractiveContentLegendChild
+	switch ElementAccessibilityIssueReason(s) {
+	case ElementAccessibilityIssueReasonDisallowedSelectChild:
+		*t = ElementAccessibilityIssueReasonDisallowedSelectChild
+	case ElementAccessibilityIssueReasonDisallowedOptGroupChild:
+		*t = ElementAccessibilityIssueReasonDisallowedOptGroupChild
+	case ElementAccessibilityIssueReasonNonPhrasingContentOptionChild:
+		*t = ElementAccessibilityIssueReasonNonPhrasingContentOptionChild
+	case ElementAccessibilityIssueReasonInteractiveContentOptionChild:
+		*t = ElementAccessibilityIssueReasonInteractiveContentOptionChild
+	case ElementAccessibilityIssueReasonInteractiveContentLegendChild:
+		*t = ElementAccessibilityIssueReasonInteractiveContentLegendChild
+	case ElementAccessibilityIssueReasonInteractiveContentSummaryDescendant:
+		*t = ElementAccessibilityIssueReasonInteractiveContentSummaryDescendant
 	default:
-		return fmt.Errorf("unknown SelectElementAccessibilityIssueReason value: %v", s)
+		return fmt.Errorf("unknown ElementAccessibilityIssueReason value: %v", s)
 	}
 	return nil
 }
 
-// SelectElementAccessibilityIssueDetails this issue warns about errors in
-// the select element content model.
+// ElementAccessibilityIssueDetails this issue warns about errors in the
+// select or summary element content model.
 //
-// See: https://chromedevtools.github.io/devtools-protocol/tot/Audits#type-SelectElementAccessibilityIssueDetails
-type SelectElementAccessibilityIssueDetails struct {
-	NodeID                                cdp.BackendNodeID                     `json:"nodeId"`
-	SelectElementAccessibilityIssueReason SelectElementAccessibilityIssueReason `json:"selectElementAccessibilityIssueReason"`
-	HasDisallowedAttributes               bool                                  `json:"hasDisallowedAttributes"`
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Audits#type-ElementAccessibilityIssueDetails
+type ElementAccessibilityIssueDetails struct {
+	NodeID                          cdp.BackendNodeID               `json:"nodeId"`
+	ElementAccessibilityIssueReason ElementAccessibilityIssueReason `json:"elementAccessibilityIssueReason"`
+	HasDisallowedAttributes         bool                            `json:"hasDisallowedAttributes"`
 }
 
 // StyleSheetLoadingIssueReason [no description].
@@ -1673,8 +1722,9 @@ const (
 	InspectorIssueCodeFederatedAuthUserInfoRequestIssue InspectorIssueCode = "FederatedAuthUserInfoRequestIssue"
 	InspectorIssueCodePropertyRuleIssue                 InspectorIssueCode = "PropertyRuleIssue"
 	InspectorIssueCodeSharedDictionaryIssue             InspectorIssueCode = "SharedDictionaryIssue"
-	InspectorIssueCodeSelectElementAccessibilityIssue   InspectorIssueCode = "SelectElementAccessibilityIssue"
+	InspectorIssueCodeElementAccessibilityIssue         InspectorIssueCode = "ElementAccessibilityIssue"
 	InspectorIssueCodeSRIMessageSignatureIssue          InspectorIssueCode = "SRIMessageSignatureIssue"
+	InspectorIssueCodeUnencodedDigestIssue              InspectorIssueCode = "UnencodedDigestIssue"
 	InspectorIssueCodeUserReidentificationIssue         InspectorIssueCode = "UserReidentificationIssue"
 )
 
@@ -1728,10 +1778,12 @@ func (t *InspectorIssueCode) UnmarshalJSON(buf []byte) error {
 		*t = InspectorIssueCodePropertyRuleIssue
 	case InspectorIssueCodeSharedDictionaryIssue:
 		*t = InspectorIssueCodeSharedDictionaryIssue
-	case InspectorIssueCodeSelectElementAccessibilityIssue:
-		*t = InspectorIssueCodeSelectElementAccessibilityIssue
+	case InspectorIssueCodeElementAccessibilityIssue:
+		*t = InspectorIssueCodeElementAccessibilityIssue
 	case InspectorIssueCodeSRIMessageSignatureIssue:
 		*t = InspectorIssueCodeSRIMessageSignatureIssue
+	case InspectorIssueCodeUnencodedDigestIssue:
+		*t = InspectorIssueCodeUnencodedDigestIssue
 	case InspectorIssueCodeUserReidentificationIssue:
 		*t = InspectorIssueCodeUserReidentificationIssue
 	default:
@@ -1767,8 +1819,9 @@ type InspectorIssueDetails struct {
 	PropertyRuleIssueDetails                 *PropertyRuleIssueDetails                 `json:"propertyRuleIssueDetails,omitempty,omitzero"`
 	FederatedAuthUserInfoRequestIssueDetails *FederatedAuthUserInfoRequestIssueDetails `json:"federatedAuthUserInfoRequestIssueDetails,omitempty,omitzero"`
 	SharedDictionaryIssueDetails             *SharedDictionaryIssueDetails             `json:"sharedDictionaryIssueDetails,omitempty,omitzero"`
-	SelectElementAccessibilityIssueDetails   *SelectElementAccessibilityIssueDetails   `json:"selectElementAccessibilityIssueDetails,omitempty,omitzero"`
+	ElementAccessibilityIssueDetails         *ElementAccessibilityIssueDetails         `json:"elementAccessibilityIssueDetails,omitempty,omitzero"`
 	SriMessageSignatureIssueDetails          *SRIMessageSignatureIssueDetails          `json:"sriMessageSignatureIssueDetails,omitempty,omitzero"`
+	UnencodedDigestIssueDetails              *UnencodedDigestIssueDetails              `json:"unencodedDigestIssueDetails,omitempty,omitzero"`
 	UserReidentificationIssueDetails         *UserReidentificationIssueDetails         `json:"userReidentificationIssueDetails,omitempty,omitzero"`
 }
 

--- a/vendor/github.com/chromedp/cdproto/bluetoothemulation/events.go
+++ b/vendor/github.com/chromedp/cdproto/bluetoothemulation/events.go
@@ -29,7 +29,7 @@ type EventCharacteristicOperationReceived struct {
 //
 // See: https://chromedevtools.github.io/devtools-protocol/tot/BluetoothEmulation#event-descriptorOperationReceived
 type EventDescriptorOperationReceived struct {
-	DescriptorID string                      `json:"descriptorId"`
-	Type         CharacteristicOperationType `json:"type"`
-	Data         string                      `json:"data,omitempty,omitzero"`
+	DescriptorID string                  `json:"descriptorId"`
+	Type         DescriptorOperationType `json:"type"`
+	Data         string                  `json:"data,omitempty,omitzero"`
 }

--- a/vendor/github.com/chromedp/cdproto/browser/browser.go
+++ b/vendor/github.com/chromedp/cdproto/browser/browser.go
@@ -527,6 +527,47 @@ func (p *SetWindowBoundsParams) Do(ctx context.Context) (err error) {
 	return cdp.Execute(ctx, CommandSetWindowBounds, p, nil)
 }
 
+// SetContentsSizeParams set size of the browser contents resizing browser
+// window as necessary.
+type SetContentsSizeParams struct {
+	WindowID WindowID `json:"windowId"`                  // Browser window id.
+	Width    int64    `json:"width,omitempty,omitzero"`  // The window contents width in DIP. Assumes current width if omitted. Must be specified if 'height' is omitted.
+	Height   int64    `json:"height,omitempty,omitzero"` // The window contents height in DIP. Assumes current height if omitted. Must be specified if 'width' is omitted.
+}
+
+// SetContentsSize set size of the browser contents resizing browser window
+// as necessary.
+//
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Browser#method-setContentsSize
+//
+// parameters:
+//
+//	windowID - Browser window id.
+func SetContentsSize(windowID WindowID) *SetContentsSizeParams {
+	return &SetContentsSizeParams{
+		WindowID: windowID,
+	}
+}
+
+// WithWidth the window contents width in DIP. Assumes current width if
+// omitted. Must be specified if 'height' is omitted.
+func (p SetContentsSizeParams) WithWidth(width int64) *SetContentsSizeParams {
+	p.Width = width
+	return &p
+}
+
+// WithHeight the window contents height in DIP. Assumes current height if
+// omitted. Must be specified if 'width' is omitted.
+func (p SetContentsSizeParams) WithHeight(height int64) *SetContentsSizeParams {
+	p.Height = height
+	return &p
+}
+
+// Do executes Browser.setContentsSize against the provided context.
+func (p *SetContentsSizeParams) Do(ctx context.Context) (err error) {
+	return cdp.Execute(ctx, CommandSetContentsSize, p, nil)
+}
+
 // SetDockTileParams set dock tile details, platform-specific.
 type SetDockTileParams struct {
 	BadgeLabel string `json:"badgeLabel,omitempty,omitzero"`
@@ -670,6 +711,7 @@ const (
 	CommandGetWindowBounds                       = "Browser.getWindowBounds"
 	CommandGetWindowForTarget                    = "Browser.getWindowForTarget"
 	CommandSetWindowBounds                       = "Browser.setWindowBounds"
+	CommandSetContentsSize                       = "Browser.setContentsSize"
 	CommandSetDockTile                           = "Browser.setDockTile"
 	CommandExecuteBrowserCommand                 = "Browser.executeBrowserCommand"
 	CommandAddPrivacySandboxEnrollmentOverride   = "Browser.addPrivacySandboxEnrollmentOverride"

--- a/vendor/github.com/chromedp/cdproto/browser/events.go
+++ b/vendor/github.com/chromedp/cdproto/browser/events.go
@@ -21,8 +21,9 @@ type EventDownloadWillBegin struct {
 //
 // See: https://chromedevtools.github.io/devtools-protocol/tot/Browser#event-downloadProgress
 type EventDownloadProgress struct {
-	GUID          string                `json:"guid"`          // Global unique identifier of the download.
-	TotalBytes    float64               `json:"totalBytes"`    // Total expected bytes to download.
-	ReceivedBytes float64               `json:"receivedBytes"` // Total bytes received.
-	State         DownloadProgressState `json:"state"`         // Download status.
+	GUID          string                `json:"guid"`                        // Global unique identifier of the download.
+	TotalBytes    float64               `json:"totalBytes"`                  // Total expected bytes to download.
+	ReceivedBytes float64               `json:"receivedBytes"`               // Total bytes received.
+	State         DownloadProgressState `json:"state"`                       // Download status.
+	FilePath      string                `json:"filePath,omitempty,omitzero"` // If download is "completed", provides the path of the downloaded file. Depending on the platform, it is not guaranteed to be set, nor the file is guaranteed to exist.
 }

--- a/vendor/github.com/chromedp/cdproto/cdp/types.go
+++ b/vendor/github.com/chromedp/cdproto/cdp/types.go
@@ -155,42 +155,44 @@ func (t PseudoType) String() string {
 
 // PseudoType values.
 const (
-	PseudoTypeFirstLine               PseudoType = "first-line"
-	PseudoTypeFirstLetter             PseudoType = "first-letter"
-	PseudoTypeCheckmark               PseudoType = "checkmark"
-	PseudoTypeBefore                  PseudoType = "before"
-	PseudoTypeAfter                   PseudoType = "after"
-	PseudoTypePickerIcon              PseudoType = "picker-icon"
-	PseudoTypeMarker                  PseudoType = "marker"
-	PseudoTypeBackdrop                PseudoType = "backdrop"
-	PseudoTypeColumn                  PseudoType = "column"
-	PseudoTypeSelection               PseudoType = "selection"
-	PseudoTypeSearchText              PseudoType = "search-text"
-	PseudoTypeTargetText              PseudoType = "target-text"
-	PseudoTypeSpellingError           PseudoType = "spelling-error"
-	PseudoTypeGrammarError            PseudoType = "grammar-error"
-	PseudoTypeHighlight               PseudoType = "highlight"
-	PseudoTypeFirstLineInherited      PseudoType = "first-line-inherited"
-	PseudoTypeScrollMarker            PseudoType = "scroll-marker"
-	PseudoTypeScrollMarkerGroup       PseudoType = "scroll-marker-group"
-	PseudoTypeScrollButton            PseudoType = "scroll-button"
-	PseudoTypeScrollbar               PseudoType = "scrollbar"
-	PseudoTypeScrollbarThumb          PseudoType = "scrollbar-thumb"
-	PseudoTypeScrollbarButton         PseudoType = "scrollbar-button"
-	PseudoTypeScrollbarTrack          PseudoType = "scrollbar-track"
-	PseudoTypeScrollbarTrackPiece     PseudoType = "scrollbar-track-piece"
-	PseudoTypeScrollbarCorner         PseudoType = "scrollbar-corner"
-	PseudoTypeResizer                 PseudoType = "resizer"
-	PseudoTypeInputListButton         PseudoType = "input-list-button"
-	PseudoTypeViewTransition          PseudoType = "view-transition"
-	PseudoTypeViewTransitionGroup     PseudoType = "view-transition-group"
-	PseudoTypeViewTransitionImagePair PseudoType = "view-transition-image-pair"
-	PseudoTypeViewTransitionOld       PseudoType = "view-transition-old"
-	PseudoTypeViewTransitionNew       PseudoType = "view-transition-new"
-	PseudoTypePlaceholder             PseudoType = "placeholder"
-	PseudoTypeFileSelectorButton      PseudoType = "file-selector-button"
-	PseudoTypeDetailsContent          PseudoType = "details-content"
-	PseudoTypePicker                  PseudoType = "picker"
+	PseudoTypeFirstLine                   PseudoType = "first-line"
+	PseudoTypeFirstLetter                 PseudoType = "first-letter"
+	PseudoTypeCheckmark                   PseudoType = "checkmark"
+	PseudoTypeBefore                      PseudoType = "before"
+	PseudoTypeAfter                       PseudoType = "after"
+	PseudoTypePickerIcon                  PseudoType = "picker-icon"
+	PseudoTypeMarker                      PseudoType = "marker"
+	PseudoTypeBackdrop                    PseudoType = "backdrop"
+	PseudoTypeColumn                      PseudoType = "column"
+	PseudoTypeSelection                   PseudoType = "selection"
+	PseudoTypeSearchText                  PseudoType = "search-text"
+	PseudoTypeTargetText                  PseudoType = "target-text"
+	PseudoTypeSpellingError               PseudoType = "spelling-error"
+	PseudoTypeGrammarError                PseudoType = "grammar-error"
+	PseudoTypeHighlight                   PseudoType = "highlight"
+	PseudoTypeFirstLineInherited          PseudoType = "first-line-inherited"
+	PseudoTypeScrollMarker                PseudoType = "scroll-marker"
+	PseudoTypeScrollMarkerGroup           PseudoType = "scroll-marker-group"
+	PseudoTypeScrollButton                PseudoType = "scroll-button"
+	PseudoTypeScrollbar                   PseudoType = "scrollbar"
+	PseudoTypeScrollbarThumb              PseudoType = "scrollbar-thumb"
+	PseudoTypeScrollbarButton             PseudoType = "scrollbar-button"
+	PseudoTypeScrollbarTrack              PseudoType = "scrollbar-track"
+	PseudoTypeScrollbarTrackPiece         PseudoType = "scrollbar-track-piece"
+	PseudoTypeScrollbarCorner             PseudoType = "scrollbar-corner"
+	PseudoTypeResizer                     PseudoType = "resizer"
+	PseudoTypeInputListButton             PseudoType = "input-list-button"
+	PseudoTypeViewTransition              PseudoType = "view-transition"
+	PseudoTypeViewTransitionGroup         PseudoType = "view-transition-group"
+	PseudoTypeViewTransitionImagePair     PseudoType = "view-transition-image-pair"
+	PseudoTypeViewTransitionGroupChildren PseudoType = "view-transition-group-children"
+	PseudoTypeViewTransitionOld           PseudoType = "view-transition-old"
+	PseudoTypeViewTransitionNew           PseudoType = "view-transition-new"
+	PseudoTypePlaceholder                 PseudoType = "placeholder"
+	PseudoTypeFileSelectorButton          PseudoType = "file-selector-button"
+	PseudoTypeDetailsContent              PseudoType = "details-content"
+	PseudoTypePicker                      PseudoType = "picker"
+	PseudoTypePermissionIcon              PseudoType = "permission-icon"
 )
 
 // UnmarshalJSON satisfies [json.Unmarshaler].
@@ -259,6 +261,8 @@ func (t *PseudoType) UnmarshalJSON(buf []byte) error {
 		*t = PseudoTypeViewTransitionGroup
 	case PseudoTypeViewTransitionImagePair:
 		*t = PseudoTypeViewTransitionImagePair
+	case PseudoTypeViewTransitionGroupChildren:
+		*t = PseudoTypeViewTransitionGroupChildren
 	case PseudoTypeViewTransitionOld:
 		*t = PseudoTypeViewTransitionOld
 	case PseudoTypeViewTransitionNew:
@@ -271,6 +275,8 @@ func (t *PseudoType) UnmarshalJSON(buf []byte) error {
 		*t = PseudoTypeDetailsContent
 	case PseudoTypePicker:
 		*t = PseudoTypePicker
+	case PseudoTypePermissionIcon:
+		*t = PseudoTypePermissionIcon
 	default:
 		return fmt.Errorf("unknown PseudoType value: %v", s)
 	}

--- a/vendor/github.com/chromedp/cdproto/cdproto.go
+++ b/vendor/github.com/chromedp/cdproto/cdproto.go
@@ -158,6 +158,7 @@ const (
 	CommandBrowserGetWindowBounds                                    = browser.CommandGetWindowBounds
 	CommandBrowserGetWindowForTarget                                 = browser.CommandGetWindowForTarget
 	CommandBrowserSetWindowBounds                                    = browser.CommandSetWindowBounds
+	CommandBrowserSetContentsSize                                    = browser.CommandSetContentsSize
 	CommandBrowserSetDockTile                                        = browser.CommandSetDockTile
 	CommandBrowserExecuteBrowserCommand                              = browser.CommandExecuteBrowserCommand
 	CommandBrowserAddPrivacySandboxEnrollmentOverride                = browser.CommandAddPrivacySandboxEnrollmentOverride
@@ -178,6 +179,7 @@ const (
 	CommandCSSGetInlineStylesForNode                                 = css.CommandGetInlineStylesForNode
 	CommandCSSGetAnimatedStylesForNode                               = css.CommandGetAnimatedStylesForNode
 	CommandCSSGetMatchedStylesForNode                                = css.CommandGetMatchedStylesForNode
+	CommandCSSGetEnvironmentVariables                                = css.CommandGetEnvironmentVariables
 	CommandCSSGetMediaQueries                                        = css.CommandGetMediaQueries
 	CommandCSSGetPlatformFontsForNode                                = css.CommandGetPlatformFontsForNode
 	CommandCSSGetStyleSheetText                                      = css.CommandGetStyleSheetText
@@ -267,6 +269,7 @@ const (
 	CommandDOMGetContainerForNode                                    = dom.CommandGetContainerForNode
 	CommandDOMGetQueryingDescendantsForContainer                     = dom.CommandGetQueryingDescendantsForContainer
 	CommandDOMGetAnchorElement                                       = dom.CommandGetAnchorElement
+	CommandDOMForceShowPopover                                       = dom.CommandForceShowPopover
 	EventDOMAttributeModified                                        = "DOM.attributeModified"
 	EventDOMAttributeRemoved                                         = "DOM.attributeRemoved"
 	EventDOMCharacterDataModified                                    = "DOM.characterDataModified"
@@ -364,12 +367,14 @@ const (
 	CommandEmulationSetEmitTouchEventsForMouse                       = emulation.CommandSetEmitTouchEventsForMouse
 	CommandEmulationSetEmulatedMedia                                 = emulation.CommandSetEmulatedMedia
 	CommandEmulationSetEmulatedVisionDeficiency                      = emulation.CommandSetEmulatedVisionDeficiency
+	CommandEmulationSetEmulatedOSTextScale                           = emulation.CommandSetEmulatedOSTextScale
 	CommandEmulationSetGeolocationOverride                           = emulation.CommandSetGeolocationOverride
 	CommandEmulationGetOverriddenSensorInformation                   = emulation.CommandGetOverriddenSensorInformation
 	CommandEmulationSetSensorOverrideEnabled                         = emulation.CommandSetSensorOverrideEnabled
 	CommandEmulationSetSensorOverrideReadings                        = emulation.CommandSetSensorOverrideReadings
 	CommandEmulationSetPressureSourceOverrideEnabled                 = emulation.CommandSetPressureSourceOverrideEnabled
 	CommandEmulationSetPressureStateOverride                         = emulation.CommandSetPressureStateOverride
+	CommandEmulationSetPressureDataOverride                          = emulation.CommandSetPressureDataOverride
 	CommandEmulationSetIdleOverride                                  = emulation.CommandSetIdleOverride
 	CommandEmulationClearIdleOverride                                = emulation.CommandClearIdleOverride
 	CommandEmulationSetPageScaleFactor                               = emulation.CommandSetPageScaleFactor
@@ -379,6 +384,7 @@ const (
 	CommandEmulationSetLocaleOverride                                = emulation.CommandSetLocaleOverride
 	CommandEmulationSetTimezoneOverride                              = emulation.CommandSetTimezoneOverride
 	CommandEmulationSetDisabledImageTypes                            = emulation.CommandSetDisabledImageTypes
+	CommandEmulationSetDataSaverOverride                             = emulation.CommandSetDataSaverOverride
 	CommandEmulationSetHardwareConcurrencyOverride                   = emulation.CommandSetHardwareConcurrencyOverride
 	CommandEmulationSetUserAgentOverride                             = emulation.CommandSetUserAgentOverride
 	CommandEmulationSetAutomationOverride                            = emulation.CommandSetAutomationOverride
@@ -616,7 +622,7 @@ const (
 	CommandPageGetAppManifest                                        = page.CommandGetAppManifest
 	CommandPageGetInstallabilityErrors                               = page.CommandGetInstallabilityErrors
 	CommandPageGetAppID                                              = page.CommandGetAppID
-	CommandPageGetAdScriptAncestryIDs                                = page.CommandGetAdScriptAncestryIDs
+	CommandPageGetAdScriptAncestry                                   = page.CommandGetAdScriptAncestry
 	CommandPageGetFrameTree                                          = page.CommandGetFrameTree
 	CommandPageGetLayoutMetrics                                      = page.CommandGetLayoutMetrics
 	CommandPageGetNavigationHistory                                  = page.CommandGetNavigationHistory
@@ -743,7 +749,6 @@ const (
 	CommandServiceWorkerDispatchSyncEvent                            = serviceworker.CommandDispatchSyncEvent
 	CommandServiceWorkerDispatchPeriodicSyncEvent                    = serviceworker.CommandDispatchPeriodicSyncEvent
 	CommandServiceWorkerEnable                                       = serviceworker.CommandEnable
-	CommandServiceWorkerInspectWorker                                = serviceworker.CommandInspectWorker
 	CommandServiceWorkerSetForceUpdateOnPageLoad                     = serviceworker.CommandSetForceUpdateOnPageLoad
 	CommandServiceWorkerSkipWaiting                                  = serviceworker.CommandSkipWaiting
 	CommandServiceWorkerStartWorker                                  = serviceworker.CommandStartWorker
@@ -799,11 +804,13 @@ const (
 	EventStorageInterestGroupAuctionEventOccurred                    = "Storage.interestGroupAuctionEventOccurred"
 	EventStorageInterestGroupAuctionNetworkRequestCreated            = "Storage.interestGroupAuctionNetworkRequestCreated"
 	EventStorageSharedStorageAccessed                                = "Storage.sharedStorageAccessed"
+	EventStorageSharedStorageWorkletOperationExecutionFinished       = "Storage.sharedStorageWorkletOperationExecutionFinished"
 	EventStorageStorageBucketCreatedOrUpdated                        = "Storage.storageBucketCreatedOrUpdated"
 	EventStorageStorageBucketDeleted                                 = "Storage.storageBucketDeleted"
 	EventStorageAttributionReportingSourceRegistered                 = "Storage.attributionReportingSourceRegistered"
 	EventStorageAttributionReportingTriggerRegistered                = "Storage.attributionReportingTriggerRegistered"
 	EventStorageAttributionReportingReportSent                       = "Storage.attributionReportingReportSent"
+	EventStorageAttributionReportingVerboseDebugReportSent           = "Storage.attributionReportingVerboseDebugReportSent"
 	CommandSystemInfoGetInfo                                         = systeminfo.CommandGetInfo
 	CommandSystemInfoGetFeatureState                                 = systeminfo.CommandGetFeatureState
 	CommandSystemInfoGetProcessInfo                                  = systeminfo.CommandGetProcessInfo
@@ -823,6 +830,7 @@ const (
 	CommandTargetAutoAttachRelated                                   = target.CommandAutoAttachRelated
 	CommandTargetSetDiscoverTargets                                  = target.CommandSetDiscoverTargets
 	CommandTargetSetRemoteLocations                                  = target.CommandSetRemoteLocations
+	CommandTargetOpenDevTools                                        = target.CommandOpenDevTools
 	EventTargetAttachedToTarget                                      = "Target.attachedToTarget"
 	EventTargetDetachedFromTarget                                    = "Target.detachedFromTarget"
 	EventTargetReceivedMessageFromTarget                             = "Target.receivedMessageFromTarget"
@@ -1054,6 +1062,8 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 		v = new(browser.GetWindowForTargetReturns)
 	case CommandBrowserSetWindowBounds:
 		return emptyVal, nil
+	case CommandBrowserSetContentsSize:
+		return emptyVal, nil
 	case CommandBrowserSetDockTile:
 		return emptyVal, nil
 	case CommandBrowserExecuteBrowserCommand:
@@ -1094,6 +1104,8 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 		v = new(css.GetAnimatedStylesForNodeReturns)
 	case CommandCSSGetMatchedStylesForNode:
 		v = new(css.GetMatchedStylesForNodeReturns)
+	case CommandCSSGetEnvironmentVariables:
+		v = new(css.GetEnvironmentVariablesReturns)
 	case CommandCSSGetMediaQueries:
 		v = new(css.GetMediaQueriesReturns)
 	case CommandCSSGetPlatformFontsForNode:
@@ -1272,6 +1284,8 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 		v = new(dom.GetQueryingDescendantsForContainerReturns)
 	case CommandDOMGetAnchorElement:
 		v = new(dom.GetAnchorElementReturns)
+	case CommandDOMForceShowPopover:
+		v = new(dom.ForceShowPopoverReturns)
 	case EventDOMAttributeModified:
 		v = new(dom.EventAttributeModified)
 	case EventDOMAttributeRemoved:
@@ -1466,6 +1480,8 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 		return emptyVal, nil
 	case CommandEmulationSetEmulatedVisionDeficiency:
 		return emptyVal, nil
+	case CommandEmulationSetEmulatedOSTextScale:
+		return emptyVal, nil
 	case CommandEmulationSetGeolocationOverride:
 		return emptyVal, nil
 	case CommandEmulationGetOverriddenSensorInformation:
@@ -1477,6 +1493,8 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 	case CommandEmulationSetPressureSourceOverrideEnabled:
 		return emptyVal, nil
 	case CommandEmulationSetPressureStateOverride:
+		return emptyVal, nil
+	case CommandEmulationSetPressureDataOverride:
 		return emptyVal, nil
 	case CommandEmulationSetIdleOverride:
 		return emptyVal, nil
@@ -1495,6 +1513,8 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 	case CommandEmulationSetTimezoneOverride:
 		return emptyVal, nil
 	case CommandEmulationSetDisabledImageTypes:
+		return emptyVal, nil
+	case CommandEmulationSetDataSaverOverride:
 		return emptyVal, nil
 	case CommandEmulationSetHardwareConcurrencyOverride:
 		return emptyVal, nil
@@ -1970,8 +1990,8 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 		v = new(page.GetInstallabilityErrorsReturns)
 	case CommandPageGetAppID:
 		v = new(page.GetAppIDReturns)
-	case CommandPageGetAdScriptAncestryIDs:
-		v = new(page.GetAdScriptAncestryIDsReturns)
+	case CommandPageGetAdScriptAncestry:
+		v = new(page.GetAdScriptAncestryReturns)
 	case CommandPageGetFrameTree:
 		v = new(page.GetFrameTreeReturns)
 	case CommandPageGetLayoutMetrics:
@@ -2224,8 +2244,6 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 		return emptyVal, nil
 	case CommandServiceWorkerEnable:
 		return emptyVal, nil
-	case CommandServiceWorkerInspectWorker:
-		return emptyVal, nil
 	case CommandServiceWorkerSetForceUpdateOnPageLoad:
 		return emptyVal, nil
 	case CommandServiceWorkerSkipWaiting:
@@ -2336,6 +2354,8 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 		v = new(storage.EventInterestGroupAuctionNetworkRequestCreated)
 	case EventStorageSharedStorageAccessed:
 		v = new(storage.EventSharedStorageAccessed)
+	case EventStorageSharedStorageWorkletOperationExecutionFinished:
+		v = new(storage.EventSharedStorageWorkletOperationExecutionFinished)
 	case EventStorageStorageBucketCreatedOrUpdated:
 		v = new(storage.EventStorageBucketCreatedOrUpdated)
 	case EventStorageStorageBucketDeleted:
@@ -2346,6 +2366,8 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 		v = new(storage.EventAttributionReportingTriggerRegistered)
 	case EventStorageAttributionReportingReportSent:
 		v = new(storage.EventAttributionReportingReportSent)
+	case EventStorageAttributionReportingVerboseDebugReportSent:
+		v = new(storage.EventAttributionReportingVerboseDebugReportSent)
 	case CommandSystemInfoGetInfo:
 		v = new(systeminfo.GetInfoReturns)
 	case CommandSystemInfoGetFeatureState:
@@ -2384,6 +2406,8 @@ func UnmarshalMessage(msg *Message, opts ...jsonv2.Options) (any, error) {
 		return emptyVal, nil
 	case CommandTargetSetRemoteLocations:
 		return emptyVal, nil
+	case CommandTargetOpenDevTools:
+		v = new(target.OpenDevToolsReturns)
 	case EventTargetAttachedToTarget:
 		v = new(target.EventAttachedToTarget)
 	case EventTargetDetachedFromTarget:

--- a/vendor/github.com/chromedp/cdproto/css/css.go
+++ b/vendor/github.com/chromedp/cdproto/css/css.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	"github.com/chromedp/cdproto/cdp"
+	"github.com/go-json-experiment/json/jsontext"
 )
 
 // AddRuleParams inserts a new rule with the given ruleText in a stylesheet
@@ -620,6 +621,39 @@ func (p *GetMatchedStylesForNodeParams) Do(ctx context.Context) (inlineStyle *St
 	}
 
 	return res.InlineStyle, res.AttributesStyle, res.MatchedCSSRules, res.PseudoElements, res.Inherited, res.InheritedPseudoElements, res.CSSKeyframesRules, res.CSSPositionTryRules, res.ActivePositionFallbackIndex, res.CSSPropertyRules, res.CSSPropertyRegistrations, res.CSSFontPaletteValuesRule, res.ParentLayoutNodeID, res.CSSFunctionRules, nil
+}
+
+// GetEnvironmentVariablesParams returns the values of the default UA-defined
+// environment variables used in env().
+type GetEnvironmentVariablesParams struct{}
+
+// GetEnvironmentVariables returns the values of the default UA-defined
+// environment variables used in env().
+//
+// See: https://chromedevtools.github.io/devtools-protocol/tot/CSS#method-getEnvironmentVariables
+func GetEnvironmentVariables() *GetEnvironmentVariablesParams {
+	return &GetEnvironmentVariablesParams{}
+}
+
+// GetEnvironmentVariablesReturns return values.
+type GetEnvironmentVariablesReturns struct {
+	EnvironmentVariables jsontext.Value `json:"environmentVariables,omitempty,omitzero"`
+}
+
+// Do executes CSS.getEnvironmentVariables against the provided context.
+//
+// returns:
+//
+//	environmentVariables
+func (p *GetEnvironmentVariablesParams) Do(ctx context.Context) (environmentVariables jsontext.Value, err error) {
+	// execute
+	var res GetEnvironmentVariablesReturns
+	err = cdp.Execute(ctx, CommandGetEnvironmentVariables, nil, &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.EnvironmentVariables, nil
 }
 
 // GetMediaQueriesParams returns all media queries parsed by the rendering
@@ -1497,6 +1531,7 @@ const (
 	CommandGetInlineStylesForNode           = "CSS.getInlineStylesForNode"
 	CommandGetAnimatedStylesForNode         = "CSS.getAnimatedStylesForNode"
 	CommandGetMatchedStylesForNode          = "CSS.getMatchedStylesForNode"
+	CommandGetEnvironmentVariables          = "CSS.getEnvironmentVariables"
 	CommandGetMediaQueries                  = "CSS.getMediaQueries"
 	CommandGetPlatformFontsForNode          = "CSS.getPlatformFontsForNode"
 	CommandGetStyleSheetText                = "CSS.getStyleSheetText"

--- a/vendor/github.com/chromedp/cdproto/css/types.go
+++ b/vendor/github.com/chromedp/cdproto/css/types.go
@@ -336,6 +336,7 @@ type ContainerQuery struct {
 	PhysicalAxes       dom.PhysicalAxes `json:"physicalAxes,omitempty,omitzero"` // Optional physical axes queried for the container.
 	LogicalAxes        dom.LogicalAxes  `json:"logicalAxes,omitempty,omitzero"`  // Optional logical axes queried for the container.
 	QueriesScrollState bool             `json:"queriesScrollState"`              // true if the query contains scroll-state() queries.
+	QueriesAnchored    bool             `json:"queriesAnchored"`                 // true if the query contains anchored() queries.
 }
 
 // Supports CSS Supports at-rule descriptor.

--- a/vendor/github.com/chromedp/cdproto/dom/types.go
+++ b/vendor/github.com/chromedp/cdproto/dom/types.go
@@ -214,6 +214,7 @@ func (t GetElementByRelationRelation) String() string {
 const (
 	GetElementByRelationRelationPopoverTarget  GetElementByRelationRelation = "PopoverTarget"
 	GetElementByRelationRelationInterestTarget GetElementByRelationRelation = "InterestTarget"
+	GetElementByRelationRelationCommandFor     GetElementByRelationRelation = "CommandFor"
 )
 
 // UnmarshalJSON satisfies [json.Unmarshaler].
@@ -226,6 +227,8 @@ func (t *GetElementByRelationRelation) UnmarshalJSON(buf []byte) error {
 		*t = GetElementByRelationRelationPopoverTarget
 	case GetElementByRelationRelationInterestTarget:
 		*t = GetElementByRelationRelationInterestTarget
+	case GetElementByRelationRelationCommandFor:
+		*t = GetElementByRelationRelationCommandFor
 	default:
 		return fmt.Errorf("unknown GetElementByRelationRelation value: %v", s)
 	}

--- a/vendor/github.com/chromedp/cdproto/emulation/emulation.go
+++ b/vendor/github.com/chromedp/cdproto/emulation/emulation.go
@@ -532,6 +532,31 @@ func (p *SetEmulatedVisionDeficiencyParams) Do(ctx context.Context) (err error) 
 	return cdp.Execute(ctx, CommandSetEmulatedVisionDeficiency, p, nil)
 }
 
+// SetEmulatedOSTextScaleParams emulates the given OS text scale.
+type SetEmulatedOSTextScaleParams struct {
+	Scale float64 `json:"scale,omitempty,omitzero"`
+}
+
+// SetEmulatedOSTextScale emulates the given OS text scale.
+//
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Emulation#method-setEmulatedOSTextScale
+//
+// parameters:
+func SetEmulatedOSTextScale() *SetEmulatedOSTextScaleParams {
+	return &SetEmulatedOSTextScaleParams{}
+}
+
+// WithScale [no description].
+func (p SetEmulatedOSTextScaleParams) WithScale(scale float64) *SetEmulatedOSTextScaleParams {
+	p.Scale = scale
+	return &p
+}
+
+// Do executes Emulation.setEmulatedOSTextScale against the provided context.
+func (p *SetEmulatedOSTextScaleParams) Do(ctx context.Context) (err error) {
+	return cdp.Execute(ctx, CommandSetEmulatedOSTextScale, p, nil)
+}
+
 // SetGeolocationOverrideParams overrides the Geolocation Position or Error.
 // Omitting latitude, longitude or accuracy emulates position unavailable.
 type SetGeolocationOverrideParams struct {
@@ -748,7 +773,8 @@ func (p *SetPressureSourceOverrideEnabledParams) Do(ctx context.Context) (err er
 	return cdp.Execute(ctx, CommandSetPressureSourceOverrideEnabled, p, nil)
 }
 
-// SetPressureStateOverrideParams provides a given pressure state that will
+// SetPressureStateOverrideParams tODO: OBSOLETE: To remove when
+// setPressureDataOverride is merged. Provides a given pressure state that will
 // be processed and eventually be delivered to PressureObserver users. |source|
 // must have been previously overridden by setPressureSourceOverrideEnabled.
 type SetPressureStateOverrideParams struct {
@@ -756,8 +782,9 @@ type SetPressureStateOverrideParams struct {
 	State  PressureState  `json:"state"`
 }
 
-// SetPressureStateOverride provides a given pressure state that will be
-// processed and eventually be delivered to PressureObserver users. |source|
+// SetPressureStateOverride tODO: OBSOLETE: To remove when
+// setPressureDataOverride is merged. Provides a given pressure state that will
+// be processed and eventually be delivered to PressureObserver users. |source|
 // must have been previously overridden by setPressureSourceOverrideEnabled.
 //
 // See: https://chromedevtools.github.io/devtools-protocol/tot/Emulation#method-setPressureStateOverride
@@ -776,6 +803,43 @@ func SetPressureStateOverride(source PressureSource, state PressureState) *SetPr
 // Do executes Emulation.setPressureStateOverride against the provided context.
 func (p *SetPressureStateOverrideParams) Do(ctx context.Context) (err error) {
 	return cdp.Execute(ctx, CommandSetPressureStateOverride, p, nil)
+}
+
+// SetPressureDataOverrideParams provides a given pressure data set that will
+// be processed and eventually be delivered to PressureObserver users. |source|
+// must have been previously overridden by setPressureSourceOverrideEnabled.
+type SetPressureDataOverrideParams struct {
+	Source                  PressureSource `json:"source"`
+	State                   PressureState  `json:"state"`
+	OwnContributionEstimate float64        `json:"ownContributionEstimate,omitempty,omitzero"`
+}
+
+// SetPressureDataOverride provides a given pressure data set that will be
+// processed and eventually be delivered to PressureObserver users. |source|
+// must have been previously overridden by setPressureSourceOverrideEnabled.
+//
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Emulation#method-setPressureDataOverride
+//
+// parameters:
+//
+//	source
+//	state
+func SetPressureDataOverride(source PressureSource, state PressureState) *SetPressureDataOverrideParams {
+	return &SetPressureDataOverrideParams{
+		Source: source,
+		State:  state,
+	}
+}
+
+// WithOwnContributionEstimate [no description].
+func (p SetPressureDataOverrideParams) WithOwnContributionEstimate(ownContributionEstimate float64) *SetPressureDataOverrideParams {
+	p.OwnContributionEstimate = ownContributionEstimate
+	return &p
+}
+
+// Do executes Emulation.setPressureDataOverride against the provided context.
+func (p *SetPressureDataOverrideParams) Do(ctx context.Context) (err error) {
+	return cdp.Execute(ctx, CommandSetPressureDataOverride, p, nil)
 }
 
 // SetIdleOverrideParams overrides the Idle state.
@@ -1041,6 +1105,35 @@ func (p *SetDisabledImageTypesParams) Do(ctx context.Context) (err error) {
 	return cdp.Execute(ctx, CommandSetDisabledImageTypes, p, nil)
 }
 
+// SetDataSaverOverrideParams override the value of
+// navigator.connection.saveData.
+type SetDataSaverOverrideParams struct {
+	DataSaverEnabled bool `json:"dataSaverEnabled"` // Override value. Omitting the parameter disables the override.
+}
+
+// SetDataSaverOverride override the value of navigator.connection.saveData.
+//
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Emulation#method-setDataSaverOverride
+//
+// parameters:
+func SetDataSaverOverride() *SetDataSaverOverrideParams {
+	return &SetDataSaverOverrideParams{
+		DataSaverEnabled: false,
+	}
+}
+
+// WithDataSaverEnabled override value. Omitting the parameter disables the
+// override.
+func (p SetDataSaverOverrideParams) WithDataSaverEnabled(dataSaverEnabled bool) *SetDataSaverOverrideParams {
+	p.DataSaverEnabled = dataSaverEnabled
+	return &p
+}
+
+// Do executes Emulation.setDataSaverOverride against the provided context.
+func (p *SetDataSaverOverrideParams) Do(ctx context.Context) (err error) {
+	return cdp.Execute(ctx, CommandSetDataSaverOverride, p, nil)
+}
+
 // SetHardwareConcurrencyOverrideParams [no description].
 type SetHardwareConcurrencyOverrideParams struct {
 	HardwareConcurrency int64 `json:"hardwareConcurrency"` // Hardware concurrency to report
@@ -1182,12 +1275,14 @@ const (
 	CommandSetEmitTouchEventsForMouse               = "Emulation.setEmitTouchEventsForMouse"
 	CommandSetEmulatedMedia                         = "Emulation.setEmulatedMedia"
 	CommandSetEmulatedVisionDeficiency              = "Emulation.setEmulatedVisionDeficiency"
+	CommandSetEmulatedOSTextScale                   = "Emulation.setEmulatedOSTextScale"
 	CommandSetGeolocationOverride                   = "Emulation.setGeolocationOverride"
 	CommandGetOverriddenSensorInformation           = "Emulation.getOverriddenSensorInformation"
 	CommandSetSensorOverrideEnabled                 = "Emulation.setSensorOverrideEnabled"
 	CommandSetSensorOverrideReadings                = "Emulation.setSensorOverrideReadings"
 	CommandSetPressureSourceOverrideEnabled         = "Emulation.setPressureSourceOverrideEnabled"
 	CommandSetPressureStateOverride                 = "Emulation.setPressureStateOverride"
+	CommandSetPressureDataOverride                  = "Emulation.setPressureDataOverride"
 	CommandSetIdleOverride                          = "Emulation.setIdleOverride"
 	CommandClearIdleOverride                        = "Emulation.clearIdleOverride"
 	CommandSetPageScaleFactor                       = "Emulation.setPageScaleFactor"
@@ -1197,6 +1292,7 @@ const (
 	CommandSetLocaleOverride                        = "Emulation.setLocaleOverride"
 	CommandSetTimezoneOverride                      = "Emulation.setTimezoneOverride"
 	CommandSetDisabledImageTypes                    = "Emulation.setDisabledImageTypes"
+	CommandSetDataSaverOverride                     = "Emulation.setDataSaverOverride"
 	CommandSetHardwareConcurrencyOverride           = "Emulation.setHardwareConcurrencyOverride"
 	CommandSetUserAgentOverride                     = "Emulation.setUserAgentOverride"
 	CommandSetAutomationOverride                    = "Emulation.setAutomationOverride"

--- a/vendor/github.com/chromedp/cdproto/emulation/types.go
+++ b/vendor/github.com/chromedp/cdproto/emulation/types.go
@@ -116,6 +116,7 @@ type UserAgentMetadata struct {
 	Mobile          bool                     `json:"mobile"`
 	Bitness         string                   `json:"bitness,omitempty,omitzero"`
 	Wow64           bool                     `json:"wow64"`
+	FormFactors     []string                 `json:"formFactors,omitempty,omitzero"` // Used to specify User Agent form-factor values. See https://wicg.github.io/ua-client-hints/#sec-ch-ua-form-factors
 }
 
 // SensorType used to specify sensor types to emulate. See

--- a/vendor/github.com/chromedp/cdproto/network/types.go
+++ b/vendor/github.com/chromedp/cdproto/network/types.go
@@ -45,6 +45,7 @@ const (
 	ResourceTypePing               ResourceType = "Ping"
 	ResourceTypeCSPViolationReport ResourceType = "CSPViolationReport"
 	ResourceTypePreflight          ResourceType = "Preflight"
+	ResourceTypeFedCM              ResourceType = "FedCM"
 	ResourceTypeOther              ResourceType = "Other"
 )
 
@@ -88,6 +89,8 @@ func (t *ResourceType) UnmarshalJSON(buf []byte) error {
 		*t = ResourceTypeCSPViolationReport
 	case ResourceTypePreflight:
 		*t = ResourceTypePreflight
+	case ResourceTypeFedCM:
+		*t = ResourceTypeFedCM
 	case ResourceTypeOther:
 		*t = ResourceTypeOther
 	default:
@@ -946,6 +949,7 @@ type Response struct {
 	AlternateProtocolUsage      AlternateProtocolUsage      `json:"alternateProtocolUsage,omitempty,omitzero"`      // The reason why Chrome uses a specific transport protocol for HTTP semantics.
 	SecurityState               security.State              `json:"securityState"`                                  // Security state of the request resource.
 	SecurityDetails             *SecurityDetails            `json:"securityDetails,omitempty,omitzero"`             // Security details for the request.
+	IsIPProtectionUsed          bool                        `json:"isIpProtectionUsed"`                             // Indicates whether the request was sent through IP Protection proxies. If set to true, the request used the IP Protection privacy feature.
 }
 
 // WebSocketRequest webSocket request data.
@@ -1487,6 +1491,7 @@ type SignedExchangeError struct {
 // See: https://chromedevtools.github.io/devtools-protocol/tot/Network#type-SignedExchangeInfo
 type SignedExchangeInfo struct {
 	OuterResponse   *Response              `json:"outerResponse"`                      // The outer response of signed HTTP exchange which was received from network.
+	HasExtraInfo    bool                   `json:"hasExtraInfo"`                       // Whether network response for the signed exchange was accompanied by extra headers.
 	Header          *SignedExchangeHeader  `json:"header,omitempty,omitzero"`          // Information about the signed exchange header.
 	SecurityDetails *SecurityDetails       `json:"securityDetails,omitempty,omitzero"` // Security details for the signed exchange header.
 	Errors          []*SignedExchangeError `json:"errors,omitempty,omitzero"`          // Errors occurred while handling the signed exchange.
@@ -1654,10 +1659,10 @@ func (t IPAddressSpace) String() string {
 
 // IPAddressSpace values.
 const (
-	IPAddressSpaceLocal   IPAddressSpace = "Local"
-	IPAddressSpacePrivate IPAddressSpace = "Private"
-	IPAddressSpacePublic  IPAddressSpace = "Public"
-	IPAddressSpaceUnknown IPAddressSpace = "Unknown"
+	IPAddressSpaceLoopback IPAddressSpace = "Loopback"
+	IPAddressSpaceLocal    IPAddressSpace = "Local"
+	IPAddressSpacePublic   IPAddressSpace = "Public"
+	IPAddressSpaceUnknown  IPAddressSpace = "Unknown"
 )
 
 // UnmarshalJSON satisfies [json.Unmarshaler].
@@ -1666,10 +1671,10 @@ func (t *IPAddressSpace) UnmarshalJSON(buf []byte) error {
 	s = strings.TrimSuffix(strings.TrimPrefix(s, `"`), `"`)
 
 	switch IPAddressSpace(s) {
+	case IPAddressSpaceLoopback:
+		*t = IPAddressSpaceLoopback
 	case IPAddressSpaceLocal:
 		*t = IPAddressSpaceLocal
-	case IPAddressSpacePrivate:
-		*t = IPAddressSpacePrivate
 	case IPAddressSpacePublic:
 		*t = IPAddressSpacePublic
 	case IPAddressSpaceUnknown:

--- a/vendor/github.com/chromedp/cdproto/overlay/types.go
+++ b/vendor/github.com/chromedp/cdproto/overlay/types.go
@@ -283,7 +283,6 @@ const (
 	InspectModeSearchForNode         InspectMode = "searchForNode"
 	InspectModeSearchForUAShadowDOM  InspectMode = "searchForUAShadowDOM"
 	InspectModeCaptureAreaScreenshot InspectMode = "captureAreaScreenshot"
-	InspectModeShowDistances         InspectMode = "showDistances"
 	InspectModeNone                  InspectMode = "none"
 )
 
@@ -299,8 +298,6 @@ func (t *InspectMode) UnmarshalJSON(buf []byte) error {
 		*t = InspectModeSearchForUAShadowDOM
 	case InspectModeCaptureAreaScreenshot:
 		*t = InspectModeCaptureAreaScreenshot
-	case InspectModeShowDistances:
-		*t = InspectModeShowDistances
 	case InspectModeNone:
 		*t = InspectModeNone
 	default:

--- a/vendor/github.com/chromedp/cdproto/page/events.go
+++ b/vendor/github.com/chromedp/cdproto/page/events.go
@@ -216,7 +216,7 @@ type EventWindowOpen struct {
 }
 
 // EventCompilationCacheProduced issued for every compilation cache
-// generated. Is only available if Page.setGenerateCompilationCache is enabled.
+// generated.
 //
 // See: https://chromedevtools.github.io/devtools-protocol/tot/Page#event-compilationCacheProduced
 type EventCompilationCacheProduced struct {

--- a/vendor/github.com/chromedp/cdproto/preload/types.go
+++ b/vendor/github.com/chromedp/cdproto/preload/types.go
@@ -45,8 +45,9 @@ func (t RuleSetErrorType) String() string {
 
 // RuleSetErrorType values.
 const (
-	RuleSetErrorTypeSourceIsNotJSONObject RuleSetErrorType = "SourceIsNotJsonObject"
-	RuleSetErrorTypeInvalidRulesSkipped   RuleSetErrorType = "InvalidRulesSkipped"
+	RuleSetErrorTypeSourceIsNotJSONObject  RuleSetErrorType = "SourceIsNotJsonObject"
+	RuleSetErrorTypeInvalidRulesSkipped    RuleSetErrorType = "InvalidRulesSkipped"
+	RuleSetErrorTypeInvalidRulesetLevelTag RuleSetErrorType = "InvalidRulesetLevelTag"
 )
 
 // UnmarshalJSON satisfies [json.Unmarshaler].
@@ -59,6 +60,8 @@ func (t *RuleSetErrorType) UnmarshalJSON(buf []byte) error {
 		*t = RuleSetErrorTypeSourceIsNotJSONObject
 	case RuleSetErrorTypeInvalidRulesSkipped:
 		*t = RuleSetErrorTypeInvalidRulesSkipped
+	case RuleSetErrorTypeInvalidRulesetLevelTag:
+		*t = RuleSetErrorTypeInvalidRulesetLevelTag
 	default:
 		return fmt.Errorf("unknown RuleSetErrorType value: %v", s)
 	}
@@ -191,7 +194,6 @@ const (
 	PrerenderFinalStatusInvalidSchemeRedirect                                      PrerenderFinalStatus = "InvalidSchemeRedirect"
 	PrerenderFinalStatusInvalidSchemeNavigation                                    PrerenderFinalStatus = "InvalidSchemeNavigation"
 	PrerenderFinalStatusNavigationRequestBlockedByCsp                              PrerenderFinalStatus = "NavigationRequestBlockedByCsp"
-	PrerenderFinalStatusMainFrameNavigation                                        PrerenderFinalStatus = "MainFrameNavigation"
 	PrerenderFinalStatusMojoBinderPolicy                                           PrerenderFinalStatus = "MojoBinderPolicy"
 	PrerenderFinalStatusRendererProcessCrashed                                     PrerenderFinalStatus = "RendererProcessCrashed"
 	PrerenderFinalStatusRendererProcessKilled                                      PrerenderFinalStatus = "RendererProcessKilled"
@@ -259,6 +261,7 @@ const (
 	PrerenderFinalStatusV8optimizerDisabled                                        PrerenderFinalStatus = "V8OptimizerDisabled"
 	PrerenderFinalStatusPrerenderFailedDuringPrefetch                              PrerenderFinalStatus = "PrerenderFailedDuringPrefetch"
 	PrerenderFinalStatusBrowsingDataRemoved                                        PrerenderFinalStatus = "BrowsingDataRemoved"
+	PrerenderFinalStatusPrerenderHostReused                                        PrerenderFinalStatus = "PrerenderHostReused"
 )
 
 // UnmarshalJSON satisfies [json.Unmarshaler].
@@ -279,8 +282,6 @@ func (t *PrerenderFinalStatus) UnmarshalJSON(buf []byte) error {
 		*t = PrerenderFinalStatusInvalidSchemeNavigation
 	case PrerenderFinalStatusNavigationRequestBlockedByCsp:
 		*t = PrerenderFinalStatusNavigationRequestBlockedByCsp
-	case PrerenderFinalStatusMainFrameNavigation:
-		*t = PrerenderFinalStatusMainFrameNavigation
 	case PrerenderFinalStatusMojoBinderPolicy:
 		*t = PrerenderFinalStatusMojoBinderPolicy
 	case PrerenderFinalStatusRendererProcessCrashed:
@@ -415,6 +416,8 @@ func (t *PrerenderFinalStatus) UnmarshalJSON(buf []byte) error {
 		*t = PrerenderFinalStatusPrerenderFailedDuringPrefetch
 	case PrerenderFinalStatusBrowsingDataRemoved:
 		*t = PrerenderFinalStatusBrowsingDataRemoved
+	case PrerenderFinalStatusPrerenderHostReused:
+		*t = PrerenderFinalStatusPrerenderHostReused
 	default:
 		return fmt.Errorf("unknown PrerenderFinalStatus value: %v", s)
 	}

--- a/vendor/github.com/chromedp/cdproto/pwa/pwa.go
+++ b/vendor/github.com/chromedp/cdproto/pwa/pwa.go
@@ -58,26 +58,38 @@ func (p *GetOsAppStateParams) Do(ctx context.Context) (badgeCount int64, fileHan
 }
 
 // InstallParams installs the given manifest identity, optionally using the
-// given install_url or IWA bundle location. TODO(crbug.com/337872319) Support
-// IWA to meet the following specific requirement. IWA-specific install
-// description: If the manifest_id is isolated-app://, install_url_or_bundle_url
-// is required, and can be either an http(s) URL or file:// URL pointing to a
-// signed web bundle (.swbn). The .swbn file's signing key must correspond to
-// manifest_id. If Chrome is not in IWA dev mode, the installation will fail,
-// regardless of the state of the allowlist.
+// given installUrlOrBundleUrl IWA-specific install description: manifestId
+// corresponds to isolated-app:// + web_package::SignedWebBundleId File
+// installation mode: The installUrlOrBundleUrl can be either file:// or
+// http(s):// pointing to a signed web bundle (.swbn). In this case
+// SignedWebBundleId must correspond to The .swbn file's signing key. Dev proxy
+// installation mode: installUrlOrBundleUrl must be http(s):// that serves dev
+// mode IWA. web_package::SignedWebBundleId must be of type dev proxy. The
+// advantage of dev proxy mode is that all changes to IWA automatically will be
+// reflected in the running app without reinstallation. To generate bundle id
+// for proxy mode: 1. Generate 32 random bytes. 2. Add a specific suffix 0x00 at
+// the end. 3. Encode the entire sequence using Base32 without padding. If
+// Chrome is not in IWA dev mode, the installation will fail, regardless of the
+// state of the allowlist.
 type InstallParams struct {
 	ManifestID            string `json:"manifestId"`
 	InstallURLOrBundleURL string `json:"installUrlOrBundleUrl,omitempty,omitzero"` // The location of the app or bundle overriding the one derived from the manifestId.
 }
 
 // Install installs the given manifest identity, optionally using the given
-// install_url or IWA bundle location. TODO(crbug.com/337872319) Support IWA to
-// meet the following specific requirement. IWA-specific install description: If
-// the manifest_id is isolated-app://, install_url_or_bundle_url is required,
-// and can be either an http(s) URL or file:// URL pointing to a signed web
-// bundle (.swbn). The .swbn file's signing key must correspond to manifest_id.
-// If Chrome is not in IWA dev mode, the installation will fail, regardless of
-// the state of the allowlist.
+// installUrlOrBundleUrl IWA-specific install description: manifestId
+// corresponds to isolated-app:// + web_package::SignedWebBundleId File
+// installation mode: The installUrlOrBundleUrl can be either file:// or
+// http(s):// pointing to a signed web bundle (.swbn). In this case
+// SignedWebBundleId must correspond to The .swbn file's signing key. Dev proxy
+// installation mode: installUrlOrBundleUrl must be http(s):// that serves dev
+// mode IWA. web_package::SignedWebBundleId must be of type dev proxy. The
+// advantage of dev proxy mode is that all changes to IWA automatically will be
+// reflected in the running app without reinstallation. To generate bundle id
+// for proxy mode: 1. Generate 32 random bytes. 2. Add a specific suffix 0x00 at
+// the end. 3. Encode the entire sequence using Base32 without padding. If
+// Chrome is not in IWA dev mode, the installation will fail, regardless of the
+// state of the allowlist.
 //
 // See: https://chromedevtools.github.io/devtools-protocol/tot/PWA#method-install
 //

--- a/vendor/github.com/chromedp/cdproto/serviceworker/serviceworker.go
+++ b/vendor/github.com/chromedp/cdproto/serviceworker/serviceworker.go
@@ -132,29 +132,6 @@ func (p *EnableParams) Do(ctx context.Context) (err error) {
 	return cdp.Execute(ctx, CommandEnable, nil, nil)
 }
 
-// InspectWorkerParams [no description].
-type InspectWorkerParams struct {
-	VersionID string `json:"versionId"`
-}
-
-// InspectWorker [no description].
-//
-// See: https://chromedevtools.github.io/devtools-protocol/tot/ServiceWorker#method-inspectWorker
-//
-// parameters:
-//
-//	versionID
-func InspectWorker(versionID string) *InspectWorkerParams {
-	return &InspectWorkerParams{
-		VersionID: versionID,
-	}
-}
-
-// Do executes ServiceWorker.inspectWorker against the provided context.
-func (p *InspectWorkerParams) Do(ctx context.Context) (err error) {
-	return cdp.Execute(ctx, CommandInspectWorker, p, nil)
-}
-
 // SetForceUpdateOnPageLoadParams [no description].
 type SetForceUpdateOnPageLoadParams struct {
 	ForceUpdateOnPageLoad bool `json:"forceUpdateOnPageLoad"`
@@ -315,7 +292,6 @@ const (
 	CommandDispatchSyncEvent         = "ServiceWorker.dispatchSyncEvent"
 	CommandDispatchPeriodicSyncEvent = "ServiceWorker.dispatchPeriodicSyncEvent"
 	CommandEnable                    = "ServiceWorker.enable"
-	CommandInspectWorker             = "ServiceWorker.inspectWorker"
 	CommandSetForceUpdateOnPageLoad  = "ServiceWorker.setForceUpdateOnPageLoad"
 	CommandSkipWaiting               = "ServiceWorker.skipWaiting"
 	CommandStartWorker               = "ServiceWorker.startWorker"

--- a/vendor/github.com/chromedp/cdproto/storage/events.go
+++ b/vendor/github.com/chromedp/cdproto/storage/events.go
@@ -5,6 +5,7 @@ package storage
 import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/cdproto/target"
 	"github.com/go-json-experiment/json/jsontext"
 )
 
@@ -102,6 +103,21 @@ type EventSharedStorageAccessed struct {
 	Params      *SharedStorageAccessParams `json:"params"`      // The sub-parameters wrapped by params are all optional and their presence/absence depends on type.
 }
 
+// EventSharedStorageWorkletOperationExecutionFinished a shared storage run
+// or selectURL operation finished its execution. The following parameters are
+// included in all events.
+//
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Storage#event-sharedStorageWorkletOperationExecutionFinished
+type EventSharedStorageWorkletOperationExecutionFinished struct {
+	FinishedTime    *cdp.TimeSinceEpoch       `json:"finishedTime"`    // Time that the operation finished.
+	ExecutionTime   int64                     `json:"executionTime"`   // Time, in microseconds, from start of shared storage JS API call until end of operation execution in the worklet.
+	Method          SharedStorageAccessMethod `json:"method"`          // Enum value indicating the Shared Storage API method invoked.
+	OperationID     string                    `json:"operationId"`     // ID of the operation call.
+	WorkletTargetID target.ID                 `json:"workletTargetId"` // Hex representation of the DevTools token used as the TargetID for the associated shared storage worklet.
+	MainFrameID     cdp.FrameID               `json:"mainFrameId"`     // DevTools Frame Token for the primary frame tree's root.
+	OwnerOrigin     string                    `json:"ownerOrigin"`     // Serialization of the origin owning the Shared Storage data.
+}
+
 // EventStorageBucketCreatedOrUpdated [no description].
 //
 // See: https://chromedevtools.github.io/devtools-protocol/tot/Storage#event-storageBucketCreatedOrUpdated
@@ -143,4 +159,15 @@ type EventAttributionReportingReportSent struct {
 	NetError       int64                            `json:"netError,omitempty,omitzero"` // If result is sent, populated with net/HTTP status.
 	NetErrorName   string                           `json:"netErrorName,omitempty,omitzero"`
 	HTTPStatusCode int64                            `json:"httpStatusCode,omitempty,omitzero"`
+}
+
+// EventAttributionReportingVerboseDebugReportSent [no description].
+//
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Storage#event-attributionReportingVerboseDebugReportSent
+type EventAttributionReportingVerboseDebugReportSent struct {
+	URL            string           `json:"url"`
+	Body           []jsontext.Value `json:"body,omitempty,omitzero"`
+	NetError       int64            `json:"netError,omitempty,omitzero"`
+	NetErrorName   string           `json:"netErrorName,omitempty,omitzero"`
+	HTTPStatusCode int64            `json:"httpStatusCode,omitempty,omitzero"`
 }

--- a/vendor/github.com/chromedp/cdproto/storage/types.go
+++ b/vendor/github.com/chromedp/cdproto/storage/types.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/target"
 )
 
 // SerializedStorageKey [no description].
@@ -409,6 +410,7 @@ type SharedStorageAccessParams struct {
 	ScriptSourceURL          string                                 `json:"scriptSourceUrl,omitempty,omitzero"`          // Spec of the module script URL. Present only for SharedStorageAccessMethods: addModule and createWorklet.
 	DataOrigin               string                                 `json:"dataOrigin,omitempty,omitzero"`               // String denoting "context-origin", "script-origin", or a custom origin to be used as the worklet's data origin. Present only for SharedStorageAccessMethod: createWorklet.
 	OperationName            string                                 `json:"operationName,omitempty,omitzero"`            // Name of the registered operation to be run. Present only for SharedStorageAccessMethods: run and selectURL.
+	OperationID              string                                 `json:"operationId,omitempty,omitzero"`              // ID of the operation call. Present only for SharedStorageAccessMethods: run and selectURL.
 	KeepAlive                bool                                   `json:"keepAlive"`                                   // Whether or not to keep the worket alive for future run or selectURL calls. Present only for SharedStorageAccessMethods: run and selectURL.
 	PrivateAggregationConfig *SharedStoragePrivateAggregationConfig `json:"privateAggregationConfig,omitempty,omitzero"` // Configures the private aggregation options. Present only for SharedStorageAccessMethods: run and selectURL.
 	SerializedData           string                                 `json:"serializedData,omitempty,omitzero"`           // The operation's serialized data in bytes (converted to a string). Present only for SharedStorageAccessMethods: run and selectURL. TODO(crbug.com/401011862): Consider updating this parameter to binary.
@@ -417,7 +419,8 @@ type SharedStorageAccessParams struct {
 	Key                      string                                 `json:"key,omitempty,omitzero"`                      // Key for a specific entry in an origin's shared storage. Present only for SharedStorageAccessMethods: set, append, delete, and get.
 	Value                    string                                 `json:"value,omitempty,omitzero"`                    // Value for a specific entry in an origin's shared storage. Present only for SharedStorageAccessMethods: set and append.
 	IgnoreIfPresent          bool                                   `json:"ignoreIfPresent"`                             // Whether or not to set an entry for a key if that key is already present. Present only for SharedStorageAccessMethod: set.
-	WorkletID                string                                 `json:"workletId,omitempty,omitzero"`                // If the method is called on a worklet, or as part of a worklet script, it will have an ID for the associated worklet. Present only for SharedStorageAccessMethods: addModule, createWorklet, run, selectURL, and any other SharedStorageAccessMethod when the SharedStorageAccessScope is worklet.
+	WorkletOrdinal           int64                                  `json:"workletOrdinal,omitempty,omitzero"`           // A number denoting the (0-based) order of the worklet's creation relative to all other shared storage worklets created by documents using the current storage partition. Present only for SharedStorageAccessMethods: addModule, createWorklet.
+	WorkletTargetID          target.ID                              `json:"workletTargetId,omitempty,omitzero"`          // Hex representation of the DevTools token used as the TargetID for the associated shared storage worklet. Present only for SharedStorageAccessMethods: addModule, createWorklet, run, selectURL, and any other SharedStorageAccessMethod when the SharedStorageAccessScope is sharedStorageWorklet.
 	WithLock                 string                                 `json:"withLock,omitempty,omitzero"`                 // Name of the lock to be acquired, if present. Optionally present only for SharedStorageAccessMethods: batchUpdate, set, append, delete, and clear.
 	BatchUpdateID            string                                 `json:"batchUpdateId,omitempty,omitzero"`            // If the method has been called as part of a batchUpdate, then this number identifies the batch to which it belongs. Optionally present only for SharedStorageAccessMethods: batchUpdate (required), set, append, delete, and clear.
 	BatchSize                int64                                  `json:"batchSize,omitempty,omitzero"`                // Number of modifier methods sent in batch. Present only for SharedStorageAccessMethod: batchUpdate.
@@ -577,14 +580,6 @@ type AttributionReportingEventReportWindows struct {
 	Ends  []int64 `json:"ends"`  // duration in seconds
 }
 
-// AttributionReportingTriggerSpec [no description].
-//
-// See: https://chromedevtools.github.io/devtools-protocol/tot/Storage#type-AttributionReportingTriggerSpec
-type AttributionReportingTriggerSpec struct {
-	TriggerData        []float64                               `json:"triggerData"` // number instead of integer because not all uint32 can be represented by int
-	EventReportWindows *AttributionReportingEventReportWindows `json:"eventReportWindows"`
-}
-
 // AttributionReportingTriggerDataMatching [no description].
 //
 // See: https://chromedevtools.github.io/devtools-protocol/tot/Storage#type-AttributionReportingTriggerDataMatching
@@ -658,8 +653,9 @@ type AttributionReportingNamedBudgetDef struct {
 // See: https://chromedevtools.github.io/devtools-protocol/tot/Storage#type-AttributionReportingSourceRegistration
 type AttributionReportingSourceRegistration struct {
 	Time                             *cdp.TimeSinceEpoch                                   `json:"time"`
-	Expiry                           int64                                                 `json:"expiry"` // duration in seconds
-	TriggerSpecs                     []*AttributionReportingTriggerSpec                    `json:"triggerSpecs"`
+	Expiry                           int64                                                 `json:"expiry"`      // duration in seconds
+	TriggerData                      []float64                                             `json:"triggerData"` // number instead of integer because not all uint32 can be represented by int
+	EventReportWindows               *AttributionReportingEventReportWindows               `json:"eventReportWindows"`
 	AggregatableReportWindow         int64                                                 `json:"aggregatableReportWindow"` // duration in seconds
 	Type                             AttributionReportingSourceType                        `json:"type"`
 	SourceOrigin                     string                                                `json:"sourceOrigin"`

--- a/vendor/github.com/chromedp/cdproto/target/target.go
+++ b/vendor/github.com/chromedp/cdproto/target/target.go
@@ -721,6 +721,45 @@ func (p *SetRemoteLocationsParams) Do(ctx context.Context) (err error) {
 	return cdp.Execute(ctx, CommandSetRemoteLocations, p, nil)
 }
 
+// OpenDevToolsParams opens a DevTools window for the target.
+type OpenDevToolsParams struct {
+	TargetID ID `json:"targetId"` // This can be the page or tab target ID.
+}
+
+// OpenDevTools opens a DevTools window for the target.
+//
+// See: https://chromedevtools.github.io/devtools-protocol/tot/Target#method-openDevTools
+//
+// parameters:
+//
+//	targetID - This can be the page or tab target ID.
+func OpenDevTools(targetID ID) *OpenDevToolsParams {
+	return &OpenDevToolsParams{
+		TargetID: targetID,
+	}
+}
+
+// OpenDevToolsReturns return values.
+type OpenDevToolsReturns struct {
+	TargetID ID `json:"targetId,omitempty,omitzero"` // The targetId of DevTools page target.
+}
+
+// Do executes Target.openDevTools against the provided context.
+//
+// returns:
+//
+//	targetID - The targetId of DevTools page target.
+func (p *OpenDevToolsParams) Do(ctx context.Context) (targetID ID, err error) {
+	// execute
+	var res OpenDevToolsReturns
+	err = cdp.Execute(ctx, CommandOpenDevTools, p, &res)
+	if err != nil {
+		return "", err
+	}
+
+	return res.TargetID, nil
+}
+
 // Command names.
 const (
 	CommandActivateTarget         = "Target.activateTarget"
@@ -739,4 +778,5 @@ const (
 	CommandAutoAttachRelated      = "Target.autoAttachRelated"
 	CommandSetDiscoverTargets     = "Target.setDiscoverTargets"
 	CommandSetRemoteLocations     = "Target.setRemoteLocations"
+	CommandOpenDevTools           = "Target.openDevTools"
 )

--- a/vendor/github.com/chromedp/cdproto/tracing/types.go
+++ b/vendor/github.com/chromedp/cdproto/tracing/types.go
@@ -17,7 +17,7 @@ type MemoryDumpConfig struct{}
 //
 // See: https://chromedevtools.github.io/devtools-protocol/tot/Tracing#type-TraceConfig
 type TraceConfig struct {
-	RecordMode           RecordMode        `json:"recordMode,omitempty,omitzero"`          // Controls how the trace buffer stores data.
+	RecordMode           RecordMode        `json:"recordMode,omitempty,omitzero"`          // Controls how the trace buffer stores data. The default is recordUntilFull.
 	TraceBufferSizeInKb  float64           `json:"traceBufferSizeInKb,omitempty,omitzero"` // Size of the trace buffer in kilobytes. If not specified or zero is passed, a default value of 200 MB would be used.
 	EnableSampling       bool              `json:"enableSampling"`                         // Turns on JavaScript stack sampling.
 	EnableSystrace       bool              `json:"enableSystrace"`                         // Turns on system tracing.
@@ -170,7 +170,8 @@ func (t *Backend) UnmarshalJSON(buf []byte) error {
 	return nil
 }
 
-// RecordMode controls how the trace buffer stores data.
+// RecordMode controls how the trace buffer stores data. The default is
+// recordUntilFull.
 //
 // See: https://chromedevtools.github.io/devtools-protocol/tot/Tracing#type-TraceConfig
 type RecordMode string

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,7 +47,7 @@ github.com/cenkalti/backoff/v5
 # github.com/cespare/xxhash/v2 v2.3.0
 ## explicit; go 1.11
 github.com/cespare/xxhash/v2
-# github.com/chromedp/cdproto v0.0.0-20250509201441-70372ae9ef75
+# github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d
 ## explicit; go 1.23
 github.com/chromedp/cdproto
 github.com/chromedp/cdproto/accessibility


### PR DESCRIPTION
## What?

Update cdproto and fix the one API call that is wrong

Change can be seen in https://github.com/chromedp/cdproto/compare/70372ae...d308e07
or 

<details>
  <summary>copilot summary</summary>
The changes between commits `70372ae` and `d308e07` in the `chromedp/cdproto` repository are extensive and span multiple files. Here is a summary of the key changes:

- **New Types and Protocol Updates:**  
  - Added new types such as `UnencodedDigestError`, `UnencodedDigestIssueDetails`, and updated various details for Audits, Accessibility, and Issue reporting to match changes in the Chrome DevTools Protocol.
  - Renamed and generalized accessibility-related types (e.g., from `SelectElementAccessibilityIssueReason` to `ElementAccessibilityIssueReason`).

- **New and Updated Commands/Events:**  
  - Added protocol commands and events, e.g., `Browser.setContentsSize`, `CSS.getEnvironmentVariables`, `DOM.forceShowPopover`, `Emulation.setEmulatedOSTextScale`, and others, with corresponding methods and parameters.
  - Added and updated enums and constants to match new protocol methods, events, and values.
  - Updated handling for new network resource types (e.g., `FedCM`), and new fields in existing types (e.g., `IsIPProtectionUsed` in network responses).

- **Type and Field Additions/Changes:**  
  - Extended many types with new fields to match protocol changes (e.g., `NavigateReturns` now includes `IsDownload`).
  - Refined and expanded enums, e.g., `IPAddressSpace` now includes `Loopback`.
  - Modified some types to use new or different field names or types to align with protocol changes.

- **Obsolete/Removed Types and Commands:**  
  - Removed obsolete types and commands (e.g., removed `ServiceWorker.inspectWorker`, `AutoResponseMode`, and `InspectModeShowDistances`).
  - Updated or replaced commands in favor of new protocol APIs (e.g., `GetAdScriptAncestry` now replaces `GetAdScriptAncestryIDs`).

- **Documentation and Comments:**  
  - Updated comments and documentation strings to match new protocol documentation and clarify usage.

**Files changed include but are not limited to:**
- `audits/types.go`
- `bluetoothemulation/events.go`
- `browser/browser.go`
- `browser/events.go`
- `cdp/types.go`
- `cdproto.go`
- `css/css.go`
- `css/types.go`
- `dom/dom.go`
- `dom/types.go`
- `emulation/emulation.go`
- `emulation/types.go`
- `network/types.go`
- `overlay/types.go`
- `page/events.go`
- `page/page.go`
- `page/types.go`
- `preload/types.go`
- `pwa/pwa.go`
- `serviceworker/serviceworker.go`
- `storage/events.go`
- `storage/types.go`
- `target/target.go`
- `tracing/types.go`

**General Theme:**  
This diff is a large protocol synchronization and refactor, updating the local Go types and protocol glue code to match new and changed features in Chrome DevTools Protocol, and cleaning up legacy or deprecated parts of the codebase.

If you need the diff for a specific file or a more detailed breakdown, let me know!
</details>




## Why?

Updating dependancy and not laggign too much behind so to not make it too hard.

Unfortunately renovate can not fix the small API breaking change that has been introduced.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
