### PR TITLE
fix(cmd/state): Use constants when possible

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -239,7 +239,7 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 			result.AutoExtensionResolution = vb
 		}
 	}
-	if v, ok := env["K6_AUTO_EXTENSION_RESOLUTION"]; ok {
+	if v, ok := env[AutoExtensionResolution]; ok {
 		vb, err := strconv.ParseBool(v)
 		if err == nil {
 			result.AutoExtensionResolution = vb
@@ -254,7 +254,7 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 			result.EnableCommunityExtensions = vb
 		}
 	}
-	if val, ok := env["K6_DEPENDENCIES_MANIFEST"]; ok {
+	if val, ok := env[DependenciesManifest]; ok {
 		result.DependenciesManifest = val
 	}
 


### PR DESCRIPTION
## What?

It replaces hardcoded string values by their equivalent, already defined, constants.

## Why?

Because I guess that's the purpose of these constants, to avoid value duplication.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
