### PR TITLE
browser: add `page.on('requestfinished')` event handler

### DIFF
--- a/examples/browser/pageon-requestfinished.js
+++ b/examples/browser/pageon-requestfinished.js
@@ -1,0 +1,41 @@
+import { browser } from 'k6/browser'
+
+export const options = {
+	scenarios: {
+		ui: {
+			executor: 'shared-iterations',
+			options: {
+				browser: {
+					type: 'chromium',
+				},
+			},
+		},
+	},
+}
+
+export default async function () {
+	const page = await browser.newPage()
+
+	// Track all completed requests
+	const finishedRequests = []
+
+	page.on('requestfinished', request => {
+		finishedRequests.push({
+			url: request.url(),
+			method: request.method(),
+			resourceType: request.resourceType(),
+		})
+
+		console.log(`✓ Request finished: ${request.method()} ${request.url()}`)
+	})
+
+	await page.goto('https://quickpizza.grafana.com/', { waitUntil: 'networkidle' })
+
+	console.log(`Total requests completed: ${finishedRequests.length}`)
+
+	// Log all API requests
+	const apiRequests = finishedRequests.filter(r => r.url.includes('/api/'))
+	console.log(`API requests: ${apiRequests.length}`)
+
+	await page.close()
+}

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -688,10 +688,11 @@ func mapPageOn(vu moduleVU, p *common.Page) func(common.PageEventName, sobek.Cal
 			mapp func(vu moduleVU, event common.PageEvent) mapping
 			wait bool // Whether to wait for the handler to complete.
 		}{
-			common.PageEventConsole:  {mapp: mapConsoleMessage},
-			common.PageEventMetric:   {mapp: mapMetricEvent, wait: true},
-			common.PageEventRequest:  {mapp: mapRequestEvent},
-			common.PageEventResponse: {mapp: mapResponseEvent},
+			common.PageEventConsole:         {mapp: mapConsoleMessage},
+			common.PageEventMetric:          {mapp: mapMetricEvent, wait: true},
+			common.PageEventRequest:         {mapp: mapRequestEvent},
+			common.PageEventResponse:        {mapp: mapResponseEvent},
+			common.PageEventRequestFinished: {mapp: mapRequestEvent},
 		}
 		pageEvent, ok := pageEvents[eventName]
 		if !ok {

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -49,6 +49,7 @@ type eventInterceptor interface {
 	urlTagName(urlTag string, method string) (string, bool)
 	onRequest(request *Request)
 	onResponse(response *Response)
+	onRequestFinished(request *Request)
 }
 
 // NetworkManager manages all frames in HTML document.
@@ -436,6 +437,7 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 	req.responseEndTiming = float64(event.Timestamp.Time().Unix()-req.timestamp.Unix()) * 1000
 	m.deleteRequestByID(event.RequestID)
 	m.frameManager.requestFinished(req)
+	m.eventInterceptor.onRequestFinished(req)
 
 	// Skip data and blob URLs when emitting metrics, since they're internal to the browser.
 	if isInternalURL(req.url) {

--- a/internal/js/modules/k6/browser/common/network_manager_test.go
+++ b/internal/js/modules/k6/browser/common/network_manager_test.go
@@ -223,6 +223,8 @@ func (m *EventInterceptorMock) onRequest(_ *Request) {}
 
 func (m *EventInterceptorMock) onResponse(_ *Response) {}
 
+func (m *EventInterceptorMock) onRequestFinished(_ *Request) {}
+
 func TestNetworkManagerEmitRequestResponseMetricsTimingSkew(t *testing.T) {
 	t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -48,6 +48,9 @@ const (
 
 	// PageEventResponse represents the page response event.
 	PageEventResponse PageEventName = "response"
+
+	// PageEventRequestFinished represents the page request finished event.
+	PageEventRequestFinished PageEventName = "requestfinished"
 )
 
 // PageEventHandler is a function type that handles a page on event.
@@ -503,6 +506,16 @@ func (p *Page) onResponse(resp *Response) {
 	for handle := range p.eventHandlersByName(PageEventResponse) {
 		if err := handle(PageEvent{Response: resp}); err != nil {
 			p.logger.Warnf("onResponse", "handler returned an error: %v", err)
+			return
+		}
+	}
+}
+
+// onRequestFinished calls [PageEventRequestFinished] handlers when a request completes successfully.
+func (p *Page) onRequestFinished(request *Request) {
+	for handle := range p.eventHandlersByName(PageEventRequestFinished) {
+		if err := handle(PageEvent{Request: request}); err != nil {
+			p.logger.Warnf("onRequestFinished", "handler returned an error: %v", err)
 			return
 		}
 	}


### PR DESCRIPTION
## What?

Implements the `page.on('requestfinished')` event handler that fires when a network request successfully completes (receives a response).

- closely followed the implementation of `page.on('request')` and `page.on('response')` events.
- Added integration test 
- Added example script

## Why?
Reasons mentioned in the issue #4300
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)
Closes: https://github.com/grafana/k6/issues/4300
Parent: https://github.com/grafana/k6/issues/4232
