### PR TITLE
Add `k6 cloud project` and `k6 cloud project list` commands

### DIFF
--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -16,12 +16,18 @@ import (
 	"go.k6.io/k6/v2/lib"
 )
 
+// Project is a Grafana Cloud k6 project.
+type Project struct {
+	ID        int32  `json:"id"`
+	Name      string `json:"name"`
+	IsDefault bool   `json:"is_default"`
+}
+
 // ListProjects retrieves the list of projects for the configured stack.
-func (c *Client) ListProjects(ctx context.Context) (_ *k6cloud.ProjectListResponse, err error) {
+func (c *Client) ListProjects(ctx context.Context) ([]Project, error) {
 	const pageSize int32 = 1000
 
-	var projects []k6cloud.ProjectApiModel
-	var count int32
+	projects := []Project{}
 	var skip int32
 
 	for {
@@ -30,14 +36,16 @@ func (c *Client) ListProjects(ctx context.Context) (_ *k6cloud.ProjectListRespon
 			return nil, err
 		}
 
-		projects = append(projects, res.Value...)
-		count += res.GetCount()
+		for _, project := range res.Value {
+			projects = append(projects, Project{
+				ID:        project.Id,
+				Name:      project.Name,
+				IsDefault: project.IsDefault,
+			})
+		}
 
 		if res.NextLink == nil || *res.NextLink == "" {
-			return &k6cloud.ProjectListResponse{
-				Value: projects,
-				Count: &count,
-			}, nil
+			return projects, nil
 		}
 
 		if len(res.Value) == 0 {

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -21,7 +21,7 @@ func (c *Client) ListProjects(ctx context.Context) (_ *k6cloud.ProjectListRespon
 	const pageSize int32 = 1000
 
 	var projects []k6cloud.ProjectApiModel
-	var count *int32
+	var count int32
 	var skip int32
 
 	for {
@@ -31,19 +31,19 @@ func (c *Client) ListProjects(ctx context.Context) (_ *k6cloud.ProjectListRespon
 		}
 
 		projects = append(projects, res.Value...)
-		count += res.Count
+		count += res.GetCount()
 
 		if res.NextLink == nil || *res.NextLink == "" {
 			return &k6cloud.ProjectListResponse{
 				Value: projects,
-				Count: count,
+				Count: &count,
 			}, nil
 		}
 
 		if len(res.Value) == 0 {
 			return nil, errors.New("received empty projects page with next link")
 		}
-		skip += *count
+		skip += pageSize
 	}
 }
 

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -43,13 +43,13 @@ func (c *Client) ListProjects(ctx context.Context) (_ *k6cloud.ProjectListRespon
 		if len(res.Value) == 0 {
 			return nil, errors.New("received empty projects page with next link")
 		}
-		skip += pageSize
+		skip += *count
 	}
 }
 
 func (c *Client) listProjectsPage(
 	ctx context.Context, skip, top int32,
-) (_ *k6cloud.ProjectListResponse, err error) {
+) (*k6cloud.ProjectListResponse, error) {
 	res, hr, err := c.apiClient.ProjectsAPI.
 		ProjectsList(c.authCtx(ctx)).
 		XStackId(c.stackID).

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -16,6 +16,24 @@ import (
 	"go.k6.io/k6/v2/lib"
 )
 
+// ListProjects retrieves the list of projects for the configured stack.
+func (c *Client) ListProjects(ctx context.Context) (_ *k6cloud.ProjectListResponse, err error) {
+	res, hr, err := c.apiClient.ProjectsAPI.
+		ProjectsList(c.authCtx(ctx)).
+		XStackId(c.stackID).
+		Execute()
+	defer closeResponse(hr, &err)
+
+	if err := CheckResponse(hr, err); err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, errUnknown
+	}
+
+	return res, nil
+}
+
 // ValidateToken validates the cloud authentication token.
 func (c *Client) ValidateToken(ctx context.Context, stackURL string) (_ *k6cloud.AuthenticationResponse, err error) {
 	if stackURL == "" {

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -18,9 +18,43 @@ import (
 
 // ListProjects retrieves the list of projects for the configured stack.
 func (c *Client) ListProjects(ctx context.Context) (_ *k6cloud.ProjectListResponse, err error) {
+	const pageSize int32 = 1000
+
+	var projects []k6cloud.ProjectApiModel
+	var count *int32
+	var skip int32
+
+	for {
+		res, err := c.listProjectsPage(ctx, skip, pageSize)
+		if err != nil {
+			return nil, err
+		}
+
+		projects = append(projects, res.Value...)
+		count = res.Count
+
+		if res.NextLink == nil || *res.NextLink == "" {
+			return &k6cloud.ProjectListResponse{
+				Value: projects,
+				Count: count,
+			}, nil
+		}
+
+		if len(res.Value) == 0 {
+			return nil, errors.New("received empty projects page with next link")
+		}
+		skip += pageSize
+	}
+}
+
+func (c *Client) listProjectsPage(
+	ctx context.Context, skip, top int32,
+) (_ *k6cloud.ProjectListResponse, err error) {
 	res, hr, err := c.apiClient.ProjectsAPI.
 		ProjectsList(c.authCtx(ctx)).
 		XStackId(c.stackID).
+		Skip(skip).
+		Top(top).
 		Execute()
 	defer closeResponse(hr, &err)
 

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -31,7 +31,7 @@ func (c *Client) ListProjects(ctx context.Context) (_ *k6cloud.ProjectListRespon
 		}
 
 		projects = append(projects, res.Value...)
-		count = res.Count
+		count += res.Count
 
 		if res.NextLink == nil || *res.NextLink == "" {
 			return &k6cloud.ProjectListResponse{

--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -105,6 +105,49 @@ func TestValidateToken(t *testing.T) {
 	})
 }
 
+func TestListProjects(t *testing.T) {
+	t.Parallel()
+
+	project := func(id int32, name string, isDefault bool) map[string]any {
+		return map[string]any{
+			"id":                 id,
+			"name":               name,
+			"is_default":         isDefault,
+			"grafana_folder_uid": nil,
+			"created":            "2025-01-01T00:00:00Z",
+			"updated":            "2025-01-01T00:00:00Z",
+		}
+	}
+
+	var requests atomic.Int32
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "1000", r.URL.Query().Get("$top"))
+
+		switch requests.Add(1) {
+		case 1:
+			assert.Equal(t, "0", r.URL.Query().Get("$skip"))
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"value":     []any{project(1, "Default project", true)},
+				"@nextLink": "https://api.k6.io/cloud/v6/projects?$skip=1000&$top=1000",
+			})
+		case 2:
+			assert.Equal(t, "1000", r.URL.Query().Get("$skip"))
+			writeJSON(t, w, http.StatusOK, map[string]any{
+				"value": []any{project(2, "My project", false)},
+			})
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+
+	resp, err := client.ListProjects(t.Context())
+	require.NoError(t, err)
+	require.Len(t, resp.Value, 2)
+	assert.Equal(t, int32(2), requests.Load())
+	assert.Equal(t, int32(1), resp.Value[0].Id)
+	assert.Equal(t, int32(2), resp.Value[1].Id)
+}
+
 func TestRetryWithConnectionClose(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -140,12 +140,12 @@ func TestListProjects(t *testing.T) {
 		}
 	}))
 
-	resp, err := client.ListProjects(t.Context())
+	projects, err := client.ListProjects(t.Context())
 	require.NoError(t, err)
-	require.Len(t, resp.Value, 2)
+	require.Len(t, projects, 2)
 	assert.Equal(t, int32(2), requests.Load())
-	assert.Equal(t, int32(1), resp.Value[0].Id)
-	assert.Equal(t, int32(2), resp.Value[1].Id)
+	assert.Equal(t, Project{ID: 1, Name: "Default project", IsDefault: true}, projects[0])
+	assert.Equal(t, Project{ID: 2, Name: "My project", IsDefault: false}, projects[1])
 }
 
 func TestRetryWithConnectionClose(t *testing.T) {

--- a/internal/cloudapi/v6/v6test/server.go
+++ b/internal/cloudapi/v6/v6test/server.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
 
@@ -47,6 +48,9 @@ type Config struct {
 	// request so tests can inspect the uploaded archive before the
 	// server returns its canned response.
 	InspectArchive func(*http.Request)
+
+	// Projects is the project list returned by the projects endpoint.
+	Projects []cloudapi.Project
 }
 
 // NewServer creates a test server that serves v6 API endpoints.
@@ -60,6 +64,7 @@ func NewServer(t *testing.T, cfg Config) *Server {
 	s := &Server{cfg: cfg}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /cloud/v6/projects", s.handleListProjects)
 	mux.HandleFunc("POST /cloud/v6/validate_options", s.handleValidateOptions)
 	mux.HandleFunc("POST /cloud/v6/projects/{projectID}/load_tests", func(w http.ResponseWriter, r *http.Request) {
 		if s.cfg.InspectArchive != nil {
@@ -85,6 +90,24 @@ func NewServer(t *testing.T, cfg Config) *Server {
 	t.Cleanup(srv.Close)
 
 	return s
+}
+
+func (s *Server) handleListProjects(w http.ResponseWriter, _ *http.Request) {
+	projects := make([]k6cloud.ProjectApiModel, len(s.cfg.Projects))
+	now := time.Unix(0, 0).UTC()
+	for i, project := range s.cfg.Projects {
+		projects[i] = *k6cloud.NewProjectApiModel(
+			project.ID,
+			project.Name,
+			project.IsDefault,
+			*k6cloud.NewNullableString(nil),
+			now,
+			now,
+		)
+	}
+	res := k6cloud.NewProjectListResponse(projects)
+	res.SetCount(int32(len(projects)))
+	writeJSON(w, http.StatusOK, res)
 }
 
 func (s *Server) handleValidateOptions(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cloudapi/v6/v6test/server.go
+++ b/internal/cloudapi/v6/v6test/server.go
@@ -106,7 +106,6 @@ func (s *Server) handleListProjects(w http.ResponseWriter, _ *http.Request) {
 		)
 	}
 	res := k6cloud.NewProjectListResponse(projects)
-	res.SetCount(int32(len(projects)))
 	writeJSON(w, http.StatusOK, res)
 }
 

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -54,7 +54,7 @@ func checkCloudLogin(conf cloudapi.Config) error {
 // errNoStackConfigured indicates that no Grafana Cloud stack has been set up,
 // which is required for stack-scoped operations like listing projects.
 var errNoStackConfigured = errors.New( //nolint:staticcheck
-	"no stack configured. Please run `k6 cloud login --stack <your-stack>` to set a default stack",
+	"no stack configured. Please run `k6 cloud login` to set a default stack",
 )
 
 // cmdCloud handles the `k6 cloud` sub-command

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -51,12 +51,6 @@ func checkCloudLogin(conf cloudapi.Config) error {
 	return nil
 }
 
-// errNoStackConfigured indicates that no Grafana Cloud stack has been set up,
-// which is required for stack-scoped operations like listing projects.
-var errNoStackConfigured = errors.New(
-	"no stack configured. Please run `k6 cloud login` to set a default stack",
-)
-
 // cmdCloud handles the `k6 cloud` sub-command
 type cmdCloud struct {
 	gs *state.GlobalState

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -447,6 +447,9 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 	uploadCmd.SetHelpTemplate((&cobra.Command{}).HelpTemplate())
 	cloudCmd.AddCommand(uploadCmd)
 
+	projectCmd := getCmdCloudProject(c)
+	cloudCmd.AddCommand(projectCmd)
+
 	cloudCmd.Flags().SortFlags = false
 	cloudCmd.Flags().AddFlagSet(c.flagSet())
 

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -53,7 +53,7 @@ func checkCloudLogin(conf cloudapi.Config) error {
 
 // errNoStackConfigured indicates that no Grafana Cloud stack has been set up,
 // which is required for stack-scoped operations like listing projects.
-var errNoStackConfigured = errors.New( //nolint:staticcheck
+var errNoStackConfigured = errors.New(
 	"no stack configured. Please run `k6 cloud login` to set a default stack",
 )
 
@@ -378,13 +378,14 @@ func getCloudUsageTemplate() string {
 	return `{{.Short}}
 
 Usage:{{if .HasAvailableSubCommands}}
-  {{.CommandPath}} [command]{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{else if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
 
 Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
 
 Flags:
-  -h, --help   Show help
+{{.LocalFlags.FlagUsagesWrapped 120 | trimTrailingWhitespaces}}
 {{if .HasExample}}
 Examples:
 {{.Example}}

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -51,6 +51,12 @@ func checkCloudLogin(conf cloudapi.Config) error {
 	return nil
 }
 
+// errNoStackConfigured indicates that no Grafana Cloud stack has been set up,
+// which is required for stack-scoped operations like listing projects.
+var errNoStackConfigured = errors.New( //nolint:staticcheck
+	"no stack configured. Please run `k6 cloud login --stack <your-stack>` to set a default stack",
+)
+
 // cmdCloud handles the `k6 cloud` sub-command
 type cmdCloud struct {
 	gs *state.GlobalState

--- a/internal/cmd/cloud_project.go
+++ b/internal/cmd/cloud_project.go
@@ -1,0 +1,57 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.k6.io/k6/v2/cmd/state"
+)
+
+type cmdCloudProject struct {
+	globalState *state.GlobalState
+}
+
+func getCmdCloudProject(cloudCmd *cmdCloud) *cobra.Command {
+	c := &cmdCloudProject{
+		globalState: cloudCmd.gs,
+	}
+
+	exampleText := getExampleText(cloudCmd.gs, `
+  # List all projects in the configured stack
+  $ {{.}} cloud project list
+
+  # List projects in JSON format
+  $ {{.}} cloud project list --json`[1:])
+
+	cloudProjectCommand := &cobra.Command{
+		Use:   "project",
+		Short: "Work with Grafana Cloud k6 projects",
+		Long:  `Work with Grafana Cloud k6 projects.`,
+
+		Example: exampleText,
+	}
+
+	defaultUsageTemplate := (&cobra.Command{}).UsageTemplate()
+	defaultUsageTemplate = strings.ReplaceAll(defaultUsageTemplate, "FlagUsages", "FlagUsagesWrapped 120")
+
+	listCmd := getCmdCloudProjectList(c)
+	listCmd.SetUsageTemplate(defaultUsageTemplate)
+	cloudProjectCommand.AddCommand(listCmd)
+
+	cloudProjectCommand.SetUsageTemplate(`Usage:
+  {{.CommandPath}} <command> [flags]
+
+Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
+
+Examples:
+{{.Example}}
+Flags:
+  -h, --help   Show help
+{{if .HasExample}}
+{{end}}
+Use "{{.CommandPath}} <command> --help" for more information about a command.
+`)
+
+	return cloudProjectCommand
+}

--- a/internal/cmd/cloud_project.go
+++ b/internal/cmd/cloud_project.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"strings"
-
 	"github.com/spf13/cobra"
 	"go.k6.io/k6/v2/cmd/state"
 )
@@ -31,27 +29,14 @@ func getCmdCloudProject(cloudCmd *cmdCloud) *cobra.Command {
 		Example: exampleText,
 	}
 
-	defaultUsageTemplate := (&cobra.Command{}).UsageTemplate()
-	defaultUsageTemplate = strings.ReplaceAll(defaultUsageTemplate, "FlagUsages", "FlagUsagesWrapped 120")
+	cloudUsageTemplate := getCloudUsageTemplate()
 
 	listCmd := getCmdCloudProjectList(c)
-	listCmd.SetUsageTemplate(defaultUsageTemplate)
+	listCmd.SetUsageTemplate(cloudUsageTemplate)
+	listCmd.SetHelpTemplate(cloudUsageTemplate)
 	cloudProjectCommand.AddCommand(listCmd)
 
-	cloudProjectCommand.SetUsageTemplate(`Usage:
-  {{.CommandPath}} <command> [flags]
-
-Available Commands:{{range .Commands}}{{if .IsAvailableCommand}}
-  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
-
-Examples:
-{{.Example}}
-Flags:
-  -h, --help   Show help
-{{if .HasExample}}
-{{end}}
-Use "{{.CommandPath}} <command> --help" for more information about a command.
-`)
+	cloudProjectCommand.SetUsageTemplate(cloudUsageTemplate)
 
 	return cloudProjectCommand
 }

--- a/internal/cmd/cloud_project_list.go
+++ b/internal/cmd/cloud_project_list.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"strings"
+	"text/tabwriter"
+
+	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
+	"github.com/spf13/cobra"
+
+	"go.k6.io/k6/v2/cloudapi"
+	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/internal/build"
+	v6cloudapi "go.k6.io/k6/v2/internal/cloudapi/v6"
+)
+
+type cmdCloudProjectList struct {
+	globalState *state.GlobalState
+	isJSON      bool
+}
+
+func getCmdCloudProjectList(projectCmd *cmdCloudProject) *cobra.Command {
+	c := &cmdCloudProjectList{
+		globalState: projectCmd.globalState,
+	}
+
+	exampleText := getExampleText(projectCmd.globalState, `
+  # List all projects in the configured stack
+  $ {{.}} cloud project list`[1:])
+
+	listCmd := &cobra.Command{
+		Use:     "list",
+		Short:   "List Grafana Cloud k6 projects",
+		Long:    `List all projects in the configured Grafana Cloud k6 stack.`,
+		Example: exampleText,
+		Args:    cobra.NoArgs,
+		RunE:    c.run,
+	}
+
+	listCmd.Flags().BoolVar(&c.isJSON, "json", false, "output project list in JSON format")
+
+	return listCmd
+}
+
+func (c *cmdCloudProjectList) run(_ *cobra.Command, _ []string) error {
+	currentDiskConf, err := readDiskConfig(c.globalState)
+	if err != nil {
+		return err
+	}
+
+	currentJSONConfigRaw := currentDiskConf.Collectors["cloud"]
+
+	cloudConfig, warn, err := cloudapi.GetConsolidatedConfig(
+		currentJSONConfigRaw, c.globalState.Env, "", nil)
+	if err != nil {
+		return err
+	}
+	if warn != "" {
+		c.globalState.Logger.Warn(warn)
+	}
+
+	if !cloudConfig.Token.Valid || cloudConfig.Token.String == "" {
+		return fmt.Errorf("%w.\n%w", errMissingToken, errCloudAuth)
+	}
+
+	if !cloudConfig.StackID.Valid || cloudConfig.StackID.Int64 == 0 {
+		return errors.New(
+			"no stack configured. Please run `k6 cloud login --stack <your-stack>` to set a default stack",
+		)
+	}
+
+	client, err := v6cloudapi.NewClient(
+		c.globalState.Logger,
+		cloudConfig.Token.String,
+		cloudConfig.Hostv6.String,
+		build.Version,
+		cloudConfig.Timeout.TimeDuration(),
+	)
+	if err != nil {
+		return err
+	}
+
+	if cloudConfig.StackID.Int64 < math.MinInt32 || cloudConfig.StackID.Int64 > math.MaxInt32 {
+		return fmt.Errorf("stack ID %d overflows int32", cloudConfig.StackID.Int64)
+	}
+	client.SetStackID(int32(cloudConfig.StackID.Int64))
+
+	resp, err := client.ListProjects(context.Background())
+	if err != nil {
+		return err
+	}
+
+	if c.isJSON {
+		return c.outputJSON(resp.Value)
+	}
+
+	stackHeader := fmt.Sprintf("Projects for stack %d:\n\n", cloudConfig.StackID.Int64)
+
+	if len(resp.Value) == 0 {
+		printToStdout(c.globalState, stackHeader+
+			"No projects found.\n"+
+			"To create a project, visit https://grafana.com/docs/grafana-cloud/testing/k6/projects/\n")
+		return nil
+	}
+
+	printToStdout(c.globalState, stackHeader+formatProjectTable(resp.Value))
+	return nil
+}
+
+func (c *cmdCloudProjectList) outputJSON(projects []k6cloud.ProjectApiModel) error {
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(projects); err != nil {
+		return fmt.Errorf("failed to encode project list: %w", err)
+	}
+
+	printToStdout(c.globalState, buf.String())
+	return nil
+}
+
+func formatProjectTable(projects []k6cloud.ProjectApiModel) string {
+	var buf strings.Builder
+	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ID\tNAME\tDEFAULT")
+	for _, p := range projects {
+		def := "no"
+		if p.IsDefault {
+			def = "yes"
+		}
+		_, _ = fmt.Fprintf(w, "%d\t%s\t%s\n", p.Id, p.Name, def)
+	}
+	_ = w.Flush()
+	return buf.String()
+}

--- a/internal/cmd/cloud_project_list.go
+++ b/internal/cmd/cloud_project_list.go
@@ -105,7 +105,7 @@ func (c *cmdCloudProjectList) run(_ *cobra.Command, _ []string) error {
 	if len(resp.Value) == 0 {
 		printToStdout(c.globalState, stackHeader+
 			"No projects found.\n"+
-			"To create a project, visit https://grafana.com/docs/grafana-cloud/testing/k6/projects/\n")
+			"To create a project, visit https://grafana.com/docs/grafana-cloud/testing/k6/projects-and-users/projects/\n")
 		return nil
 	}
 

--- a/internal/cmd/cloud_project_list.go
+++ b/internal/cmd/cloud_project_list.go
@@ -13,7 +13,7 @@ import (
 	"go.k6.io/k6/v2/cloudapi"
 	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/internal/build"
-	v6cloudapi "go.k6.io/k6/v2/internal/cloudapi/v6"
+	cloudapiv6 "go.k6.io/k6/v2/internal/cloudapi/v6"
 )
 
 type cmdCloudProjectList struct {
@@ -65,7 +65,7 @@ func (c *cmdCloudProjectList) run(_ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	client, err := v6cloudapi.NewClient(
+	client, err := cloudapiv6.NewClient(
 		c.globalState.Logger,
 		cloudConfig.Token.String,
 		cloudConfig.Hostv6.String,
@@ -107,7 +107,7 @@ func (c *cmdCloudProjectList) run(_ *cobra.Command, _ []string) error {
 	return nil
 }
 
-func (c *cmdCloudProjectList) outputJSON(projects []v6cloudapi.Project) error {
+func (c *cmdCloudProjectList) outputJSON(projects []cloudapiv6.Project) error {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetEscapeHTML(false)
@@ -120,7 +120,7 @@ func (c *cmdCloudProjectList) outputJSON(projects []v6cloudapi.Project) error {
 	return nil
 }
 
-func formatProjectTable(projects []v6cloudapi.Project) string {
+func formatProjectTable(projects []cloudapiv6.Project) string {
 	var buf strings.Builder
 	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
 	_, _ = fmt.Fprintln(w, "ID\tNAME\tDEFAULT")

--- a/internal/cmd/cloud_project_list.go
+++ b/internal/cmd/cloud_project_list.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
 	"github.com/spf13/cobra"
 
 	"go.k6.io/k6/v2/cloudapi"
@@ -82,13 +81,13 @@ func (c *cmdCloudProjectList) run(_ *cobra.Command, _ []string) error {
 	}
 	client.SetStackID(int32(cloudConfig.StackID.Int64))
 
-	resp, err := client.ListProjects(c.globalState.Ctx)
+	projects, err := client.ListProjects(c.globalState.Ctx)
 	if err != nil {
 		return err
 	}
 
 	if c.isJSON {
-		return c.outputJSON(resp.Value)
+		return c.outputJSON(projects)
 	}
 
 	stackName := cloudConfig.StackURL.String
@@ -97,18 +96,18 @@ func (c *cmdCloudProjectList) run(_ *cobra.Command, _ []string) error {
 	}
 	stackHeader := fmt.Sprintf("Projects for %s:\n\n", stackName)
 
-	if len(resp.Value) == 0 {
+	if len(projects) == 0 {
 		printToStdout(c.globalState, stackHeader+
 			"No projects found.\n"+
 			"To create a project, visit https://grafana.com/docs/grafana-cloud/testing/k6/projects-and-users/projects/\n")
 		return nil
 	}
 
-	printToStdout(c.globalState, stackHeader+formatProjectTable(resp.Value))
+	printToStdout(c.globalState, stackHeader+formatProjectTable(projects))
 	return nil
 }
 
-func (c *cmdCloudProjectList) outputJSON(projects []k6cloud.ProjectApiModel) error {
+func (c *cmdCloudProjectList) outputJSON(projects []v6cloudapi.Project) error {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetEscapeHTML(false)
@@ -121,7 +120,7 @@ func (c *cmdCloudProjectList) outputJSON(projects []k6cloud.ProjectApiModel) err
 	return nil
 }
 
-func formatProjectTable(projects []k6cloud.ProjectApiModel) string {
+func formatProjectTable(projects []v6cloudapi.Project) string {
 	var buf strings.Builder
 	w := tabwriter.NewWriter(&buf, 0, 0, 3, ' ', 0)
 	_, _ = fmt.Fprintln(w, "ID\tNAME\tDEFAULT")
@@ -130,7 +129,7 @@ func formatProjectTable(projects []k6cloud.ProjectApiModel) string {
 		if p.IsDefault {
 			def = "yes"
 		}
-		_, _ = fmt.Fprintf(w, "%d\t%s\t%s\n", p.Id, p.Name, def)
+		_, _ = fmt.Fprintf(w, "%d\t%s\t%s\n", p.ID, p.Name, def)
 	}
 	_ = w.Flush()
 	return buf.String()

--- a/internal/cmd/cloud_project_list.go
+++ b/internal/cmd/cloud_project_list.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"math"
 	"strings"
@@ -69,9 +68,7 @@ func (c *cmdCloudProjectList) run(_ *cobra.Command, _ []string) error {
 	}
 
 	if !cloudConfig.StackID.Valid || cloudConfig.StackID.Int64 == 0 {
-		return errors.New(
-			"no stack configured. Please run `k6 cloud login --stack <your-stack>` to set a default stack",
-		)
+		return errNoStackConfigured
 	}
 
 	client, err := v6cloudapi.NewClient(

--- a/internal/cmd/cloud_project_list.go
+++ b/internal/cmd/cloud_project_list.go
@@ -96,7 +96,11 @@ func (c *cmdCloudProjectList) run(_ *cobra.Command, _ []string) error {
 		return c.outputJSON(resp.Value)
 	}
 
-	stackHeader := fmt.Sprintf("Projects for stack %d:\n\n", cloudConfig.StackID.Int64)
+	stackName := cloudConfig.StackURL.String
+	if !cloudConfig.StackURL.Valid {
+		stackName = fmt.Sprintf("stack-%d", cloudConfig.StackID.Int64)
+	}
+	stackHeader := fmt.Sprintf("Projects for %s:\n\n", stackName)
 
 	if len(resp.Value) == 0 {
 		printToStdout(c.globalState, stackHeader+

--- a/internal/cmd/cloud_project_list.go
+++ b/internal/cmd/cloud_project_list.go
@@ -62,12 +62,8 @@ func (c *cmdCloudProjectList) run(_ *cobra.Command, _ []string) error {
 		c.globalState.Logger.Warn(warn)
 	}
 
-	if !cloudConfig.Token.Valid || cloudConfig.Token.String == "" {
-		return fmt.Errorf("%w.\n%w", errMissingToken, errCloudAuth)
-	}
-
-	if !cloudConfig.StackID.Valid || cloudConfig.StackID.Int64 == 0 {
-		return errNoStackConfigured
+	if err := checkCloudLogin(cloudConfig); err != nil {
+		return err
 	}
 
 	client, err := v6cloudapi.NewClient(

--- a/internal/cmd/cloud_project_list.go
+++ b/internal/cmd/cloud_project_list.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -87,7 +86,7 @@ func (c *cmdCloudProjectList) run(_ *cobra.Command, _ []string) error {
 	}
 	client.SetStackID(int32(cloudConfig.StackID.Int64))
 
-	resp, err := client.ListProjects(context.Background())
+	resp, err := client.ListProjects(c.globalState.Ctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/tests/cmd_cloud_project_list_test.go
+++ b/internal/cmd/tests/cmd_cloud_project_list_test.go
@@ -36,34 +36,6 @@ func TestCloudProjectList(t *testing.T) {
 		assert.Contains(t, stdout, "2    My project        no")
 	})
 
-	t.Run("fails without token", func(t *testing.T) {
-		t.Parallel()
-
-		ts := NewGlobalTestState(t)
-		ts.CmdArgs = []string{"k6", "cloud", "project", "list"}
-		ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
-		ts.ExpectedExitCode = -1
-
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stderr := ts.Stderr.String()
-		assert.Contains(t, stderr, "authenticate")
-	})
-
-	t.Run("fails without stack ID", func(t *testing.T) {
-		t.Parallel()
-
-		ts := NewGlobalTestState(t)
-		ts.CmdArgs = []string{"k6", "cloud", "project", "list"}
-		ts.Env["K6_CLOUD_TOKEN"] = validToken
-		ts.ExpectedExitCode = -1
-
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stderr := ts.Stderr.String()
-		assert.Contains(t, stderr, "no stack configured")
-	})
-
 	t.Run("empty project list", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/cmd/tests/cmd_cloud_project_list_test.go
+++ b/internal/cmd/tests/cmd_cloud_project_list_test.go
@@ -20,7 +20,6 @@ func TestCloudProjectList(t *testing.T) {
 		t.Parallel()
 
 		srv := mockProjectListServer(t)
-		defer srv.Close()
 
 		ts := NewGlobalTestState(t)
 		ts.CmdArgs = []string{"k6", "cloud", "project", "list"}
@@ -147,7 +146,7 @@ func TestCloudProjectList(t *testing.T) {
 func mockProjectListServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
-	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/cloud/v6/projects" {
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -182,4 +181,8 @@ func mockProjectListServer(t *testing.T) *httptest.Server {
 		}`)
 		require.NoError(t, err)
 	}))
+
+	t.Cleanup(mockServer.Close)
+
+	return mockServer
 }

--- a/internal/cmd/tests/cmd_cloud_project_list_test.go
+++ b/internal/cmd/tests/cmd_cloud_project_list_test.go
@@ -1,0 +1,185 @@
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/internal/cmd"
+)
+
+func TestCloudProjectList(t *testing.T) {
+	t.Parallel()
+
+	t.Run("lists projects successfully", func(t *testing.T) {
+		t.Parallel()
+
+		srv := mockProjectListServer(t)
+		defer srv.Close()
+
+		ts := NewGlobalTestState(t)
+		ts.CmdArgs = []string{"k6", "cloud", "project", "list"}
+		ts.Env["K6_CLOUD_TOKEN"] = validToken
+		ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		assert.Contains(t, stdout, fmt.Sprintf("Projects for stack %d:", validStackID))
+		assert.Contains(t, stdout, "ID   NAME              DEFAULT")
+		assert.Contains(t, stdout, "1    Default project   yes")
+		assert.Contains(t, stdout, "2    My project        no")
+	})
+
+	t.Run("fails without token", func(t *testing.T) {
+		t.Parallel()
+
+		ts := NewGlobalTestState(t)
+		ts.CmdArgs = []string{"k6", "cloud", "project", "list"}
+		ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
+		ts.ExpectedExitCode = -1
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stderr := ts.Stderr.String()
+		assert.Contains(t, stderr, "authenticate")
+	})
+
+	t.Run("fails without stack ID", func(t *testing.T) {
+		t.Parallel()
+
+		ts := NewGlobalTestState(t)
+		ts.CmdArgs = []string{"k6", "cloud", "project", "list"}
+		ts.Env["K6_CLOUD_TOKEN"] = validToken
+		ts.ExpectedExitCode = -1
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stderr := ts.Stderr.String()
+		assert.Contains(t, stderr, "no stack configured")
+	})
+
+	t.Run("empty project list", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := fmt.Fprint(w, `{"value": []}`)
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		ts := NewGlobalTestState(t)
+		ts.CmdArgs = []string{"k6", "cloud", "project", "list"}
+		ts.Env["K6_CLOUD_TOKEN"] = validToken
+		ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		assert.Contains(t, stdout, fmt.Sprintf("Projects for stack %d:", validStackID))
+		assert.Contains(t, stdout, "No projects found.")
+		assert.Contains(t, stdout, "https://grafana.com/docs/grafana-cloud/testing/k6/projects/")
+	})
+
+	t.Run("--json outputs JSON", func(t *testing.T) {
+		t.Parallel()
+
+		srv := mockProjectListServer(t)
+		defer srv.Close()
+
+		ts := NewGlobalTestState(t)
+		ts.CmdArgs = []string{"k6", "cloud", "project", "list", "--json"}
+		ts.Env["K6_CLOUD_TOKEN"] = validToken
+		ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+
+		var projects []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(stdout), &projects))
+		require.Len(t, projects, 2)
+
+		assert.Equal(t, float64(1), projects[0]["id"])
+		assert.Equal(t, "Default project", projects[0]["name"])
+		assert.Equal(t, true, projects[0]["is_default"])
+
+		assert.Equal(t, float64(2), projects[1]["id"])
+		assert.Equal(t, "My project", projects[1]["name"])
+		assert.Equal(t, false, projects[1]["is_default"])
+	})
+
+	t.Run("--json with empty list outputs empty array", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, err := fmt.Fprint(w, `{"value": []}`)
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		ts := NewGlobalTestState(t)
+		ts.CmdArgs = []string{"k6", "cloud", "project", "list", "--json"}
+		ts.Env["K6_CLOUD_TOKEN"] = validToken
+		ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+
+		var projects []map[string]any
+		require.NoError(t, json.Unmarshal([]byte(stdout), &projects))
+		assert.Empty(t, projects)
+	})
+}
+
+func mockProjectListServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/cloud/v6/projects" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		authHeader := r.Header.Get("Authorization")
+		if authHeader != fmt.Sprintf("Bearer %s", validToken) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := fmt.Fprint(w, `{
+			"value": [
+				{
+					"id": 1,
+					"name": "Default project",
+					"is_default": true,
+					"grafana_folder_uid": null,
+					"created": "2025-01-01T00:00:00Z",
+					"updated": "2025-01-01T00:00:00Z"
+				},
+				{
+					"id": 2,
+					"name": "My project",
+					"is_default": false,
+					"grafana_folder_uid": null,
+					"created": "2025-01-02T00:00:00Z",
+					"updated": "2025-01-02T00:00:00Z"
+				}
+			]
+		}`)
+		require.NoError(t, err)
+	}))
+}

--- a/internal/cmd/tests/cmd_cloud_project_list_test.go
+++ b/internal/cmd/tests/cmd_cloud_project_list_test.go
@@ -31,7 +31,7 @@ func TestCloudProjectList(t *testing.T) {
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()
-		assert.Contains(t, stdout, fmt.Sprintf("Projects for stack %d:", validStackID))
+		assert.Contains(t, stdout, fmt.Sprintf("Projects for stack-%d:", validStackID))
 		assert.Contains(t, stdout, "ID   NAME              DEFAULT")
 		assert.Contains(t, stdout, "1    Default project   yes")
 		assert.Contains(t, stdout, "2    My project        no")
@@ -84,7 +84,7 @@ func TestCloudProjectList(t *testing.T) {
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()
-		assert.Contains(t, stdout, fmt.Sprintf("Projects for stack %d:", validStackID))
+		assert.Contains(t, stdout, fmt.Sprintf("Projects for stack-%d:", validStackID))
 		assert.Contains(t, stdout, "No projects found.")
 		assert.Contains(t, stdout, "https://grafana.com/docs/grafana-cloud/testing/k6/projects/")
 	})

--- a/internal/cmd/tests/cmd_cloud_project_list_test.go
+++ b/internal/cmd/tests/cmd_cloud_project_list_test.go
@@ -85,7 +85,23 @@ func TestCloudProjectList(t *testing.T) {
 		stdout := ts.Stdout.String()
 		assert.Contains(t, stdout, fmt.Sprintf("Projects for stack-%d:", validStackID))
 		assert.Contains(t, stdout, "No projects found.")
-		assert.Contains(t, stdout, "https://grafana.com/docs/grafana-cloud/testing/k6/projects/")
+		assert.Contains(t, stdout, "https://grafana.com/docs/grafana-cloud/testing/k6/projects-and-users/projects/")
+	})
+
+	t.Run("--help includes usage", func(t *testing.T) {
+		t.Parallel()
+
+		ts := NewGlobalTestState(t)
+		ts.CmdArgs = []string{"k6", "cloud", "project", "list", "--help"}
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		assert.Contains(t, stdout, "Usage:\n  k6 cloud project list [flags]")
+		assert.Contains(t, stdout, "--json")
+		assert.NotContains(t, stdout, "Global Flags:")
+		assert.NotContains(t, stdout, "--config")
+		assert.NotContains(t, stdout, "\n\n\nExamples:")
 	})
 
 	t.Run("--json outputs JSON", func(t *testing.T) {

--- a/internal/cmd/tests/cmd_cloud_project_list_test.go
+++ b/internal/cmd/tests/cmd_cloud_project_list_test.go
@@ -3,13 +3,13 @@ package tests
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cloudapiv6 "go.k6.io/k6/v2/internal/cloudapi/v6"
+	"go.k6.io/k6/v2/internal/cloudapi/v6/v6test"
 	"go.k6.io/k6/v2/internal/cmd"
 )
 
@@ -19,13 +19,7 @@ func TestCloudProjectList(t *testing.T) {
 	t.Run("lists projects successfully", func(t *testing.T) {
 		t.Parallel()
 
-		srv := mockProjectListServer(t)
-
-		ts := NewGlobalTestState(t)
-		ts.CmdArgs = []string{"k6", "cloud", "project", "list"}
-		ts.Env["K6_CLOUD_TOKEN"] = validToken
-		ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
-		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+		ts := newCloudProjectListTestState(t, testProjects())
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
@@ -39,18 +33,7 @@ func TestCloudProjectList(t *testing.T) {
 	t.Run("empty project list", func(t *testing.T) {
 		t.Parallel()
 
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, err := fmt.Fprint(w, `{"value": []}`)
-			require.NoError(t, err)
-		}))
-		defer srv.Close()
-
-		ts := NewGlobalTestState(t)
-		ts.CmdArgs = []string{"k6", "cloud", "project", "list"}
-		ts.Env["K6_CLOUD_TOKEN"] = validToken
-		ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
-		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+		ts := newCloudProjectListTestState(t, nil)
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
@@ -79,98 +62,51 @@ func TestCloudProjectList(t *testing.T) {
 	t.Run("--json outputs JSON", func(t *testing.T) {
 		t.Parallel()
 
-		srv := mockProjectListServer(t)
-		defer srv.Close()
-
-		ts := NewGlobalTestState(t)
-		ts.CmdArgs = []string{"k6", "cloud", "project", "list", "--json"}
-		ts.Env["K6_CLOUD_TOKEN"] = validToken
-		ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
-		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+		ts := newCloudProjectListTestState(t, testProjects(), "--json")
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()
 
-		var projects []map[string]any
+		var projects []cloudapiv6.Project
 		require.NoError(t, json.Unmarshal([]byte(stdout), &projects))
-		require.Len(t, projects, 2)
-
-		assert.Equal(t, float64(1), projects[0]["id"])
-		assert.Equal(t, "Default project", projects[0]["name"])
-		assert.Equal(t, true, projects[0]["is_default"])
-
-		assert.Equal(t, float64(2), projects[1]["id"])
-		assert.Equal(t, "My project", projects[1]["name"])
-		assert.Equal(t, false, projects[1]["is_default"])
+		assert.Equal(t, testProjects(), projects)
 	})
 
 	t.Run("--json with empty list outputs empty array", func(t *testing.T) {
 		t.Parallel()
 
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			_, err := fmt.Fprint(w, `{"value": []}`)
-			require.NoError(t, err)
-		}))
-		defer srv.Close()
-
-		ts := NewGlobalTestState(t)
-		ts.CmdArgs = []string{"k6", "cloud", "project", "list", "--json"}
-		ts.Env["K6_CLOUD_TOKEN"] = validToken
-		ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
-		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+		ts := newCloudProjectListTestState(t, nil, "--json")
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()
 
-		var projects []map[string]any
+		var projects []cloudapiv6.Project
 		require.NoError(t, json.Unmarshal([]byte(stdout), &projects))
 		assert.Empty(t, projects)
 	})
 }
 
-func mockProjectListServer(t *testing.T) *httptest.Server {
+func testProjects() []cloudapiv6.Project {
+	return []cloudapiv6.Project{
+		{ID: 1, Name: "Default project", IsDefault: true},
+		{ID: 2, Name: "My project", IsDefault: false},
+	}
+}
+
+func newCloudProjectListTestState(
+	t *testing.T, projects []cloudapiv6.Project, args ...string,
+) *GlobalTestState {
 	t.Helper()
 
-	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/cloud/v6/projects" {
-			w.WriteHeader(http.StatusNotFound)
-			return
-		}
+	srv := v6test.NewServer(t, v6test.Config{Projects: projects})
 
-		authHeader := r.Header.Get("Authorization")
-		if authHeader != fmt.Sprintf("Bearer %s", validToken) {
-			w.WriteHeader(http.StatusUnauthorized)
-			return
-		}
+	ts := NewGlobalTestState(t)
+	ts.CmdArgs = append([]string{"k6", "cloud", "project", "list"}, args...)
+	ts.Env["K6_CLOUD_TOKEN"] = validToken
+	ts.Env["K6_CLOUD_STACK_ID"] = fmt.Sprintf("%d", validStackID)
+	ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
 
-		w.Header().Set("Content-Type", "application/json")
-		_, err := fmt.Fprint(w, `{
-			"value": [
-				{
-					"id": 1,
-					"name": "Default project",
-					"is_default": true,
-					"grafana_folder_uid": null,
-					"created": "2025-01-01T00:00:00Z",
-					"updated": "2025-01-01T00:00:00Z"
-				},
-				{
-					"id": 2,
-					"name": "My project",
-					"is_default": false,
-					"grafana_folder_uid": null,
-					"created": "2025-01-02T00:00:00Z",
-					"updated": "2025-01-02T00:00:00Z"
-				}
-			]
-		}`)
-		require.NoError(t, err)
-	}))
-
-	t.Cleanup(mockServer.Close)
-
-	return mockServer
+	return ts
 }


### PR DESCRIPTION
## What?

This pull request introduces a new `cloud project` command group to the CLI, with a `k6 cloud project list` subcommand allowing users to list their Grafana Cloud k6 projects. It adds the implementation, command wiring, output formatting (including JSON support), and comprehensive tests for the new functionality.

<img width="1113" height="235" alt="CleanShot 2026-02-13 at 08 50 19" src="https://github.com/user-attachments/assets/9803edd5-728c-411f-80e0-11ce6d860e3c" />

<img width="946" height="764" alt="CleanShot 2026-02-13 at 08 51 00" src="https://github.com/user-attachments/assets/af838f2c-e4b4-4926-b996-e204debdb9db" />


## Why?

As per #5644.

## Checklist

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

#5644 
<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
