### PR TITLE
Refactor `onAttachedToTarget` context done detection

### DIFF
--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -234,16 +234,7 @@ func (b *Browser) initEvents() error {
 			case event := <-chHandler:
 				if ev, ok := event.data.(*target.EventAttachedToTarget); ok {
 					b.logger.Debugf("Browser:initEvents:onAttachedToTarget", "sid:%v tid:%v", ev.SessionID, ev.TargetInfo.TargetID)
-					err := b.onAttachedToTarget(ev)
-					if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-						b.logger.Debugf(
-							"Browser:initEvents:onAttachedToTarget:suppressed",
-							"sid:%v tid:%v err:%v",
-							ev.SessionID, ev.TargetInfo.TargetID, err,
-						)
-						continue
-					}
-					if err != nil {
+					if err := b.onAttachedToTarget(ev); err != nil {
 						k6ext.Panicf(b.vuCtx, "browser is attaching to target: %w", err)
 					}
 				} else if ev, ok := event.data.(*target.EventDetachedFromTarget); ok {
@@ -413,6 +404,7 @@ func (b *Browser) isPageAttachmentErrorIgnorable(ev *target.EventAttachedToTarge
 			ev.SessionID, targetPage.TargetID, targetPage.Type, err)
 		return true
 	}
+
 	// No need to register the page if the test run is over.
 	select {
 	case <-b.vuCtx.Done():
@@ -421,6 +413,12 @@ func (b *Browser) isPageAttachmentErrorIgnorable(ev *target.EventAttachedToTarge
 			ev.SessionID, targetPage.TargetID, targetPage.Type, b.vuCtx.Err())
 		return true
 	default:
+	}
+	// No need to register the page if the context is already done.
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		b.logger.Debugf("Browser:isPageAttachmentErrorIgnorable:return:context.Done",
+			"sid:%v tid:%v pageType:%s err:%v", ev.SessionID, targetPage.TargetID, targetPage.Type, err)
+		return true
 	}
 	// Another VU or instance closed the page, and the session is closed.
 	// This can happen if the page is closed before the attachedToTarget


### PR DESCRIPTION
## What?

Moved the logic from #5526 to the specific method, where we decide whether to ignore the attachment errors.

## Why?

Tiny refactoring to avoid scattering the page-attachment error-detection logic, improve maintainability.

I wanted to do it now in 10 minutes rather than forget to do it later 😄 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#5526