### PR TITLE
Add ExecutionStatusMarkedAsFailed

### DIFF
--- a/lib/execution.go
+++ b/lib/execution.go
@@ -47,6 +47,7 @@ const (
 	ExecutionStatusTeardown
 	ExecutionStatusEnded
 	ExecutionStatusInterrupted
+	ExecutionStatusMarkedAsFailed
 )
 
 // ExecutionState contains a few different things:

--- a/lib/execution_status_gen.go
+++ b/lib/execution_status_gen.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 )
 
-const _ExecutionStatusName = "CreatedInitVUsInitExecutorsInitDonePausedBeforeRunStartedSetupRunningTeardownEndedInterrupted"
+const _ExecutionStatusName = "CreatedInitVUsInitExecutorsInitDonePausedBeforeRunStartedSetupRunningTeardownEndedInterruptedMarkedAsFailed"
 
-var _ExecutionStatusIndex = [...]uint8{0, 7, 14, 27, 35, 50, 57, 62, 69, 77, 82, 93}
+var _ExecutionStatusIndex = [...]uint8{0, 7, 14, 27, 35, 50, 57, 62, 69, 77, 82, 93, 107}
 
 func (i ExecutionStatus) String() string {
 	if i >= ExecutionStatus(len(_ExecutionStatusIndex)-1) {
@@ -17,20 +17,21 @@ func (i ExecutionStatus) String() string {
 	return _ExecutionStatusName[_ExecutionStatusIndex[i]:_ExecutionStatusIndex[i+1]]
 }
 
-var _ExecutionStatusValues = []ExecutionStatus{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+var _ExecutionStatusValues = []ExecutionStatus{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}
 
 var _ExecutionStatusNameToValueMap = map[string]ExecutionStatus{
-	_ExecutionStatusName[0:7]:   0,
-	_ExecutionStatusName[7:14]:  1,
-	_ExecutionStatusName[14:27]: 2,
-	_ExecutionStatusName[27:35]: 3,
-	_ExecutionStatusName[35:50]: 4,
-	_ExecutionStatusName[50:57]: 5,
-	_ExecutionStatusName[57:62]: 6,
-	_ExecutionStatusName[62:69]: 7,
-	_ExecutionStatusName[69:77]: 8,
-	_ExecutionStatusName[77:82]: 9,
-	_ExecutionStatusName[82:93]: 10,
+	_ExecutionStatusName[0:7]:    0,
+	_ExecutionStatusName[7:14]:   1,
+	_ExecutionStatusName[14:27]:  2,
+	_ExecutionStatusName[27:35]:  3,
+	_ExecutionStatusName[35:50]:  4,
+	_ExecutionStatusName[50:57]:  5,
+	_ExecutionStatusName[57:62]:  6,
+	_ExecutionStatusName[62:69]:  7,
+	_ExecutionStatusName[69:77]:  8,
+	_ExecutionStatusName[77:82]:  9,
+	_ExecutionStatusName[82:93]:  10,
+	_ExecutionStatusName[93:107]: 11,
 }
 
 // ExecutionStatusString retrieves an enum value from the enum constants string name.


### PR DESCRIPTION
## What?

This PR adds a new status to mark the end of a test: ExecutionStatusMarkedAsFailed that should be set when `execution.test.fail()` is called in the test. This is only creating the status so we can use it in the test-coordinator (see [PR](https://github.com/grafana/k6-cloud-testcoordinator/pull/373))

Then, we'll be able to use it in [another PR](https://github.com/grafana/k6/pull/5423) but this PR requires the changes in the test-coordinator to be merged and deployed first so it knows how to handle this new status. 

## Why?

This will allow to return a better status in the Cloud. For now, the associated [k6-cloud-testcoordinator PR](https://github.com/grafana/k6-cloud-testcoordinator/pull/373) uses this to return `cloudapi.RunStatusAbortedUser` (as if the test was interrupted with `abort`) but we could work with the cloud team next to introduce a new status.

Note, that an alternative to this if we only want to focus on the short-term solution would be to use `ExecutionStatusInterrupted` instead. Then, we wouldn't need the PR in k6-cloud-testcoordinator to return `cloudapi.RunStatusAbortedUser` (as it's already the case when `ExecutionStatusInterrupted` is received).

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Part of https://github.com/grafana/k6-cloud/issues/4022
