### PR TITLE
Shell completions for auto-provisioned extensions

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -175,14 +175,20 @@ func (c *rootCommand) execute() {
 		}
 	}()
 
-	err := c.cmd.Execute()
+	// Completion requests for unregistered extensions must bypass Execute:
+	// cobra's __complete writes to stdout as a side-effect, and the
+	// provisioned binary's output would append to it, producing double output.
+	var err error
+	if ext, ok := detectExtensionCompletion(c.cmd, c.globalState); ok {
+		err = buildExtensionDeps(c.globalState, ext)
+	} else {
+		err = c.cmd.Execute()
+	}
 	if err == nil {
 		exitCode = 0
 		return
 	}
-
 	newExitCode, err := handleUnsatisfiedDependencies(err, c)
-
 	if err == nil {
 		exitCode = int(newExitCode)
 		return

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -63,20 +63,26 @@ allowing them to extend k6's functionality with custom commands.
 			}
 
 			// Subcommand not found - trigger provisioning
-			deps, err := dependenciesFromSubcommand(gs, args[0])
-			if err != nil {
-				return err
-			}
-
-			return binaryIsNotSatisfyingDependenciesError{
-				deps: deps,
-			}
+			return buildExtensionDeps(gs, args[0])
 		},
 	}
 
 	cmd.AddCommand(extensionSubcommands(gs)...)
 
 	return cmd
+}
+
+// buildExtensionDeps returns a [binaryIsNotSatisfyingDependenciesError] for
+// the given extension name if the required dependencies are not satisfied.
+// It's used by both [getX] and extension completions check in root.go to
+// trigger provisioning via [handleUnsatisfiedDependencies].
+func buildExtensionDeps(gs *state.GlobalState, extName string) error {
+	deps, err := dependenciesFromSubcommand(gs, extName)
+	if err != nil {
+		return err
+	}
+	// Will kickoff the provisioning flow in [handleUnsatisfiedDependencies].
+	return binaryIsNotSatisfyingDependenciesError{deps: deps}
 }
 
 // extensionSubcommands retrieves all subcommands provided by extensions.

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -114,6 +114,27 @@ func getCmdForExtension(extension *ext.Extension, gs *state.GlobalState) *cobra.
 	return cmd
 }
 
+// detectExtensionCompletion checks whether CmdArgs represent a completion
+// request for an unregistered extension subcommand (e.g. k6 __complete x docs "").
+// Returns true and the extension name when provisioning is needed.
+func detectExtensionCompletion(root *cobra.Command, gs *state.GlobalState) (string, bool) {
+	if !gs.Flags.AutoExtensionResolution {
+		return "", false
+	}
+
+	args := gs.CmdArgs[1:]
+	if len(args) == 0 || (args[0] != cobra.ShellCompRequestCmd && args[0] != cobra.ShellCompNoDescRequestCmd) {
+		return "", false
+	}
+
+	cmd, remaining, err := root.Find(args[1:])
+	if err != nil || cmd.Name() != "x" || len(remaining) < 2 {
+		return "", false
+	}
+
+	return remaining[0], true
+}
+
 // dependenciesFromSubcommand constructs a dependencies object for the given subcommand,
 // potentially using the manifest file specified in the global state.
 //

--- a/internal/cmd/subcommand_test.go
+++ b/internal/cmd/subcommand_test.go
@@ -136,6 +136,50 @@ func Test_dependenciesFromSubcommand(t *testing.T) {
 	})
 }
 
+func TestXCompletion(t *testing.T) {
+	t.Parallel()
+
+	registerTestSubcommandExtensions(t)
+
+	tt := []struct {
+		name    string
+		args    []string
+		want    []string
+		notWant []string
+	}{
+		{
+			name:    "committed extension name completes its args",
+			args:    []string{"k6", "__complete", "x", "test-cmd-1", ""},
+			want:    []string{"alpha", "bravo", "charlie"},
+			notWant: []string{"test-cmd-1"},
+		},
+		{
+			name:    "deeper args complete within extension",
+			args:    []string{"k6", "__complete", "x", "test-cmd-1", "alpha", ""},
+			want:    []string{"deep-one", "deep-two"},
+			notWant: []string{"alpha"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := tests.NewGlobalTestState(t)
+			ts.CmdArgs = tc.args
+			newRootCommand(ts.GlobalState).execute()
+
+			out := ts.Stdout.String()
+			for _, w := range tc.want {
+				require.Contains(t, out, w)
+			}
+			for _, nw := range tc.notWant {
+				require.NotContains(t, out, nw)
+			}
+		})
+	}
+}
+
 func Test_detectExtensionCompletion(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/subcommand_test.go
+++ b/internal/cmd/subcommand_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"maps"
 	"sync"
 	"testing"
 
@@ -135,6 +136,83 @@ func Test_dependenciesFromSubcommand(t *testing.T) {
 	})
 }
 
+func Test_detectExtensionCompletion(t *testing.T) {
+	t.Parallel()
+
+	registerTestSubcommandExtensions(t)
+
+	tt := []struct {
+		name    string
+		args    []string
+		env     map[string]string
+		want    bool
+		wantExt string
+	}{
+		{
+			name: "partial name single char",
+			args: []string{"k6", "__complete", "x", "d"},
+		},
+		{
+			name: "partial name without trailing space",
+			args: []string{"k6", "__complete", "x", "docs"},
+		},
+		{
+			name: "not a completion request",
+			args: []string{"k6", "x", "docs", ""},
+		},
+		{
+			name: "completion not targeting x",
+			args: []string{"k6", "__complete", "run", "script.js", ""},
+		},
+		{
+			name: "auto resolution disabled",
+			args: []string{"k6", "__complete", "x", "unknown-ext", ""},
+			env:  map[string]string{"K6_AUTO_EXTENSION_RESOLUTION": "false"},
+		},
+		{
+			name: "registered extension handled by cobra",
+			args: []string{"k6", "__complete", "x", "test-cmd-1", ""},
+		},
+		{
+			name:    "unregistered extension with committed name",
+			args:    []string{"k6", "__complete", "x", "docs", ""},
+			want:    true,
+			wantExt: "docs",
+		},
+		{
+			name:    "unregistered extension with deeper args",
+			args:    []string{"k6", "__complete", "x", "docs", "http", ""},
+			want:    true,
+			wantExt: "docs",
+		},
+		{
+			name:    "__completeNoDesc variant",
+			args:    []string{"k6", "__completeNoDesc", "x", "docs", ""},
+			want:    true,
+			wantExt: "docs",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := tests.NewGlobalTestState(t)
+			ts.CmdArgs = tc.args
+			maps.Copy(ts.Env, tc.env)
+			if len(tc.env) > 0 {
+				ts.ReparseFlags()
+			}
+
+			root := newRootCommand(ts.GlobalState)
+			ext, ok := detectExtensionCompletion(root.cmd, ts.GlobalState)
+
+			require.Equal(t, tc.want, ok)
+			require.Equal(t, tc.wantExt, ext)
+		})
+	}
+}
+
 func Test_buildExtensionDeps(t *testing.T) {
 	t.Parallel()
 
@@ -157,6 +235,12 @@ func registerTestSubcommandExtensions(t *testing.T) {
 				Use:   "test-cmd-1",
 				Short: "Test command 1",
 				Run:   func(_ *cobra.Command, _ []string) {},
+				ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+					if len(args) > 0 {
+						return []string{"deep-one", "deep-two"}, cobra.ShellCompDirectiveNoFileComp
+					}
+					return []string{"alpha", "bravo", "charlie"}, cobra.ShellCompDirectiveNoFileComp
+				},
 			}
 		})
 

--- a/internal/cmd/subcommand_test.go
+++ b/internal/cmd/subcommand_test.go
@@ -135,6 +135,17 @@ func Test_dependenciesFromSubcommand(t *testing.T) {
 	})
 }
 
+func Test_buildExtensionDeps(t *testing.T) {
+	t.Parallel()
+
+	ts := tests.NewGlobalTestState(t)
+	err := buildExtensionDeps(ts.GlobalState, "docs")
+
+	var derr binaryIsNotSatisfyingDependenciesError
+	require.ErrorAs(t, err, &derr)
+	require.Contains(t, derr.deps, "subcommand:docs")
+}
+
 var registerTestSubcommandExtensionsOnce sync.Once //nolint:gochecknoglobals
 
 func registerTestSubcommandExtensions(t *testing.T) {


### PR DESCRIPTION
## What?

Shell completions now work for auto-provisioned extension subcommands.

```bash
$ k6 x docs <TAB>        # provisions and delegates completion
$ k6 x docs <TAB>        # cached docs returns topic completions
best-practices  execution  net-grpc timers  x-mqtt
$ k6 x docs http <TAB>   # deeper completions
get  post  head  options  del  patch  request
```

## Why?

Tab completion silently returns nothing for extensions that aren't compiled into the binary. Users who rely on auto-provisioning get no completions even though the extension supports them when bundled with `xk6`.

## Notes

- Partial names (`k6 x d<TAB>`) and registered extensions are unaffected. Cobra handles those natively.
- Completions for `x` bypass `Execute()` and go through the existing `handleUnsatisfiedDependencies` provisioning. This avoids Cobra's stdout overwriting the provisioned binary's completions.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

Closes #5757
Depends on #5664