### PR TITLE
browser: avoid test browser panic on missing browser

### DIFF
--- a/internal/js/modules/k6/browser/tests/test_browser.go
+++ b/internal/js/modules/k6/browser/tests/test_browser.go
@@ -84,7 +84,8 @@ func newTestBrowser(tb testing.TB, opts ...func(*testBrowser)) *testBrowser {
 
 	b, pid, err := tbr.browserType.Launch(context.Background(), tbr.vu.Context())
 	if err != nil {
-		tb.Fatalf("testBrowser: %v", err)
+		tb.Errorf("testBrowser: %v", err)
+		return tbr
 	}
 	tbr.Browser = b
 	tbr.ctx = tbr.browserType.Ctx


### PR DESCRIPTION
## What?

`newTestBrowser` no longer panics when the browser executable isn't available.

## Why?

Browser tests panic on ARM CI runners (and any environment without Chromium installed) instead of failing cleanly. This makes CI output harder to read and masks the actual problem behind a huge stack trace.