### PR TITLE
browser: Fix `TestNavigationSpanCreation`

### DIFF
--- a/internal/js/modules/k6/browser/tests/tracing_test.go
+++ b/internal/js/modules/k6/browser/tests/tracing_test.go
@@ -263,7 +263,13 @@ func TestNavigationSpanCreation(t *testing.T) {
 				await Promise.all([
 					page.waitForNavigation(),
 					page.evaluate(() => window.history.back()),
-				]);
+				]).catch(e => {
+					// only throw exception if it's not related to navigational
+					// race condition, which can happen in slow machines.
+					if (!e.toString().includes('Inspected target navigated or closed')) {
+						throw e;
+					}
+				});
 				page.close();
 				`, ts.URL),
 			expected: []string{


### PR DESCRIPTION
## What?

Fixes `TestNavigationSpanCreation`

## Why?

Without this, most [CI jobs fail](https://github.com/grafana/k6/actions?query=is%3Afailure+branch%3Arefactor%2Fbrowser-taskqueue) all the time.

This error is a navigational issue that occurs when the code (i.e., `window.history.back`) executes on Chrome, causing the page to navigate back before the CDP command (`eval`) completes, resulting in unnecessary noise. That's not a real error, but rather a sentinel message, similar to Go's `io.EOF`. It's expected and should be handled that way, as Chrome [runs the code but terminates the CDP command](https://source.chromium.org/chromium/chromium/src/+/001ceaaaa92cf3dbfa573fb40c3a682e0dc72fd7) due to cross-navigation.

This error previously occurred on CI, but it has become more apparent now due to our involved browser tests.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_

<!-- - [ ] Any other relevant item -->