### PR TITLE
Remove redundant GitHub Actions rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,12 +10,6 @@
   "prConcurrentLimit": 50,
   "packageRules": [
     {
-      "description": "GitHub Actions",
-      "matchManagers": [
-        "github-actions"
-      ]
-    },
-    {
       "description": "Enable gomod updates with common options",
       "matchManagers": [
         "gomod"


### PR DESCRIPTION
Removed GitHub Actions package rule from renovate.json

## What?

<!-- A short (or detailed) description of what this PR does. -->

Drop the useless rule.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

It already part of the base config.