### PR TITLE
usage: report calls to require only on first load

### DIFF
--- a/js/modules/require_impl.go
+++ b/js/modules/require_impl.go
@@ -13,8 +13,10 @@ import (
 
 // Require is the actual call that implements require
 func (ms *ModuleSystem) Require(specifier string) (*sobek.Object, error) {
-	if err := ms.resolver.usage.Uint64("usage/require", 1); err != nil {
-		ms.resolver.logger.WithError(err).Warn("couldn't report usage")
+	if !ms.resolver.locked {
+		if err := ms.resolver.usage.Uint64("usage/require", 1); err != nil {
+			ms.resolver.logger.WithError(err).Warn("couldn't report usage")
+		}
 	}
 
 	if specifier == "" {


### PR DESCRIPTION
## What?

Only report `require` calls during the initial loading of modules, instead for each call in all execution of all VUs

## Why?
We really want to know how much this used in the scripts, not the number of require multipled by the VUs. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
