### PR TITLE
Move PageEmulateMediaOptions parsing to the browser mapping layer

### DIFF
--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -85,8 +85,8 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			}), nil
 		},
 		"emulateMedia": func(opts sobek.Value) (*sobek.Promise, error) {
-			popts := common.NewPageEmulateMediaOptions(p)
-			if err := popts.Parse(vu.Context(), opts); err != nil {
+			popts, err := parsePageEmulateMediaOptions(rt, opts, common.NewPageEmulateMediaOptions(p))
+			if err != nil {
 				return nil, fmt.Errorf("parsing emulateMedia options: %w", err)
 			}
 			return promise(vu, func() (any, error) {
@@ -1126,4 +1126,29 @@ func parseSize(rt *sobek.Runtime, opts sobek.Value) (*common.Size, error) {
 	}
 
 	return size, nil
+}
+
+// parsePageEmulateMediaOptions parses the page emulate media options from a Sobek value.
+//
+//nolint:unparam
+func parsePageEmulateMediaOptions(
+	rt *sobek.Runtime, opts sobek.Value, defaults *common.PageEmulateMediaOptions,
+) (*common.PageEmulateMediaOptions, error) {
+	if k6common.IsNullish(opts) {
+		return defaults, nil
+	}
+
+	obj := opts.ToObject(rt)
+	for _, k := range obj.Keys() {
+		switch k {
+		case "colorScheme":
+			defaults.ColorScheme = common.ColorScheme(obj.Get(k).String())
+		case "media":
+			defaults.Media = common.MediaType(obj.Get(k).String())
+		case "reducedMotion":
+			defaults.ReducedMotion = common.ReducedMotion(obj.Get(k).String())
+		}
+	}
+
+	return defaults, nil
 }

--- a/internal/js/modules/k6/browser/browser/page_mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping_test.go
@@ -129,3 +129,59 @@ func TestParseSize(t *testing.T) {
 		})
 	}
 }
+
+func TestParsePageEmulateMediaOptions(t *testing.T) {
+	t.Parallel()
+
+	newDefaults := func() *common.PageEmulateMediaOptions {
+		return &common.PageEmulateMediaOptions{
+			ColorScheme:   common.ColorSchemeLight,
+			Media:         common.MediaTypeScreen,
+			ReducedMotion: common.ReducedMotionNoPreference,
+		}
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  *common.PageEmulateMediaOptions
+	}{
+		{
+			name:  "defaults_on_null",
+			input: `null`,
+			want:  newDefaults(),
+		},
+		{
+			name:  "all_options",
+			input: `({colorScheme: "dark", media: "print", reducedMotion: "reduce"})`,
+			want: &common.PageEmulateMediaOptions{
+				ColorScheme:   "dark",
+				Media:         "print",
+				ReducedMotion: "reduce",
+			},
+		},
+		{
+			name:  "partial_option",
+			input: `({media: "print"})`,
+			want: &common.PageEmulateMediaOptions{
+				ColorScheme:   common.ColorSchemeLight,
+				Media:         "print",
+				ReducedMotion: common.ReducedMotionNoPreference,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			vu := k6test.NewVU(t)
+			v, err := vu.Runtime().RunString(tt.input)
+			require.NoError(t, err)
+
+			opts, err := parsePageEmulateMediaOptions(vu.Runtime(), v, newDefaults())
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, opts)
+		})
+	}
+}

--- a/internal/js/modules/k6/browser/common/page_options.go
+++ b/internal/js/modules/k6/browser/common/page_options.go
@@ -47,25 +47,6 @@ func NewPageEmulateMediaOptions(from *Page) *PageEmulateMediaOptions {
 	}
 }
 
-// Parse parses the page emulate media options.
-func (o *PageEmulateMediaOptions) Parse(ctx context.Context, opts sobek.Value) error {
-	rt := k6ext.Runtime(ctx)
-	if !common.IsNullish(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "colorScheme":
-				o.ColorScheme = ColorScheme(opts.Get(k).String())
-			case "media":
-				o.Media = MediaType(opts.Get(k).String())
-			case "reducedMotion":
-				o.ReducedMotion = ReducedMotion(opts.Get(k).String())
-			}
-		}
-	}
-	return nil
-}
-
 func NewPageReloadOptions(defaultWaitUntil LifecycleEvent, defaultTimeout time.Duration) *PageReloadOptions {
 	return &PageReloadOptions{
 		WaitUntil: defaultWaitUntil,

--- a/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
+++ b/internal/js/modules/k6/browser/tests/launch_options_slowmo_test.go
@@ -55,11 +55,7 @@ func TestBrowserOptionsSlowMo(t *testing.T) {
 			tb := newTestBrowser(t, withFileServer())
 			testPageSlowMoImpl(t, tb, func(_ *testBrowser, p *common.Page) {
 				popts := common.NewPageEmulateMediaOptions(p)
-				require.NoError(t, popts.Parse(tb.context(), tb.toSobekValue(struct {
-					Media string `js:"media"`
-				}{
-					Media: "print",
-				})))
+				popts.Media = "print"
 				err := p.EmulateMedia(popts)
 				require.NoError(t, err)
 			})

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -30,12 +30,6 @@ import (
 	"go.k6.io/k6/metrics"
 )
 
-type emulateMediaOpts struct {
-	Media         string `js:"media"`
-	ColorScheme   string `js:"colorScheme"`
-	ReducedMotion string `js:"reducedMotion"`
-}
-
 type jsFrameBaseOpts struct {
 	Timeout string
 	Strict  bool
@@ -98,12 +92,11 @@ func TestPageEmulateMedia(t *testing.T) {
 	tb := newTestBrowser(t)
 	p := tb.NewPage(nil)
 
-	popts := common.NewPageEmulateMediaOptions(p)
-	require.NoError(t, popts.Parse(tb.context(), tb.toSobekValue(emulateMediaOpts{
+	popts := &common.PageEmulateMediaOptions{
 		Media:         "print",
 		ColorScheme:   "dark",
 		ReducedMotion: "reduce",
-	})))
+	}
 	err := p.EmulateMedia(popts)
 	require.NoError(t, err)
 


### PR DESCRIPTION
## What?

Move `PageEmulateMediaOptions` parsing from `common` into the browser mapping layer.

## Why?

`PageEmulateMediaOptions.Parse` uses Sobek and is only needed for browser option parsing, so I moved it to the mapping layer.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/issues/5305