### PR TITLE
Unblock the release workflow pkg publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -597,6 +597,9 @@ jobs:
           echo "${PGP_SIGN_KEY}" > packaging/sign-key.gpg
       - name: Login to GitHub Container Registry
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           registry: ghcr.io
           username: ${{ env.GITHUB_ACTOR }}


### PR DESCRIPTION
## What?

Fixes [the authentication error](https://github.com/grafana/k6/actions/runs/19551264332/job/55984329737) in `publish-packages` when logging.

## Why?

`publish-packages` fails with `"Username and password required"` when attempting to log in. This issue happens because the step tries to use `${{ env.GITHUB_ACTOR }}` and `${{ env.GITHUB_TOKEN }}` environment variables that are never set.

So, we've added the missing `env:` block to the `"Login to GitHub Container Registry"` step to correctly set the environment variables before using them. This matches the pattern already used successfully in `build-docker`.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_