### PR TITLE
fix: always depend on k6 so that manifest can override it

### DIFF
--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -296,6 +296,12 @@ func collectTestDependencies(
 		return nil, err
 	}
 
+	// Ensure k6 is always a dependency with "*" constraint by default.
+	// This can be overridden by "use k6" or "use k6 with k6/x/..." directives in the script.
+	if _, ok := deps["k6"]; !ok {
+		deps["k6"] = nil
+	}
+
 	if err := analyseUseContraints(imports, fileSystems, deps); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## What?

Always add k6 as a build dependency to any test just with no contraint 

## Why?

As part of #5410 and #5427 k6 started to figure out build dependancies and support a manifest to overwrite default values for the ones that are not constraint.

As part of this it was always expected that you can overwrite the k6 version unless the script specifies one. But due to lack of testing of that exact scenario it was not implemented.

This PR makes certain this i now fixed.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
