### PR TITLE
Close stale PRs after 2 months of inactivity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,7 +22,7 @@ jobs:
           days-before-pr-close: 7
 
           stale-pr-label: stale
-          exempt-pr-labels: "do-not-close,wip,do not merge"
+          exempt-pr-labels: "wip"
 
           stale-pr-message: |
             This pull request has been automatically marked as stale because it has not had


### PR DESCRIPTION
## What?

This PR introduces [Close Stale Issues](https://github.com/marketplace/actions/close-stale-issues) action to k6. The goal is to use [`grafana/grafana`](https://github.com/grafana/grafana/blob/main/.github/workflows/stale.yml) as an example and automate maintenance of stale PRs and close them after 2 months of inactivity.

## Why?

We manually maintain open PRs to k6, which is time consuming and requires us to periodically check whether there was any activity on them. This becomes especially problematic with PRs that were open a while ago.

## Checklist

- [x] I have performed a self-review of my code.