### PR TITLE
fix(output/opentelemetry): fix `Config.String()` to display `ExporterProtocol`

### DIFF
--- a/internal/output/opentelemetry/config.go
+++ b/internal/output/opentelemetry/config.go
@@ -297,24 +297,25 @@ func (cfg Config) validateExporterProtocol() error {
 // String returns a string representation of the config
 func (cfg Config) String() string {
 	var endpoint string
-	exporter := cfg.ExporterType.String
-
-	if cfg.ExporterType.String == httpExporterType {
+	protocol := mergeExporterTypeAndProtocol(cfg)
+	switch protocol {
+	case httpExporterProtocol:
 		endpoint = "http"
 		if !cfg.HTTPExporterInsecure.Bool {
 			endpoint += "s"
 		}
-
 		endpoint += "://" + cfg.HTTPExporterEndpoint.String + cfg.HTTPExporterURLPath.String
-	} else {
+	case grpcExporterProtocol:
 		endpoint = cfg.GRPCExporterEndpoint.String
-
 		if cfg.GRPCExporterInsecure.Bool {
-			exporter += " (insecure)"
+			protocol += " (insecure)"
 		}
+	default:
+		// This should never happen after validation
+		panic("unsupported OpenTelemetry exporter protocol: " + protocol)
 	}
 
-	return fmt.Sprintf("%s, %s", exporter, endpoint)
+	return fmt.Sprintf("%s, %s", protocol, endpoint)
 }
 
 // parseJSON parses the supplied JSON into a Config.

--- a/internal/output/opentelemetry/config_test.go
+++ b/internal/output/opentelemetry/config_test.go
@@ -224,3 +224,80 @@ func TestConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestConfigString(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		config   Config
+		expected string
+	}{
+		"default grpc": {
+			config: Config{
+				ExporterProtocol:     null.NewString(grpcExporterProtocol, false),
+				GRPCExporterEndpoint: null.NewString("localhost:4317", false),
+				GRPCExporterInsecure: null.NewBool(false, false),
+			},
+			expected: "grpc, localhost:4317",
+		},
+		"grpc with ExporterProtocol set": {
+			config: Config{
+				ExporterProtocol:     null.NewString(grpcExporterProtocol, true),
+				GRPCExporterEndpoint: null.NewString("localhost:4317", true),
+				GRPCExporterInsecure: null.NewBool(false, true),
+			},
+			expected: "grpc, localhost:4317",
+		},
+		"grpc insecure with ExporterProtocol set": {
+			config: Config{
+				ExporterProtocol:     null.NewString(grpcExporterProtocol, true),
+				GRPCExporterEndpoint: null.NewString("localhost:4317", true),
+				GRPCExporterInsecure: null.NewBool(true, true),
+			},
+			expected: "grpc (insecure), localhost:4317",
+		},
+		"http/protobuf with ExporterProtocol set": {
+			config: Config{
+				ExporterProtocol:     null.NewString(httpExporterProtocol, true),
+				HTTPExporterEndpoint: null.NewString("localhost:4318", true),
+				HTTPExporterURLPath:  null.NewString("/v1/metrics", true),
+				HTTPExporterInsecure: null.NewBool(false, true),
+			},
+			expected: "http/protobuf, https://localhost:4318/v1/metrics",
+		},
+		"http/protobuf insecure with ExporterProtocol set": {
+			config: Config{
+				ExporterProtocol:     null.NewString(httpExporterProtocol, true),
+				HTTPExporterEndpoint: null.NewString("localhost:4318", true),
+				HTTPExporterURLPath:  null.NewString("/v1/metrics", true),
+				HTTPExporterInsecure: null.NewBool(true, true),
+			},
+			expected: "http/protobuf, http://localhost:4318/v1/metrics",
+		},
+		"deprecated ExporterType http": {
+			config: Config{
+				ExporterType:         null.NewString(httpExporterType, true),
+				HTTPExporterEndpoint: null.NewString("localhost:4318", true),
+				HTTPExporterURLPath:  null.NewString("/v1/metrics", true),
+				HTTPExporterInsecure: null.NewBool(false, true),
+			},
+			expected: "http/protobuf, https://localhost:4318/v1/metrics",
+		},
+		"deprecated ExporterType grpc": {
+			config: Config{
+				ExporterType:         null.NewString(grpcExporterType, true),
+				GRPCExporterEndpoint: null.NewString("localhost:4317", true),
+				GRPCExporterInsecure: null.NewBool(false, true),
+			},
+			expected: "grpc, localhost:4317",
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			result := testCase.config.String()
+			require.Equal(t, testCase.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## What?

Fixes `opentelemetry.Config.String()` to display the value of `ExporterProtocol`.

## Why?

Because, as described in #5589, when the protocol is set through the `K6_OTEL_EXPORTER_PROTOCOL` environment variable, the actual protocol in use isn't correctly displayed in the console's output.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #5589 

<!-- Thanks for your contribution! 🙏🏼 -->
