### PR TITLE
fix(options): merge RunTags across config layers instead of replacing

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"path/filepath"
 	"strings"
 	"time"
@@ -17,6 +18,7 @@ import (
 	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/errext"
 	"go.k6.io/k6/v2/errext/exitcodes"
+	"go.k6.io/k6/v2/internal/features"
 	"go.k6.io/k6/v2/lib"
 	"go.k6.io/k6/v2/lib/executor"
 	"go.k6.io/k6/v2/lib/fsext"
@@ -211,7 +213,9 @@ func readEnvConfig(envMap map[string]string) (Config, error) {
 // - set some defaults if they weren't previously specified
 // TODO: add better validation, more explicit default values and improve consistency between formats
 // TODO: accumulate all errors and differentiate between the layers?
-func getConsolidatedConfig(gs *state.GlobalState, cliConf Config, runnerOpts lib.Options) (Config, error) {
+func getConsolidatedConfig(
+	gs *state.GlobalState, cliConf Config, runnerOpts lib.Options, flags *features.Flags,
+) (Config, error) {
 	fileConf, err := readDiskConfig(gs)
 	if err != nil {
 		err = fmt.Errorf("failed to load the configuration file from the local file system: %w", err)
@@ -234,6 +238,15 @@ func getConsolidatedConfig(gs *state.GlobalState, cliConf Config, runnerOpts lib
 	warnOnShortHandOverride(conf.Options, cliConf.Options, "cli", gs.Logger)
 	conf = conf.Apply(cliConf)
 
+	if flags != nil && flags.MergeRunTags {
+		conf.RunTags = mergeRunTags(
+			fileConf.RunTags,
+			runnerOpts.RunTags,
+			envConf.RunTags,
+			cliConf.RunTags,
+		)
+	}
+
 	conf = applyDefault(conf)
 
 	// TODO(imiric): Move this validation where it makes sense in the configuration
@@ -246,6 +259,20 @@ func getConsolidatedConfig(gs *state.GlobalState, cliConf Config, runnerOpts lib
 	}
 
 	return conf, nil
+}
+
+// mergeRunTags accumulates RunTags from each layer in precedence order (lowest first).
+// On key collision, later (higher-priority) layers overwrite earlier ones.
+// Returns nil when every layer is empty to preserve the codebase's "tags":null serialization.
+func mergeRunTags(layers ...map[string]string) map[string]string {
+	merged := map[string]string{}
+	for _, l := range layers {
+		maps.Copy(merged, l)
+	}
+	if len(merged) == 0 {
+		return nil
+	}
+	return merged
 }
 
 func warnOnShortHandOverride(a, b lib.Options, bName string, logger logrus.FieldLogger) {

--- a/internal/cmd/config_consolidation_test.go
+++ b/internal/cmd/config_consolidation_test.go
@@ -11,6 +11,7 @@ import (
 
 	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/internal/cmd/tests"
+	"go.k6.io/k6/v2/internal/features"
 	"go.k6.io/k6/v2/lib"
 	"go.k6.io/k6/v2/lib/executor"
 	"go.k6.io/k6/v2/lib/fsext"
@@ -105,11 +106,12 @@ func getFS(files []file) fsext.Fs {
 }
 
 type opts struct {
-	cli    []string
-	env    []string
-	runner *lib.Options
-	fs     fsext.Fs
-	cmds   []string
+	cli      []string
+	env      []string
+	runner   *lib.Options
+	fs       fsext.Fs
+	cmds     []string
+	features *features.Flags
 }
 
 // exp contains the different events or errors we expect our test case to trigger.
@@ -349,6 +351,66 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 				assert.Equal(t, exp, c.RunTags)
 			},
 		},
+		// merge-run-tags off: each layer that sets tags replaces the previous one wholesale.
+		{
+			opts{
+				fs:     defaultConfig(`{"tags": {"file_only": "f", "shared": "from-file"}}`),
+				runner: &lib.Options{RunTags: map[string]string{"script_only": "s", "shared": "from-script"}},
+				env:    []string{"K6_TAGS=env_only:e,shared:from-env"},
+				cli:    []string{"--tag", "cli_only=c", "--tag", "shared=from-cli"},
+			},
+			exp{},
+			func(t *testing.T, c Config) {
+				assert.Equal(t, map[string]string{
+					"cli_only": "c",
+					"shared":   "from-cli",
+				}, c.RunTags)
+			},
+		},
+		// merge-run-tags on: every layer contributes; higher-priority wins on key collision.
+		// Precedence: file < script < env < CLI.
+		{
+			opts{
+				fs:       defaultConfig(`{"tags": {"file_only": "f", "shared": "from-file"}}`),
+				runner:   &lib.Options{RunTags: map[string]string{"script_only": "s", "shared": "from-script"}},
+				env:      []string{"K6_TAGS=env_only:e,shared:from-env"},
+				cli:      []string{"--tag", "cli_only=c", "--tag", "shared=from-cli"},
+				features: &features.Flags{MergeRunTags: true},
+			},
+			exp{},
+			func(t *testing.T, c Config) {
+				assert.Equal(t, map[string]string{
+					"file_only":   "f",
+					"script_only": "s",
+					"env_only":    "e",
+					"cli_only":    "c",
+					"shared":      "from-cli",
+				}, c.RunTags)
+			},
+		},
+		// merge-run-tags on with only file + CLI tags (the original PR scenario).
+		{
+			opts{
+				fs:       defaultConfig(`{"tags": {"codeTagKey": "codeTagValue"}}`),
+				cli:      []string{"--tag", "clitagkey=clitagvalue"},
+				features: &features.Flags{MergeRunTags: true},
+			},
+			exp{},
+			func(t *testing.T, c Config) {
+				assert.Equal(t, map[string]string{
+					"codeTagKey": "codeTagValue",
+					"clitagkey":  "clitagvalue",
+				}, c.RunTags)
+			},
+		},
+		// merge-run-tags on with no tags anywhere: result stays nil.
+		{
+			opts{features: &features.Flags{MergeRunTags: true}},
+			exp{},
+			func(t *testing.T, c Config) {
+				assert.Nil(t, c.RunTags)
+			},
+		},
 
 		// Test summary trend stats
 		{opts{}, exp{}, func(t *testing.T, c Config) {
@@ -544,7 +606,7 @@ func runTestCase(t *testing.T, testCase configConsolidationTestCase, subCmd stri
 	if testCase.options.runner != nil {
 		opts = *testCase.options.runner
 	}
-	consolidatedConfig, err := getConsolidatedConfig(ts.GlobalState, cliConf, opts)
+	consolidatedConfig, err := getConsolidatedConfig(ts.GlobalState, cliConf, opts, testCase.options.features)
 	if testCase.expected.consolidationError {
 		require.Error(t, err)
 		return

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -544,7 +544,8 @@ func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 	}
 
 	gs.Logger.Debug("Consolidating config layers...")
-	consolidatedConfig, err := getConsolidatedConfig(gs, cliConfig, lt.initRunner.GetOptions())
+	consolidatedConfig, err := getConsolidatedConfig(
+		gs, cliConfig, lt.initRunner.GetOptions(), lt.preInitState.FeatureFlags)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/tests/cmd_run_merge_run_tags_test.go
+++ b/internal/cmd/tests/cmd_run_merge_run_tags_test.go
@@ -1,0 +1,89 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/lib/fsext"
+)
+
+const mergeRunTagsScript = `
+	export const options = {
+		tags: { env: 'staging', team: 'backend' },
+		scenarios: {
+			s: { executor: 'per-vu-iterations', vus: 1, iterations: 1 },
+		},
+	};
+	export default function () {}
+`
+
+// Without the flag, CLI --tag replaces script-level options.tags wholesale.
+// Samples should NOT carry the script-level `env` tag.
+func TestRunMergeRunTagsFlagOff(t *testing.T) {
+	t.Parallel()
+
+	ts := getSingleFileTestState(t, mergeRunTagsScript,
+		[]string{"--out", "json=results.json", "--no-usage-report", "--tag", "region=us-east"}, 0)
+
+	results := runAndReadResults(t, ts)
+
+	withScriptTag := getSampleValues(t, results, "iterations", map[string]string{"env": "staging"})
+	assert.Empty(t, withScriptTag, "script-level tags must be replaced wholesale when the flag is off")
+
+	withCLITag := getSampleValues(t, results, "iterations", map[string]string{"region": "us-east"})
+	assert.NotEmpty(t, withCLITag, "CLI --tag must still apply")
+}
+
+// With the flag on, CLI --tag, script options.tags, and env K6_TAGS all contribute.
+func TestRunMergeRunTagsFlagOn(t *testing.T) {
+	t.Parallel()
+
+	ts := getSingleFileTestState(t, mergeRunTagsScript,
+		[]string{
+			"--out", "json=results.json", "--no-usage-report",
+			"--features", "merge-run-tags",
+			"--tag", "region=us-east",
+		}, 0)
+
+	results := runAndReadResults(t, ts)
+
+	for k, v := range map[string]string{
+		"env":    "staging", // from script options.tags
+		"team":   "backend", // from script options.tags
+		"region": "us-east", // from CLI --tag
+	} {
+		samples := getSampleValues(t, results, "iterations", map[string]string{k: v})
+		assert.NotEmpty(t, samples, "expected merged tag %s=%s", k, v)
+	}
+}
+
+// Higher-priority layers must win on key collision when the flag is on.
+func TestRunMergeRunTagsCLIWinsOnCollision(t *testing.T) {
+	t.Parallel()
+
+	ts := getSingleFileTestState(t, mergeRunTagsScript,
+		[]string{
+			"--out", "json=results.json", "--no-usage-report",
+			"--features", "merge-run-tags",
+			"--tag", "env=prod",
+		}, 0)
+
+	results := runAndReadResults(t, ts)
+
+	wins := getSampleValues(t, results, "iterations", map[string]string{"env": "prod"})
+	assert.NotEmpty(t, wins, "CLI --tag must win over script-level options.tags on collision")
+
+	loses := getSampleValues(t, results, "iterations", map[string]string{"env": "staging"})
+	assert.Empty(t, loses, "lower-priority value must not appear when the higher-priority layer overrides it")
+}
+
+func runAndReadResults(t *testing.T, ts *GlobalTestState) []byte {
+	t.Helper()
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	data, err := fsext.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+	return data
+}

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -42,6 +42,7 @@ func (l Lifecycle) String() string {
 // Flags declares every feature flag as a tagged bool field.
 type Flags struct {
 	NativeHistograms bool `lifecycle:"experimental" help:"Use native histograms for trend metrics"`
+	MergeRunTags     bool `lifecycle:"experimental" help:"Merge run tags across config layers instead of replacing"`
 	_                noCopy
 	activated        []string
 }


### PR DESCRIPTION
## What?

`Options.Apply` previously replaced `RunTags` wholesale when a higher-priority layer set any tags. This caused `options.tags` in a script to be silently discarded whenever `--tag` or `K6_TAGS` was also used.

Tags are now merged per-key across all config layers.

## Why?

Per the [order of precedence](https://grafana.com/docs/k6/latest/using-k6/k6-options/how-to/#order-of-precedence), higher-priority layers should win on conflict — not erase everything from lower-priority layers. Every other map-type option (e.g. `Thresholds`) replaces wholesale because replacement is the right semantic there. For tags the user expectation is additive: script sets `env=staging`, CLI adds `team=backend`, both should appear.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

Closes #2694

- grafana/k6-operator#220 — same root cause; k6-operator adds `instance_id`/`job_name` tags via CLI which wiped script-level tags for operator users