### PR TITLE
browser: fix frame document ordering

### DIFF
--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -335,6 +335,18 @@ func (f *Frame) requestByDocumentID(id string) *Request {
 	return nil
 }
 
+func (f *Frame) responseByDocumentID(id string) *Response {
+	request := f.requestByDocumentID(id)
+	if request == nil {
+		return nil
+	}
+
+	request.responseMu.RLock()
+	defer request.responseMu.RUnlock()
+
+	return request.response
+}
+
 func (f *Frame) navigated(name string, url string, loaderID string) {
 	f.log.Debugf("Frame:navigated", "fid:%s furl:%q lid:%s name:%q url:%q", f.ID(), f.URL(), loaderID, name, url)
 

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -317,6 +317,24 @@ func (f *Frame) hasLifecycleEventFired(event LifecycleEvent) bool {
 	return f.lifecycleEvents[event]
 }
 
+func (f *Frame) requestByDocumentID(id string) *Request {
+	if id == "" {
+		return nil
+	}
+
+	f.documentMu.RLock()
+	defer f.documentMu.RUnlock()
+
+	if f.pendingDocument.is(id) {
+		return f.pendingDocument.request
+	}
+	if f.currentDocument.is(id) {
+		return f.currentDocument.request
+	}
+
+	return nil
+}
+
 func (f *Frame) navigated(name string, url string, loaderID string) {
 	f.log.Debugf("Frame:navigated", "fid:%s furl:%q lid:%s name:%q url:%q", f.ID(), f.URL(), loaderID, name, url)
 

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -110,9 +110,9 @@ type Frame struct {
 	inflightRequestsMu sync.RWMutex
 	inflightRequests   map[network.RequestID]bool
 
-	currentDocument   *DocumentInfo
-	pendingDocumentMu sync.RWMutex
-	pendingDocument   *DocumentInfo
+	currentDocument *DocumentInfo
+	pendingDocument *DocumentInfo
+	documentMu      sync.RWMutex
 
 	log *log.Logger
 }

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -27,6 +27,10 @@ type DocumentInfo struct {
 	request    *Request
 }
 
+func (d *DocumentInfo) is(id string) bool {
+	return d != nil && d.documentID == id
+}
+
 // DOMElementState represents a DOM element state.
 type DOMElementState int
 

--- a/internal/js/modules/k6/browser/common/frame_manager.go
+++ b/internal/js/modules/k6/browser/common/frame_manager.go
@@ -720,7 +720,7 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *Frame
 		return err // TODO maybe wrap this as well?
 	}
 
-	var resp *Response
+	var docID string
 	select {
 	case evt := <-navEvtCh:
 		if e, ok := evt.(*NavigationEvent); ok {
@@ -729,7 +729,7 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *Frame
 			}
 
 			if e.newDocument != nil {
-				resp = frame.responseByDocumentID(e.newDocument.documentID)
+				docID = e.newDocument.documentID
 			}
 		}
 	case <-timeoutCtx.Done():
@@ -742,7 +742,7 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *Frame
 		return nil, wrapTimeoutError(ContextErr(timeoutCtx))
 	}
 
-	return resp, nil
+	return frame.responseByDocumentID(docID), nil
 }
 
 // Page returns the page that this frame manager belongs to.

--- a/internal/js/modules/k6/browser/common/frame_manager.go
+++ b/internal/js/modules/k6/browser/common/frame_manager.go
@@ -720,10 +720,7 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *Frame
 		return err // TODO maybe wrap this as well?
 	}
 
-	var (
-		request *Request
-		resp    *Response
-	)
+	var resp *Response
 	select {
 	case evt := <-navEvtCh:
 		if e, ok := evt.(*NavigationEvent); ok {
@@ -732,12 +729,7 @@ func (m *FrameManager) NavigateFrame(frame *Frame, url string, parsedOpts *Frame
 			}
 
 			if e.newDocument != nil {
-				request = frame.requestByDocumentID(e.newDocument.documentID)
-			}
-			if request != nil {
-				request.responseMu.RLock()
-				resp = request.response
-				request.responseMu.RUnlock()
+				resp = frame.responseByDocumentID(e.newDocument.documentID)
 			}
 		}
 	case <-timeoutCtx.Done():

--- a/internal/js/modules/k6/browser/common/frame_manager.go
+++ b/internal/js/modules/k6/browser/common/frame_manager.go
@@ -532,7 +532,17 @@ func (m *FrameManager) requestStarted(req *Request) {
 	frame.addRequest(req.getID())
 	if req.documentID != "" {
 		frame.documentMu.Lock()
-		frame.pendingDocument = &DocumentInfo{documentID: req.documentID, request: req}
+		switch {
+		case frame.currentDocument.is(req.documentID):
+			frame.currentDocument.request = req
+			if frame.pendingDocument.is(req.documentID) {
+				frame.pendingDocument = nil
+			}
+		case frame.pendingDocument.is(req.documentID):
+			frame.pendingDocument.request = req
+		default:
+			frame.pendingDocument = &DocumentInfo{documentID: req.documentID, request: req}
+		}
 		frame.documentMu.Unlock()
 	}
 

--- a/internal/js/modules/k6/browser/common/frame_manager.go
+++ b/internal/js/modules/k6/browser/common/frame_manager.go
@@ -309,7 +309,7 @@ func (m *FrameManager) frameNavigated(
 		if pendingDocument.documentID == "" {
 			pendingDocument.documentID = documentID
 		}
-		if pendingDocument.documentID == documentID {
+		if pendingDocument.is(documentID) {
 			// Committing a pending document.
 			frame.currentDocument = pendingDocument
 		} else {
@@ -403,7 +403,7 @@ func (m *FrameManager) frameRequestedNavigation(frameID cdp.FrameID, url string,
 	frame.documentMu.Lock()
 	defer frame.documentMu.Unlock()
 
-	if frame.pendingDocument != nil && frame.pendingDocument.documentID == documentID {
+	if frame.pendingDocument.is(documentID) {
 		m.logger.Debugf("FrameManager:frameRequestedNavigation:return",
 			"fmid:%d fid:%v furl:%s url:%s docid:%s pdocid:%s pdoc:dontSet",
 			m.ID(), frameID, frame.URL(), url, documentID,

--- a/internal/js/modules/k6/browser/tests/webvital_test.go
+++ b/internal/js/modules/k6/browser/tests/webvital_test.go
@@ -2,7 +2,6 @@ package tests
 
 import (
 	"context"
-	"runtime"
 	"testing"
 	"time"
 
@@ -19,9 +18,7 @@ import (
 // a web page.
 func TestWebVitalMetric(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("timeouts on windows")
-	}
+
 	var (
 		samples  = make(chan k6metrics.SampleContainer)
 		browser  = newTestBrowser(t, withFileServer(), withSamples(samples))
@@ -92,9 +89,7 @@ func TestWebVitalMetric(t *testing.T) {
 
 func TestWebVitalMetricNoInteraction(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("timeouts on windows")
-	}
+
 	var (
 		samples  = make(chan k6metrics.SampleContainer)
 		browser  = newTestBrowser(t, withFileServer(), withSamples(samples))


### PR DESCRIPTION
## What?

This PR fixes how navigation responses are resolved during Goto and WaitForNavigation. 

Instead of reading the response directly from the navigation event (before network handling has caught up), it now waits for lifecycle events to complete, then looks up the response by document ID. It also fixes request binding during redirects, where a request could end up associated with the wrong document.

## Why?

Improves stability, reduces the flaky behavior, and should reduce other flaky behavior in CI.

Before this, there was a timing window where the response was read as `nil` even though the request had completed. This caused flaky results and was the reason WebVital tests had to be skipped on Windows.

## Note

This PR requires #5656 to be merged. Otherwise, it will fail.

## Related PR(s)/Issue(s)

Depends on #5656
Closes #4371