### PR TITLE
Add redirect extra headers

### DIFF
--- a/internal/js/modules/k6/browser/browser/request_mapping.go
+++ b/internal/js/modules/k6/browser/browser/request_mapping.go
@@ -18,6 +18,7 @@ func mapRequest(vu moduleVU, r *common.Request) mapping {
 	maps := mapping{
 		"allHeaders": func() *sobek.Promise {
 			return promise(vu, func() (any, error) {
+				r.WaitForRawHeaders()
 				return r.AllHeaders(), nil
 			})
 		},
@@ -27,6 +28,7 @@ func mapRequest(vu moduleVU, r *common.Request) mapping {
 		},
 		"headerValue": func(name string) *sobek.Promise {
 			return promise(vu, func() (any, error) {
+				r.WaitForRawHeaders()
 				v, ok := r.HeaderValue(name)
 				if !ok {
 					return nil, nil
@@ -38,6 +40,7 @@ func mapRequest(vu moduleVU, r *common.Request) mapping {
 		"headers": r.Headers,
 		"headersArray": func() *sobek.Promise {
 			return promise(vu, func() (any, error) {
+				r.WaitForRawHeaders()
 				return r.HeadersArray(), nil
 			})
 		},

--- a/internal/js/modules/k6/browser/browser/response_mapping.go
+++ b/internal/js/modules/k6/browser/browser/response_mapping.go
@@ -20,6 +20,7 @@ func mapResponse(vu moduleVU, r *common.Response) mapping {
 	maps := mapping{
 		"allHeaders": func() *sobek.Promise {
 			return promise(vu, func() (any, error) {
+				r.WaitForRawHeaders()
 				return r.AllHeaders(), nil
 			})
 		},
@@ -47,6 +48,7 @@ func mapResponse(vu moduleVU, r *common.Response) mapping {
 		},
 		"headerValue": func(name string) *sobek.Promise {
 			return promise(vu, func() (any, error) {
+				r.WaitForRawHeaders()
 				v, ok := r.HeaderValue(name)
 				if !ok {
 					return nil, nil
@@ -56,12 +58,14 @@ func mapResponse(vu moduleVU, r *common.Response) mapping {
 		},
 		"headerValues": func(name string) *sobek.Promise {
 			return promise(vu, func() (any, error) {
+				r.WaitForRawHeaders()
 				return r.HeaderValues(name), nil
 			})
 		},
 		"headers": r.Headers,
 		"headersArray": func() *sobek.Promise {
 			return promise(vu, func() (any, error) {
+				r.WaitForRawHeaders()
 				return r.HeadersArray(), nil
 			})
 		},

--- a/internal/js/modules/k6/browser/common/extra_info_tracker.go
+++ b/internal/js/modules/k6/browser/common/extra_info_tracker.go
@@ -1,0 +1,133 @@
+package common
+
+import (
+	"github.com/chromedp/cdproto/network"
+)
+
+// requestExtraInfo tracks the index-based pairing of extra info events
+// and requests/responses for a single requestId.
+//
+// CDP dispatches events on two independent channels:
+//   - Channel A: requestWillBeSent, responseReceived, loadingFinished/loadingFailed
+//   - Channel B: requestWillBeSentExtraInfo, responseReceivedExtraInfo
+//
+// Events can arrive in any order between channels, but within each channel
+// they arrive in order for a given requestId. In a redirect chain, a single
+// requestId produces multiple request/response pairs. We pair them by index:
+// the i-th extraInfo event corresponds to the i-th request/response since the
+// ordering is guaranteed within each channel.
+//
+// Example:
+// requestWillBeSentExtraInfo(123, hdrs) → pairs with Request_A at index 0
+// responseReceivedExtraInfo(123, hdrs) → pairs with Response_0 at index 0
+// requestWillBeSentExtraInfo(123, hdrs) → pairs with Request_B at index 1
+// responseReceivedExtraInfo(123, hdrs) → pairs with Response_1 at index 1
+// requestWillBeSentExtraInfo(123, hdrs) → pairs with Request_C at index 2
+// responseReceivedExtraInfo(123, hdrs) → pairs with Response_2 at index 2
+type requestExtraInfo struct {
+	// Indexed queues of parsed extra headers. Slots are set to nil after
+	// pairing to avoid applying headers twice.
+	requestExtraHeaders  []map[string][]string
+	responseExtraHeaders []map[string][]string
+
+	// Indexed queues of requests/responses awaiting extra headers. Slots
+	// are set to nil after pairing.
+	requests  []*Request
+	responses []*Response
+}
+
+// extraInfoTracker pairs requestWillBeSentExtraInfo / responseReceivedExtraInfo
+// events with their corresponding Request / Response objects using index-based
+// matching (modelled after Playwright's ResponseExtraInfoTracker).
+type extraInfoTracker struct {
+	requests map[network.RequestID]*requestExtraInfo
+}
+
+func newExtraInfoTracker() *extraInfoTracker {
+	return &extraInfoTracker{
+		requests: make(map[network.RequestID]*requestExtraInfo),
+	}
+}
+
+// getOrCreate returns the requestExtraInfo for the given requestId,
+// creating one if it doesn't exist yet.
+func (t *extraInfoTracker) getOrCreate(reqID network.RequestID) *requestExtraInfo {
+	info, ok := t.requests[reqID]
+	if !ok {
+		info = &requestExtraInfo{}
+		t.requests[reqID] = info
+	}
+	return info
+}
+
+// requestWillBeSentExtraInfo records parsed request extra headers and
+// tries to pair them with an already-registered Request at the same index.
+func (t *extraInfoTracker) requestWillBeSentExtraInfo(reqID network.RequestID, headers map[string][]string) {
+	info := t.getOrCreate(reqID)
+	info.requestExtraHeaders = append(info.requestExtraHeaders, headers)
+	t.patchRequestHeaders(info, len(info.requestExtraHeaders)-1)
+}
+
+// responseReceivedExtraInfo records parsed response extra headers and
+// tries to pair them with an already-registered Response at the same index.
+func (t *extraInfoTracker) responseReceivedExtraInfo(reqID network.RequestID, headers map[string][]string) {
+	info := t.getOrCreate(reqID)
+	info.responseExtraHeaders = append(info.responseExtraHeaders, headers)
+	t.patchResponseHeaders(info, len(info.responseExtraHeaders)-1)
+}
+
+// processRequest registers a Request and tries to pair it with
+// already-received request extra headers at the same index.
+func (t *extraInfoTracker) processRequest(reqID network.RequestID, req *Request) {
+	info := t.getOrCreate(reqID)
+	info.requests = append(info.requests, req)
+	t.patchRequestHeaders(info, len(info.requests)-1)
+}
+
+// processResponse registers a Response and tries to pair it with
+// already-received response extra headers at the same index.
+func (t *extraInfoTracker) processResponse(reqID network.RequestID, resp *Response) {
+	info := t.getOrCreate(reqID)
+	info.responses = append(info.responses, resp)
+	t.patchResponseHeaders(info, len(info.responses)-1)
+}
+
+// patchRequestHeaders applies request extra headers at the given index
+// if both the Request and the extra headers are available. After applying,
+// both slots are nilled out to avoid double-application.
+func (t *extraInfoTracker) patchRequestHeaders(info *requestExtraInfo, index int) {
+	if index >= len(info.requests) || index >= len(info.requestExtraHeaders) {
+		return
+	}
+	req := info.requests[index]
+	extra := info.requestExtraHeaders[index]
+	if req == nil || extra == nil {
+		return
+	}
+	req.addExtraHeaders(extra)
+	info.requests[index] = nil
+	info.requestExtraHeaders[index] = nil
+}
+
+// patchResponseHeaders applies response extra headers at the given index
+// if both the Response and the extra headers are available. After applying,
+// both slots are nilled out to avoid double-application.
+func (t *extraInfoTracker) patchResponseHeaders(info *requestExtraInfo, index int) {
+	if index >= len(info.responses) || index >= len(info.responseExtraHeaders) {
+		return
+	}
+	resp := info.responses[index]
+	extra := info.responseExtraHeaders[index]
+	if resp == nil || extra == nil {
+		return
+	}
+	resp.addExtraHeaders(extra)
+	info.responses[index] = nil
+	info.responseExtraHeaders[index] = nil
+}
+
+// cleanup removes the tracking entry for the given requestId. Should be
+// called when loading finishes or fails.
+func (t *extraInfoTracker) cleanup(reqID network.RequestID) {
+	delete(t.requests, reqID)
+}

--- a/internal/js/modules/k6/browser/common/extra_info_tracker.go
+++ b/internal/js/modules/k6/browser/common/extra_info_tracker.go
@@ -94,6 +94,10 @@ func (t *extraInfoTracker) requestServedFromCache(reqID network.RequestID) {
 func (t *extraInfoTracker) processResponse(reqID network.RequestID, resp *Response, hasExtraInfo bool) {
 	info, ok := t.requests[reqID]
 	if !hasExtraInfo || (ok && info.servedFromCache) {
+		// No raw headers will arrive, so the provisional headers are final.
+		// Unblock any readers waiting for the raw headers.
+		resp.resolveRawHeaders()
+		resp.request.resolveRawHeaders()
 		return
 	}
 	if !ok {
@@ -136,6 +140,7 @@ func (t *extraInfoTracker) loadingFinished(reqID network.RequestID) {
 		return
 	}
 	info.loadingFinished = true
+	t.resolvePending(info)
 	t.checkFinished(reqID, info)
 }
 
@@ -147,7 +152,22 @@ func (t *extraInfoTracker) loadingFailed(reqID network.RequestID) {
 		return
 	}
 	info.loadingFailed = true
+	t.resolvePending(info)
 	t.checkFinished(reqID, info)
+}
+
+// resolvePending unblocks readers waiting on the raw headers of any tracked
+// response (and its request) whose ExtraInfo never arrived. It is a backstop
+// run on the terminal event so a reader never waits forever; the entry itself
+// is kept (see checkFinished) so a late ExtraInfo event can still be applied.
+func (t *extraInfoTracker) resolvePending(info *requestInfo) {
+	for _, resp := range info.responses {
+		if resp == nil {
+			continue
+		}
+		resp.resolveRawHeaders()
+		resp.request.resolveRawHeaders()
+	}
 }
 
 // checkFinished removes the tracking entry once loading has finished/failed and

--- a/internal/js/modules/k6/browser/common/extra_info_tracker.go
+++ b/internal/js/modules/k6/browser/common/extra_info_tracker.go
@@ -4,130 +4,161 @@ import (
 	"github.com/chromedp/cdproto/network"
 )
 
-// requestExtraInfo tracks the index-based pairing of extra info events
-// and requests/responses for a single requestId.
+// requestInfo aligns CDP ExtraInfo events with their Response objects for a
+// single requestId, modelled after Playwright's ResponseExtraInfoTracker.
 //
 // CDP dispatches events on two independent channels:
 //   - Channel A: requestWillBeSent, responseReceived, loadingFinished/loadingFailed
 //   - Channel B: requestWillBeSentExtraInfo, responseReceivedExtraInfo
 //
-// Events can arrive in any order between channels, but within each channel
-// they arrive in order for a given requestId. In a redirect chain, a single
-// requestId produces multiple request/response pairs. We pair them by index:
-// the i-th extraInfo event corresponds to the i-th request/response since the
-// ordering is guaranteed within each channel.
+// They are not synchronised, so events arrive in any order between the
+// channels, but within each channel they arrive in order for a given
+// requestId. A single requestId can produce multiple request/response pairs
+// (a redirect chain reuses the requestId), so we pair by index: the i-th
+// tracked response pairs with the i-th request/response ExtraInfo event.
 //
-// Example:
-// requestWillBeSentExtraInfo(123, hdrs) → pairs with Request_A at index 0
-// responseReceivedExtraInfo(123, hdrs) → pairs with Response_0 at index 0
-// requestWillBeSentExtraInfo(123, hdrs) → pairs with Request_B at index 1
-// responseReceivedExtraInfo(123, hdrs) → pairs with Response_1 at index 1
-// requestWillBeSentExtraInfo(123, hdrs) → pairs with Request_C at index 2
-// responseReceivedExtraInfo(123, hdrs) → pairs with Response_2 at index 2
-type requestExtraInfo struct {
-	// Indexed queues of parsed extra headers. Slots are set to nil after
-	// pairing to avoid applying headers twice.
+// Only responses that expect ExtraInfo are tracked (see processResponse).
+// Because the ExtraInfo events are likewise only emitted for those responses,
+// the indexes stay aligned even when some hops (e.g. cached redirects) carry no
+// ExtraInfo. The raw request headers are attached to the response's Request,
+// matching Playwright.
+type requestInfo struct {
+	// Indexed queues of parsed raw headers. Slots are set to nil after
+	// pairing to avoid applying the same headers twice.
 	requestExtraHeaders  []map[string][]string
 	responseExtraHeaders []map[string][]string
 
-	// Indexed queues of requests/responses awaiting extra headers. Slots
-	// are set to nil after pairing.
-	requests  []*Request
+	// Responses that expect ExtraInfo, in arrival order.
 	responses []*Response
+
+	loadingFinished bool
+	loadingFailed   bool
+	servedFromCache bool
 }
 
 // extraInfoTracker pairs requestWillBeSentExtraInfo / responseReceivedExtraInfo
-// events with their corresponding Request / Response objects using index-based
+// events with their corresponding Response (and its Request) using index-based
 // matching (modelled after Playwright's ResponseExtraInfoTracker).
 type extraInfoTracker struct {
-	requests map[network.RequestID]*requestExtraInfo
+	requests map[network.RequestID]*requestInfo
 }
 
 func newExtraInfoTracker() *extraInfoTracker {
 	return &extraInfoTracker{
-		requests: make(map[network.RequestID]*requestExtraInfo),
+		requests: make(map[network.RequestID]*requestInfo),
 	}
 }
 
-// getOrCreate returns the requestExtraInfo for the given requestId,
-// creating one if it doesn't exist yet.
-func (t *extraInfoTracker) getOrCreate(reqID network.RequestID) *requestExtraInfo {
+// getOrCreate returns the requestInfo for the given requestId, creating one if
+// it doesn't exist yet.
+func (t *extraInfoTracker) getOrCreate(reqID network.RequestID) *requestInfo {
 	info, ok := t.requests[reqID]
 	if !ok {
-		info = &requestExtraInfo{}
+		info = &requestInfo{}
 		t.requests[reqID] = info
 	}
 	return info
 }
 
-// requestWillBeSentExtraInfo records parsed request extra headers and
-// tries to pair them with an already-registered Request at the same index.
+// requestWillBeSentExtraInfo records parsed raw request headers and tries to
+// pair them with an already-registered response at the same index.
 func (t *extraInfoTracker) requestWillBeSentExtraInfo(reqID network.RequestID, headers map[string][]string) {
 	info := t.getOrCreate(reqID)
 	info.requestExtraHeaders = append(info.requestExtraHeaders, headers)
-	t.patchRequestHeaders(info, len(info.requestExtraHeaders)-1)
+	t.patchHeaders(info, len(info.requestExtraHeaders)-1)
+	t.checkFinished(reqID, info)
 }
 
-// responseReceivedExtraInfo records parsed response extra headers and
-// tries to pair them with an already-registered Response at the same index.
+// responseReceivedExtraInfo records parsed raw response headers and tries to
+// pair them with an already-registered response at the same index.
 func (t *extraInfoTracker) responseReceivedExtraInfo(reqID network.RequestID, headers map[string][]string) {
 	info := t.getOrCreate(reqID)
 	info.responseExtraHeaders = append(info.responseExtraHeaders, headers)
-	t.patchResponseHeaders(info, len(info.responseExtraHeaders)-1)
+	t.patchHeaders(info, len(info.responseExtraHeaders)-1)
+	t.checkFinished(reqID, info)
 }
 
-// processRequest registers a Request and tries to pair it with
-// already-received request extra headers at the same index.
-func (t *extraInfoTracker) processRequest(reqID network.RequestID, req *Request) {
+// requestServedFromCache marks the requestId as served from cache. Chrome can
+// report hasExtraInfo=true for cached responses but never emit the matching
+// ExtraInfo event (crbug.com/1340398), so such responses must not be tracked,
+// otherwise the index would slip and later headers would land on the wrong
+// response.
+func (t *extraInfoTracker) requestServedFromCache(reqID network.RequestID) {
 	info := t.getOrCreate(reqID)
-	info.requests = append(info.requests, req)
-	t.patchRequestHeaders(info, len(info.requests)-1)
+	info.servedFromCache = true
 }
 
-// processResponse registers a Response and tries to pair it with
-// already-received response extra headers at the same index.
-func (t *extraInfoTracker) processResponse(reqID network.RequestID, resp *Response) {
-	info := t.getOrCreate(reqID)
+// processResponse registers a Response that expects ExtraInfo. Responses that
+// do not expect it (hasExtraInfo=false, or served from cache) are not tracked,
+// so they keep their provisional headers as the raw ones.
+func (t *extraInfoTracker) processResponse(reqID network.RequestID, resp *Response, hasExtraInfo bool) {
+	info, ok := t.requests[reqID]
+	if !hasExtraInfo || (ok && info.servedFromCache) {
+		return
+	}
+	if !ok {
+		info = t.getOrCreate(reqID)
+	}
 	info.responses = append(info.responses, resp)
-	t.patchResponseHeaders(info, len(info.responses)-1)
+	t.patchHeaders(info, len(info.responses)-1)
 }
 
-// patchRequestHeaders applies request extra headers at the given index
-// if both the Request and the extra headers are available. After applying,
-// both slots are nilled out to avoid double-application.
-func (t *extraInfoTracker) patchRequestHeaders(info *requestExtraInfo, index int) {
-	if index >= len(info.requests) || index >= len(info.requestExtraHeaders) {
-		return
-	}
-	req := info.requests[index]
-	extra := info.requestExtraHeaders[index]
-	if req == nil || extra == nil {
-		return
-	}
-	req.addExtraHeaders(extra)
-	info.requests[index] = nil
-	info.requestExtraHeaders[index] = nil
-}
-
-// patchResponseHeaders applies response extra headers at the given index
-// if both the Response and the extra headers are available. After applying,
-// both slots are nilled out to avoid double-application.
-func (t *extraInfoTracker) patchResponseHeaders(info *requestExtraInfo, index int) {
-	if index >= len(info.responses) || index >= len(info.responseExtraHeaders) {
+// patchHeaders attaches the raw request and response headers at the given index
+// when both the response and the corresponding ExtraInfo event are available.
+// Consumed ExtraInfo slots are set to nil to avoid applying them twice.
+func (t *extraInfoTracker) patchHeaders(info *requestInfo, index int) {
+	if index < 0 || index >= len(info.responses) {
 		return
 	}
 	resp := info.responses[index]
-	extra := info.responseExtraHeaders[index]
-	if resp == nil || extra == nil {
+	if resp == nil {
 		return
 	}
-	resp.addExtraHeaders(extra)
-	info.responses[index] = nil
-	info.responseExtraHeaders[index] = nil
+	if index < len(info.requestExtraHeaders) {
+		if extra := info.requestExtraHeaders[index]; extra != nil {
+			resp.request.addExtraHeaders(extra)
+			info.requestExtraHeaders[index] = nil
+		}
+	}
+	if index < len(info.responseExtraHeaders) {
+		if extra := info.responseExtraHeaders[index]; extra != nil {
+			resp.addExtraHeaders(extra)
+			info.responseExtraHeaders[index] = nil
+		}
+	}
 }
 
-// cleanup removes the tracking entry for the given requestId. Should be
-// called when loading finishes or fails.
-func (t *extraInfoTracker) cleanup(reqID network.RequestID) {
-	delete(t.requests, reqID)
+// loadingFinished records that loading finished and stops tracking once every
+// tracked response has been paired with its ExtraInfo event.
+func (t *extraInfoTracker) loadingFinished(reqID network.RequestID) {
+	info, ok := t.requests[reqID]
+	if !ok {
+		return
+	}
+	info.loadingFinished = true
+	t.checkFinished(reqID, info)
+}
+
+// loadingFailed records that loading failed and stops tracking once every
+// tracked response has been paired with its ExtraInfo event.
+func (t *extraInfoTracker) loadingFailed(reqID network.RequestID) {
+	info, ok := t.requests[reqID]
+	if !ok {
+		return
+	}
+	info.loadingFailed = true
+	t.checkFinished(reqID, info)
+}
+
+// checkFinished removes the tracking entry once loading has finished/failed and
+// every tracked response has its response ExtraInfo. Deletion is deferred until
+// then so a late-arriving ExtraInfo event (CDP may emit it after
+// loadingFinished) can still be paired instead of being dropped.
+func (t *extraInfoTracker) checkFinished(reqID network.RequestID, info *requestInfo) {
+	if !info.loadingFinished && !info.loadingFailed {
+		return
+	}
+	if len(info.responses) <= len(info.responseExtraHeaders) {
+		delete(t.requests, reqID)
+	}
 }

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -314,11 +314,17 @@ func (r *Request) Headers() map[string]string {
 // HeadersArray returns the request headers as an array of objects.
 func (r *Request) HeadersArray() []HTTPHeader {
 	headers := make([]HTTPHeader, 0)
-	for n, vals := range r.headers {
-		for _, v := range vals {
-			headers = append(headers, HTTPHeader{Name: n, Value: v})
+	r.extraHeadersMu.RLock()
+	source := r.headers
+	if len(r.extraHeaders) != 0 {
+		source = r.extraHeaders
+	}
+	for name, values := range source {
+		for _, v := range values {
+			headers = append(headers, HTTPHeader{Name: name, Value: v})
 		}
 	}
+	r.extraHeadersMu.RUnlock()
 	return headers
 }
 

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -216,6 +216,12 @@ func validateResourceType(logger *log.Logger, t string) string {
 	return t
 }
 
+func (r *Request) addExtraHeaders(extra map[string][]string) {
+	r.extraHeadersMu.Lock()
+	defer r.extraHeadersMu.Unlock()
+	r.extraHeaders = extra
+}
+
 func (r *Request) getFrame() *Frame {
 	return r.frame
 }
@@ -492,6 +498,12 @@ func NewHTTPResponse(
 	}
 
 	return &r
+}
+
+func (r *Response) addExtraHeaders(extra map[string][]string) {
+	r.extraHeadersMu.Lock()
+	defer r.extraHeadersMu.Unlock()
+	r.extraHeaders = extra
 }
 
 func (r *Response) fetchBody() error {

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -70,16 +70,18 @@ type RequestFailure struct {
 
 // Request represents a browser HTTP request.
 type Request struct {
-	ctx           context.Context
-	frame         *Frame
-	responseMu    sync.RWMutex
-	response      *Response
-	redirectChain []*Request
-	requestID     network.RequestID
-	documentID    string
-	url           *url.URL
-	method        string
-	headers       map[string][]string
+	ctx            context.Context
+	frame          *Frame
+	responseMu     sync.RWMutex
+	response       *Response
+	redirectChain  []*Request
+	requestID      network.RequestID
+	documentID     string
+	url            *url.URL
+	method         string
+	headers        map[string][]string
+	extraHeaders   map[string][]string
+	extraHeadersMu sync.RWMutex
 	// For now we're only going to work with the 0th entry of postDataEntries.
 	// We've not been able to reproduce a situation where more than one entry
 	// occupies the slice. Once we have a better idea of when more than one
@@ -428,6 +430,8 @@ type Response struct {
 	bodyMu            sync.RWMutex
 	body              []byte
 	headers           map[string][]string
+	extraHeaders      map[string][]string
+	extraHeadersMu    sync.RWMutex
 	fromDiskCache     bool
 	fromServiceWorker bool
 	fromPrefetchCache bool

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -275,11 +275,18 @@ func (r *Request) setLoadedFromCache(fromMemoryCache bool) {
 
 // AllHeaders returns all the request headers.
 func (r *Request) AllHeaders() map[string]string {
-	// TODO: fix this data to include "ExtraInfo" header data
 	headers := make(map[string]string)
-	for n, v := range r.headers {
-		headers[strings.ToLower(n)] = strings.Join(v, ",")
+	r.extraHeadersMu.RLock()
+	if len(r.extraHeaders) != 0 {
+		for name, values := range r.extraHeaders {
+			headers[strings.ToLower(name)] = strings.Join(values, "\n")
+		}
+	} else {
+		for name, values := range r.headers {
+			headers[strings.ToLower(name)] = strings.Join(values, "\n")
+		}
 	}
+	r.extraHeadersMu.RUnlock()
 	return headers
 }
 

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -239,9 +239,21 @@ func (r *Request) headersSize() int64 {
 	size += len(r.method)
 	size += len(r.url.Path)
 	size += 8 // httpVersion
-	for n, v := range r.headers {
-		size += len(n) + len(strings.Join(v, "")) + 4 // 4 = ': ' + '\r\n'
+	r.extraHeadersMu.RLock()
+	if len(r.extraHeaders) != 0 {
+		for name, values := range r.extraHeaders {
+			for _, value := range values {
+				size += len(name) + len(value) + 4 // 4 = ': ' + '\r\n'
+			}
+		}
+	} else {
+		for name, values := range r.headers {
+			for _, value := range values {
+				size += len(name) + len(value) + 4 // 4 = ': ' + '\r\n'
+			}
+		}
 	}
+	r.extraHeadersMu.RUnlock()
 	return int64(size)
 }
 

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -660,10 +660,13 @@ func (r *Response) HeaderValue(name string) (string, bool) {
 	return v, ok
 }
 
-// HeaderValues returns the values of the given header.
+// HeaderValues returns the values of the given header. The header name is
+// matched case-insensitively, and headers that carry multiple values (such as
+// Set-Cookie) are returned as separate entries. AllHeaders joins multiple
+// values with a newline, so we split on the same separator here.
 func (r *Response) HeaderValues(name string) []string {
 	headers := r.AllHeaders()
-	return strings.Split(headers[name], ",")
+	return strings.Split(headers[strings.ToLower(name)], "\n")
 }
 
 // FromCache returns whether this response was served from disk cache.

--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -82,6 +82,11 @@ type Request struct {
 	headers        map[string][]string
 	extraHeaders   map[string][]string
 	extraHeadersMu sync.RWMutex
+	// rawHeadersCh is closed once the raw (ExtraInfo) headers have been
+	// resolved: either applied, or known not to arrive. Readers that need the
+	// raw headers wait on it; see waitForRawHeaders.
+	rawHeadersCh   chan struct{}
+	rawHeadersOnce sync.Once
 	// For now we're only going to work with the 0th entry of postDataEntries.
 	// We've not been able to reproduce a situation where more than one entry
 	// occupies the slice. Once we have a better idea of when more than one
@@ -171,6 +176,7 @@ func NewRequest(ctx context.Context, logger *log.Logger, rp NewRequestParams) (*
 		documentID:          documentID.String(),
 		headers:             make(map[string][]string, len(ev.Request.Headers)),
 		ctx:                 ctx,
+		rawHeadersCh:        make(chan struct{}),
 	}
 	for n, v := range ev.Request.Headers {
 		if s, ok := v.(string); ok {
@@ -218,8 +224,25 @@ func validateResourceType(logger *log.Logger, t string) string {
 
 func (r *Request) addExtraHeaders(extra map[string][]string) {
 	r.extraHeadersMu.Lock()
-	defer r.extraHeadersMu.Unlock()
 	r.extraHeaders = extra
+	r.extraHeadersMu.Unlock()
+	r.resolveRawHeaders()
+}
+
+// resolveRawHeaders unblocks readers waiting for the raw (ExtraInfo) headers.
+// It is called once the raw headers have been applied, or once it is known
+// that none will arrive (so the provisional headers are the final ones).
+func (r *Request) resolveRawHeaders() {
+	r.rawHeadersOnce.Do(func() { close(r.rawHeadersCh) })
+}
+
+// WaitForRawHeaders blocks until the raw headers are resolved or the request
+// context is done, whichever comes first.
+func (r *Request) WaitForRawHeaders() {
+	select {
+	case <-r.rawHeadersCh:
+	case <-r.ctx.Done():
+	}
 }
 
 func (r *Request) getFrame() *Frame {
@@ -463,6 +486,8 @@ type Response struct {
 	headers           map[string][]string
 	extraHeaders      map[string][]string
 	extraHeadersMu    sync.RWMutex
+	rawHeadersCh      chan struct{}
+	rawHeadersOnce    sync.Once
 	fromDiskCache     bool
 	fromServiceWorker bool
 	fromPrefetchCache bool
@@ -494,6 +519,7 @@ func NewHTTPResponse(
 		statusText:        resp.StatusText,
 		body:              nil,
 		headers:           make(map[string][]string, len(resp.Headers)),
+		rawHeadersCh:      make(chan struct{}),
 		fromDiskCache:     resp.FromDiskCache,
 		fromServiceWorker: resp.FromServiceWorker,
 		fromPrefetchCache: resp.FromPrefetchCache,
@@ -527,8 +553,25 @@ func NewHTTPResponse(
 
 func (r *Response) addExtraHeaders(extra map[string][]string) {
 	r.extraHeadersMu.Lock()
-	defer r.extraHeadersMu.Unlock()
 	r.extraHeaders = extra
+	r.extraHeadersMu.Unlock()
+	r.resolveRawHeaders()
+}
+
+// resolveRawHeaders unblocks readers waiting for the raw (ExtraInfo) headers.
+// It is called once the raw headers have been applied, or once it is known
+// that none will arrive (so the provisional headers are the final ones).
+func (r *Response) resolveRawHeaders() {
+	r.rawHeadersOnce.Do(func() { close(r.rawHeadersCh) })
+}
+
+// WaitForRawHeaders blocks until the raw headers are resolved or the response
+// context is done, whichever comes first.
+func (r *Response) WaitForRawHeaders() {
+	select {
+	case <-r.rawHeadersCh:
+	case <-r.ctx.Done():
+	}
 }
 
 func (r *Response) fetchBody() error {

--- a/internal/js/modules/k6/browser/common/http_test.go
+++ b/internal/js/modules/k6/browser/common/http_test.go
@@ -127,6 +127,42 @@ func TestResponse(t *testing.T) {
 	})
 }
 
+func TestResponseHeaderValuesExtraInfo(t *testing.T) {
+	t.Parallel()
+
+	ts := cdp.MonotonicTime(time.Now())
+	vu := k6test.NewVU(t)
+	vu.ActivateVU()
+	req := &Request{
+		offset: 0,
+	}
+	res := NewHTTPResponse(vu.Context(), req, &network.Response{
+		URL:     "https://test/post",
+		Headers: network.Headers(map[string]any{"content-type": "text/plain"}),
+	}, &ts)
+
+	// Simulate the raw wire headers arriving via responseReceivedExtraInfo,
+	// where a multi-valued header (Set-Cookie) is carried as separate values.
+	res.addExtraHeaders(map[string][]string{
+		"Set-Cookie": {"a=1; Path=/", "b=2; Path=/"},
+	})
+
+	t.Run("AllHeaders()_joins_multivalue_with_newline", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "a=1; Path=/\nb=2; Path=/", res.AllHeaders()["set-cookie"])
+	})
+
+	t.Run("HeaderValues()_splits_multivalue", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []string{"a=1; Path=/", "b=2; Path=/"}, res.HeaderValues("set-cookie"))
+	})
+
+	t.Run("HeaderValues()_is_case_insensitive", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, []string{"a=1; Path=/", "b=2; Path=/"}, res.HeaderValues("Set-Cookie"))
+	})
+}
+
 func TestValidateResourceType(t *testing.T) {
 	t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/http_test.go
+++ b/internal/js/modules/k6/browser/common/http_test.go
@@ -161,6 +161,17 @@ func TestResponseHeaderValuesExtraInfo(t *testing.T) {
 		t.Parallel()
 		assert.Equal(t, []string{"a=1; Path=/", "b=2; Path=/"}, res.HeaderValues("Set-Cookie"))
 	})
+
+	t.Run("HeadersArray()_keeps_values_separate", func(t *testing.T) {
+		t.Parallel()
+		var cookies []string
+		for _, h := range res.HeadersArray() {
+			if strings.EqualFold(h.Name, "Set-Cookie") {
+				cookies = append(cookies, h.Value)
+			}
+		}
+		assert.ElementsMatch(t, []string{"a=1; Path=/", "b=2; Path=/"}, cookies)
+	})
 }
 
 func TestValidateResourceType(t *testing.T) {

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -412,10 +412,12 @@ func (m *NetworkManager) handleEvents(in <-chan Event) bool {
 			m.onLoadingFinished(ev)
 		case *network.EventRequestWillBeSent:
 			m.onRequestWillBeSent(ev)
+		case *network.EventRequestWillBeSentExtraInfo:
 		case *network.EventRequestServedFromCache:
 			m.onRequestServedFromCache(ev)
 		case *network.EventResponseReceived:
 			m.onResponseReceived(ev)
+		case *network.EventResponseReceivedExtraInfo:
 		case *fetch.EventRequestPaused:
 			m.onRequestPaused(ev)
 		case *fetch.EventAuthRequired:

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -377,8 +377,10 @@ func (m *NetworkManager) initEvents() {
 		cdproto.EventNetworkLoadingFailed,
 		cdproto.EventNetworkLoadingFinished,
 		cdproto.EventNetworkRequestWillBeSent,
+		cdproto.EventNetworkRequestWillBeSentExtraInfo,
 		cdproto.EventNetworkRequestServedFromCache,
 		cdproto.EventNetworkResponseReceived,
+		cdproto.EventNetworkResponseReceivedExtraInfo,
 		cdproto.EventFetchRequestPaused,
 		cdproto.EventFetchAuthRequired,
 	}, chHandler)

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -413,11 +413,13 @@ func (m *NetworkManager) handleEvents(in <-chan Event) bool {
 		case *network.EventRequestWillBeSent:
 			m.onRequestWillBeSent(ev)
 		case *network.EventRequestWillBeSentExtraInfo:
+			m.onRequestWillBeSentExtraInfo(ev)
 		case *network.EventRequestServedFromCache:
 			m.onRequestServedFromCache(ev)
 		case *network.EventResponseReceived:
 			m.onResponseReceived(ev)
 		case *network.EventResponseReceivedExtraInfo:
+			m.onResponseReceivedExtraInfo(ev)
 		case *fetch.EventRequestPaused:
 			m.onRequestPaused(ev)
 		case *fetch.EventAuthRequired:
@@ -611,6 +613,13 @@ func (m *NetworkManager) onRequestWillBeSent(event *network.EventRequestWillBeSe
 	}
 }
 
+func (m *NetworkManager) onRequestWillBeSentExtraInfo(event *network.EventRequestWillBeSentExtraInfo) {
+	extra := parseExtraHeaders(event.Headers)
+	if len(extra) == 0 {
+		return
+	}
+}
+
 // onRequestPaused can send one of these two CDP events:
 // - Fetch.failRequest if the URL is part of the blocked hosts or IPs
 // - Fetch.continueRequest if the request is not blocked and no route is configured
@@ -777,6 +786,13 @@ func (m *NetworkManager) onResponseReceived(event *network.EventResponseReceived
 	m.logger.Debugf("FrameManager:onResponseReceived", "rid:%s rurl:%s", event.RequestID, resp.URL())
 
 	m.eventInterceptor.onResponse(resp)
+}
+
+func (m *NetworkManager) onResponseReceivedExtraInfo(event *network.EventResponseReceivedExtraInfo) {
+	extra := parseExtraHeaders(event.Headers)
+	if len(extra) == 0 {
+		return
+	}
 }
 
 func (m *NetworkManager) requestFromID(reqID network.RequestID) (*Request, bool) {

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -620,6 +620,7 @@ func (m *NetworkManager) onRequestWillBeSentExtraInfo(event *network.EventReques
 	if len(extra) == 0 {
 		return
 	}
+	m.extraInfoTracker.requestWillBeSentExtraInfo(event.RequestID, extra)
 }
 
 // onRequestPaused can send one of these two CDP events:
@@ -795,6 +796,7 @@ func (m *NetworkManager) onResponseReceivedExtraInfo(event *network.EventRespons
 	if len(extra) == 0 {
 		return
 	}
+	m.extraInfoTracker.responseReceivedExtraInfo(event.RequestID, extra)
 }
 
 func (m *NetworkManager) requestFromID(reqID network.RequestID) (*Request, bool) {

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -443,6 +443,7 @@ func (m *NetworkManager) onLoadingFailed(event *network.EventLoadingFailed) {
 	req.responseEndTiming = float64(event.Timestamp.Time().Unix()-req.timestamp.Unix()) * 1000
 	m.eventInterceptor.onRequestFailed(req)
 	m.deleteRequestByID(event.RequestID)
+	m.extraInfoTracker.cleanup(event.RequestID)
 	m.frameManager.requestFailed(req, event.Canceled)
 }
 
@@ -455,6 +456,7 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 
 	req.responseEndTiming = float64(event.Timestamp.Time().Unix()-req.timestamp.Unix()) * 1000
 	m.deleteRequestByID(event.RequestID)
+	m.extraInfoTracker.cleanup(event.RequestID)
 	m.frameManager.requestFinished(req)
 	m.eventInterceptor.onRequestFinished(req)
 

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -1066,3 +1066,40 @@ func (m *NetworkManager) SetCacheEnabled(enabled bool) {
 func (m *NetworkManager) wait() {
 	m.wg.Wait()
 }
+
+func parseExtraHeaders(headers network.Headers) map[string][]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	parsed := make(map[string][]string, len(headers))
+	for name, value := range headers {
+		switch v := value.(type) {
+		case string:
+			parsed[name] = splitHeaderValues(v)
+		case []string:
+			parsed[name] = append([]string{}, v...)
+		case []any:
+			values := make([]string, 0, len(v))
+			for _, item := range v {
+				if s, ok := item.(string); ok {
+					values = append(values, s)
+				}
+			}
+			if len(values) > 0 {
+				parsed[name] = values
+			}
+		}
+	}
+	if len(parsed) == 0 {
+		return nil
+	}
+	return parsed
+}
+
+// CDP concatenates duplicate header values with newlines; split to match Playwright.
+func splitHeaderValues(value string) []string {
+	if strings.Contains(value, "\n") {
+		return strings.Split(value, "\n")
+	}
+	return []string{value}
+}

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -784,6 +784,7 @@ func (m *NetworkManager) onResponseReceived(event *network.EventResponseReceived
 		return
 	}
 	resp := NewHTTPResponse(m.ctx, req, event.Response, event.Timestamp)
+	m.extraInfoTracker.processResponse(event.RequestID, resp)
 	req.responseMu.Lock()
 	req.response = resp
 	req.responseMu.Unlock()

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -337,6 +337,7 @@ func (m *NetworkManager) handleRequestRedirect(
 	req *Request, redirectResponse *network.Response, timestamp *cdp.MonotonicTime,
 ) {
 	resp := NewHTTPResponse(m.ctx, req, redirectResponse, timestamp)
+	m.extraInfoTracker.processResponse(req.requestID, resp)
 	req.responseMu.Lock()
 	req.response = resp
 	req.responseMu.Unlock()
@@ -576,6 +577,7 @@ func (m *NetworkManager) onRequest(event *network.EventRequestWillBeSent,
 		m.logger.Errorf("NetworkManager", "creating request: %s", err)
 		return
 	}
+	m.extraInfoTracker.processRequest(event.RequestID, req)
 	// Skip data and blob URLs, since they're internal to the browser.
 	if isInternalURL(req.url) {
 		m.logger.Debugf("NetworkManager", "skipping request handling of %s URL", req.url.Scheme)

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -80,6 +80,7 @@ type NetworkManager struct {
 	eventsWillBeSentMu            sync.RWMutex
 	reqIDToRequestPausedEvent     map[network.RequestID]*fetch.EventRequestPaused
 	eventsPausedMu                sync.RWMutex
+	extraInfoTracker              *extraInfoTracker
 
 	attemptedAuth map[fetch.RequestID]bool
 
@@ -125,6 +126,7 @@ func NewNetworkManager(
 		reqIDToRequest:                make(map[network.RequestID]*Request),
 		reqIDToRequestWillBeSentEvent: make(map[network.RequestID]*network.EventRequestWillBeSent),
 		reqIDToRequestPausedEvent:     make(map[network.RequestID]*fetch.EventRequestPaused),
+		extraInfoTracker:              newExtraInfoTracker(),
 		attemptedAuth:                 make(map[fetch.RequestID]bool),
 		extraHTTPHeaders:              make(map[string]string),
 		networkProfile:                NewNetworkProfile(),

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -343,7 +343,13 @@ func (m *NetworkManager) handleRequestRedirect(
 	req.responseMu.Unlock()
 	req.redirectChain = append(req.redirectChain, req)
 
-	m.emitResponseMetrics(resp, req)
+	// Emit the response metrics once the raw headers are resolved, off the
+	// event goroutine so the wait does not block the goroutine that resolves
+	// them (the redirect's ExtraInfo may still be in flight here).
+	m.wg.Go(func() {
+		resp.WaitForRawHeaders()
+		m.emitResponseMetrics(resp, req)
+	})
 	m.deleteRequestByID(req.requestID)
 
 	/*
@@ -466,26 +472,21 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 	if isInternalURL(req.url) {
 		return
 	}
-	emitResponseMetrics := func() {
-		req.responseMu.RLock()
-		m.emitResponseMetrics(req.response, req)
-		req.responseMu.RUnlock()
-	}
-	if !req.allowInterception {
-		emitResponseMetrics()
-		return
-	}
-	// When request interception is enabled, we need to process requestPaused messages
-	// from CDP in order to get the response for the request. However, we can't process
-	// them until the request is unblocked. Since we're blocking the NetworkManager
-	// goroutine here, we need to spawn a new goroutine to allow the requestPaused
-	// messages to be processed by the NetworkManager.
-	//
-	// This happens when the main page request redirects before it finishes loading.
-	// So the new redirect request will be blocked until the main page finishes loading.
-	// The main page will wait forever since its subrequest is blocked.
+	// Emit the response metrics in a separate goroutine, once the raw headers
+	// are resolved, so the reported size is computed from a stable source.
+	// This must not run on the NetworkManager event goroutine: waiting for the
+	// raw headers there would block the goroutine that resolves them. Spawning
+	// a goroutine is also required for intercepted requests, so that CDP
+	// requestPaused messages can still be processed while a redirected main
+	// page request waits for its subrequest to finish loading.
 	m.wg.Go(func() {
-		emitResponseMetrics()
+		req.responseMu.RLock()
+		resp := req.response
+		req.responseMu.RUnlock()
+		if resp != nil {
+			resp.WaitForRawHeaders()
+		}
+		m.emitResponseMetrics(resp, req)
 	})
 }
 
@@ -589,7 +590,13 @@ func (m *NetworkManager) onRequest(event *network.EventRequestWillBeSent,
 	m.reqsMu.Lock()
 	m.reqIDToRequest[event.RequestID] = req
 	m.reqsMu.Unlock()
-	m.emitRequestMetrics(req)
+	// Emit the request metrics once the raw headers are resolved, off the
+	// event goroutine so the wait does not block the goroutine that resolves
+	// them. The metric uses req.wallTime, so the deferral does not skew it.
+	m.wg.Go(func() {
+		req.WaitForRawHeaders()
+		m.emitRequestMetrics(req)
+	})
 	m.frameManager.requestStarted(req)
 
 	m.eventInterceptor.onRequest(req)

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -334,10 +334,10 @@ func handleURLTag(mi eventInterceptor, url string, method string, tags *k6metric
 }
 
 func (m *NetworkManager) handleRequestRedirect(
-	req *Request, redirectResponse *network.Response, timestamp *cdp.MonotonicTime,
+	req *Request, redirectResponse *network.Response, hasExtraInfo bool, timestamp *cdp.MonotonicTime,
 ) {
 	resp := NewHTTPResponse(m.ctx, req, redirectResponse, timestamp)
-	m.extraInfoTracker.processResponse(req.requestID, resp)
+	m.extraInfoTracker.processResponse(req.requestID, resp, hasExtraInfo)
 	req.responseMu.Lock()
 	req.response = resp
 	req.responseMu.Unlock()
@@ -443,7 +443,7 @@ func (m *NetworkManager) onLoadingFailed(event *network.EventLoadingFailed) {
 	req.responseEndTiming = float64(event.Timestamp.Time().Unix()-req.timestamp.Unix()) * 1000
 	m.eventInterceptor.onRequestFailed(req)
 	m.deleteRequestByID(event.RequestID)
-	m.extraInfoTracker.cleanup(event.RequestID)
+	m.extraInfoTracker.loadingFailed(event.RequestID)
 	m.frameManager.requestFailed(req, event.Canceled)
 }
 
@@ -456,7 +456,7 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 
 	req.responseEndTiming = float64(event.Timestamp.Time().Unix()-req.timestamp.Unix()) * 1000
 	m.deleteRequestByID(event.RequestID)
-	m.extraInfoTracker.cleanup(event.RequestID)
+	m.extraInfoTracker.loadingFinished(event.RequestID)
 	m.frameManager.requestFinished(req)
 	m.eventInterceptor.onRequestFinished(req)
 
@@ -532,7 +532,7 @@ func (m *NetworkManager) onRequest(event *network.EventRequestWillBeSent,
 	if event.RedirectResponse != nil {
 		req, ok := m.requestFromID(event.RequestID)
 		if ok {
-			m.handleRequestRedirect(req, event.RedirectResponse, event.Timestamp)
+			m.handleRequestRedirect(req, event.RedirectResponse, event.RedirectHasExtraInfo, event.Timestamp)
 			redirectChain = req.redirectChain
 		}
 	} else {
@@ -579,7 +579,6 @@ func (m *NetworkManager) onRequest(event *network.EventRequestWillBeSent,
 		m.logger.Errorf("NetworkManager", "creating request: %s", err)
 		return
 	}
-	m.extraInfoTracker.processRequest(event.RequestID, req)
 	// Skip data and blob URLs, since they're internal to the browser.
 	if isInternalURL(req.url) {
 		m.logger.Debugf("NetworkManager", "skipping request handling of %s URL", req.url.Scheme)
@@ -773,6 +772,7 @@ func (m *NetworkManager) onAuthRequired(event *fetch.EventAuthRequired) {
 }
 
 func (m *NetworkManager) onRequestServedFromCache(event *network.EventRequestServedFromCache) {
+	m.extraInfoTracker.requestServedFromCache(event.RequestID)
 	req, ok := m.requestFromID(event.RequestID)
 	if ok {
 		req.setLoadedFromCache(true)
@@ -786,7 +786,7 @@ func (m *NetworkManager) onResponseReceived(event *network.EventResponseReceived
 		return
 	}
 	resp := NewHTTPResponse(m.ctx, req, event.Response, event.Timestamp)
-	m.extraInfoTracker.processResponse(event.RequestID, resp)
+	m.extraInfoTracker.processResponse(event.RequestID, resp, event.HasExtraInfo)
 	req.responseMu.Lock()
 	req.response = resp
 	req.responseMu.Unlock()

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -444,6 +444,7 @@ func (m *NetworkManager) onLoadingFailed(event *network.EventLoadingFailed) {
 	m.eventInterceptor.onRequestFailed(req)
 	m.deleteRequestByID(event.RequestID)
 	m.extraInfoTracker.loadingFailed(event.RequestID)
+	req.resolveRawHeaders()
 	m.frameManager.requestFailed(req, event.Canceled)
 }
 
@@ -457,6 +458,7 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 	req.responseEndTiming = float64(event.Timestamp.Time().Unix()-req.timestamp.Unix()) * 1000
 	m.deleteRequestByID(event.RequestID)
 	m.extraInfoTracker.loadingFinished(event.RequestID)
+	req.resolveRawHeaders()
 	m.frameManager.requestFinished(req)
 	m.eventInterceptor.onRequestFinished(req)
 

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2499,16 +2499,39 @@ func TestPageOnRequest(t *testing.T) {
 	}
 
 	// Compare each request one by one for better test failure visibility
+	// We only want to compare against the exepcted values. The actual values
+	// may contain extra headers that are not present in the expected values.
+	// Extra headers are racey and can be present or may not be present when
+	// the page.on('request') handler is called.
 	for _, req := range requests {
 		i := slices.IndexFunc(expected, func(r request) bool { return req.URL == r.URL })
 		assert.NotEqual(t, -1, i, "failed to find expected request with URL %s", req.URL)
 
-		sortByName := func(m1, m2 map[string]string) int {
-			return strings.Compare(m1["name"], m2["name"])
+		expectedHeadersArray := make(map[string]string)
+		for _, header := range expected[i].HeadersArray {
+			expectedHeadersArray[header["name"]] = header["value"]
 		}
-		slices.SortFunc(req.HeadersArray, sortByName)
-		slices.SortFunc(expected[i].HeadersArray, sortByName)
-		assert.Equal(t, expected[i], req)
+		for name, value := range expected[i].AllHeaders {
+			actualValue, ok := req.AllHeaders[name]
+			require.True(t, ok, "missing allHeaders[%s] for %s", name, req.URL)
+			require.Equal(t, value, actualValue, "allHeaders[%s] mismatch for %s", name, req.URL)
+		}
+		require.Equal(t, expected[i].FrameURL, req.FrameURL, i)
+		require.Equal(t, expected[i].AcceptLanguageHeader, req.AcceptLanguageHeader, i)
+		require.Equal(t, expected[i].Headers, req.Headers, i)
+		for _, header := range req.HeadersArray {
+			if expectedValue, ok := expectedHeadersArray[header["name"]]; ok {
+				require.Equal(t, expectedValue, header["value"], "headersArray[%s] mismatch for %s", header["name"], req.URL)
+				delete(expectedHeadersArray, header["name"])
+			}
+		}
+		require.Empty(t, expectedHeadersArray, "missing headersArray entries for %s", req.URL)
+		require.Equal(t, expected[i].IsNavigationRequest, req.IsNavigationRequest, i)
+		require.Equal(t, expected[i].Method, req.Method, i)
+		require.Equal(t, expected[i].PostData, req.PostData, i)
+		require.Equal(t, expected[i].PostDataBuffer, req.PostDataBuffer, i)
+		require.Equal(t, expected[i].ResourceType, req.ResourceType, i)
+		require.Equal(t, expected[i].URL, req.URL, i)
 	}
 }
 
@@ -2813,16 +2836,44 @@ func TestPageOnResponse(t *testing.T) {
 	}
 
 	// Compare each response one by one for better test failure visibility
+	// We only want to compare against the expected values. The actual values
+	// may contain extra headers that are not present in the expected values.
+	// Extra headers are racey and can be present or may not be present when
+	// the page.on('response') handler is called.
 	for _, resp := range responses {
 		i := slices.IndexFunc(expected, func(r response) bool { return resp.URL == r.URL })
 		assert.NotEqual(t, -1, i, "failed to find expected request with URL %s", resp.URL)
 
-		sortByName := func(m1, m2 map[string]string) int {
-			return strings.Compare(m1["name"], m2["name"])
+		expectedHeadersArray := make(map[string]string)
+		for _, header := range expected[i].HeadersArray {
+			expectedHeadersArray[header["name"]] = header["value"]
 		}
-		slices.SortFunc(resp.HeadersArray, sortByName)
-		slices.SortFunc(expected[i].HeadersArray, sortByName)
-		assert.Equal(t, expected[i], resp)
+		for name, value := range expected[i].AllHeaders {
+			actualValue, ok := resp.AllHeaders[name]
+			require.True(t, ok, "missing allHeaders[%s] for %s", name, resp.URL)
+			require.Equal(t, value, actualValue, "allHeaders[%s] mismatch for %s", name, resp.URL)
+		}
+		require.Equal(t, expected[i].Body, resp.Body, i)
+		require.Equal(t, expected[i].FrameURL, resp.FrameURL, i)
+		require.Equal(t, expected[i].AcceptLanguageHeader, resp.AcceptLanguageHeader, i)
+		require.Equal(t, expected[i].AcceptLanguageHeaders, resp.AcceptLanguageHeaders, i)
+		require.Equal(t, expected[i].Headers, resp.Headers, i)
+		for _, header := range resp.HeadersArray {
+			if expectedValue, ok := expectedHeadersArray[header["name"]]; ok {
+				require.Equal(t, expectedValue, header["value"], "headersArray[%s] mismatch for %s", header["name"], resp.URL)
+				delete(expectedHeadersArray, header["name"])
+			}
+		}
+		require.Empty(t, expectedHeadersArray, "missing headersArray entries for %s", resp.URL)
+		require.Equal(t, expected[i].JSON, resp.JSON, i)
+		require.Equal(t, expected[i].OK, resp.OK, i)
+		require.Equal(t, expected[i].RequestURL, resp.RequestURL, i)
+		require.Equal(t, expected[i].SecurityDetails, resp.SecurityDetails, i)
+		require.Equal(t, expected[i].ServerAddr, resp.ServerAddr, i)
+		require.Equal(t, expected[i].Status, resp.Status, i)
+		require.Equal(t, expected[i].StatusText, resp.StatusText, i)
+		require.Equal(t, expected[i].URL, resp.URL, i)
+		require.Equal(t, expected[i].Text, resp.Text, i)
 	}
 }
 

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2926,6 +2926,50 @@ func TestPageOnRequestAllHeadersExtraInfo(t *testing.T) {
 	assert.Contains(t, ev.Request.AllHeaders()["cookie"], "test_cookie_name=test_cookie_value")
 }
 
+func TestPageOnResponseAllHeadersExtraInfo(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withHTTPServer())
+	tb.withHandler("/set-cookie", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Add("Set-Cookie", "test_cookie_name=test_cookie_value; Path=/")
+		_, err := fmt.Fprint(w, "ok")
+		require.NoError(t, err)
+	})
+
+	p := tb.NewPage(nil)
+
+	opts := &common.FrameGotoOptions{
+		WaitUntil: common.LifecycleEventNetworkIdle,
+		Timeout:   common.DefaultTimeout,
+	}
+	gotoPage := func() error {
+		_, err := p.Goto(tb.url("/set-cookie"), opts)
+		return err
+	}
+
+	// We are only guaranteed to have the extra headers when the requestfinished
+	// event is fired. Trying to retrieve the extra headers on anyother event will
+	// be racey and may not be present.
+	var ev common.PageEvent
+	waitForRequestFinished := func() error {
+		var err error
+		ev, err = p.WaitForEvent(
+			common.PageEventRequestFinished,
+			&common.PageWaitForEventOptions{Timeout: p.Timeout()},
+			func(pe common.PageEvent) (bool, error) {
+				return strings.Contains(pe.Request.URL(), "/set-cookie"), nil
+			},
+		)
+		return err
+	}
+
+	err := tb.run(tb.context(), gotoPage, waitForRequestFinished)
+	require.NoError(t, err)
+	require.NotNil(t, ev.Request)
+
+	assert.Contains(t, ev.Request.Response().AllHeaders()["set-cookie"], "test_cookie_name=test_cookie_value")
+}
+
 // TestPageOnRequestFinished tests that the requestfinished event fires when requests complete successfully.
 func TestPageOnRequestFinished(t *testing.T) {
 	t.Parallel()

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2973,60 +2973,83 @@ func TestPageOnResponseAllHeadersRedirectChain(t *testing.T) {
 
 	tb := newTestBrowser(t, withHTTPServer())
 
-	// Set up a 3-step redirect chain, each response has a distinct X-Step header.
+	// A 3-step redirect chain where each hop sets a distinct Set-Cookie.
+	// Set-Cookie is delivered only via responseReceivedExtraInfo (Chrome
+	// strips it from the provisional responseReceived headers), so a hop's
+	// cookie can appear in allHeaders() only if the ExtraInfo events were
+	// paired with the correct response. This catches both mis-attribution (a
+	// later hop's cookie landing on an earlier response) and merging.
 	tb.withHandler("/redir-start", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Step", "1")
+		w.Header().Set("Set-Cookie", "step=1; Path=/")
 		http.Redirect(w, r, tb.url("/redir-mid"), http.StatusFound)
 	})
 	tb.withHandler("/redir-mid", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Step", "2")
+		w.Header().Set("Set-Cookie", "step=2; Path=/")
 		http.Redirect(w, r, tb.url("/redir-end"), http.StatusFound)
 	})
 	tb.withHandler("/redir-end", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("X-Step", "3")
+		w.Header().Set("Set-Cookie", "step=3; Path=/")
 		w.Header().Set("Content-Type", "text/html")
 		_, err := fmt.Fprint(w, "<html><body>done</body></html>")
 		require.NoError(t, err)
 	})
 
-	p := tb.NewPage(nil)
+	tb.vu.ActivateVU()
+	tb.vu.StartIteration(t)
+	defer tb.vu.EndIteration(t)
 
-	opts := &common.FrameGotoOptions{
-		WaitUntil: common.LifecycleEventNetworkIdle,
-		Timeout:   common.DefaultTimeout,
-	}
-	gotoPage := func() error {
-		_, err := p.Goto(tb.url("/redir-start"), opts)
-		return err
-	}
+	gv, err := tb.vu.RunAsync(t, `
+		const page = await browser.newPage();
 
-	// Wait for the final request to finish so we are guaranteed to
-	// have extra headers available on all responses in the chain.
-	var ev common.PageEvent
-	waitForRequestFinished := func() error {
-		var err error
-		ev, err = p.WaitForEvent(
-			common.PageEventRequestFinished,
-			&common.PageWaitForEventOptions{Timeout: p.Timeout()},
-			func(pe common.PageEvent) (bool, error) {
-				return strings.Contains(pe.Request.URL(), "/redir-end"), nil
-			},
-		)
-		return err
-	}
+		var responses = [];
+		page.on('response', async (response) => {
+			const headers = await response.allHeaders();
+			responses.push({
+				url: response.url(),
+				setCookie: headers['set-cookie'] || '',
+			});
+		});
 
-	err := tb.run(tb.context(), gotoPage, waitForRequestFinished)
+		await page.goto('%s', {waitUntil: 'networkidle'});
+		await page.close();
+
+		return JSON.stringify(responses);
+	`, tb.url("/redir-start"))
 	require.NoError(t, err)
-	require.NotNil(t, ev.Request)
 
-	finalResp := ev.Request.Response()
-	require.NotNil(t, finalResp)
+	got := k6test.ToPromise(t, gv)
 
-	// Verify the final (200) response has only its own X-Step header,
-	// not a merged set of values from all redirects.
-	finalHeaders := finalResp.AllHeaders()
-	assert.Equal(t, "3", finalHeaders["x-step"],
-		"final response should have x-step=3, not merged values from earlier redirects")
+	var responses []struct {
+		URL       string `json:"url"`
+		SetCookie string `json:"setCookie"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(got.Result().String()), &responses))
+
+	setCookieByURL := make(map[string]string, len(responses))
+	for _, r := range responses {
+		setCookieByURL[r.URL] = r.SetCookie
+	}
+
+	// Each hop must carry only its own Set-Cookie.
+	steps := []string{"step=1", "step=2", "step=3"}
+	for _, tc := range []struct {
+		url  string
+		step string
+	}{
+		{tb.url("/redir-start"), "step=1"},
+		{tb.url("/redir-mid"), "step=2"},
+		{tb.url("/redir-end"), "step=3"},
+	} {
+		cookie, ok := setCookieByURL[tc.url]
+		require.True(t, ok, "no response captured for %s", tc.url)
+		assert.Contains(t, cookie, tc.step, "wrong Set-Cookie on %s", tc.url)
+		for _, other := range steps {
+			if other != tc.step {
+				assert.NotContains(t, cookie, other,
+					"%s leaked %s from another hop", tc.url, other)
+			}
+		}
+	}
 }
 
 // TestPageOnRequestFinished tests that the requestfinished event fires when requests complete successfully.

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2877,6 +2877,55 @@ func TestPageOnResponse(t *testing.T) {
 	}
 }
 
+func TestPageOnRequestAllHeadersExtraInfo(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withHTTPServer())
+	tb.withHandler("/set-cookie", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Add("Set-Cookie", "test_cookie_name=test_cookie_value; Path=/")
+		_, err := fmt.Fprint(w, "ok")
+		require.NoError(t, err)
+	})
+
+	p := tb.NewPage(nil)
+
+	opts := &common.FrameGotoOptions{
+		WaitUntil: common.LifecycleEventNetworkIdle,
+		Timeout:   common.DefaultTimeout,
+	}
+	// This will tell the browser to store the cookie
+	_, err := p.Goto(tb.url("/set-cookie"), opts)
+	require.NoError(t, err)
+
+	// The cookie in the browser store is sent as a header in the request
+	gotoPage := func() error {
+		_, err := p.Goto(tb.url("/set-cookie"), opts)
+		return err
+	}
+
+	// We are only guaranteed to have the extra headers when the requestfinished
+	// event is fired. Trying to retrieve the extra headers on anyother event will
+	// be racey and may not be present.
+	var ev common.PageEvent
+	waitForRequestFinished := func() error {
+		var err error
+		ev, err = p.WaitForEvent(
+			common.PageEventRequestFinished,
+			&common.PageWaitForEventOptions{Timeout: p.Timeout()},
+			func(pe common.PageEvent) (bool, error) {
+				return strings.Contains(pe.Request.URL(), "/set-cookie"), nil
+			},
+		)
+		return err
+	}
+
+	err = tb.run(tb.context(), gotoPage, waitForRequestFinished)
+	require.NoError(t, err)
+	require.NotNil(t, ev.Request)
+
+	assert.Contains(t, ev.Request.AllHeaders()["cookie"], "test_cookie_name=test_cookie_value")
+}
+
 // TestPageOnRequestFinished tests that the requestfinished event fires when requests complete successfully.
 func TestPageOnRequestFinished(t *testing.T) {
 	t.Parallel()

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2496,7 +2496,7 @@ func TestPageOnRequest(t *testing.T) {
 	}
 
 	// Compare each request one by one for better test failure visibility
-	// We only want to compare against the exepcted values. The actual values
+	// We only want to compare against the expected values. The actual values
 	// may contain extra headers that are not present in the expected values.
 	// Extra headers are racey and can be present or may not be present when
 	// the page.on('request') handler is called.

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2970,6 +2970,70 @@ func TestPageOnResponseAllHeadersExtraInfo(t *testing.T) {
 	assert.Contains(t, ev.Request.Response().AllHeaders()["set-cookie"], "test_cookie_name=test_cookie_value")
 }
 
+// TestPageOnResponseAllHeadersRedirectChain verifies that each response in a
+// redirect chain receives its own distinct extra headers from
+// responseReceivedExtraInfo, rather than merging them all together.
+func TestPageOnResponseAllHeadersRedirectChain(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withHTTPServer())
+
+	// Set up a 3-step redirect chain, each response has a distinct X-Step header.
+	tb.withHandler("/redir-start", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Step", "1")
+		http.Redirect(w, r, tb.url("/redir-mid"), http.StatusFound)
+	})
+	tb.withHandler("/redir-mid", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Step", "2")
+		http.Redirect(w, r, tb.url("/redir-end"), http.StatusFound)
+	})
+	tb.withHandler("/redir-end", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Step", "3")
+		w.Header().Set("Content-Type", "text/html")
+		_, err := fmt.Fprint(w, "<html><body>done</body></html>")
+		require.NoError(t, err)
+	})
+
+	p := tb.NewPage(nil)
+
+	opts := &common.FrameGotoOptions{
+		WaitUntil: common.LifecycleEventNetworkIdle,
+		Timeout:   common.DefaultTimeout,
+	}
+	gotoPage := func() error {
+		_, err := p.Goto(tb.url("/redir-start"), opts)
+		return err
+	}
+
+	// Wait for the final request to finish so we are guaranteed to
+	// have extra headers available on all responses in the chain.
+	var ev common.PageEvent
+	waitForRequestFinished := func() error {
+		var err error
+		ev, err = p.WaitForEvent(
+			common.PageEventRequestFinished,
+			&common.PageWaitForEventOptions{Timeout: p.Timeout()},
+			func(pe common.PageEvent) (bool, error) {
+				return strings.Contains(pe.Request.URL(), "/redir-end"), nil
+			},
+		)
+		return err
+	}
+
+	err := tb.run(tb.context(), gotoPage, waitForRequestFinished)
+	require.NoError(t, err)
+	require.NotNil(t, ev.Request)
+
+	finalResp := ev.Request.Response()
+	require.NotNil(t, finalResp)
+
+	// Verify the final (200) response has only its own X-Step header,
+	// not a merged set of values from all redirects.
+	finalHeaders := finalResp.AllHeaders()
+	assert.Equal(t, "3", finalHeaders["x-step"],
+		"final response should have x-step=3, not merged values from earlier redirects")
+}
+
 // TestPageOnRequestFinished tests that the requestfinished event fires when requests complete successfully.
 func TestPageOnRequestFinished(t *testing.T) {
 	t.Parallel()

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2343,7 +2343,8 @@ func TestPageOnRequest(t *testing.T) {
 		page.on('request', async (request) => {
 			returnValue.push({
 				allHeaders: await request.allHeaders(),
-				frameUrl: request.frame().url(),
+				// Ignoring frameUrl as it is racey due to the async nature of how it is set.
+				// frameUrl: request.frame().url(),
 				acceptLanguageHeader: await request.headerValue('Accept-Language'),
 				headers: request.headers(),
 				headersArray: await request.headersArray(),
@@ -2383,7 +2384,6 @@ func TestPageOnRequest(t *testing.T) {
 				"upgrade-insecure-requests": "1",
 				"user-agent":                "some-user-agent",
 			},
-			FrameURL:             "about:blank",
 			AcceptLanguageHeader: "en-US",
 			Headers: map[string]string{
 				"Accept-Language":           "en-US",
@@ -2412,7 +2412,6 @@ func TestPageOnRequest(t *testing.T) {
 				"referer":         tb.url("/home"),
 				"user-agent":      "some-user-agent",
 			},
-			FrameURL:             tb.url("/home"),
 			AcceptLanguageHeader: "en-US",
 			Headers: map[string]string{
 				"Accept-Language": "en-US",
@@ -2442,7 +2441,6 @@ func TestPageOnRequest(t *testing.T) {
 				"referer":         tb.url("/home"),
 				"user-agent":      "some-user-agent",
 			},
-			FrameURL:             tb.url("/home"),
 			AcceptLanguageHeader: "en-US",
 			Headers: map[string]string{
 				"Accept-Language": "en-US",
@@ -2473,7 +2471,6 @@ func TestPageOnRequest(t *testing.T) {
 				"referer":         tb.url("/home"),
 				"user-agent":      "some-user-agent",
 			},
-			FrameURL:             tb.url("/home"),
 			AcceptLanguageHeader: "en-US",
 			Headers: map[string]string{
 				"Accept-Language": "en-US",
@@ -2516,7 +2513,6 @@ func TestPageOnRequest(t *testing.T) {
 			require.True(t, ok, "missing allHeaders[%s] for %s", name, req.URL)
 			require.Equal(t, value, actualValue, "allHeaders[%s] mismatch for %s", name, req.URL)
 		}
-		require.Equal(t, expected[i].FrameURL, req.FrameURL, i)
 		require.Equal(t, expected[i].AcceptLanguageHeader, req.AcceptLanguageHeader, i)
 		require.Equal(t, expected[i].Headers, req.Headers, i)
 		for _, header := range req.HeadersArray {
@@ -2537,7 +2533,6 @@ func TestPageOnRequest(t *testing.T) {
 
 type request struct {
 	AllHeaders           map[string]string   `json:"allHeaders"`
-	FrameURL             string              `json:"frameUrl"`
 	AcceptLanguageHeader string              `json:"acceptLanguageHeader"`
 	Headers              map[string]string   `json:"headers"`
 	HeadersArray         []map[string]string `json:"headersArray"`


### PR DESCRIPTION
## What?

Introduces an index-based `extraInfoTracker` to correctly pair CDP `ExtraInfo` events with their corresponding `Request`/`Response` objects, replacing the previous approach that incorrectly merged extra headers across redirect chains.

It also enables and registers the handlers for the `ExtraInfo` which contain the raw headers.

## Why?

### Raw headers vs provisional headers

CDP provides two sets of headers for every network request/response:

- **Provisional headers** (from `responseReceived` / `requestWillBeSent`): refined by Chrome's internal processing — may omit cookies, rewrite header names, etc.
- **Raw wire headers** (from `responseReceivedExtraInfo` / `requestWillBeSentExtraInfo`): exactly what was sent/received over the network, including cookies, `Host`, etc.

The raw headers are what `allHeaders()` should return.

### Two independent "channels"

These two sets of events are not synchronised. This isn't an explicit concept in the CDP protocol — there's no "channel" field in the payload. It's an **observed behavioural pattern** in how Chrome's internals emit events. The CDP docs confirm this:

> *"responseReceivedExtraInfo may be fired before or after responseReceived."*
> — [CDP docs: responseReceivedExtraInfo](https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-responseReceivedExtraInfo)

> *"there is no guarantee whether requestWillBeSent or requestWillBeSentExtraInfo will be fired first for the same request."*
> — [CDP docs: requestWillBeSentExtraInfo](https://chromedevtools.github.io/devtools-protocol/tot/Network/#event-requestWillBeSentExtraInfo)

The main network stack emits `requestWillBeSent`, `responseReceived`, `loadingFinished`, etc. A separate layer (closer to the wire/transport) emits the `ExtraInfo` variants. Because they come from different parts of Chrome's architecture, they arrive independently. The only thing linking them is the shared `requestId`.

### Redirect chains make it harder

During a redirect chain (e.g. `/` → `/r/3` → `/r/2` → `/final`), Chrome **reuses the same `requestId`** for the entire chain. Each hop produces its own pair of events on both "channels":

```mermaid
sequenceDiagram
    participant Browser
    participant Main as Main events
    participant Extra as ExtraInfo events

    Note over Main,Extra: requestId = "ABC123" reused for entire chain

    Browser->>Extra: requestWillBeSentExtraInfo[0] (request headers for /)
    Browser->>Extra: responseReceivedExtraInfo[0] (302 response headers from /)
    Browser->>Main: requestWillBeSent (redirectResponse for /)
    Note over Main: creates Request[0] + Response[0]

    Browser->>Extra: requestWillBeSentExtraInfo[1] (request headers for /r/3)
    Browser->>Extra: responseReceivedExtraInfo[1] (302 response headers from /r/3)
    Browser->>Main: requestWillBeSent (redirectResponse for /r/3)
    Note over Main: creates Request[1] + Response[1]

    Browser->>Extra: requestWillBeSentExtraInfo[2] (request headers for /final)
    Browser->>Main: responseReceived (200 from /final)
    Note over Main: creates Request[2] + Response[2]
    Browser->>Extra: responseReceivedExtraInfo[2] (200 response headers from /final)

    Browser->>Main: loadingFinished
```

### Index-based pairing

Within each "channel", events for a given `requestId` arrive in order. So the i-th `responseReceivedExtraInfo` always corresponds to the i-th response for that `requestId`. The `extraInfoTracker` uses this invariant to pair by index position — the same approach [Playwright](https://github.com/microsoft/playwright/blob/23a8d5006d89d5cb355a2f241f7364c2435802e5/packages/playwright-core/src/server/chromium/crNetworkManager.ts#L685-L700) uses. When either side arrives first, it queues up. As soon as both sides are available at the same index, the tracker patches the raw headers onto the `Response` object.

## Example

<details>
<summary>k6 script</summary>

```js
import { expect } from "https://jslib.k6.io/k6-testing/0.6.1/index.js";
import { browser } from 'k6/browser';

export const options = {
  scenarios: {
    redirectHeaders: {
      executor: 'shared-iterations',
      options: {
        browser: {
          type: 'chromium',
        },
      },
    },
  },
};

export default async function () {
  const page = await browser.newPage();

  const responses = [];
  page.on('requestfinished', async (request) => {
    const response = await request.response();
    if (!response) {
      return;
    }
    const url = response.url();
    const status = response.status();
    const headers = await response.allHeaders();
    responses.push({ url, status, headers });
    console.log(`[response] ${status} ${url}`);
    console.log('  allHeaders:', JSON.stringify(headers, null, 2));
  });

  await page.goto('http://localhost:8765/', {
    waitUntil: 'networkidle',
  });

  const body = await page.locator('body').textContent();
  expect(body).toContain('OK: redirect chain finished');

  const redirectResponses = responses.filter((r) => r.status === 302);
  expect(redirectResponses.length).toBeGreaterThanOrEqual(3);

  const finalResponse = responses.find((r) => r.url.endsWith('/final') && r.status === 200);
  expect(finalResponse).toBeDefined();
  expect(finalResponse.headers['x-redirect-step']).toEqual('final');
  expect(finalResponse.headers['x-extra-info']).toEqual('visible-in-allHeaders');

  await page.close();
}
```

</details>

<details>
<summary>Go server to test the change</summary>

```go
// Redirect server for testing redirect chains and response headers (e.g. allHeaders() in k6 browser / Playwright).
//
// Run: go run .   (listens on http://localhost:8765)
//
// Endpoints:
//   - GET /           → 302 to /r/3 (start of chain)
//   - GET /r/3        → 302 to /r/2
//   - GET /r/2        → 302 to /r/1
//   - GET /r/1        → 302 to /final
//   - GET /final      → 200 OK with body
//
// Each response sets distinct headers so you can see which step you're on in allHeaders():
//
//	X-Redirect-Step, X-Response-Path, X-Server-Time, X-Request-Id (per request)
package main

import (
	"fmt"
	"log"
	"net/http"
	"time"
)

const port = 8765

func main() {
	mux := http.NewServeMux()

	// Return 404 for favicon to avoid the catch-all triggering a second redirect chain.
	mux.HandleFunc("/favicon.ico", func(w http.ResponseWriter, _ *http.Request) {
		http.NotFound(w, nil)
	})

	// Start of chain
	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		setExtraHeaders(w, "/", 0)
		http.Redirect(w, r, "/r/3", http.StatusFound)
	})

	// Redirect steps: /r/3 → /r/2 → /r/1 → /final
	mux.HandleFunc("/r/3", redirectHandler("/r/2", 3))
	mux.HandleFunc("/r/2", redirectHandler("/r/1", 2))
	mux.HandleFunc("/r/1", redirectHandler("/final", 1))

	// Final response
	mux.HandleFunc("/final", func(w http.ResponseWriter, r *http.Request) {
		setExtraHeaders(w, "/final", -1)
		w.Header().Set("Content-Type", "text/plain")
		w.WriteHeader(http.StatusOK)
		_, _ = w.Write([]byte("OK: redirect chain finished\n"))
	})

	addr := fmt.Sprintf(":%d", port)
	log.Printf("Redirect server listening on http://localhost%s", addr)
	log.Printf("  Try: http://localhost%s then inspect allHeaders() on each response in the chain.", addr)
	if err := http.ListenAndServe(addr, mux); err != nil {
		log.Fatal(err)
	}
}

func redirectHandler(target string, step int) http.HandlerFunc {
	return func(w http.ResponseWriter, r *http.Request) {
		setExtraHeaders(w, r.URL.Path, step)
		http.Redirect(w, r, target, http.StatusFound)
	}
}

func setExtraHeaders(w http.ResponseWriter, path string, step int) {
	stepStr := fmt.Sprintf("%d", step)
	if step < 0 {
		stepStr = "final"
	}
	w.Header().Set("X-Redirect-Step", stepStr)
	w.Header().Set("X-Response-Path", path)
	w.Header().Set("X-Server-Time", time.Now().UTC().Format(time.RFC3339Nano))
	w.Header().Set("X-Extra-Info", "visible-in-allHeaders")
}
```

</details>

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->

Closes: https://github.com/grafana/k6/issues/4291

---

## Follow-up commits (review feedback)

These commits address the review feedback on top of the original change:

- **Fix extra-info pairing across redirect chains** — the tracker now gates on `hasExtraInfo` / `redirectHasExtraInfo` / `servedFromCache` and is keyed off the response (mirroring Playwright's `ResponseExtraInfoTracker`). A redirect chain with a hop that carries no ExtraInfo (cached redirect, HSTS upgrade, [crbug.com/1340398](https://crbug.com/1340398)) no longer slips the index and applies a later hop's headers to the wrong response. Cleanup is deferred until every tracked response is paired, so a late `responseReceivedExtraInfo` is no longer dropped. Removing `processRequest` also means internal `data:`/`blob:` requests no longer leak a tracker entry.
- **Wait for raw headers in the header accessors** — `allHeaders()`, `headerValue(s)()` and `headersArray()` now wait for the raw headers to resolve before returning, so reading them inside a `page.on('response')` handler reliably returns `Set-Cookie` etc., matching Playwright (previously only guaranteed from `requestfinished`).
- **Deterministic traffic metrics** — `browser_data_sent` / `browser_data_received` are emitted once the raw headers are resolved, so the reported size no longer varies run-to-run with CDP event ordering. The sizes now include the raw header bytes.
- **Stronger tests** — the redirect-chain test asserts a distinct `Set-Cookie` per hop (only delivered via ExtraInfo, so it actually exercises the pairing), plus added unit coverage for `HeaderValues` / `HeadersArray`.

### ⚠️ Behaviour change: `response.headerValues()`

`headerValues()` now matches the header name case-insensitively and splits repeated values on `\n` instead of `,`:

- A capitalised name such as `headerValues('Set-Cookie')` previously returned `['']`; it now returns the values.
- A response header whose single value contains commas (e.g. `Vary: Accept-Encoding, User-Agent`) is no longer split on the comma.

The `\n` separator is required for `Set-Cookie` — whose values contain commas in `Expires` — and matches Playwright. Worth a release-note line.
