### PR TITLE
Fix browser connection goroutine leaks in tests

### DIFF
--- a/internal/js/modules/k6/browser/tests/browser_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_test.go
@@ -329,6 +329,7 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 
 	b1, err := tb.browserType.Connect(context.Background(), ctx, tb.wsURL)
 	require.NoError(t, err)
+	t.Cleanup(b1.Close)
 	bctx1, err := b1.NewContext(nil)
 	require.NoError(t, err)
 	p1, err := bctx1.NewPage()
@@ -336,6 +337,7 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 
 	b2, err := tb.browserType.Connect(context.Background(), ctx, tb.wsURL)
 	require.NoError(t, err)
+	t.Cleanup(b2.Close)
 	bctx2, err := b2.NewContext(nil)
 	require.NoError(t, err)
 

--- a/internal/js/modules/k6/browser/tests/browser_type_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_type_test.go
@@ -24,6 +24,7 @@ func TestBrowserTypeConnect(t *testing.T) {
 
 	b, err := bt.Connect(context.Background(), context.Background(), tb.wsURL)
 	require.NoError(t, err)
+	t.Cleanup(b.Close)
 	_, err = b.NewPage(nil)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## What?

Add t.Cleanup(b.Close) to ensure browsers created via Connect are properly closed when the test finishes.

## Why?

TestBrowserTypeConnect and TestMultiConnectToSingleBrowser create browser connections via bt.Connect() but never close them. Since both contexts are context.Background(), the child goroutines (Connection, Session, BaseEventEmitter.syncAll, etc.) live forever.

## Goroutine leak comparison (800s timeout, with Exit event fix applied)

| Goroutine | Before fix | After fix |
|---|---|---|
| `BaseEventEmitter.syncAll` (leaked) | 20 | 0 |
| `NetworkManager.handleEvents` (leaked) | 3 | 0 |
| `Browser.initEvents` (leaked) | 3 | 0 |
| `Connection.sendLoop` (leaked) | 3 | 0 |
| `Connection.handleIOError` (leaked) | 3 | 0 |
| `BrowserProcess.handleClose` (leaked) | 3 | 0 |
| **Total leaked goroutines** | **35** | **0** |

Leaked goroutines were from `TestBrowserTypeConnect` and `TestMultiConnectToSingleBrowser`, which created browser connections via `bt.Connect()` but never closed them. All remaining browser goroutines in the dump belong to the single actively running test at timeout.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## AI tool usage

 - [ ] Claude
 - [x] Cursor
 - [ ] Codex
 - [ ] Other
 - [x] I acknowledge that I fully understand the code change

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
