### PR TITLE
Browser: Don't panic on nil `page.on` handlers

### DIFF
--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -680,6 +680,10 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 // It provides a generic way to map different event types to their respective handler functions.
 func mapPageOn(vu moduleVU, p *common.Page) func(common.PageEventName, sobek.Callable) error {
 	return func(eventName common.PageEventName, handle sobek.Callable) error {
+		if handle == nil {
+			panic(vu.Runtime().NewTypeError(`The "listener" argument must be a function`))
+		}
+
 		pageEvents := map[common.PageEventName]struct {
 			mapp func(vu moduleVU, event common.PageEvent) mapping
 			wait bool // Whether to wait for the handler to complete.

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1327,6 +1327,10 @@ type PageEvent struct {
 // passing in the ConsoleMessage associated with the event.
 // The only accepted event value is 'console'.
 func (p *Page) On(event PageEventName, handler PageEventHandler) error {
+	if handler == nil {
+		return errors.New(`"handler" argument cannot be nil`)
+	}
+
 	_, err := p.addEventHandler(event, handler)
 	return err
 }

--- a/internal/js/modules/k6/browser/common/page_test.go
+++ b/internal/js/modules/k6/browser/common/page_test.go
@@ -139,3 +139,30 @@ func TestPageEventHandlerIterator(t *testing.T) {
 		}
 	})
 }
+
+func TestPageOn(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil handler", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Page{}
+
+		err := p.On("metric", nil)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, `"handler" argument cannot be nil`)
+	})
+
+	t.Run("valid handler", func(t *testing.T) {
+		t.Parallel()
+
+		p := &Page{
+			eventHandlers: make(map[PageEventName][]pageEventHandlerRecord),
+		}
+		handler := func(PageEvent) error { return nil }
+
+		err := p.On("metric", handler)
+		assert.NoError(t, err)
+		assert.Len(t, p.eventHandlers[("metric")], 1)
+	})
+}


### PR DESCRIPTION
## What?

It handles `nil` `page.on` handlers at both layers:
- JS
- Go API 

## Why?

Because now it makes k6 to panic.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
