### PR TITLE
browser: install chromium via snap on arm runners

### DIFF
--- a/.github/actions/test-common/action.yml
+++ b/.github/actions/test-common/action.yml
@@ -35,5 +35,20 @@ runs:
       if: ${{contains(inputs.platform, 'arm') }}
       shell: bash
       run: |
-        sudo apt update && sudo apt install chromium-browser
-        chromium --version || true
+        set -euo pipefail
+
+        if command -v chromium >/dev/null 2>&1; then
+          chromium --version || true
+          exit 0
+        fi
+
+        # Installing Chromium via snap avoids failing apt updates when runner images include
+        # third-party apt repos that may be temporarily unavailable.
+        if command -v snap >/dev/null 2>&1; then
+          sudo snap install chromium || sudo snap refresh chromium
+        else
+          sudo apt-get update
+          sudo apt-get install -y chromium-browser
+        fi
+
+        chromium --version


### PR DESCRIPTION
## What
- Update ARM Chromium setup in `.github/actions/test-common` to prefer snap installation
- Avoid relying on `apt update` for the Chromium path on self-hosted ARM runners
- Keep `apt-get` as a fallback if snap is unavailable

## Why
Recent [CI failures](https://github.com/grafana/k6/actions/runs/22187191392/job/64164227489) on `ubuntu-arm64-large` started failing before tests even start.

## Related

Fixes #5680