### PR TITLE
Add FID deprecation warn on web vital measure

### DIFF
--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -350,7 +350,10 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 
 	if wv.Name == "FID" {
 		fidDeprecationWarningOnce.Do(func() {
-			fs.logger.Warnf("MetricDeprecation", "browser_web_vital_fid has been deprecated and superseded by browser_web_vital_inp")
+			fs.logger.Warnf(
+				"MetricDeprecation",
+				"browser_web_vital_fid has been deprecated and superseded by browser_web_vital_inp",
+			)
 		})
 	}
 


### PR DESCRIPTION
## What?

When the FID metric is measured, a warning will be logged to let users know to move away from working with `browser_web_vital_fid` and instead use `browser_web_vital_inp`.

## Why?

FID has been deprecated -- ttps://web.dev/blog/fid.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
https://github.com/grafana/k6/issues/5179