### PR TITLE
feat(grpc): add discardUnknownFields param to invoke and stream

### DIFF
--- a/internal/js/modules/k6/grpc/client.go
+++ b/internal/js/modules/k6/grpc/client.go
@@ -400,6 +400,7 @@ func (c *Client) buildInvokeRequest(
 		MethodDescriptor:       methodDesc,
 		Timeout:                p.Timeout,
 		DiscardResponseMessage: p.DiscardResponseMessage,
+		DiscardUnknownFields:   p.DiscardUnknownFields,
 		Message:                b,
 		TagsAndMeta:            &p.TagsAndMeta,
 		Metadata:               p.Metadata,

--- a/internal/js/modules/k6/grpc/params.go
+++ b/internal/js/modules/k6/grpc/params.go
@@ -22,6 +22,7 @@ type callParams struct {
 	TagsAndMeta            metrics.TagsAndMeta
 	Timeout                time.Duration
 	DiscardResponseMessage bool
+	DiscardUnknownFields   bool
 }
 
 // newCallParams constructs the call parameters from the input value.
@@ -61,6 +62,8 @@ func newCallParams(vu modules.VU, input sobek.Value) (*callParams, error) {
 			}
 		case "discardResponseMessage":
 			result.DiscardResponseMessage = params.Get(k).ToBoolean()
+		case "discardUnknownFields":
+			result.DiscardUnknownFields = params.Get(k).ToBoolean()
 		default:
 			return result, fmt.Errorf("unknown param: %q", k)
 		}

--- a/internal/js/modules/k6/grpc/params_test.go
+++ b/internal/js/modules/k6/grpc/params_test.go
@@ -172,6 +172,45 @@ func TestCallParamsDiscardResponseMessageParse(t *testing.T) {
 	}
 }
 
+func TestCallParamsDiscardUnknownFieldsParse(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Name                 string
+		JSON                 string
+		DiscardUnknownFields bool
+	}{
+		{
+			Name:                 "Empty",
+			JSON:                 `{}`,
+			DiscardUnknownFields: false,
+		},
+		{
+			Name:                 "DiscardUnknownFieldsFalse",
+			JSON:                 `{ discardUnknownFields: false }`,
+			DiscardUnknownFields: false,
+		},
+		{
+			Name:                 "DiscardUnknownFieldsTrue",
+			JSON:                 `{ discardUnknownFields: true }`,
+			DiscardUnknownFields: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			testRuntime, params := newParamsTestRuntime(t, tc.JSON)
+
+			p, err := newCallParams(testRuntime.VU, params)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.DiscardUnknownFields, p.DiscardUnknownFields)
+		})
+	}
+}
+
 func TestConnectParamsAuthority(t *testing.T) {
 	t.Parallel()
 

--- a/internal/js/modules/k6/grpc/stream.go
+++ b/internal/js/modules/k6/grpc/stream.go
@@ -83,6 +83,7 @@ func (s *stream) beginStream(p *callParams) error {
 		Method:                 s.method,
 		MethodDescriptor:       s.methodDescriptor,
 		DiscardResponseMessage: p.DiscardResponseMessage,
+		DiscardUnknownFields:   p.DiscardUnknownFields,
 		TagsAndMeta:            &p.TagsAndMeta,
 		Metadata:               p.Metadata,
 	}

--- a/internal/lib/netext/grpcext/conn.go
+++ b/internal/lib/netext/grpcext/conn.go
@@ -39,6 +39,7 @@ type InvokeRequest struct {
 	Timeout                time.Duration
 	TagsAndMeta            *metrics.TagsAndMeta
 	DiscardResponseMessage bool
+	DiscardUnknownFields   bool
 	Message                []byte
 	Metadata               metadata.MD
 }
@@ -58,6 +59,7 @@ type StreamRequest struct {
 	MethodDescriptor       protoreflect.MethodDescriptor
 	Timeout                time.Duration
 	DiscardResponseMessage bool
+	DiscardUnknownFields   bool
 	TagsAndMeta            *metrics.TagsAndMeta
 	Metadata               metadata.MD
 }
@@ -149,7 +151,11 @@ func (c *Conn) Invoke(
 	ctx = metadata.NewOutgoingContext(ctx, req.Metadata)
 
 	reqdm := dynamicpb.NewMessage(req.MethodDescriptor.Input())
-	if err := (protojson.UnmarshalOptions{Resolver: c.types}).Unmarshal(req.Message, reqdm); err != nil {
+	unmarshalOpts := protojson.UnmarshalOptions{
+		Resolver:       c.types,
+		DiscardUnknown: req.DiscardUnknownFields,
+	}
+	if err := unmarshalOpts.Unmarshal(req.Message, reqdm); err != nil {
 		return nil, fmt.Errorf("unable to serialise request object to protocol buffer: %w", err)
 	}
 
@@ -229,7 +235,7 @@ func (c *Conn) NewStream(
 		methodDescriptor:       req.MethodDescriptor,
 		discardResponseMessage: req.DiscardResponseMessage,
 		marshaler:              protojson.MarshalOptions{Resolver: c.types, EmitUnpopulated: true},
-		unmarshaler:            protojson.UnmarshalOptions{Resolver: c.types},
+		unmarshaler:            protojson.UnmarshalOptions{Resolver: c.types, DiscardUnknown: req.DiscardUnknownFields},
 	}, nil
 }
 


### PR DESCRIPTION
## What?

Allow gRPC clients to silently ignore unknown fields during protobuf serialization by passing `discardUnknownFields: true` in call params.

Usage:
```
  client.invoke('service/Method', request, {
    discardUnknownFields: true,
  });
```

## Why?

This enables working with JSON request data that contains fields not present in the proto definition, such as extension fields or newer schema additions.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
