### PR TITLE
Fill lib.ScenarioOptions when using k6/browser with CLI shortcuts

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -322,10 +322,10 @@ func applyDefault(conf Config) Config {
 }
 
 func deriveAndValidateConfig(
-	conf Config, isExecutable func(string) bool, logger logrus.FieldLogger,
+	conf Config, isExecutable func(string) bool, importedModules []string, logger logrus.FieldLogger,
 ) (result Config, err error) {
 	result = conf
-	result.Options, err = executor.DeriveScenariosFromShortcuts(conf.Options, logger)
+	result.Options, err = executor.DeriveScenariosFromShortcuts(conf.Options, importedModules, logger)
 	if err == nil {
 		err = validateConfig(result, isExecutable)
 	}

--- a/internal/cmd/config_consolidation_test.go
+++ b/internal/cmd/config_consolidation_test.go
@@ -551,7 +551,7 @@ func runTestCase(t *testing.T, testCase configConsolidationTestCase, subCmd stri
 	require.NoError(t, err)
 
 	derivedConfig := consolidatedConfig
-	derivedConfig.Options, err = executor.DeriveScenariosFromShortcuts(consolidatedConfig.Options, ts.Logger)
+	derivedConfig.Options, err = executor.DeriveScenariosFromShortcuts(consolidatedConfig.Options, nil, ts.Logger)
 	if testCase.expected.derivationError {
 		require.Error(t, err)
 		return

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -192,7 +192,7 @@ func TestDeriveAndValidateConfig(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := deriveAndValidateConfig(tc.conf,
-				func(_ string) bool { return tc.isExec }, nil)
+				func(_ string) bool { return tc.isExec }, nil, nil)
 			if tc.err != "" {
 				var ecerr errext.HasExitCode
 				assert.ErrorAs(t, err, &ecerr)

--- a/internal/cmd/report_test.go
+++ b/internal/cmd/report_test.go
@@ -23,7 +23,7 @@ func TestCreateReport(t *testing.T) {
 	opts, err := executor.DeriveScenariosFromShortcuts(lib.Options{
 		VUs:        null.IntFrom(10),
 		Iterations: null.IntFrom(170),
-	}, logger)
+	}, nil, logger)
 	require.NoError(t, err)
 
 	initSchedulerWithEnv := func(lookupEnv func(string) (string, bool)) (*execution.Scheduler, error) {

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -392,7 +392,18 @@ func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 		}
 	}
 
-	derivedConfig, err := deriveAndValidateConfig(consolidatedConfig, lt.initRunner.IsExecutable, gs.Logger)
+	// Get imported modules to check for browser import
+	var importedModules []string
+	if lt.moduleResolver != nil {
+		importedModules = lt.moduleResolver.Imported()
+	}
+
+	derivedConfig, err := deriveAndValidateConfig(
+		consolidatedConfig,
+		lt.initRunner.IsExecutable,
+		importedModules,
+		gs.Logger,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/execution/scheduler_ext_test.go
+++ b/internal/execution/scheduler_ext_test.go
@@ -68,7 +68,7 @@ func newTestScheduler(
 	ctx, cancel = context.WithCancel(context.Background())
 	newOpts, err := executor.DeriveScenariosFromShortcuts(lib.Options{
 		MetricSamplesBufferSize: null.NewInt(200, false),
-	}.Apply(runner.GetOptions()).Apply(opts), nil)
+	}.Apply(runner.GetOptions()).Apply(opts), nil, nil)
 	require.NoError(t, err)
 
 	testRunState := getTestRunState(t, getTestPreInitState(t), newOpts, runner)
@@ -963,7 +963,7 @@ func TestSchedulerEndIterations(t *testing.T) {
 	options, err := executor.DeriveScenariosFromShortcuts(lib.Options{
 		VUs:        null.IntFrom(1),
 		Iterations: null.IntFrom(100),
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 	require.Empty(t, options.Validate())
 
@@ -1199,7 +1199,7 @@ func TestRealTimeAndSetupTeardownMetrics(t *testing.T) {
 		SystemTags:      &metrics.DefaultSystemTagSet,
 		SetupTimeout:    types.NullDurationFrom(4 * time.Second),
 		TeardownTimeout: types.NullDurationFrom(4 * time.Second),
-	}), nil)
+	}), nil, nil)
 	require.NoError(t, err)
 
 	testRunState := getTestRunState(t, piState, options, runner)


### PR DESCRIPTION
## What?

Fill `lib.ScenarioOptions` when using `k6/browser` with CLI shortcuts.

## Why?

Because of #3742 👉🏻 currently, if you import the Browser module and use some of these CLI shortcuts, you end up having the following error: `ERRO[0000] Uncaught (in promise) browser not found in registry. make sure to set browser type option in scenario definition in order to use the browser module  executor=shared-iterations scenario=default`.

This change make that combination to work (as expected? 🤔)

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#3742 

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
