### PR TITLE
Add repro test for gotip race

### DIFF
--- a/internal/secretsource/url/race_repro_test.go
+++ b/internal/secretsource/url/race_repro_test.go
@@ -1,0 +1,59 @@
+package url
+
+// Minimal reproduction for a data race detected in Go 1.27-devel (gotip) CI.
+//
+// The race is in runtime.moduleTypelinks() — a Go runtime-internal type cache
+// map — triggered when encoding/json calls reflect.PointerTo() concurrently
+// from multiple goroutines.
+//
+// CI stack trace (gotip @ 9777cec, linux/amd64):
+//
+//	Goroutine 85: mapaccess2_fast64 → moduleTypelinks → reflect.PointerTo → json.newTypeEncoder
+//	              → json.Encoder.Encode  (url_test.go:1207)
+//	Goroutine 86: mapassign_fast64  → moduleTypelinks → reflect.PointerTo → json.newTypeEncoder
+//	              → json.Encoder.Encode  (url_test.go:1167)
+//
+// Reproduce with gotip @ 9777cec:
+//
+//	gotip test -race -count=100 -failfast -v ./internal/secretsource/url/ -run TestConcurrentJSONEncode_RaceRepro
+
+import (
+	"encoding/json"
+	"io"
+	"sync"
+	"testing"
+)
+
+// TestConcurrentJSONEncode_RaceRepro hammers json.NewEncoder().Encode() from
+// many goroutines in a tight loop. Each iteration creates a fresh encoder
+// writing to io.Discard and encodes a map value. On gotip builds that carry
+// the moduleTypelinks race, the race detector should flag this quickly.
+func TestConcurrentJSONEncode_RaceRepro(t *testing.T) {
+	t.Parallel()
+
+	const (
+		workers    = 64
+		iterations = 2000
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				resp := map[string]interface{}{
+					"code":    "not_found",
+					"message": "Secret not found",
+					"nested": map[string]string{
+						"key": "value",
+					},
+				}
+				_ = json.NewEncoder(io.Discard).Encode(resp)
+			}
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
Add a stress test that hammers
json.NewEncoder(io.Discard).Encode() from 64
goroutines x 2000 iterations to reproduce a
data race in runtime.moduleTypelinks() seen
in CI on gotip (go1.27-devel @ 9777cec).

The race is in the Go runtime's internal type
cache, not in k6 code. This test is intended
to confirm the issue on the test-tip CI job.

## What?

<!-- A short (or detailed) description of what this PR does. -->

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
