### PR TITLE
Renovate: extends base config and stop updating go.mod toolchain

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json",
     "schedule:weekly"
   ],
   "ignorePaths": [
@@ -33,16 +34,6 @@
       "enabled": false
     },
     {
-      "description": "Update Go versions only when a patch version exists (z > 0 in v1.x.z)",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "go"
-      ],
-      "allowedVersions": "/^(?:v)?\\d+\\.\\d+\\.[1-9]\\d*$/"
-    },
-    {
       "groupName": "golangx",
       "description": "Group golang.org/x modules",
       "matchManagers": [
@@ -60,16 +51,6 @@
       ],
       "matchPackageNames": [
         "/^google\\.golang\\.org//"
-      ]
-    },
-    {
-      "groupName": "otel",
-      "description": "Group OpenTelemetry modules",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchPackageNames": [
-        "/^go\\.opentelemetry\\.io//"
       ]
     },
     {


### PR DESCRIPTION
## What?

This PR extends Renovate base config added here: https://github.com/grafana/grafana-renovate-config/blob/main/presets/k6/k6-engine-base.json
- Rules about Go version and grouping OpenTelemetry modules were removed as they are present in the base config
- This will add one rule about not updating the go.mod toolchain directive (see discussion on [this PR](https://github.com/grafana/k6-cloud-scripts-to-archive/pull/118))

## Why?

Rules in the base config are also used by other k6 Cloud services we own so it allows to not duplicate them. 

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
