### PR TITLE
Fix error handling by downgrading to debug

### DIFF
--- a/internal/js/modules/k6/browser/common/execution_context.go
+++ b/internal/js/modules/k6/browser/common/execution_context.go
@@ -217,7 +217,7 @@ func (e *ExecutionContext) eval(
 			return nil, errors.New(cdpe.Message)
 		}
 
-		e.logger.Warnf("ExecutionContext:eval", "Unexpected DevTools server error: %v", err)
+		e.logger.Debugf("ExecutionContext:eval", "Unexpected DevTools server error: %v", err)
 		return nil, err
 	}
 	if exceptionDetails != nil {


### PR DESCRIPTION
## What?

Downgrading warning log to debug.

## Why?

We're already handling the error when one occurs here, and it is propagated back to the user via the API they were calling when the error occurred. No need to also log a warning, which is confusing and causes noise in the terminal.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
