### PR TITLE
chore: Use synctest within lib/executor tests

### DIFF
--- a/lib/executor/execution_test.go
+++ b/lib/executor/execution_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
-	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -61,111 +61,117 @@ func TestExecutionStateVUIDs(t *testing.T) {
 			r := rand.New(rand.NewSource(seed))
 			t.Logf("Random source seeded with %d\n", seed)
 			count := 100 + r.Intn(50)
-			wg := sync.WaitGroup{}
-			wg.Add(count)
-			for range count {
-				go func() {
-					es.GetUniqueVUIdentifiers()
-					wg.Done()
-				}()
-			}
-			wg.Wait()
-			idl, idg = es.GetUniqueVUIdentifiers()
-			assert.EqualValues(t, 4+count, idl)
-			assert.EqualValues(t, (3+count)*int(offsets[0])+int(start+1), idg)
+
+			synctest.Test(t, func(t *testing.T) {
+				for range count {
+					go func() {
+						es.GetUniqueVUIdentifiers()
+					}()
+				}
+				synctest.Wait()
+				idl, idg = es.GetUniqueVUIdentifiers()
+				assert.EqualValues(t, 4+count, idl)
+				assert.EqualValues(t, (3+count)*int(offsets[0])+int(start+1), idg)
+			})
 		})
 	}
 }
 
 func TestExecutionStateGettingVUsWhenNonAreAvailable(t *testing.T) {
 	t.Parallel()
-	et, err := lib.NewExecutionTuple(nil, nil)
-	require.NoError(t, err)
-	es := lib.NewExecutionState(nil, et, 0, 0)
-	logHook := testutils.NewLogHook(logrus.WarnLevel)
-	testLog := logrus.New()
-	testLog.AddHook(logHook)
-	testLog.SetOutput(io.Discard)
-	vu, err := es.GetPlannedVU(logrus.NewEntry(testLog), true)
-	require.Nil(t, vu)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "could not get a VU from the buffer in")
-	entries := logHook.Drain()
-	require.Equal(t, lib.MaxRetriesGetPlannedVU, len(entries))
-	for _, entry := range entries {
-		require.Contains(t, entry.Message, "Could not get a VU from the buffer for ")
-	}
+
+	synctest.Test(t, func(t *testing.T) {
+		et, err := lib.NewExecutionTuple(nil, nil)
+		require.NoError(t, err)
+		es := lib.NewExecutionState(nil, et, 0, 0)
+		logHook := testutils.NewLogHook(logrus.WarnLevel)
+		testLog := logrus.New()
+		testLog.AddHook(logHook)
+		testLog.SetOutput(io.Discard)
+		vu, err := es.GetPlannedVU(logrus.NewEntry(testLog), true)
+		require.Nil(t, vu)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "could not get a VU from the buffer in")
+		entries := logHook.Drain()
+		require.Equal(t, lib.MaxRetriesGetPlannedVU, len(entries))
+		for _, entry := range entries {
+			require.Contains(t, entry.Message, "Could not get a VU from the buffer for ")
+		}
+	})
 }
 
 func TestExecutionStateGettingVUs(t *testing.T) {
 	t.Parallel()
-	logHook := testutils.NewLogHook(logrus.WarnLevel, logrus.DebugLevel)
-	testLog := logrus.New()
-	testLog.AddHook(logHook)
-	testLog.SetOutput(io.Discard)
-	logEntry := logrus.NewEntry(testLog)
 
-	et, err := lib.NewExecutionTuple(nil, nil)
-	require.NoError(t, err)
-	es := lib.NewExecutionState(nil, et, 10, 20)
-	es.SetInitVUFunc(func(_ context.Context, _ *logrus.Entry) (lib.InitializedVU, error) {
-		return &minirunner.VU{}, nil
-	})
+	synctest.Test(t, func(t *testing.T) {
+		logHook := testutils.NewLogHook(logrus.WarnLevel, logrus.DebugLevel)
+		testLog := logrus.New()
+		testLog.AddHook(logHook)
+		testLog.SetOutput(io.Discard)
+		logEntry := logrus.NewEntry(testLog)
 
-	var vu lib.InitializedVU
-	for i := range 10 {
-		require.EqualValues(t, i, es.GetInitializedVUsCount())
-		vu, err = es.InitializeNewVU(context.Background(), logEntry)
+		et, err := lib.NewExecutionTuple(nil, nil)
 		require.NoError(t, err)
-		require.EqualValues(t, i+1, es.GetInitializedVUsCount())
-		es.ReturnVU(vu, false)
-		require.EqualValues(t, 0, es.GetCurrentlyActiveVUsCount())
-		require.EqualValues(t, i+1, es.GetInitializedVUsCount())
-	}
+		es := lib.NewExecutionState(nil, et, 10, 20)
+		es.SetInitVUFunc(func(_ context.Context, _ *logrus.Entry) (lib.InitializedVU, error) {
+			return &minirunner.VU{}, nil
+		})
 
-	// Test getting initialized VUs is okay :)
-	for i := range 10 {
-		require.EqualValues(t, i, es.GetCurrentlyActiveVUsCount())
+		var vu lib.InitializedVU
+		for i := range 10 {
+			require.EqualValues(t, i, es.GetInitializedVUsCount())
+			vu, err = es.InitializeNewVU(context.Background(), logEntry)
+			require.NoError(t, err)
+			require.EqualValues(t, i+1, es.GetInitializedVUsCount())
+			es.ReturnVU(vu, false)
+			require.EqualValues(t, 0, es.GetCurrentlyActiveVUsCount())
+			require.EqualValues(t, i+1, es.GetInitializedVUsCount())
+		}
+
+		// Test getting initialized VUs is okay :)
+		for i := range 10 {
+			require.EqualValues(t, i, es.GetCurrentlyActiveVUsCount())
+			vu, err = es.GetPlannedVU(logEntry, true)
+			require.NoError(t, err)
+			require.Empty(t, logHook.Drain())
+			require.NotNil(t, vu)
+			require.EqualValues(t, i+1, es.GetCurrentlyActiveVUsCount())
+			require.EqualValues(t, 10, es.GetInitializedVUsCount())
+		}
+
+		// Check that getting 1 more planned VU will error out
 		vu, err = es.GetPlannedVU(logEntry, true)
-		require.NoError(t, err)
-		require.Empty(t, logHook.Drain())
-		require.NotNil(t, vu)
-		require.EqualValues(t, i+1, es.GetCurrentlyActiveVUsCount())
-		require.EqualValues(t, 10, es.GetInitializedVUsCount())
-	}
+		require.Nil(t, vu)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "could not get a VU from the buffer in")
+		entries := logHook.Drain()
+		require.Equal(t, lib.MaxRetriesGetPlannedVU, len(entries))
+		for _, entry := range entries {
+			require.Contains(t, entry.Message, "Could not get a VU from the buffer for ")
+		}
 
-	// Check that getting 1 more planned VU will error out
-	vu, err = es.GetPlannedVU(logEntry, true)
-	require.Nil(t, vu)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "could not get a VU from the buffer in")
-	entries := logHook.Drain()
-	require.Equal(t, lib.MaxRetriesGetPlannedVU, len(entries))
-	for _, entry := range entries {
-		require.Contains(t, entry.Message, "Could not get a VU from the buffer for ")
-	}
+		// Test getting uninitialized vus will work
+		for i := range 10 {
+			require.EqualValues(t, 10+i, es.GetInitializedVUsCount())
+			vu, err = es.GetUnplannedVU(context.Background(), logEntry)
+			require.NoError(t, err)
+			require.Empty(t, logHook.Drain())
+			require.NotNil(t, vu)
+			require.EqualValues(t, 10+i+1, es.GetInitializedVUsCount())
+			require.EqualValues(t, 10, es.GetCurrentlyActiveVUsCount())
+		}
 
-	// Test getting uninitialized vus will work
-	for i := range 10 {
-		require.EqualValues(t, 10+i, es.GetInitializedVUsCount())
+		// Check that getting 1 more unplanned VU will error out
 		vu, err = es.GetUnplannedVU(context.Background(), logEntry)
-		require.NoError(t, err)
-		require.Empty(t, logHook.Drain())
-		require.NotNil(t, vu)
-		require.EqualValues(t, 10+i+1, es.GetInitializedVUsCount())
-		require.EqualValues(t, 10, es.GetCurrentlyActiveVUsCount())
-	}
-
-	// Check that getting 1 more unplanned VU will error out
-	vu, err = es.GetUnplannedVU(context.Background(), logEntry)
-	require.Nil(t, vu)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "could not get a VU from the buffer in")
-	entries = logHook.Drain()
-	require.Equal(t, lib.MaxRetriesGetPlannedVU, len(entries))
-	for _, entry := range entries {
-		require.Contains(t, entry.Message, "Could not get a VU from the buffer for ")
-	}
+		require.Nil(t, vu)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "could not get a VU from the buffer in")
+		entries = logHook.Drain()
+		require.Equal(t, lib.MaxRetriesGetPlannedVU, len(entries))
+		for _, entry := range entries {
+			require.Contains(t, entry.Message, "Could not get a VU from the buffer for ")
+		}
+	})
 }
 
 func TestMarkStartedPanicsOnSecondRun(t *testing.T) {

--- a/lib/executor/per_vu_iterations_test.go
+++ b/lib/executor/per_vu_iterations_test.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -56,67 +57,73 @@ func TestPerVUIterationsRun(t *testing.T) {
 // This is the reverse behavior of the SharedIterations executor.
 func TestPerVUIterationsRunVariableVU(t *testing.T) {
 	t.Parallel()
-	var (
-		result   sync.Map
-		slowVUID = uint64(1)
-	)
 
-	runner := simpleRunner(func(_ context.Context, state *lib.State) error {
-		if state.VUID == slowVUID {
-			time.Sleep(200 * time.Millisecond)
-		}
-		currIter, _ := result.LoadOrStore(state.VUID, uint64(0))
-		result.Store(state.VUID, currIter.(uint64)+1)
-		return nil
+	synctest.Test(t, func(t *testing.T) {
+		var (
+			result   sync.Map
+			slowVUID = uint64(1)
+		)
+
+		runner := simpleRunner(func(_ context.Context, state *lib.State) error {
+			if state.VUID == slowVUID {
+				time.Sleep(201 * time.Millisecond)
+			}
+			currIter, _ := result.LoadOrStore(state.VUID, uint64(0))
+			result.Store(state.VUID, currIter.(uint64)+1)
+			return nil
+		})
+
+		test := setupExecutorTest(t, "", "", lib.Options{}, runner, getTestPerVUIterationsConfig())
+		defer test.cancel()
+
+		engineOut := make(chan metrics.SampleContainer, 1000)
+		require.NoError(t, test.executor.Run(test.ctx, engineOut))
+
+		val, ok := result.Load(slowVUID)
+		assert.True(t, ok)
+
+		var totalIters uint64
+		result.Range(func(key, value any) bool {
+			vuIters := value.(uint64)
+			if key != slowVUID {
+				assert.Equal(t, uint64(100), vuIters)
+			}
+			totalIters += vuIters
+			return true
+		})
+
+		// The slow VU should complete 15 iterations given these timings,
+		// while the rest should equally complete their assigned 100 iterations.
+		assert.EqualValues(t, 15, val)
+		assert.EqualValues(t, 9*100+val.(uint64), totalIters)
 	})
-
-	test := setupExecutorTest(t, "", "", lib.Options{}, runner, getTestPerVUIterationsConfig())
-	defer test.cancel()
-
-	engineOut := make(chan metrics.SampleContainer, 1000)
-	require.NoError(t, test.executor.Run(test.ctx, engineOut))
-
-	val, ok := result.Load(slowVUID)
-	assert.True(t, ok)
-
-	var totalIters uint64
-	result.Range(func(key, value any) bool {
-		vuIters := value.(uint64)
-		if key != slowVUID {
-			assert.Equal(t, uint64(100), vuIters)
-		}
-		totalIters += vuIters
-		return true
-	})
-
-	// The slow VU should complete 15 iterations given these timings,
-	// while the rest should equally complete their assigned 100 iterations.
-	assert.Equal(t, uint64(15), val)
-	assert.Equal(t, uint64(915), totalIters)
 }
 
 func TestPerVuIterationsEmitDroppedIterations(t *testing.T) {
 	t.Parallel()
-	var count int64
 
-	config := PerVUIterationsConfig{
-		VUs:         null.IntFrom(5),
-		Iterations:  null.IntFrom(20),
-		MaxDuration: types.NullDurationFrom(1 * time.Second),
-	}
+	synctest.Test(t, func(t *testing.T) {
+		var count int64
 
-	runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
-		atomic.AddInt64(&count, 1)
-		<-ctx.Done()
-		return nil
+		config := PerVUIterationsConfig{
+			VUs:         null.IntFrom(5),
+			Iterations:  null.IntFrom(20),
+			MaxDuration: types.NullDurationFrom(1 * time.Second),
+		}
+
+		runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+			atomic.AddInt64(&count, 1)
+			<-ctx.Done()
+			return nil
+		})
+
+		test := setupExecutorTest(t, "", "", lib.Options{}, runner, config)
+		defer test.cancel()
+
+		engineOut := make(chan metrics.SampleContainer, 1000)
+		require.NoError(t, test.executor.Run(test.ctx, engineOut))
+		assert.Empty(t, test.logHook.Drain())
+		assert.Equal(t, int64(5), count)
+		assert.Equal(t, float64(95), sumMetricValues(engineOut, metrics.DroppedIterationsName))
 	})
-
-	test := setupExecutorTest(t, "", "", lib.Options{}, runner, config)
-	defer test.cancel()
-
-	engineOut := make(chan metrics.SampleContainer, 1000)
-	require.NoError(t, test.executor.Run(test.ctx, engineOut))
-	assert.Empty(t, test.logHook.Drain())
-	assert.Equal(t, int64(5), count)
-	assert.Equal(t, float64(95), sumMetricValues(engineOut, metrics.DroppedIterationsName))
 }


### PR DESCRIPTION
## What?

Among other things this makes this test hopefully completely not flaky. It also makes them very fast as now the only not ~0s tests are the ones that actually do calculations.

This does require a change to arrival rate cal method which calculates when the next iteration should happen.

This is due to this actually not stopping on being cancelled and just blocking on a channel. The change unfortunately does have performance impact as shown by the benchmarks

```
goos: linux
goarch: amd64
pkg: go.k6.io/k6/lib/executor
cpu: AMD Ryzen 7 PRO 6850U with Radeon Graphics
                                  │ old_bench.result │           new_bench.result           │
                                  │   iterations/s   │ iterations/s  vs base                │
RampingArrivalRateRun/VUs10-16          1.568M ±  6%   1.258M ± 12%  -19.77% (p=0.000 n=10)
RampingArrivalRateRun/VUs100-16         1.937M ± 11%   1.565M ±  7%  -19.20% (p=0.000 n=10)
RampingArrivalRateRun/VUs1000-16        1.789M ± 12%   1.542M ± 12%  -13.82% (p=0.000 n=10)
RampingArrivalRateRun/VUs10000-16       1.317M ± 11%   1.187M ±  4%   -9.88% (p=0.000 n=10)
geomean                                 1.636M         1.378M        -15.76%

                                                                                                          │ old_bench.result │             new_bench.result             │
                                                                                                          │      sec/op      │     sec/op      vs base                  │
Cal/1s-16                                                                                                       1.463µ ± 13%    17.690µ ±  8%  +1109.16% (p=0.000 n=10)
Cal/1m0s-16                                                                                                     60.79µ ± 39%   1006.74µ ±  4%  +1556.06% (p=0.000 n=10)
CalRat/1s-16                                                                                                    7.058m ± 22%     6.713m ±  9%          ~ (p=0.739 n=10)
CalRat/1m0s-16                                                                                                   4.421 ±  6%      4.312 ±  9%          ~ (p=0.796 n=10)
RampingVUsGetRawExecutionSteps/seq:;segment:/normal-16                                                          105.2µ ±  8%     115.4µ ± 10%     +9.67% (p=0.043 n=10)
RampingVUsGetRawExecutionSteps/seq:;segment:/rollercoaster-16                                                   986.0µ ± 11%    1009.5µ ± 42%          ~ (p=0.529 n=10)
RampingVUsGetRawExecutionSteps/seq:;segment:0:1/normal-16                                                       103.9µ ± 16%     115.4µ ± 10%    +11.04% (p=0.023 n=10)
RampingVUsGetRawExecutionSteps/seq:;segment:0:1/rollercoaster-16                                                992.5µ ± 12%    1009.5µ ± 16%          ~ (p=0.631 n=10)
RampingVUsGetRawExecutionSteps/seq:0,0.3,0.5,0.6,0.7,0.8,0.9,1;segment:0:0.3/normal-16                          34.68µ ±  6%     34.98µ ± 26%          ~ (p=0.912 n=10)
RampingVUsGetRawExecutionSteps/seq:0,0.3,0.5,0.6,0.7,0.8,0.9,1;segment:0:0.3/rollercoaster-16                   321.0µ ± 13%     327.7µ ± 17%          ~ (p=0.247 n=10)
RampingVUsGetRawExecutionSteps/seq:0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1;segment:0:0.1/normal-16              10.53µ ±  7%     11.58µ ± 12%          ~ (p=0.143 n=10)
RampingVUsGetRawExecutionSteps/seq:0,0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1;segment:0:0.1/rollercoaster-16       118.7µ ± 19%     124.5µ ± 25%          ~ (p=0.631 n=10)
RampingVUsGetRawExecutionSteps/seq:;segment:2/5:4/5/normal-16                                                   44.93µ ±  8%     43.29µ ± 10%          ~ (p=0.436 n=10)
RampingVUsGetRawExecutionSteps/seq:;segment:2/5:4/5/rollercoaster-16                                            438.7µ ± 11%     471.9µ ± 10%          ~ (p=0.190 n=10)
RampingVUsGetRawExecutionSteps/seq:;segment:2235/5213:4/5/normal-16                                             47.26µ ±  6%     48.65µ ±  9%          ~ (p=0.684 n=10)
RampingVUsGetRawExecutionSteps/seq:;segment:2235/5213:4/5/rollercoaster-16                                      425.2µ ±  7%     446.1µ ±  7%     +4.91% (p=0.011 n=10)
VUHandleIterations-16                                                                                            1.001 ±  0%      1.000 ±  0%          ~ (p=0.631 n=10)
geomean                                                                                                         398.9µ           559.3µ          +40.22%

                      │ old_bench.result │        new_bench.result         │
                      │  iterations/ns   │ iterations/ns  vs base          │
VUHandleIterations-16       96.91m ± 22%   102.55m ± 24%  ~ (p=0.075 n=10)
```

I would argue the RampingArrivalRateRun are more relevant, but this is still running an empty iteration as fast as possible, so now just the ceiling is down. I do not think running 1 million iterations on my machine is feasible in any way to be honest.

On the other hand this is one more case where we do not leave goroutine hanging so that is nice.


## Why?


This practically makes this test completely not flaky for me locally and I do expect also in the CI.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
