### PR TITLE
Fix the fallback directory for the binary cache

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -115,7 +115,7 @@ func NewGlobalState(ctx context.Context) *GlobalState {
 
 	cacheDir, err := os.UserCacheDir()
 	if err != nil {
-		confDir = ".cache"
+		cacheDir = ".cache"
 	}
 
 	binary, err := os.Executable()


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

Fixes the directory to set in case `os.UserCacheDir` returns an error. 

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

In case `os.UserCacheDir` returns an error the current logic overwrites the config path instead of the expected cache path.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
