### PR TITLE
Remove legacy config path migration and fallbacks

### DIFF
--- a/internal/cmd/cloud_login.go
+++ b/internal/cmd/cloud_login.go
@@ -68,13 +68,6 @@ func getCmdCloudLogin(gs *state.GlobalState) *cobra.Command {
 //
 //nolint:funlen
 func (c *cmdCloudLogin) run(cmd *cobra.Command, _ []string) error {
-	if !checkIfMigrationCompleted(c.globalState) {
-		err := migrateLegacyConfigFileIfAny(c.globalState)
-		if err != nil {
-			return err
-		}
-	}
-
 	currentDiskConf, err := readDiskConfig(c.globalState)
 	if err != nil {
 		return err

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/mstoykov/envconfig"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
@@ -15,7 +14,6 @@ import (
 	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/errext"
 	"go.k6.io/k6/errext/exitcodes"
-	"go.k6.io/k6/internal/lib/testutils"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/executor"
 	"go.k6.io/k6/lib/fsext"
@@ -401,120 +399,4 @@ func TestWriteDiskConfigNoJSONContentError(t *testing.T) {
 	err := writeDiskConfig(gs, c)
 	var serr *json.SyntaxError
 	assert.ErrorAs(t, err, &serr)
-}
-
-func TestMigrateLegacyConfigFileIfAny(t *testing.T) {
-	t.Parallel()
-	memfs := fsext.NewMemMapFs()
-
-	conf := []byte(`{"iterations":1028,"cloud":{"field1":"testvalue"}}`)
-	legacyConfigPath := ".config/loadimpact/k6/config.json"
-	require.NoError(t, fsext.WriteFile(memfs, legacyConfigPath, conf, 0o644))
-
-	l, hook := testutils.NewLoggerWithHook(t)
-	logger := l.(*logrus.Logger) //nolint:forbidigo // no alternative, required
-
-	defaultFlags := state.GetDefaultFlags(".config", ".cache")
-	gs := &state.GlobalState{
-		FS:              memfs,
-		Flags:           defaultFlags,
-		DefaultFlags:    defaultFlags,
-		UserOSConfigDir: ".config",
-		Logger:          logger,
-	}
-
-	err := migrateLegacyConfigFileIfAny(gs)
-	require.NoError(t, err)
-
-	f, err := fsext.ReadFile(memfs, ".config/k6/config.json")
-	require.NoError(t, err)
-	assert.Equal(t, f, conf)
-
-	testutils.LogContains(hook.Drain(), logrus.InfoLevel, "migrated")
-}
-
-func TestMigrateLegacyConfigFileIfAnyWhenFileDoesNotExist(t *testing.T) {
-	t.Parallel()
-	memfs := fsext.NewMemMapFs()
-
-	defaultFlags := state.GetDefaultFlags(".config", ".cache")
-	gs := &state.GlobalState{
-		FS:              memfs,
-		Flags:           defaultFlags,
-		DefaultFlags:    defaultFlags,
-		UserOSConfigDir: ".config",
-	}
-
-	err := migrateLegacyConfigFileIfAny(gs)
-	require.NoError(t, err)
-
-	_, err = fsext.ReadFile(memfs, ".config/k6/config.json")
-	assert.ErrorIs(t, err, fs.ErrNotExist)
-}
-
-func TestLoadConfig(t *testing.T) {
-	t.Parallel()
-
-	testcases := []struct {
-		name          string
-		memfs         fsext.Fs
-		expConf       Config
-		expLegacyWarn bool
-	}{
-		{
-			name: "old and new default paths both populated",
-			memfs: testutils.MakeMemMapFs(t, map[string][]byte{
-				".config/loadimpact/k6/config.json": []byte(`{"iterations":1028}`),
-				".config/k6/config.json":            []byte(`{"iterations":1027}`), // use different conf to be sure on assertions
-			}),
-			expConf:       Config{Options: lib.Options{Iterations: null.IntFrom(1027)}},
-			expLegacyWarn: false,
-		},
-		{
-			name: "only old path",
-			memfs: testutils.MakeMemMapFs(t, map[string][]byte{
-				".config/loadimpact/k6/config.json": []byte(`{"iterations":1028}`),
-			}),
-			expConf:       Config{Options: lib.Options{Iterations: null.IntFrom(1028)}},
-			expLegacyWarn: true,
-		},
-		{
-			name: "only new path",
-			memfs: testutils.MakeMemMapFs(t, map[string][]byte{
-				".config/k6/config.json": []byte(`{"iterations":1028}`),
-			}),
-			expConf:       Config{Options: lib.Options{Iterations: null.IntFrom(1028)}},
-			expLegacyWarn: false,
-		},
-		{
-			name:          "no config files", // the startup condition
-			memfs:         fsext.NewMemMapFs(),
-			expConf:       Config{},
-			expLegacyWarn: false,
-		},
-	}
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			l, hook := testutils.NewLoggerWithHook(t)
-			logger := l.(*logrus.Logger) //nolint:forbidigo // no alternative, required
-
-			defaultFlags := state.GetDefaultFlags(".config", ".cache")
-			gs := &state.GlobalState{
-				FS:              tc.memfs,
-				Flags:           defaultFlags,
-				DefaultFlags:    defaultFlags,
-				UserOSConfigDir: ".config",
-				Logger:          logger,
-			}
-
-			c, err := loadConfigFile(gs)
-			require.NoError(t, err)
-
-			assert.Equal(t, tc.expConf, c)
-
-			// it reads only the new one and it doesn't care about the old path
-			assert.Equal(t, tc.expLegacyWarn, testutils.LogContains(hook.Drain(), logrus.WarnLevel, "old default path"))
-		})
-	}
 }

--- a/internal/cmd/login_cloud.go
+++ b/internal/cmd/login_cloud.go
@@ -42,10 +42,6 @@ This will set the default token used when just "k6 run -o cloud" is passed.`,
 Please use the "k6 cloud login" command instead.
 `,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			if err := migrateLegacyConfigFileIfAny(gs); err != nil {
-				return err
-			}
-
 			currentDiskConf, err := readDiskConfig(gs)
 			if err != nil {
 				return err

--- a/internal/cmd/login_influxdb.go
+++ b/internal/cmd/login_influxdb.go
@@ -25,10 +25,6 @@ func getCmdLoginInfluxDB(gs *state.GlobalState) *cobra.Command {
 This will set the default server used when just "-o influxdb" is passed.`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			if err := migrateLegacyConfigFileIfAny(gs); err != nil {
-				return err
-			}
-
 			config, err := readDiskConfig(gs)
 			if err != nil {
 				return err


### PR DESCRIPTION
## What?
Removed all code responsible for handling migration from the old legacy config file path to the new one.
Also dropped fallback logic.

<!-- A short (or detailed) description of what this PR does. -->

## Why?
The migration/fallback was intended to stick around for v1 only and, as a breaking change with v2, we are now intentionally removing it to simplify the code.
<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)
Closes #5572 

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
