### PR TITLE
vendor: add z/OS build flags to vendored afero

### DIFF
--- a/vendor/github.com/spf13/afero/const_bsds.go
+++ b/vendor/github.com/spf13/afero/const_bsds.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin openbsd freebsd netbsd dragonfly
+// +build darwin openbsd freebsd netbsd dragonfly zos
 
 package afero
 

--- a/vendor/github.com/spf13/afero/const_win_unix.go
+++ b/vendor/github.com/spf13/afero/const_win_unix.go
@@ -15,6 +15,7 @@
 // +build !freebsd
 // +build !dragonfly
 // +build !netbsd
+// +build !zos
 
 package afero
 


### PR DESCRIPTION
## What?

Add zos build tags to vendored spf13/afero files to enable building on z/OS USS. This mirrors the upstream fix in spf13/afero#384 which was merged in v1.15.0, but the vendored version (v1.1.2) predates it.

- const_bsds.go: add zos to include list (uses syscall.EBADF)
- const_win_unix.go: add !zos to exclude list (syscall.EBADFD unavailable)

## Why?

I am actively promoting the use of the k6 test tool in our z/OS test squads. However, it is difficult to maintain the most up-to-date version due to build complexities with cloning both afero and k6. I wanted to streamline it by allowing a simpler build that just involves a `git clone` and `go build`. These changes fix the build error:
```
  vendor/github.com/spf13/afero/const_win_unix.go:25:23: undefined: syscall.EBADFD
```

Follow-up to #2888 and #2892. Closes #5547

```
# ./k6 version
k6 v1.5.1-0.20260109162857-b9b1d57948fc+dirty (commit/b9b1d57948-dirty, go1.25.3, zos/s390x)
# k6

         /\      Grafana   /‾‾/  
    /\  /  \     |\  __   /  /   
   /  \/    \    | |/ /  /   ‾‾\ 
  /          \   |   (  |  (‾)  |
 / __________ \  |_|\_\  \_____/ 

Full CLI documentation is available at: https://grafana.com/docs/k6/latest/using-k6/k6-options/reference/

Usage:
  k6 [command]

Available Commands:
  archive     Create an archive
  cloud       Run a test on the cloud
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  inspect     Inspect a script or archive
  new         Create and initialize a new k6 script
  pause       Pause a running test
  resume      Resume a paused test
  run         Start a test
  scale       Scale a running test
  stats       Show test metrics
  status      Show test status
  version     Show application version

Flags:
  -a, --address string              address for the REST API server (default "localhost:6565")
  -c, --config string               JSON config file (default "/ist/home/amrahman/.config/k6/config.json")
  -h, --help                        help for k6
      --log-format string           log output format
      --log-output string           change the output for k6 logs, possible values are: 'stderr', 'stdout',
                                    'none', 'loki[=host:port]', 'file[=./path.fileformat]' (default "stderr")
      --no-color                    disable colored output
      --profiling-enabled           enable profiling (pprof) endpoints, k6's REST API should be enabled as well
  -q, --quiet                       disable progress updates
      --secret-source stringArray   setting secret sources for k6 file[=./path.fileformat],
  -v, --verbose                     enable verbose logging
      --version                     version for k6

Use "k6 [command] --help" for more information about a command.

```
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

No new tests added, this is a build-tag-only change. The change mirrors upstream [spf13/afero#384](https://github.com/spf13/afero/pull/384) and the past modification to ui_unix.go. 

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
