### PR TITLE
Preload modules from `require` calls

### DIFF
--- a/internal/cmd/runtime_options.go
+++ b/internal/cmd/runtime_options.go
@@ -36,6 +36,9 @@ extended: base + sets "global" as alias for "globalThis"
 	if err := flags.MarkDeprecated("no-summary", "use --summary-mode=disabled instead"); err != nil {
 		panic(err) // Should never happen
 	}
+	// TODO(@mstoykov): remove by k6 v2.0, check if there is considerable usage
+	flags.Bool("experimental-require-preloading", false, "try to and load `require` calls during parsing, "+
+		"which then will make Auto Extension Resolution take `require` calls into account")
 	flags.String("summary-mode", summary.ModeCompact.String(), "determine the summary mode,"+
 		" \"compact\", \"full\" or \"disabled\"")
 	flags.String(
@@ -87,6 +90,8 @@ func runtimeOptionsFromFlags(flags *pflag.FlagSet) lib.RuntimeOptions {
 		SummaryExport:        getNullString(flags, "summary-export"),
 		TracesOutput:         getNullString(flags, "traces-output"),
 		Env:                  make(map[string]string),
+
+		ExperimentalRequirePreload: getNullBool(flags, "experimental-require-preloading"),
 	}
 	return opts
 }
@@ -116,6 +121,11 @@ func populateRuntimeOptionsFromEnv(opts lib.RuntimeOptions, environment map[stri
 	}
 
 	if err := saveBoolFromEnv(environment, "K6_NO_SUMMARY", &opts.NoSummary); err != nil {
+		return opts, err
+	}
+	if err := saveBoolFromEnv(
+		environment, "K6_EXPERIMENTAL_REQUIRE_PRELOADING", &opts.ExperimentalRequirePreload,
+	); err != nil {
 		return opts, err
 	}
 

--- a/internal/js/bundle.go
+++ b/internal/js/bundle.go
@@ -553,6 +553,8 @@ func generateFileLoad(logger logrus.FieldLogger, filesystems map[string]fsext.Fs
 func NewModuleResolver(pwd *url.URL, preInitState *lib.TestPreInitState, filesystems map[string]fsext.Fs,
 ) *modules.ModuleResolver {
 	c := newCompiler(preInitState, filesystems)
-	return modules.NewModuleResolver(
+	mr := modules.NewModuleResolver(
 		getJSModules(), generateFileLoad(preInitState.Logger, filesystems), c, pwd, preInitState.Usage, preInitState.Logger)
+	mr.SetExperimentalRequirePreload(preInitState.RuntimeOptions.ExperimentalRequirePreload.Bool)
+	return mr
 }

--- a/js/modules/cjsmodule.go
+++ b/js/modules/cjsmodule.go
@@ -121,7 +121,7 @@ func cjsModuleFromString(prg *ast.Program) (sobek.ModuleRecord, error) {
 	return newCjsModule(pgm), nil
 }
 
-// This is helper functiosn to find `require` calls and preload them
+//  findRequireFunctionInAST is helper function to find `require` calls and preload them
 func findRequireFunctionInAST(prg []ast.Statement) []string {
 	result := make([]string, 0)
 	for _, i := range prg {
@@ -144,7 +144,6 @@ func findRequireFunctionInStatement(i ast.Statement) []string { //nolint:cyclop,
 		*ast.ImportDeclaration,
 		*ast.BranchStatement:
 		// we do not have to do anything
-		// TODO the meaining ones below seem to require something to happen
 		return nil
 	case *ast.ExportDeclaration:
 		result := findRequireFunctionInExpression(t.AssignExpression)

--- a/js/modules/cjsmodule.go
+++ b/js/modules/cjsmodule.go
@@ -121,7 +121,7 @@ func cjsModuleFromString(prg *ast.Program) (sobek.ModuleRecord, error) {
 	return newCjsModule(pgm), nil
 }
 
-//  findRequireFunctionInAST is helper function to find `require` calls and preload them
+// findRequireFunctionInAST is helper function to find `require` calls and preload them
 func findRequireFunctionInAST(prg []ast.Statement) []string {
 	result := make([]string, 0)
 	for _, i := range prg {

--- a/js/modules/cjsmodule_test.go
+++ b/js/modules/cjsmodule_test.go
@@ -1,0 +1,53 @@
+package modules
+
+import (
+	"testing"
+
+	"github.com/grafana/sobek"
+	"github.com/grafana/sobek/parser"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireCalls(t *testing.T) {
+	t.Parallel()
+	ts := []struct {
+		script string
+		list   []string
+	}{
+		{
+			script: `require("something")`,
+			list:   []string{"something"},
+		},
+		{
+			script: `require("something"); require("else")`,
+			list:   []string{"something", "else"},
+		},
+		{
+			script: `function a() { require("something"); } require("else")`,
+			list:   []string{"something", "else"},
+		},
+		{
+			script: `export function a () { require("something"); } require("else")`,
+			list:   []string{"something", "else"},
+		},
+		{
+			script: `export const a = require("something");  require("else")`,
+			list:   []string{"something", "else"},
+		},
+		{
+			script: `var a = require("something");  require("else")`,
+			list:   []string{"something", "else"},
+		},
+	}
+
+	for _, test := range ts {
+		t.Run(test.script, func(t *testing.T) {
+			t.Parallel()
+			a, err := sobek.Parse("script", test.script, parser.IsModule)
+			require.NoError(t, err)
+
+			list := findRequireFunctionInAST(a.Body)
+			require.EqualValues(t, test.list, list)
+		})
+	}
+}

--- a/js/modules/resolution.go
+++ b/js/modules/resolution.go
@@ -125,12 +125,9 @@ func (mr *ModuleResolver) resolveLoaded(basePWD *url.URL, arg string, data []byt
 	} else {
 		mod, err = cjsModuleFromString(prg)
 	}
-	// TODO(@mstoykov): put this behind a flag
+	// TODO(@mstoykov): put the whole preloading behind a flag, maybe auto extension resolution one, or one dependent
 	if err != nil {
 		potentialRequireCalls := findRequireFunctionInAST(prg.Body)
-		if len(potentialRequireCalls) > 0 {
-				specifier, potentialRequireCalls)
-		}
 		for _, requireArg := range potentialRequireCalls {
 			_, requireErr := mr.resolve(basePWD, requireArg)
 			if requireErr != nil {

--- a/js/modules/resolution.go
+++ b/js/modules/resolution.go
@@ -125,6 +125,18 @@ func (mr *ModuleResolver) resolveLoaded(basePWD *url.URL, arg string, data []byt
 	} else {
 		mod, err = cjsModuleFromString(prg)
 	}
+	// TODO(@mstoykov): put this behind a flag
+	potentialRequireCalls := findRequireFunctionInAST(prg.Body)
+	if len(potentialRequireCalls) > 0 {
+		mr.logger.Debugf("will try to preload the potential `require` calls from within %q: %q",
+			specifier, potentialRequireCalls)
+	}
+	for _, requireArg := range potentialRequireCalls {
+		_, requireErr := mr.resolve(basePWD, requireArg)
+		if requireErr != nil {
+			mr.logger.WithError(requireErr).Debugf("error while preloading potential require call for %q", requireArg)
+		}
+	}
 	mr.reverse[mod] = specifier
 	mr.cache[specifier.String()] = moduleCacheElement{mod: mod, err: err}
 	return mod, err

--- a/js/modules/resolution.go
+++ b/js/modules/resolution.go
@@ -129,13 +129,12 @@ func (mr *ModuleResolver) resolveLoaded(basePWD *url.URL, arg string, data []byt
 	if err != nil {
 		potentialRequireCalls := findRequireFunctionInAST(prg.Body)
 		if len(potentialRequireCalls) > 0 {
-			mr.logger.Debugf("will try to preload the potential `require` calls from within %q: %q",
 				specifier, potentialRequireCalls)
 		}
 		for _, requireArg := range potentialRequireCalls {
 			_, requireErr := mr.resolve(basePWD, requireArg)
 			if requireErr != nil {
-				mr.logger.WithError(requireErr).Debugf("error while preloading potential require call for %q", requireArg)
+				mr.logger.WithError(requireErr).Debugf("failed preloading %q call for %q", "require", requireArg)
 			}
 			if err := mr.usage.Uint64("usage/requirePreload", 1); err != nil {
 				mr.logger.WithError(err).Warn("couldn't report require preloading usage for " + requireArg)

--- a/js/modules/resolution.go
+++ b/js/modules/resolution.go
@@ -126,7 +126,7 @@ func (mr *ModuleResolver) resolveLoaded(basePWD *url.URL, arg string, data []byt
 		mod, err = cjsModuleFromString(prg)
 	}
 	// TODO(@mstoykov): put the whole preloading behind a flag, maybe auto extension resolution one, or one dependent
-	if err != nil {
+	if err == nil {
 		potentialRequireCalls := findRequireFunctionInAST(prg.Body)
 		for _, requireArg := range potentialRequireCalls {
 			_, requireErr := mr.resolve(basePWD, requireArg)

--- a/js/modulestest/runtime.go
+++ b/js/modulestest/runtime.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/sobek"
 	"github.com/stretchr/testify/require"
+
 	"go.k6.io/k6/internal/js/compiler"
 	"go.k6.io/k6/internal/js/eventloop"
 	"go.k6.io/k6/internal/js/tc55/timers"
@@ -79,6 +80,7 @@ func (r *Runtime) SetupModuleSystem(goModules map[string]any, loader modules.Fil
 
 	r.mr = modules.NewModuleResolver(
 		goModules, loader, c, r.VU.InitEnvField.CWD, r.VU.InitEnvField.Usage, r.VU.InitEnvField.Logger)
+	r.mr.SetExperimentalRequirePreload(r.VU.InitEnvField.RuntimeOptions.ExperimentalRequirePreload.Bool)
 	return r.innerSetupModuleSystem()
 }
 

--- a/lib/runtime_options.go
+++ b/lib/runtime_options.go
@@ -45,6 +45,9 @@ type RuntimeOptions struct {
 	SummaryExport null.String `json:"summaryExport"`
 	KeyWriter     null.String `json:"-"`
 	TracesOutput  null.String `json:"tracesOutput"`
+
+	// Temporarily
+	ExperimentalRequirePreload null.Bool `json:"experimentalRequirePreload"`
 }
 
 // ValidateCompatibilityMode checks if the provided val is a valid compatibility mode


### PR DESCRIPTION

## What?

Now when a loaded js module has a `require` function call its arguTo be disabment (if string) will be loaded as a module and we will repeat the process.

This should load all modules, and more importantly will help with finding if any missing modules can not be loaded.

This is very likely not a good idea in general, but is what esbuild is doing currently if auto extension resolution is enabled. So this is copying this behaviour.

It is likely that this will be disabled in the future (v2) and might need or not need additional testing.


## Why?

This is what currently happens in esbuild+k6deps dependancy analysis so this just copies it

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
https://github.com/grafana/k6/pull/5320 combines this and #5240  to reimplement auto extension resolution without esbuild and k6deps.
Issue/discussion for stopping this in v2 #5325 