### PR TITLE
Define error types in Go that convert to proper JS errors 

### DIFF
--- a/internal/js/modules/k6/experimental/fs/errors.go
+++ b/internal/js/modules/k6/experimental/fs/errors.go
@@ -2,13 +2,26 @@ package fs
 
 import "go.k6.io/k6/js/common"
 
+const fsErrorConstructorName = "FSError"
+
+// fsError represents a custom error object emitted by the fs module.
+type fsError struct {
+	*common.JSError
+
+	// kind contains the kind of error that has occurred.
+	kind errorKind
+}
+
 // newFsError creates a new Error object of the provided kind and with the
 // provided message.
 func newFsError(k errorKind, message string) *fsError {
 	return &fsError{
-		Name:    k.String(),
-		Message: message,
-		kind:    k,
+		JSError: common.NewJSError(common.JSErrorConfig{
+			Constructor: fsErrorConstructorName,
+			Name:        k.String(),
+			Message:     message,
+		}),
+		kind: k,
 	}
 }
 
@@ -40,29 +53,6 @@ const (
 	// EOFError is emitted when the end of a file has been reached.
 	EOFError
 )
-
-// fsError represents a custom error object emitted by the fs module.
-//
-// It is used to provide a more detailed error message to the user, and
-// provide a concrete error type that can be used to differentiate between
-// different types of errors.
-//
-// Exposing error types to the user in a way that's compatible with some
-// JavaScript error handling constructs such as `instanceof` is still non-trivial
-// in Go. See the [dedicated goja issue] with have opened for more details.
-//
-// [dedicated goja issue]: https://github.com/dop251/goja/issues/529
-type fsError struct {
-	// Name contains the name of the error as formalized by the [ErrorKind]
-	// type.
-	Name string `json:"name"`
-
-	// Message contains the error message as presented to the user.
-	Message string `json:"message"`
-
-	// kind contains the kind of error that has occurred.
-	kind errorKind
-}
 
 // Ensure that the Error type implements the Go `error` interface.
 var (

--- a/internal/js/modules/k6/experimental/fs/errors.go
+++ b/internal/js/modules/k6/experimental/fs/errors.go
@@ -1,5 +1,7 @@
 package fs
 
+import "go.k6.io/k6/js/common"
+
 // newFsError creates a new Error object of the provided kind and with the
 // provided message.
 func newFsError(k errorKind, message string) *fsError {
@@ -63,9 +65,7 @@ type fsError struct {
 }
 
 // Ensure that the Error type implements the Go `error` interface.
-var _ error = (*fsError)(nil)
-
-// Error implements the Go `error` interface.
-func (e *fsError) Error() string {
-	return e.Name + ": " + e.Message
-}
+var (
+	_ error              = (*fsError)(nil)
+	_ common.JSException = (*fsError)(nil)
+)

--- a/js/common/js_error_constructor.go
+++ b/js/common/js_error_constructor.go
@@ -1,0 +1,199 @@
+package common
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/grafana/sobek"
+)
+
+// JSErrorConfig describes a JS-visible error type.
+type JSErrorConfig struct {
+	// Constructor is the name of the constructor function exposed to JS (required).
+	Constructor string
+	// Name is assigned to the error's `name` property.
+	Name string
+	// Message is the error message.
+	Message string
+	// Properties contains additional properties to copy onto the JS error object.
+	Properties map[string]interface{}
+	// Decorator runs after the error has been instantiated, allowing callers to
+	// set additional state or computed properties.
+	Decorator func(rt *sobek.Runtime, obj *sobek.Object)
+}
+
+// JSError implements both error and JSException and can be embedded into custom error structs.
+type JSError struct {
+	constructor string
+	name        string
+	message     string
+	properties  map[string]interface{}
+	decorator   func(rt *sobek.Runtime, obj *sobek.Object)
+}
+
+// ExportNamedError returns a function suitable for use in module exports. It returns
+// a constructor proxy bound to the caller's runtime.
+func ExportNamedError(name string) func(rt *sobek.Runtime) sobek.Value {
+	return func(rt *sobek.Runtime) sobek.Value {
+		return ExportErrorConstructor(rt, name)
+	}
+}
+
+// NewJSError returns a new JS-aware error helper.
+func NewJSError(cfg JSErrorConfig) *JSError {
+	if cfg.Constructor == "" {
+		panic("common.NewJSError: Constructor is required")
+	}
+
+	return &JSError{
+		constructor: cfg.Constructor,
+		name:        cfg.Name,
+		message:     cfg.Message,
+		properties:  cfg.Properties,
+		decorator:   cfg.Decorator,
+	}
+}
+
+// Error satisfies the Go error interface.
+func (e *JSError) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	switch {
+	case e.name == "" && e.message == "":
+		return e.constructor
+	case e.name == "":
+		return e.message
+	case e.message == "":
+		return e.name
+	default:
+		return e.name + ": " + e.message
+	}
+}
+
+// JSValue materializes the error as a JS Error instance.
+func (e *JSError) JSValue(rt *sobek.Runtime) sobek.Value {
+	if e == nil {
+		return sobek.Null()
+	}
+
+	ctor, err := EnsureErrorConstructor(rt, e.constructor)
+	if err != nil {
+		panic(err)
+	}
+
+	jsConstructor, ok := sobek.AssertConstructor(ctor)
+	if !ok {
+		panic(rt.NewGoError(fmt.Errorf("%s constructor is not callable", e.constructor)))
+	}
+
+	obj, err := jsConstructor(nil, rt.ToValue(e.message))
+	if err != nil {
+		panic(err)
+	}
+
+	if e.name != "" {
+		if setErr := obj.Set("name", e.name); setErr != nil {
+			panic(setErr)
+		}
+	}
+
+	for key, value := range e.properties {
+		if setErr := obj.Set(key, value); setErr != nil {
+			panic(setErr)
+		}
+	}
+
+	if e.decorator != nil {
+		e.decorator(rt, obj)
+	}
+
+	return obj
+}
+
+var (
+	_ error       = (*JSError)(nil)
+	_ JSException = (*JSError)(nil)
+)
+
+// EnsureErrorConstructor ensures a named Error subclass exists in the runtime and
+// returns the constructor function. The constructor is stored on the global object
+// so user scripts can import it and perform instanceof checks.
+func EnsureErrorConstructor(rt *sobek.Runtime, name string) (*sobek.Object, error) {
+	if name == "" {
+		name = "Error"
+	}
+
+	if val := rt.GlobalObject().Get(name); val != nil && !sobek.IsUndefined(val) {
+		if obj, ok := val.(*sobek.Object); ok {
+			return obj, nil
+		}
+	}
+
+	script := fmt.Sprintf(`(function(name) {
+		if (typeof globalThis[name] === "function") {
+			return globalThis[name];
+		}
+
+		const ctor = class extends Error {
+			constructor(message) {
+				super(message);
+				this.name = name;
+			}
+		};
+
+		Object.defineProperty(ctor, "name", { value: name, configurable: true });
+		globalThis[name] = ctor;
+		return ctor;
+	})(%s);`, strconv.Quote(name))
+
+	value, err := rt.RunString(script)
+	if err != nil {
+		return nil, err
+	}
+
+	return value.ToObject(rt), nil
+}
+
+// ExportErrorConstructor returns a proxy constructor suitable for module exports that
+// always delegates to the runtime-local Error constructor, keeping instanceof checks working.
+//
+// Note: We intentionally don't cache proxies because runtimes are short-lived per-VU,
+// and caching would cause memory leaks by preventing runtime garbage collection.
+func ExportErrorConstructor(rt *sobek.Runtime, name string) sobek.Value {
+	// Make sure the constructor exists so the proxy can reference it.
+	if _, err := EnsureErrorConstructor(rt, name); err != nil {
+		panic(err)
+	}
+
+	script := fmt.Sprintf(`(function(name) {
+		const getCtor = () => globalThis[name];
+		return new Proxy(function () {}, {
+			construct(_target, args, newTarget) {
+				return Reflect.construct(getCtor(), args, newTarget);
+			},
+			apply(_target, thisArg, args) {
+				return Reflect.apply(getCtor(), thisArg, args);
+			},
+			get(_target, prop, receiver) {
+				if (prop === Symbol.hasInstance) {
+					return function (value) {
+						return value instanceof getCtor();
+					};
+				}
+				return Reflect.get(getCtor(), prop, receiver);
+			},
+			set(_target, prop, value, receiver) {
+				return Reflect.set(getCtor(), prop, value, receiver);
+			}
+		});
+	})(%s);`, strconv.Quote(name))
+
+	proxy, err := rt.RunString(script)
+	if err != nil {
+		panic(err)
+	}
+
+	return proxy
+}

--- a/js/common/js_error_constructor_test.go
+++ b/js/common/js_error_constructor_test.go
@@ -1,0 +1,248 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/grafana/sobek"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnsureErrorConstructor(t *testing.T) {
+	t.Parallel()
+
+	rt := sobek.New()
+	ctor, err := EnsureErrorConstructor(rt, "FooError")
+	require.NoError(t, err)
+	require.NotNil(t, ctor)
+
+	constructor, ok := sobek.AssertConstructor(ctor)
+	require.True(t, ok, "FooError constructor not callable")
+
+	instance, err := constructor(nil, rt.ToValue("boom"))
+	require.NoError(t, err)
+
+	require.Equal(t, "FooError", instance.Get("name").Export())
+	require.Equal(t, "boom", instance.Get("message").Export())
+
+	glob := rt.GlobalObject().Get("FooError")
+	require.Same(t, ctor, glob)
+}
+
+func TestJSError(t *testing.T) {
+	t.Parallel()
+
+	rt := sobek.New()
+	jsErr := NewJSError(JSErrorConfig{
+		Constructor: "FooError",
+		Name:        "Foo",
+		Message:     "boom",
+		Properties: map[string]interface{}{
+			"code": "E_FAIL",
+		},
+	})
+
+	require.Equal(t, "Foo: boom", jsErr.Error())
+
+	value := jsErr.JSValue(rt).ToObject(rt)
+	require.Equal(t, "Foo", value.Get("name").String())
+	require.Equal(t, "boom", value.Get("message").String())
+	require.Equal(t, "E_FAIL", value.Get("code").String())
+
+	_, err := rt.RunString(`
+		const err = new FooError("message");
+		if (!(err instanceof FooError)) {
+			throw new Error("instanceof failed");
+		}
+	`)
+	require.NoError(t, err)
+}
+
+func TestExportErrorConstructor(t *testing.T) {
+	t.Parallel()
+
+	rt := sobek.New()
+	exported := ExportErrorConstructor(rt, "FooError")
+	require.NotNil(t, exported)
+
+	require.NoError(t, rt.Set("FooErrorProxy", exported))
+
+	_, err := rt.RunString(`
+		const err = new FooErrorProxy("boom");
+		if (!(err instanceof FooErrorProxy)) {
+			throw new Error("proxy constructor mismatch");
+		}
+		if (!(err instanceof FooError)) {
+			throw new Error("instanceof FooError failed");
+		}
+	`)
+	require.NoError(t, err)
+}
+
+func TestExportNamedError(t *testing.T) {
+	t.Parallel()
+
+	rt := sobek.New()
+	exportFn := ExportNamedError("FooError")
+	proxy := exportFn(rt)
+	require.NotNil(t, proxy)
+
+	require.NoError(t, rt.Set("FooNamedError", proxy))
+
+	_, err := rt.RunString(`
+		const err = new FooNamedError("boom");
+		if (!(err instanceof FooNamedError)) {
+			throw new Error("proxy constructor mismatch");
+		}
+		if (!(err instanceof FooError)) {
+			throw new Error("instanceof FooError failed");
+		}
+	`)
+	require.NoError(t, err)
+}
+
+func TestJSErrorNilHandling(t *testing.T) {
+	t.Parallel()
+
+	rt := sobek.New()
+
+	var nilErr *JSError
+	require.Equal(t, "", nilErr.Error())
+	require.True(t, sobek.IsNull(nilErr.JSValue(rt)))
+}
+
+func TestJSErrorInstanceofBaseError(t *testing.T) {
+	t.Parallel()
+
+	rt := sobek.New()
+	jsErr := NewJSError(JSErrorConfig{
+		Constructor: "CustomError",
+		Message:     "test message",
+	})
+
+	_ = jsErr.JSValue(rt)
+
+	_, err := rt.RunString(`
+		const e = new CustomError("msg");
+		if (!(e instanceof Error)) {
+			throw new Error("custom error should be instanceof Error");
+		}
+		if (!(e instanceof CustomError)) {
+			throw new Error("should be instanceof CustomError");
+		}
+	`)
+	require.NoError(t, err)
+}
+
+func TestJSErrorMessageWithSpecialCharacters(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		message string
+	}{
+		{"newlines", "line1\nline2\nline3"},
+		{"quotes", `message with "double" and 'single' quotes`},
+		{"unicode", "unicode: 你好世界 🚀"},
+		{"backslashes", `path\to\file`},
+		{"tabs", "col1\tcol2\tcol3"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			rt := sobek.New()
+			jsErr := NewJSError(JSErrorConfig{
+				Constructor: "TestError",
+				Message:     tc.message,
+			})
+
+			obj := jsErr.JSValue(rt).ToObject(rt)
+			require.Equal(t, tc.message, obj.Get("message").String())
+		})
+	}
+}
+
+func TestJSErrorStringFormats(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		constructor string
+		errName     string
+		message     string
+		expected    string
+	}{
+		{
+			name:        "all fields",
+			constructor: "FooError",
+			errName:     "Foo",
+			message:     "boom",
+			expected:    "Foo: boom",
+		},
+		{
+			name:        "no name",
+			constructor: "FooError",
+			errName:     "",
+			message:     "boom",
+			expected:    "boom",
+		},
+		{
+			name:        "no message",
+			constructor: "FooError",
+			errName:     "Foo",
+			message:     "",
+			expected:    "Foo",
+		},
+		{
+			name:        "only constructor",
+			constructor: "FooError",
+			errName:     "",
+			message:     "",
+			expected:    "FooError",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			jsErr := NewJSError(JSErrorConfig{
+				Constructor: tc.constructor,
+				Name:        tc.errName,
+				Message:     tc.message,
+			})
+
+			require.Equal(t, tc.expected, jsErr.Error())
+		})
+	}
+}
+
+func TestEnsureErrorConstructorIdempotent(t *testing.T) {
+	t.Parallel()
+
+	rt := sobek.New()
+
+	// Call multiple times - should return the same constructor
+	ctor1, err := EnsureErrorConstructor(rt, "IdempotentError")
+	require.NoError(t, err)
+
+	ctor2, err := EnsureErrorConstructor(rt, "IdempotentError")
+	require.NoError(t, err)
+
+	require.Same(t, ctor1, ctor2, "EnsureErrorConstructor should return the same constructor on repeated calls")
+}
+
+func TestEnsureErrorConstructorEmptyName(t *testing.T) {
+	t.Parallel()
+
+	rt := sobek.New()
+
+	// Empty name should default to "Error"
+	ctor, err := EnsureErrorConstructor(rt, "")
+	require.NoError(t, err)
+
+	// Should return the built-in Error constructor
+	builtinError := rt.Get("Error")
+	require.Equal(t, builtinError, ctor)
+}

--- a/js/common/util_test.go
+++ b/js/common/util_test.go
@@ -22,6 +22,11 @@ func TestThrow(t *testing.T) {
 	require.True(t, ok, "fn2 is invalid")
 	_, err = fn2(sobek.Undefined())
 	assert.EqualError(t, err, "GoError: aaaa")
+
+	fn3, ok := sobek.AssertFunction(rt.ToValue(func() { Throw(rt, testJSExceptionError{message: "failed"}) }))
+	require.True(t, ok, "fn3 is invalid")
+	_, err = fn3(sobek.Undefined())
+	assert.EqualError(t, err, "TypeError: failed")
 }
 
 func TestToBytes(t *testing.T) {
@@ -77,4 +82,16 @@ func TestToString(t *testing.T) {
 			assert.Equal(t, tc.expOut, out)
 		})
 	}
+}
+
+type testJSExceptionError struct {
+	message string
+}
+
+func (t testJSExceptionError) Error() string {
+	return t.message
+}
+
+func (t testJSExceptionError) JSValue(rt *sobek.Runtime) sobek.Value {
+	return rt.NewTypeError(t.message)
 }

--- a/js/promises/promises.go
+++ b/js/promises/promises.go
@@ -4,6 +4,7 @@ package promises
 import (
 	"github.com/grafana/sobek"
 
+	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
 )
 
@@ -40,6 +41,9 @@ func New(vu modules.VU) (p *sobek.Promise, resolve func(result any), reject func
 
 	reject = func(reason any) {
 		callback(func() error {
+			if jsErr, ok := reason.(common.JSException); ok {
+				return rejectFunc(jsErr.JSValue(vu.Runtime()))
+			}
 			return rejectFunc(reason)
 		})
 	}


### PR DESCRIPTION
## What?

This pull request introduces a new mechanism/API for surfacing structured, JS-visible error types from Go modules in k6, enabling proper JavaScript `instanceof` checks and richer error handling for users. 

This is probably not the right way to do it, but it has the benefit of demonstrating the target UX and feature, and open the discussion on how we might implement this

The changes include new helper types and functions for error construction, conversion, and export. It also, **for demonstration purposes only** refactors the `fs` module to use these new error types that can be defined.

This is by no mean meant to be production-ready, it might even need to live in sobek itself, but this feature has been discussed and requested internally many times, and I just wanted to kickoff the implementation. Let's make it better together 🤝 

## Example

### Implementing a custom error type

Define your custom error structure(s) in your go module definition::
```go
const fsErrorConstructorName = "FSError"

type FSError {
    // Embedding the JSError in your type is what will make being handled as
    // expected by the JS runtime.
	*common.JSError

	// kind contains the kind of error that has occurred. This is specific to the fs module, and
	// it could be any field you want, although, note that JSError also has a `Properties` map property
	// for these use cases.
	kind errorKind
}

// newFSError creates a new Error object of the provided kind and with the
// provided message.
func newFSError(k errorKind, message string) *fsError {
	return &FSError{
		JSError: common.NewJSError(common.JSErrorConfig{
			Constructor: fsErrorConstructorName,
			Name:        k.String(),
			Message:     message,
		}),
		kind: k,
	}
}
```

Export the type during the module exports phase:
```go
// Exports implements the modules.Module interface and returns the exports of
// our module.
func (mi *ModuleInstance) Exports() modules.Exports {
	return modules.Exports{
		Named: map[string]any{
			"open": mi.Open,
			"SeekMode": map[string]any{
				"Start":   SeekModeStart,
				"Current": SeekModeCurrent,
				"End":     SeekModeEnd,
			},
			"FSError": common.ExportNamedError(fsErrorConstructorName)(mi.vu.Runtime()),
		},
	}
}
```

### Using the new custom type

```javascript
import { operation, FSError } from 'k6/experimental/fs';

export default async function () {
    try {
        await operation("it's supposed to fail");
    } catch (err) {
        if (err instanceof FSError) {
            console.log("THIS IS THE WAY!");
        } else {
            console.log("not what we expected...");
        }
        console.log(JSON.stringify(err))
    }
}
```