### PR TITLE
fix(js/compiler): Disable t.Parallel() on TestCompile for now

### DIFF
--- a/internal/js/compiler/compiler_test.go
+++ b/internal/js/compiler/compiler_test.go
@@ -13,8 +13,11 @@ import (
 	"go.k6.io/k6/internal/lib/testutils"
 )
 
+//nolint:tparallel
 func TestCompile(t *testing.T) {
-	t.Parallel()
+	// TODO(@joanlopez): Revisit later: it started to fail after the commit below, but hopefully will be fixed soon.
+	// https://github.com/golang/go/commit/481ab86aafe0cac177df793c9946c5ef2126137c
+	// t.Parallel()
 	t.Run("ES5", func(t *testing.T) {
 		t.Parallel()
 		c := New(testutils.NewLogger(t))


### PR DESCRIPTION
## What?

It disable `t.Parallel()` on `TestCompile` for now.

## Why?

As explained in the code comment I left, it started to fail since: https://github.com/golang/go/commit/481ab86aafe0cac177df793c9946c5ef2126137c
So, our `gotip` CI pipelines are failing.

I tried to create a minimal Go test example that reproduces the issue, to report it, as it looks like nobody encountered it yet, but I haven't able to spend much time on it, and haven't managed to use AI smart enough to create a test that reproduces it in pure Go. Using Sobek is trivial, so I'll most likely open the issue with that, and/or pointing to our own test, which after all is open source.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
