### PR TITLE
Remove K6_ENABLE_COMMUNITY_EXTENSIONS flag

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -2,7 +2,6 @@ package state
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"os/signal"
@@ -30,9 +29,6 @@ const (
 
 	// DependenciesManifest defines the default values for dependency resolution
 	DependenciesManifest = "K6_DEPENDENCIES_MANIFEST"
-
-	// communityExtensionsCatalog defines the catalog for community extensions
-	communityExtensionsCatalog = "oss"
 
 	// defaultBuildServiceURL defines the URL to the default (grafana hosted) build service
 	defaultBuildServiceURL = "https://ingest.k6.io/builder/api/v1"
@@ -184,24 +180,22 @@ type GlobalFlags struct {
 	LogFormat        string
 	Verbose          bool
 
-	AutoExtensionResolution   bool
-	BuildServiceURL           string
-	BinaryCache               string
-	EnableCommunityExtensions bool
-	DependenciesManifest      string
+	AutoExtensionResolution bool
+	BuildServiceURL         string
+	BinaryCache             string
+	DependenciesManifest    string
 }
 
 // GetDefaultFlags returns the default global flags.
 func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 	return GlobalFlags{
-		Address:                   "localhost:6565",
-		ProfilingEnabled:          false,
-		ConfigFilePath:            filepath.Join(homeDir, "k6", defaultConfigFileName),
-		LogOutput:                 "stderr",
-		AutoExtensionResolution:   true,
-		BuildServiceURL:           defaultBuildServiceURL,
-		EnableCommunityExtensions: false,
-		BinaryCache:               filepath.Join(cacheDir, "k6", defaultBinaryCacheDir),
+		Address:                 "localhost:6565",
+		ProfilingEnabled:        false,
+		ConfigFilePath:          filepath.Join(homeDir, "k6", defaultConfigFileName),
+		LogOutput:               "stderr",
+		AutoExtensionResolution: true,
+		BuildServiceURL:         defaultBuildServiceURL,
+		BinaryCache:             filepath.Join(cacheDir, "k6", defaultBinaryCacheDir),
 	}
 }
 
@@ -240,21 +234,8 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 	if val, ok := env["K6_BUILD_SERVICE_URL"]; ok {
 		result.BuildServiceURL = val
 	}
-	if v, ok := env["K6_ENABLE_COMMUNITY_EXTENSIONS"]; ok {
-		vb, err := strconv.ParseBool(v)
-		if err == nil {
-			result.EnableCommunityExtensions = vb
-		}
-	}
 	if val, ok := env[DependenciesManifest]; ok {
 		result.DependenciesManifest = val
-	}
-
-	// adjust BuildServiceURL if community extensions are enable
-	// community extensions flag only takes effect if the default build service is used
-	// for custom build service URLs it has no effect (because the /oss path may not be implemented)
-	if result.EnableCommunityExtensions && result.BuildServiceURL == defaultBuildServiceURL {
-		result.BuildServiceURL = fmt.Sprintf("%s/%s", defaultBuildServiceURL, communityExtensionsCatalog)
 	}
 
 	if val, ok := env["K6_SECRET_SOURCE"]; ok {


### PR DESCRIPTION
## What?

Remove the `K6_ENABLE_COMMUNITY_EXTENSIONS` environment variable and all supporting code.

## Why?

The community and cloud extension catalogs were merged server-side into a single catalog, making this flag ineffective. All extensions are now resolved through the default build service URL without needing the `/oss` catalog suffix.

This was deferred from v1.x as a breaking change (see closed PR #5167) and is now being landed for v2.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Prior attempt (closed): https://github.com/grafana/k6/pull/5167
- Original feature: https://github.com/grafana/k6/pull/4922

Closes #5431