### PR TITLE
Update Go toolchain version to 1.24.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.k6.io/k6
 
 go 1.24.0
 
-toolchain go1.24.11
+toolchain go1.24.13
 
 require (
 	buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.36.11-20251118093737-4105057cc7d4.1


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

Follow-up from https://github.com/grafana/k6/pull/5614

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

Keep Go version up to date
