### PR TITLE
[refactor] Add `K6_SECRET_SOURCE`

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"slices"
 	"strconv"
-	"strings"
 	"sync"
 
 	"go.k6.io/k6/lib"
@@ -126,7 +125,7 @@ func NewGlobalState(ctx context.Context) *GlobalState {
 
 	env := BuildEnvMap(os.Environ())
 	defaultFlags := GetDefaultFlags(confDir, cacheDir)
-	globalFlags := GetFlags(defaultFlags, env, os.Args)
+	globalFlags := getFlags(defaultFlags, env, os.Args)
 
 	logLevel := logrus.InfoLevel
 	if globalFlags.Verbose {
@@ -182,7 +181,6 @@ type GlobalFlags struct {
 	ProfilingEnabled bool
 	LogOutput        string
 	SecretSource     []string
-	SecretSourceEnv  string
 	LogFormat        string
 	Verbose          bool
 
@@ -207,9 +205,7 @@ func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 	}
 }
 
-// GetFlags builds GlobalFlags by applying environment variables and CLI args on
-// top of the provided defaults.
-func GetFlags(defaultFlags GlobalFlags, env map[string]string, args []string) GlobalFlags {
+func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) GlobalFlags {
 	result := defaultFlags
 
 	// TODO: add env vars for the rest of the values (after adjusting
@@ -269,10 +265,9 @@ func GetFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 		result.BuildServiceURL = fmt.Sprintf("%s/%s", defaultBuildServiceURL, communityExtensionsCatalog)
 	}
 
-	// K6_SECRET_SOURCE is equivalent to a single extra --secret-source flag value.
-	// Stored separately so that merging with cobra-parsed SecretSource can happen
-	// after cobra parses flags (cobra replaces StringArrayVar defaults on any explicit flag).
-	result.SecretSourceEnv = strings.TrimSpace(env["K6_SECRET_SOURCE"])
+	if val, ok := env["K6_SECRET_SOURCE"]; ok {
+		result.SecretSource = []string{val}
+	}
 
 	// check if verbose flag is set
 	if slices.Contains(args, "-v") || slices.Contains(args, "--verbose") {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	stdlog "log"
 	"runtime/debug"
-	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -116,11 +115,6 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 		`{{with .Name}}{{printf "%s " .}}{{end}}{{printf "v%s\n" .Version}}`,
 	)
 
-	// Refresh SecretSourceEnv from the current env map so that env vars set after
-	// GlobalState construction (e.g. in tests) are picked up before cobra registers
-	// flag defaults. Other flags are left unchanged to preserve any modifications
-	// made directly to gs.Flags (e.g. in tests).
-	gs.Flags.SecretSourceEnv = strings.TrimSpace(gs.Env["K6_SECRET_SOURCE"])
 	rootCmd.PersistentFlags().AddFlagSet(rootCmdPersistentFlagSet(gs))
 	rootCmd.SetArgs(gs.CmdArgs[1:])
 	rootCmd.SetOut(gs.Stdout)
@@ -422,15 +416,8 @@ func createSecretSources(gs *state.GlobalState) (map[string]secretsource.Source,
 		Usage:       gs.Usage,
 	}
 
-	// Merge --secret-source flags with K6_SECRET_SOURCE env var (parsed by GetFlags).
-	// K6_SECRET_SOURCE is treated as one complete spec; exact duplicates are skipped.
-	secretSources := gs.Flags.SecretSource
-	if envSrc := gs.Flags.SecretSourceEnv; envSrc != "" && !slices.Contains(secretSources, envSrc) {
-		secretSources = append(secretSources, envSrc)
-	}
-
 	result := make(map[string]secretsource.Source)
-	for _, line := range secretSources {
+	for _, line := range gs.Flags.SecretSource {
 		t, config, ok := strings.Cut(line, "=")
 		if !ok {
 			// Special case: allow --secret-source=url without explicit config

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -2733,14 +2733,16 @@ func TestK6SecretSourceEnvVar(t *testing.T) {
 			notContains: []string{"level=error", "something", "other"},
 		},
 		{
-			name:     "empty env var is ignored, no source configured error",
-			envVar:   "",
-			contains: []string{"no secret sources are configured"},
+			name:             "empty env var is error",
+			envVar:           "",
+			expectedExitCode: -1,
+			contains:         []string{"couldn't parse secret source configuration \\\"\\\""},
 		},
 		{
-			name:     "whitespace-only env var is ignored",
-			envVar:   "   ",
-			contains: []string{"no secret sources are configured"},
+			name:             "whitespace-only env var is error",
+			envVar:           "   ",
+			expectedExitCode: -1,
+			contains:         []string{"couldn't parse secret source configuration \\\"   \\\""},
 		},
 		{
 			name:             "invalid source type gives clear error",
@@ -2760,6 +2762,7 @@ func TestK6SecretSourceEnvVar(t *testing.T) {
 			ts.Env["K6_SECRET_SOURCE"] = tc.envVar
 			ts.CmdArgs = []string{"k6", "run", "script.js"}
 
+			ts.ReparseFlags()
 			cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 			stderr := ts.Stderr.String()
@@ -2783,6 +2786,7 @@ func TestK6SecretSourceEnvVar(t *testing.T) {
 		ts.Env["K6_SECRET_SOURCE"] = "file=" + secretFile
 		ts.CmdArgs = []string{"k6", "run", "script.js"}
 
+		ts.ReparseFlags()
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stderr := ts.Stderr.String()
@@ -2808,6 +2812,7 @@ func TestK6SecretSourceEnvVar(t *testing.T) {
 
 		ts.Env["K6_SECRET_SOURCE"] = fmt.Sprintf("url=urlTemplate=%s/secrets/{key},maxRetries=0", srv.URL)
 		ts.CmdArgs = []string{"k6", "run", "script.js"}
+		ts.ReparseFlags()
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
@@ -2837,6 +2842,7 @@ func TestK6SecretSourceEnvVar(t *testing.T) {
 		ts.Env["K6_SECRET_SOURCE"] = "mock=name=mysource,cool=secretval"
 		ts.CmdArgs = []string{"k6", "run", "script.js"}
 
+		ts.ReparseFlags()
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stderr := ts.Stderr.String()
@@ -2864,6 +2870,7 @@ func TestK6SecretSourceEnvVar(t *testing.T) {
 		ts.Env["K6_SECRET_SOURCE"] = "mock=name=named,cool=secretval,default"
 		ts.CmdArgs = []string{"k6", "run", "script.js"}
 
+		ts.ReparseFlags()
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stderr := ts.Stderr.String()
@@ -2872,16 +2879,20 @@ func TestK6SecretSourceEnvVar(t *testing.T) {
 		assert.Contains(t, stderr, `level=info msg="***SECRET_REDACTED***" source=console`)
 	})
 
-	t.Run("env var merged with flag provides two separate sources", func(t *testing.T) {
+	t.Run("cli flags overrides env variable", func(t *testing.T) {
 		t.Parallel()
 		multiScript := `
 			import secrets from "k6/secrets";
 			export default async () => {
-				const a = await secrets.source("first").get("cool");
-				const b = await secrets.source("second").get("cool");
-				console.log(a);
+				let secondMissing = false;
+				try {
+					const a = await secrets.source("second").get("cool");
+				} catch (e) {
+					secondMissing = true
+				}
+				const b = await secrets.source("first").get("cool");
 				console.log(b);
-				console.log(a === b);
+				console.log(secondMissing);
 			}
 		`
 		ts := NewGlobalTestState(t)
@@ -2890,6 +2901,7 @@ func TestK6SecretSourceEnvVar(t *testing.T) {
 		ts.Env["K6_SECRET_SOURCE"] = "mock=name=second,cool=second-secret"
 		ts.CmdArgs = []string{"k6", "run", "--secret-source=mock=name=first,cool=first-secret", "script.js"}
 
+		ts.ReparseFlags()
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stderr := ts.Stderr.String()
@@ -2898,52 +2910,7 @@ func TestK6SecretSourceEnvVar(t *testing.T) {
 		// Both secrets are redacted in the output.
 		assert.Contains(t, stderr, `level=info msg="***SECRET_REDACTED***" source=console`)
 		// The boolean false is not a secret — it is logged as-is.
-		assert.Contains(t, stderr, `level=info msg=false source=console`)
-	})
-
-	t.Run("exact duplicate of flag value is silently deduplicated", func(t *testing.T) {
-		// When K6_SECRET_SOURCE equals a --secret-source value exactly, only one
-		// source is registered (no "already registered" error).
-		t.Parallel()
-		singleScript := `
-			import secrets from "k6/secrets";
-			export default async () => {
-				const v = await secrets.get("cool");
-				console.log(v);
-			}
-		`
-		ts := NewGlobalTestState(t)
-		require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "script.js"), []byte(singleScript), 0o644))
-
-		ts.Env["K6_SECRET_SOURCE"] = "mock=cool=secretval"
-		ts.CmdArgs = []string{"k6", "run", "--secret-source=mock=cool=secretval", "script.js"}
-
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stderr := ts.Stderr.String()
-		t.Log(stderr)
-		assert.NotContains(t, stderr, "level=error")
-		assert.Contains(t, stderr, `level=info msg="***SECRET_REDACTED***" source=console`)
-	})
-
-	t.Run("conflicting source name via env var and flag gives clear error", func(t *testing.T) {
-		// --secret-source is registered first; K6_SECRET_SOURCE is appended after.
-		// When both resolve to the same source name (but different configs), the
-		// second registration fails with a clear "already registered" error.
-		// This also documents precedence: the flag spec wins, env var loses.
-		t.Parallel()
-		ts := NewGlobalTestState(t)
-		require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "script.js"), []byte(script), 0o644))
-
-		ts.ExpectedExitCode = -1
-		ts.Env["K6_SECRET_SOURCE"] = "mock=name=src,cool=fromenv"
-		ts.CmdArgs = []string{"k6", "run", "--secret-source=mock=name=src,cool=fromflag", "script.js"}
-
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stderr := ts.Stderr.String()
-		t.Log(stderr)
-		assert.Contains(t, stderr, "already registered")
+		assert.Contains(t, stderr, `level=info msg=true source=console`)
 	})
 }
 

--- a/internal/cmd/tests/test_state.go
+++ b/internal/cmd/tests/test_state.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	_ "unsafe" //nolint:revive,nolintlint // needed for the go:linkname and nolintlint is buggy
 
 	"go.k6.io/k6/lib"
 
@@ -122,6 +123,19 @@ func NewGlobalTestState(tb testing.TB) *GlobalTestState {
 
 	return ts
 }
+
+// ReparseFlags reparses flags so it can take into account changes to env variables and arguments
+func (ts *GlobalTestState) ReparseFlags() {
+	defaultFlags := getFlags(ts.DefaultFlags, ts.Env, ts.CmdArgs)
+	ts.DefaultFlags = defaultFlags
+	ts.Flags = defaultFlags
+}
+
+// TODO(@mstoykov): Figure out how to not do it this way and not have more public APIs
+// Also use this for testing more of the GlobalState.Flags
+//
+//go:linkname getFlags go.k6.io/k6/cmd/state.getFlags
+func getFlags(defaultFlags state.GlobalFlags, env map[string]string, args []string) state.GlobalFlags
 
 var portRangeStart uint64 = 6565 //nolint:gochecknoglobals
 


### PR DESCRIPTION
https://github.com/grafana/k6-cloud/issues/4266

## What?

Add support for configuring secret sources via the `K6_SECRET_SOURCE` environment variable, as an alternative to the `--secret-source` CLI flag. `K6_SECRET_SOURCE` is treated as a single complete source spec — equivalent to one `--secret-source flag` — so its value follows the exact same syntax. 
      
## Why?

The `--secret-source` flag works well for interactive use, but there are cases where having this alternative might be useful.

## Checklist

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [X] I have added tests for my changes.
- [X] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
