### PR TITLE
Revert "fix(js/compiler): Disable t.Parallel() on TestCompile for now (#5621)

### DIFF
--- a/internal/js/compiler/compiler_test.go
+++ b/internal/js/compiler/compiler_test.go
@@ -13,11 +13,8 @@ import (
 	"go.k6.io/k6/internal/lib/testutils"
 )
 
-//nolint:tparallel
 func TestCompile(t *testing.T) {
-	// TODO(@joanlopez): Revisit later: it started to fail after the commit below, but hopefully will be fixed soon.
-	// https://github.com/golang/go/commit/481ab86aafe0cac177df793c9946c5ef2126137c
-	// t.Parallel()
+	t.Parallel()
 	t.Run("ES5", func(t *testing.T) {
 		t.Parallel()
 		c := New(testutils.NewLogger(t))


### PR DESCRIPTION
This reverts commit 16737a4e4d966ccf904a37663aca4d1b4c99a5f2.

Closes #5623 

## What?

<!-- A short (or detailed) description of what this PR does. -->

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
