### PR TITLE
Expose a checks total count in addition to a rate.

### DIFF
--- a/internal/js/modules/k6/k6.go
+++ b/internal/js/modules/k6/k6.go
@@ -214,6 +214,22 @@ func (mi *K6) Check(arg0, checks sobek.Value, extras ...sobek.Value) (bool, erro
 
 		metrics.PushIfNotDone(ctx, state.Samples, sample)
 
+		// Emit checks_total counter with status label
+		status := "fail"
+		if booleanVal {
+			status = "pass"
+		}
+		checksCountSample := metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: state.BuiltinMetrics.ChecksTotal,
+				Tags:   tags.With("status", status),
+			},
+			Time:     t,
+			Metadata: commonTagsAndMeta.Metadata,
+			Value:    1,
+		}
+		metrics.PushIfNotDone(ctx, state.Samples, checksCountSample)
+
 		if exc != nil {
 			return false, exc
 		}

--- a/metrics/builtin.go
+++ b/metrics/builtin.go
@@ -9,6 +9,7 @@ const (
 	DroppedIterationsName = "dropped_iterations"
 
 	ChecksName        = "checks"
+	ChecksTotalName   = "checks_total"
 	GroupDurationName = "group_duration"
 
 	HTTPReqsName              = "http_reqs"
@@ -44,6 +45,7 @@ type BuiltinMetrics struct {
 
 	// Runner-emitted.
 	Checks        *Metric
+	ChecksTotal   *Metric
 	GroupDuration *Metric
 
 	// HTTP-related.
@@ -83,6 +85,7 @@ func RegisterBuiltinMetrics(registry *Registry) *BuiltinMetrics {
 		DroppedIterations: registry.MustNewMetric(DroppedIterationsName, Counter),
 
 		Checks:        registry.MustNewMetric(ChecksName, Rate),
+		ChecksTotal:   registry.MustNewMetric(ChecksTotalName, Counter),
 		GroupDuration: registry.MustNewMetric(GroupDurationName, Trend, Time),
 
 		HTTPReqs:              registry.MustNewMetric(HTTPReqsName, Counter),


### PR DESCRIPTION
## What?
This change adds a `checks_total` counter metric in addition to the `checks` rate metric.

## Why?
A rate is harder to handle for SLOs etc where the time range might vary. Also, the number if issued checks is useful as well.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
