### PR TITLE
Bump k6 to 1.5.0

### DIFF
--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -3,4 +3,4 @@ package build
 
 // Version contains the current version of k6
 // represented using Semantic Versioning expression.
-const Version = "1.4.1"
+const Version = "1.5.0"


### PR DESCRIPTION
## What?

Bump k6 to 1.5.0

## Why?

To release 1.5.0.

## Related PR(s)/Issue(s)

#5371