### PR TITLE
Add `Page.waitForEvent` by refactoring page event handling

### DIFF
--- a/internal/js/modules/k6/browser/browser/console_message_mapping.go
+++ b/internal/js/modules/k6/browser/browser/console_message_mapping.go
@@ -5,7 +5,7 @@ import (
 )
 
 // mapConsoleMessage to the JS module.
-func mapConsoleMessage(vu moduleVU, event common.PageOnEvent) mapping {
+func mapConsoleMessage(vu moduleVU, event common.PageEvent) mapping {
 	cm := event.ConsoleMessage
 
 	return mapping{

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -196,7 +196,7 @@ func TestMappings(t *testing.T) {
 		"mapConsoleMessage": {
 			apiInterface: (*consoleMessageAPI)(nil),
 			mapp: func() mapping {
-				return mapConsoleMessage(moduleVU{VU: vu}, common.PageOnEvent{
+				return mapConsoleMessage(moduleVU{VU: vu}, common.PageEvent{
 					ConsoleMessage: &common.ConsoleMessage{},
 				})
 			},
@@ -204,7 +204,7 @@ func TestMappings(t *testing.T) {
 		"mapMetricEvent": {
 			apiInterface: (*metricEventAPI)(nil),
 			mapp: func() mapping {
-				return mapMetricEvent(moduleVU{VU: vu}, common.PageOnEvent{
+				return mapMetricEvent(moduleVU{VU: vu}, common.PageEvent{
 					Metric: &common.MetricEvent{},
 				})
 			},
@@ -348,7 +348,7 @@ type pageAPI interface { //nolint:interfacebloat
 	IsVisible(selector string, opts sobek.Value) (bool, error)
 	Locator(selector string, opts sobek.Value) *common.Locator
 	MainFrame() *common.Frame
-	On(event common.PageOnEventName, handler func(common.PageOnEvent) error) error
+	On(event common.PageEventName, handler func(common.PageEvent) error) error
 	Opener() pageAPI
 	Press(selector string, key string, opts sobek.Value) error
 	Query(selector string) (*common.ElementHandle, error)

--- a/internal/js/modules/k6/browser/browser/metric_event_mapping.go
+++ b/internal/js/modules/k6/browser/browser/metric_event_mapping.go
@@ -7,7 +7,7 @@ import (
 )
 
 // mapMetricEvent to the JS module.
-func mapMetricEvent(vu moduleVU, event common.PageOnEvent) mapping {
+func mapMetricEvent(vu moduleVU, event common.PageEvent) mapping {
 	rt := vu.Runtime()
 	em := event.Metric
 

--- a/internal/js/modules/k6/browser/browser/request_mapping.go
+++ b/internal/js/modules/k6/browser/browser/request_mapping.go
@@ -7,7 +7,7 @@ import (
 	"go.k6.io/k6/internal/js/modules/k6/browser/k6ext"
 )
 
-func mapRequestEvent(vu moduleVU, event common.PageOnEvent) mapping {
+func mapRequestEvent(vu moduleVU, event common.PageEvent) mapping {
 	r := event.Request
 
 	return mapRequest(vu, r)

--- a/internal/js/modules/k6/browser/browser/response_mapping.go
+++ b/internal/js/modules/k6/browser/browser/response_mapping.go
@@ -7,7 +7,7 @@ import (
 	"go.k6.io/k6/internal/js/modules/k6/browser/k6ext"
 )
 
-func mapResponseEvent(vu moduleVU, event common.PageOnEvent) mapping {
+func mapResponseEvent(vu moduleVU, event common.PageEvent) mapping {
 	return mapResponse(vu, event.Response)
 }
 

--- a/internal/js/modules/k6/browser/common/page_test.go
+++ b/internal/js/modules/k6/browser/common/page_test.go
@@ -36,27 +36,27 @@ func TestPageEventHandlersLifecycle(t *testing.T) {
 	t.Parallel()
 
 	p := &Page{
-		eventHandlers: make(map[PageOnEventName][]pageOnHandlerRecord),
+		eventHandlers: make(map[PageEventName][]pageEventHandlerRecord),
 	}
 
 	// Add some handlers to the page event handling system.
-	handler := func(PageOnEvent) error { return nil }
-	id1, err := p.addEventHandler(EventPageRequestCalled, handler)
+	handler := func(PageEvent) error { return nil }
+	id1, err := p.addEventHandler(PageEventRequest, handler)
 	assert.NoError(t, err)
-	id2, err := p.addEventHandler(EventPageRequestCalled, handler)
+	id2, err := p.addEventHandler(PageEventRequest, handler)
 	assert.NoError(t, err)
-	id3, err := p.addEventHandler(EventPageResponseCalled, handler)
+	id3, err := p.addEventHandler(PageEventResponse, handler)
 	assert.NoError(t, err)
 
 	// Check if the handlers are registered correctly.
-	assert.True(t, p.hasPageOnHandler(EventPageRequestCalled))
-	assert.True(t, p.hasPageOnHandler(EventPageResponseCalled))
-	assert.False(t, p.hasPageOnHandler(EventPageConsoleAPICalled))
+	assert.True(t, p.hasEventHandler(PageEventRequest))
+	assert.True(t, p.hasEventHandler(PageEventResponse))
+	assert.False(t, p.hasEventHandler(PageEventConsole))
 
 	// Remove the handlers and check if they are removed correctly.
-	p.removeEventHandler(EventPageRequestCalled, id1)
-	p.removeEventHandler(EventPageRequestCalled, id2)
-	assert.False(t, p.hasPageOnHandler(EventPageRequestCalled))
-	p.removeEventHandler(EventPageResponseCalled, id3)
-	assert.False(t, p.hasPageOnHandler(EventPageResponseCalled))
+	p.removeEventHandler(PageEventRequest, id1)
+	p.removeEventHandler(PageEventRequest, id2)
+	assert.False(t, p.hasEventHandler(PageEventRequest))
+	p.removeEventHandler(PageEventResponse, id3)
+	assert.False(t, p.hasEventHandler(PageEventResponse))
 }

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -1285,13 +1285,13 @@ func TestPageOn(t *testing.T) {
 			)
 
 			// Console Messages should be multiplexed for every registered handler
-			eventHandlerOne := func(event common.PageOnEvent) error {
+			eventHandlerOne := func(event common.PageEvent) error {
 				defer close(done1)
 				tc.assertFn(t, event.ConsoleMessage)
 				return nil
 			}
 
-			eventHandlerTwo := func(event common.PageOnEvent) error {
+			eventHandlerTwo := func(event common.PageEvent) error {
 				defer close(done2)
 				tc.assertFn(t, event.ConsoleMessage)
 				return nil

--- a/internal/js/modules/k6/browser/tests/remote_obj_test.go
+++ b/internal/js/modules/k6/browser/tests/remote_obj_test.go
@@ -80,7 +80,7 @@ func TestConsoleLogParse(t *testing.T) {
 
 			done := make(chan bool)
 
-			eventHandler := func(event common.PageOnEvent) error {
+			eventHandler := func(event common.PageEvent) error {
 				defer close(done)
 				assert.Equal(t, tt.want, event.ConsoleMessage.Text)
 				return nil


### PR DESCRIPTION
## What?

- Adds `Page.waitForEvent` for waiting until a `PageEvent` occurs.
- Enables `WaitForResponse` to use the existing `PageEvent` handling system.
- Removes duplicated page response event handling mechanics and a goroutine.
- Renames related page event handling types for consistency with the refactored code.

## Why?

- Improves the module's maintainability by using the existing event handling system.
- Unlocks future `WaitForX` methods, such as [`WaitForEvent`](https://github.com/grafana/k6/issues/4935).

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- #5310
- #5002 
- #4483
