### PR TITLE
chore: Fix tests and subcommand handling in `version` command

### DIFF
--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -150,6 +150,8 @@ func versionDetailsWithExtensions(exts []*ext.Extension) (map[string]any, error)
 			info.Imports = append(info.Imports, e.Name)
 		case ext.SecretSourceExtension:
 			// currently, no special handling is needed for secret source extensions
+		case ext.SubcommandExtension:
+			// currently, no special handling is needed for subcommand extensions
 		default:
 			// report unhandled extension type for future proofing
 			return details, fmt.Errorf("unhandled extension type: %s", e.Type)


### PR DESCRIPTION
## What?

Fixes tests and version command when subcommand extension are registered

## Why?

The addition of subcommand extension did not handle the case in versions. As such if there are subcommand extensions, version fails.

In tests this might happen if the test for subcommand runs before the one for version - which is constant locally, but seems rare in the CI.

It will likely be better to add this and the secret source to the output, but this can be done in a separate PR with testing, once the CI and tests are stable.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
#5399 
