### PR TITLE
Fix retry on frame has been detached

### DIFF
--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -1771,7 +1771,8 @@ func retryPointerAction(
 		}
 
 		if !errors.Is(err, ErrElementNotVisible) &&
-			!errors.Is(err, ErrElementNotAttachedToDOM) {
+			!errors.Is(err, ErrElementNotAttachedToDOM) &&
+			!strings.Contains(err.Error(), "frame has been detached") {
 			return res, err
 		}
 


### PR DESCRIPTION
## What?

Retries click when a "frame has been detached" error is returned when click on an element in a detached parent frame.

## Why?

The element must be in the DOM, but its parent frame is detached. Once the parent frame is attached the element should be clickable. Difficult to create the test for this.

With a specific test I seem to have issues with the initial click. I can share the test so you can try before and after the fix.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [x] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
