### PR TITLE
Fix loading files with spaces - fixes #5437

### DIFF
--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -243,20 +243,25 @@ func analyseUseContraints(imports []string, fileSystems map[string]fsext.Fs, dep
 		}
 		u, err := url.Parse(imported)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		// We always have URLs here with scheme and everything
 		_, path, _ := strings.Cut(imported, "://")
 		if u.Scheme == "https" {
 			path = "/" + path
 		}
+		path, err = url.PathUnescape(filepath.FromSlash(path))
+		if err != nil {
+			return err
+		}
+
 		data, err := fsext.ReadFile(fileSystems[u.Scheme], path)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		err = processUseDirectives(imported, data, deps)
 		if err != nil {
-			panic(err)
+			return err
 		}
 	}
 	return nil

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -3170,3 +3170,32 @@ func TestMachineReadableSummary(t *testing.T) {
 		assertSummaryExport(t, string(summaryExport))
 	})
 }
+
+func TestSpaceInPath(t *testing.T) {
+	t.Parallel()
+	depScript := `
+		export default function() {
+			let p = 42;
+			return p;
+		}
+	`
+	mainScript := `
+		import bar from "./foo bar.js";
+		let s = "something";
+		export default function() {
+			console.log(s, bar());
+		};
+	`
+
+	ts := NewGlobalTestState(t)
+	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test me.js"), []byte(mainScript), 0o644))
+	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "foo bar.js"), []byte(depScript), 0o644))
+
+	ts.CmdArgs = []string{"k6", "run", "--quiet", "test me.js"}
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stderr := ts.Stderr.String()
+	t.Log(stderr)
+	assert.Contains(t, stderr, `something 42`)
+}


### PR DESCRIPTION
## What?

Fixes test that have spaces in their path

## Why?

This should be working, and I am extremely suprised that we do not have a test and it took over a week to get caught. 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
