### PR TITLE
Transition `k6 cloud run/upload` to the v6 cloud api

### DIFF
--- a/cloudapi/api.go
+++ b/cloudapi/api.go
@@ -69,19 +69,6 @@ type SecretsConfig struct {
 	ResponsePath string `json:"response_path,omitempty"`
 }
 
-// TestProgressResponse represents the progress of a cloud test.
-type TestProgressResponse struct {
-	RunStatusText string       `json:"run_status_text"`
-	RunStatus     RunStatus    `json:"run_status"`
-	ResultStatus  ResultStatus `json:"result_status"`
-	Progress      float64      `json:"progress"`
-}
-
-// LoginResponse includes the token after a successful login.
-type LoginResponse struct {
-	Token string `json:"token"`
-}
-
 // ValidateTokenResponse is the response of a token validation.
 type ValidateTokenResponse struct {
 	IsValid bool   `json:"is_valid"`
@@ -182,68 +169,6 @@ func (c *Client) makeCreateTestRunRequest(url string, testRun *TestRun) (*http.R
 	return req, nil
 }
 
-// StartCloudTestRun starts a cloud test run, i.e. `k6 cloud script.js`.
-func (c *Client) StartCloudTestRun(name string, projectID int64, arc *lib.Archive) (*CreateTestRunResponse, error) {
-	fields := [][2]string{{"name", name}}
-
-	if projectID != 0 {
-		fields = append(fields, [2]string{"project_id", strconv.FormatInt(projectID, 10)})
-	}
-
-	return c.uploadArchive(fields, arc)
-}
-
-// UploadTestOnly uploads a test run to the cloud without actually starting it.
-func (c *Client) UploadTestOnly(name string, projectID int64, arc *lib.Archive) (*CreateTestRunResponse, error) {
-	fields := [][2]string{{"name", name}, {"upload_only", "true"}}
-
-	if projectID != 0 {
-		fields = append(fields, [2]string{"project_id", strconv.FormatInt(projectID, 10)})
-	}
-
-	return c.uploadArchive(fields, arc)
-}
-
-func (c *Client) uploadArchive(fields [][2]string, arc *lib.Archive) (*CreateTestRunResponse, error) {
-	requestURL := fmt.Sprintf("%s/archive-upload", c.baseURL)
-
-	var buf bytes.Buffer
-	mp := multipart.NewWriter(&buf)
-
-	for _, field := range fields {
-		if err := mp.WriteField(field[0], field[1]); err != nil {
-			return nil, err
-		}
-	}
-
-	fw, err := mp.CreateFormFile("file", "archive.tar")
-	if err != nil {
-		return nil, err
-	}
-
-	if err = arc.Write(fw); err != nil {
-		return nil, err
-	}
-
-	if err = mp.Close(); err != nil {
-		return nil, err
-	}
-
-	req, err := http.NewRequest(http.MethodPost, requestURL, &buf) //nolint:noctx
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("Content-Type", mp.FormDataContentType())
-
-	ctrr := CreateTestRunResponse{}
-	if err := c.Do(req, &ctrr); err != nil {
-		return nil, err
-	}
-	c.handleLogEntriesFromCloud(ctrr)
-	return &ctrr, nil
-}
-
 // TestFinished sends the result and run status values to the cloud, along with
 // information for the test thresholds, and marks the test run as finished.
 func (c *Client) TestFinished(referenceID string, thresholds ThresholdResult, tained bool, runStatus RunStatus) error {
@@ -270,69 +195,6 @@ func (c *Client) TestFinished(referenceID string, thresholds ThresholdResult, ta
 	}
 
 	return c.Do(req, nil)
-}
-
-// GetTestProgress for the provided referenceID.
-func (c *Client) GetTestProgress(referenceID string) (*TestProgressResponse, error) {
-	req, err := c.NewRequest(http.MethodGet, c.baseURL+"/test-progress/"+referenceID, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	ctrr := TestProgressResponse{}
-	err = c.Do(req, &ctrr)
-	if err != nil {
-		return nil, err
-	}
-
-	return &ctrr, nil
-}
-
-// StopCloudTestRun tells the cloud to stop the test with the provided referenceID.
-func (c *Client) StopCloudTestRun(referenceID string) error {
-	req, err := c.NewRequest("POST", c.baseURL+"/tests/"+referenceID+"/stop", nil)
-	if err != nil {
-		return err
-	}
-
-	return c.Do(req, nil)
-}
-
-type validateOptionsRequest struct {
-	Options lib.Options `json:"options"`
-}
-
-// ValidateOptions sends the provided options to the cloud for validation.
-func (c *Client) ValidateOptions(options lib.Options) error {
-	data := validateOptionsRequest{Options: options}
-	req, err := c.NewRequest("POST", c.baseURL+"/validate-options", data)
-	if err != nil {
-		return err
-	}
-
-	return c.Do(req, nil)
-}
-
-type loginRequest struct {
-	Email    string `json:"email"`
-	Password string `json:"password"` //nolint:gosec
-}
-
-// Login the user with the specified email and password.
-func (c *Client) Login(email string, password string) (*LoginResponse, error) {
-	data := loginRequest{Email: email, Password: password}
-	req, err := c.NewRequest("POST", c.baseURL+"/login", data)
-	if err != nil {
-		return nil, err
-	}
-
-	lr := LoginResponse{}
-	err = c.Do(req, &lr)
-	if err != nil {
-		return nil, err
-	}
-
-	return &lr, nil
 }
 
 type validateTokenRequest struct {

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -2,6 +2,8 @@ package cloudapi
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -156,6 +158,47 @@ func (c *Client) updateScript(ctx context.Context, testID int32, arc *lib.Archiv
 	defer closeResponse(res, &err)
 
 	return CheckResponse(res, err)
+}
+
+// StartTest starts a cloud load test run.
+func (c *Client) StartTest(ctx context.Context, loadTestID int32) (_ *k6cloud.StartLoadTestResponse, err error) {
+	var key [8]byte
+	if _, err := rand.Read(key[:]); err != nil {
+		return nil, err
+	}
+
+	res, hr, err := c.apiClient.LoadTestsAPI.
+		LoadTestsStart(c.authCtx(ctx), loadTestID).
+		XStackId(c.stackID).
+		K6IdempotencyKey(hex.EncodeToString(key[:])).
+		Execute()
+	defer closeResponse(hr, &err)
+
+	if err := CheckResponse(hr, err); err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, errUnknown
+	}
+
+	return res, nil
+}
+
+// StopTest aborts a running cloud test run.
+func (c *Client) StopTest(ctx context.Context, testRunID int32) (err error) {
+	hr, err := c.apiClient.TestRunsAPI.
+		TestRunsAbort(c.authCtx(ctx), testRunID).
+		XStackId(c.stackID).
+		Execute()
+	defer closeResponse(hr, &err)
+
+	err = CheckResponse(hr, err)
+	var rerr ResponseError
+	if errors.As(err, &rerr) && rerr.Response != nil && rerr.Response.StatusCode == http.StatusConflict {
+		return nil // Already stopped: swallow the error to keep the caller/TUI clean.
+	}
+
+	return err
 }
 
 func (c *Client) authCtx(ctx context.Context) context.Context {

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -201,6 +201,30 @@ func (c *Client) StopTest(ctx context.Context, testRunID int32) (err error) {
 	return err
 }
 
+// FetchTest fetches the current progress of a cloud test run.
+func (c *Client) FetchTest(ctx context.Context, testRunID int32) (_ *TestProgress, err error) {
+	res, hr, err := c.apiClient.TestRunsAPI.
+		TestRunsRetrieve(c.authCtx(ctx), testRunID).
+		XStackId(c.stackID).
+		Execute()
+	defer closeResponse(hr, &err)
+
+	if err := CheckResponse(hr, err); err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, errUnknown
+	}
+
+	return &TestProgress{
+		Status:            Status(res.GetStatus()),
+		Result:            Result(res.GetResult()),
+		EstimatedDuration: res.GetEstimatedDuration(),
+		ExecutionDuration: res.GetExecutionDuration(),
+		StatusHistory:     FromStatusModel(res.GetStatusHistory()),
+	}, nil
+}
+
 func (c *Client) authCtx(ctx context.Context) context.Context {
 	return context.WithValue(ctx, k6cloud.ContextAccessToken, c.token)
 }

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -73,6 +73,91 @@ func (c *Client) ValidateOptions(ctx context.Context, projectID int32, opts lib.
 	return nil
 }
 
+// UploadTest creates or updates a cloud load test's script.
+func (c *Client) UploadTest(
+	ctx context.Context, name string, projectID int32, arc *lib.Archive,
+) (*k6cloud.LoadTestApiModel, error) {
+	lt, err := c.createTest(ctx, name, projectID, arc)
+	if err == nil {
+		return lt, nil
+	}
+	var rerr ResponseError
+	if !errors.As(err, &rerr) || rerr.Response == nil || rerr.Response.StatusCode != http.StatusConflict {
+		return nil, err
+	}
+
+	// 409: a test with this name already exists in this project. Look it
+	// up by exact-match filter and update its script.
+	lt, err = c.findTestByName(ctx, projectID, name)
+	if err != nil {
+		return nil, err
+	}
+	if err := c.updateScript(ctx, lt.GetId(), arc); err != nil {
+		return nil, err
+	}
+
+	return lt, nil
+}
+
+// createTest creates a new cloud load test in the given project.
+func (c *Client) createTest(
+	ctx context.Context, name string, projectID int32, arc *lib.Archive,
+) (_ *k6cloud.LoadTestApiModel, err error) {
+	res, hr, err := c.apiClient.LoadTestsAPI.
+		ProjectsLoadTestsCreate(c.authCtx(ctx), projectID).
+		XStackId(c.stackID).
+		Name(name).
+		Script(archiveReader(arc)).
+		Execute()
+	defer closeResponse(hr, &err)
+
+	if err := CheckResponse(hr, err); err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, errUnknown
+	}
+
+	return res, nil
+}
+
+func (c *Client) findTestByName(
+	ctx context.Context, projectID int32, name string,
+) (_ *k6cloud.LoadTestApiModel, err error) {
+	res, hr, err := c.apiClient.LoadTestsAPI.
+		ProjectsLoadTestsRetrieve(c.authCtx(ctx), projectID).
+		XStackId(c.stackID).
+		Name(name).
+		Top(1).
+		Execute()
+	defer closeResponse(hr, &err)
+
+	if err := CheckResponse(hr, err); err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, errUnknown
+	}
+
+	tests := res.GetValue()
+	if len(tests) == 0 {
+		return nil, errUnknown
+	}
+
+	return &tests[0], nil
+}
+
+func (c *Client) updateScript(ctx context.Context, testID int32, arc *lib.Archive) (err error) {
+	res, err := c.apiClient.LoadTestsAPI.
+		LoadTestsScriptUpdate(c.authCtx(ctx), testID).
+		XStackId(c.stackID).
+		Body(archiveReader(arc)).
+		Execute()
+	defer closeResponse(res, &err)
+
+	return CheckResponse(res, err)
+}
+
 func (c *Client) authCtx(ctx context.Context) context.Context {
 	return context.WithValue(ctx, k6cloud.ContextAccessToken, c.token)
 }

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -2,6 +2,7 @@ package cloudapi
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -36,6 +37,40 @@ func (c *Client) ValidateToken(ctx context.Context, stackURL string) (_ *k6cloud
 	}
 
 	return res, nil
+}
+
+// ValidateOptions validates cloud test options.
+func (c *Client) ValidateOptions(ctx context.Context, projectID int32, opts lib.Options) (err error) {
+	// Round-trip [lib.Options] through JSON so every script option
+	// reaches the backend via [k6cloud.Options.AdditionalProperties].
+	buf, err := json.Marshal(opts)
+	if err != nil {
+		return err
+	}
+	copts := *k6cloud.NewOptions()
+	if err := json.Unmarshal(buf, &copts.AdditionalProperties); err != nil {
+		return err
+	}
+
+	req := k6cloud.NewValidateOptionsRequest(copts)
+	if projectID > 0 {
+		req.SetProjectId(projectID)
+	}
+	res, hr, err := c.apiClient.LoadTestsAPI.
+		ValidateOptions(c.authCtx(ctx)).
+		XStackId(c.stackID).
+		ValidateOptionsRequest(req).
+		Execute()
+	defer closeResponse(hr, &err)
+
+	if err := CheckResponse(hr, err); err != nil {
+		return err
+	}
+	if res == nil {
+		return errUnknown
+	}
+
+	return nil
 }
 
 func (c *Client) authCtx(ctx context.Context) context.Context {

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -5,46 +5,57 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 
 	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
+
+	"go.k6.io/k6/v2/lib"
 )
 
-// ValidateToken calls the endpoint to validate the Client's token and returns the result.
-func (c *Client) ValidateToken(stackURL string) (_ *k6cloud.AuthenticationResponse, err error) {
+// ValidateToken validates the cloud authentication token.
+func (c *Client) ValidateToken(ctx context.Context, stackURL string) (_ *k6cloud.AuthenticationResponse, err error) {
 	if stackURL == "" {
 		return nil, errors.New("stack URL is required to validate token")
 	}
-
 	if _, err := url.Parse(stackURL); err != nil {
 		return nil, fmt.Errorf("invalid stack URL: %w", err)
 	}
 
-	ctx := context.WithValue(context.Background(), k6cloud.ContextAccessToken, c.token)
-	req := c.apiClient.AuthorizationAPI.
-		Auth(ctx).
-		XStackUrl(stackURL)
+	res, hr, err := c.apiClient.AuthorizationAPI.
+		Auth(c.authCtx(ctx)).
+		XStackUrl(stackURL).
+		Execute()
+	defer closeResponse(hr, &err)
 
-	resp, httpRes, rerr := req.Execute()
-	defer func() {
-		if httpRes != nil {
-			_, _ = io.Copy(io.Discard, httpRes.Body)
-			if cerr := httpRes.Body.Close(); cerr != nil && err == nil {
-				err = cerr
-			}
-		}
+	if err := CheckResponse(hr, err); err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, errUnknown
+	}
+
+	return res, nil
+}
+
+func (c *Client) authCtx(ctx context.Context) context.Context {
+	return context.WithValue(ctx, k6cloud.ContextAccessToken, c.token)
+}
+
+func closeResponse(res *http.Response, rerr *error) {
+	if res == nil {
+		return
+	}
+	_, _ = io.Copy(io.Discard, res.Body)
+	if err := res.Body.Close(); err != nil && *rerr == nil {
+		*rerr = err
+	}
+}
+
+func archiveReader(arc *lib.Archive) io.ReadCloser {
+	pr, pw := io.Pipe()
+	go func() {
+		pw.CloseWithError(arc.Write(pw))
 	}()
-
-	if rerr != nil {
-		var apiErr *k6cloud.GenericOpenAPIError
-		if !errors.As(rerr, &apiErr) {
-			return nil, fmt.Errorf("failed to validate token: %w", rerr)
-		}
-	}
-
-	if err := CheckResponse(httpRes); err != nil {
-		return nil, fmt.Errorf("failed to validate token: %w", err)
-	}
-
-	return resp, err
+	return pr
 }

--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -102,6 +102,16 @@ func TestValidateToken(t *testing.T) {
 	})
 }
 
+func TestClientRetry(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(testutils.NewLogger(t), "test-token", "http://example.com", "1.0", 1*time.Second)
+	require.NoError(t, err)
+	// the client already tests retries. we just verify we set it up correctly.
+	assert.Equal(t, MaxRetries, client.apiClient.GetConfig().MaxRetries)
+	assert.Equal(t, RetryInterval, client.apiClient.GetConfig().RetryInterval)
+}
+
 func fprint(t *testing.T, w io.Writer, format string) int {
 	n, err := fmt.Fprint(w, format)
 	require.NoError(t, err)

--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -1,6 +1,7 @@
 package cloudapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -38,7 +39,7 @@ func TestValidateToken(t *testing.T) {
 		client, err := NewClient(testutils.NewLogger(t), "test-token", server.URL, "1.0", 1*time.Second)
 		require.NoError(t, err)
 
-		resp, err := client.ValidateToken("https://stack.grafana.net")
+		resp, err := client.ValidateToken(t.Context(), "https://stack.grafana.net")
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 		assert.Equal(t, int32(123), resp.StackId)
@@ -48,21 +49,14 @@ func TestValidateToken(t *testing.T) {
 	t.Run("unauthorized token should fail", func(t *testing.T) {
 		t.Parallel()
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-			w.Header().Add("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnauthorized)
-			fprint(t, w, `{
-				"error": {
-					"code": "error",
-					"message": "Invalid token"
-				}
-			}`)
+			writeError(t, w, http.StatusUnauthorized, "error", "Invalid token")
 		}))
 		defer server.Close()
 
 		client, err := NewClient(testutils.NewLogger(t), "invalid-token", server.URL, "1.0", 1*time.Second)
 		require.NoError(t, err)
 
-		resp, err := client.ValidateToken("https://stack.grafana.net")
+		resp, err := client.ValidateToken(t.Context(), "https://stack.grafana.net")
 		assert.Error(t, err)
 		assert.Nil(t, resp)
 		assert.Contains(t, err.Error(), "(401/error) Invalid token")
@@ -74,7 +68,7 @@ func TestValidateToken(t *testing.T) {
 		client, err := NewClient(testutils.NewLogger(t), "test-token", "http://invalid-url-that-does-not-exist", "1.0", 1*time.Second)
 		require.NoError(t, err)
 
-		resp, err := client.ValidateToken("https://stack.grafana.net")
+		resp, err := client.ValidateToken(t.Context(), "https://stack.grafana.net")
 		assert.Error(t, err)
 		assert.Nil(t, resp)
 	})
@@ -84,7 +78,7 @@ func TestValidateToken(t *testing.T) {
 		client, err := NewClient(testutils.NewLogger(t), "test-token", "http://example.com", "1.0", 1*time.Second)
 		require.NoError(t, err)
 
-		resp, err := client.ValidateToken("")
+		resp, err := client.ValidateToken(t.Context(), "")
 		assert.Error(t, err)
 		assert.Nil(t, resp)
 		assert.Equal(t, "stack URL is required to validate token", err.Error())
@@ -95,7 +89,7 @@ func TestValidateToken(t *testing.T) {
 		client, err := NewClient(testutils.NewLogger(t), "test-token", "http://example.com", "1.0", 1*time.Second)
 		require.NoError(t, err)
 
-		resp, err := client.ValidateToken("://invalid-url")
+		resp, err := client.ValidateToken(t.Context(), "://invalid-url")
 		assert.Error(t, err)
 		assert.Nil(t, resp)
 		assert.Contains(t, err.Error(), "invalid stack URL")
@@ -112,8 +106,37 @@ func TestClientRetry(t *testing.T) {
 	assert.Equal(t, RetryInterval, client.apiClient.GetConfig().RetryInterval)
 }
 
+func newTestClient(t *testing.T, handler http.Handler) *Client {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	client, err := NewClient(testutils.NewLogger(t), "test-token", srv.URL, "1.0", 5*time.Second)
+	require.NoError(t, err)
+	client.SetStackID(1)
+
+	return client
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, status int, v any) {
+	t.Helper()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	assert.NoError(t, json.NewEncoder(w).Encode(v))
+}
+
+func writeError(t *testing.T, w http.ResponseWriter, status int, code, msg string) {
+	t.Helper()
+
+	writeJSON(t, w, status, map[string]any{
+		"error": map[string]string{"code": code, "message": msg},
+	})
+}
+
 func fprint(t *testing.T, w io.Writer, format string) int {
 	n, err := fmt.Fprint(w, format)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	return n
 }

--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -274,6 +274,43 @@ func TestStopTest(t *testing.T) {
 	})
 }
 
+func TestFetchTest(t *testing.T) {
+	t.Parallel()
+
+	want := &TestProgress{
+		Status:            StatusRunning,
+		Result:            ResultFailed,
+		EstimatedDuration: 120,
+		ExecutionDuration: 60,
+		StatusHistory: []StatusEvent{{
+			Status:  StatusCreated,
+			Entered: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			ByUser:  "u@e.com",
+			Code:    3,
+			Message: "boom",
+		}},
+	}
+
+	res := k6cloud.NewTestRunApiModelWithDefaults()
+	res.SetStatus(want.Status.String())
+	res.SetResult(want.Result.String())
+	res.SetEstimatedDuration(want.EstimatedDuration)
+	res.SetExecutionDuration(want.ExecutionDuration)
+	res.SetStatusHistory(ToStatusModel(want.StatusHistory))
+	res.SetDistribution([]k6cloud.DistributionZoneApiModel{*k6cloud.NewDistributionZoneApiModelWithDefaults()})
+	res.SetResultDetails(map[string]any{"foo": "bar"})
+	res.SetOptions(map[string]any{"vus": 10})
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/test_runs/42")
+		writeJSON(t, w, http.StatusOK, res)
+	}))
+
+	got, err := client.FetchTest(t.Context(), 42)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
 func newTestClient(t *testing.T, handler http.Handler) *Client {
 	t.Helper()
 

--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -1,18 +1,23 @@
 package cloudapi
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
+	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/v2/internal/build"
 	"go.k6.io/k6/v2/internal/lib/testutils"
 	"go.k6.io/k6/v2/lib"
+	"go.k6.io/k6/v2/lib/fsext"
 	"go.k6.io/k6/v2/lib/types"
 	"gopkg.in/guregu/null.v3"
 )
@@ -135,6 +140,98 @@ func TestValidateOptions(t *testing.T) {
 	assert.Equal(t, int32(42), body.ProjectID)
 }
 
+func TestUploadTest(t *testing.T) {
+	t.Parallel()
+
+	newTestArchive := func(t *testing.T) *lib.Archive {
+		t.Helper()
+
+		fs := fsext.NewMemMapFs()
+		require.NoError(t, fsext.WriteFile(fs, "/a.js", []byte(`// c`), 0o644))
+		return &lib.Archive{
+			Type:        "js",
+			K6Version:   build.Version,
+			FilenameURL: &url.URL{Scheme: "file", Path: "/a.js"},
+			PwdURL:      &url.URL{Scheme: "file", Path: "/"},
+			Data:        []byte(`// c`),
+			Filesystems: map[string]fsext.Fs{"file": fs},
+		}
+	}
+
+	loadTest := k6cloud.NewLoadTestApiModelWithDefaults()
+	loadTest.SetId(42)
+
+	t.Run("creates new on success", func(t *testing.T) {
+		t.Parallel()
+
+		var script []byte
+		client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !assert.NoError(t, r.ParseMultipartForm(1<<20)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			f, _, err := r.FormFile("script")
+			if !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			script, err = io.ReadAll(f)
+			if !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			writeJSON(t, w, http.StatusCreated, loadTest)
+		}))
+		arc := newTestArchive(t)
+		got, err := client.UploadTest(t.Context(), "test", 1, arc)
+		require.NoError(t, err)
+		assertJSONEqual(t, loadTest, got)
+		assertArchiveEqual(t, arc, script)
+	})
+
+	t.Run("updates existing on 409", func(t *testing.T) {
+		t.Parallel()
+
+		var script []byte
+		client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPost:
+				writeError(t, w, http.StatusConflict, "conflict", "already exists")
+			case http.MethodGet:
+				writeJSON(t, w, http.StatusOK, map[string]any{"value": []any{loadTest}})
+			case http.MethodPut:
+				var err error
+				script, err = io.ReadAll(r.Body)
+				if !assert.NoError(t, err) {
+					w.WriteHeader(http.StatusBadRequest)
+					return
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}
+		}))
+		arc := newTestArchive(t)
+		got, err := client.UploadTest(t.Context(), "test", 1, arc)
+		require.NoError(t, err)
+		assertJSONEqual(t, loadTest, got)
+		assertArchiveEqual(t, arc, script)
+	})
+
+	t.Run("fails when not found", func(t *testing.T) {
+		t.Parallel()
+
+		client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.Method {
+			case http.MethodPost:
+				writeError(t, w, http.StatusConflict, "conflict", "already exists")
+			case http.MethodGet:
+				writeJSON(t, w, http.StatusOK, map[string]any{"value": []any{}})
+			}
+		}))
+		_, err := client.UploadTest(t.Context(), "test", 1, newTestArchive(t))
+		assert.ErrorIs(t, err, errUnknown)
+	})
+}
+
 func newTestClient(t *testing.T, handler http.Handler) *Client {
 	t.Helper()
 
@@ -168,4 +265,20 @@ func fprint(t *testing.T, w io.Writer, format string) int {
 	n, err := fmt.Fprint(w, format)
 	assert.NoError(t, err)
 	return n
+}
+
+func assertJSONEqual(t *testing.T, want, got any) {
+	t.Helper()
+	w, err := json.Marshal(want)
+	require.NoError(t, err)
+	g, err := json.Marshal(got)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(w), string(g))
+}
+
+func assertArchiveEqual(t *testing.T, want *lib.Archive, got []byte) {
+	t.Helper()
+	var b bytes.Buffer
+	require.NoError(t, want.Write(&b))
+	assert.Equal(t, b.Bytes(), got)
 }

--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/v2/internal/lib/testutils"
+	"go.k6.io/k6/v2/lib"
+	"go.k6.io/k6/v2/lib/types"
+	"gopkg.in/guregu/null.v3"
 )
 
 func TestValidateToken(t *testing.T) {
@@ -104,6 +107,32 @@ func TestClientRetry(t *testing.T) {
 	// the client already tests retries. we just verify we set it up correctly.
 	assert.Equal(t, MaxRetries, client.apiClient.GetConfig().MaxRetries)
 	assert.Equal(t, RetryInterval, client.apiClient.GetConfig().RetryInterval)
+}
+
+func TestValidateOptions(t *testing.T) {
+	t.Parallel()
+
+	var body struct {
+		Options   json.RawMessage `json:"options"`
+		ProjectID int32           `json:"project_id"`
+	}
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		writeJSON(t, w, http.StatusOK, map[string]any{}) // the actual response body is not relevant
+	}))
+
+	opts := lib.Options{
+		VUs:      null.IntFrom(5),
+		Duration: types.NullDurationFrom(10 * time.Second),
+		Stages:   []lib.Stage{{Duration: types.NullDurationFrom(30 * time.Second), Target: null.IntFrom(20)}},
+		RunTags:  map[string]string{"env": "staging"},
+	}
+	require.NoError(t, client.ValidateOptions(t.Context(), 42, opts))
+
+	want, err := json.Marshal(opts)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(want), string(body.Options))
+	assert.Equal(t, int32(42), body.ProjectID)
 }
 
 func newTestClient(t *testing.T, handler http.Handler) *Client {

--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -232,6 +232,48 @@ func TestUploadTest(t *testing.T) {
 	})
 }
 
+func TestStartTest(t *testing.T) {
+	t.Parallel()
+
+	res := k6cloud.NewStartLoadTestResponseWithDefaults()
+	res.SetId(7)
+	res.SetDistribution([]k6cloud.DistributionZoneApiModel{})
+	res.SetResultDetails(map[string]any{})
+	res.SetOptions(map[string]any{})
+
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/42/start")
+		assert.Regexpf(t, `^[0-9a-f]{16}$`, r.Header.Get("K6-Idempotency-Key"),
+			"missing or invalid K6-Idempotency-Key header")
+		writeJSON(t, w, http.StatusOK, res)
+	}))
+
+	got, err := client.StartTest(t.Context(), 42)
+	require.NoError(t, err)
+	assertJSONEqual(t, res, got)
+}
+
+func TestStopTest(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no content succeeds", func(t *testing.T) {
+		t.Parallel()
+		client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Contains(t, r.URL.Path, "/42/abort")
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		require.NoError(t, client.StopTest(t.Context(), 42))
+	})
+	t.Run("already stopped is swallowed", func(t *testing.T) {
+		t.Parallel()
+		client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Contains(t, r.URL.Path, "/42/abort")
+			writeError(t, w, http.StatusConflict, "conflict", "already stopped")
+		}))
+		require.NoError(t, client.StopTest(t.Context(), 42))
+	})
+}
+
 func newTestClient(t *testing.T, handler http.Handler) *Client {
 	t.Helper()
 

--- a/internal/cloudapi/v6/client.go
+++ b/internal/cloudapi/v6/client.go
@@ -2,6 +2,7 @@ package cloudapi
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -71,7 +72,14 @@ func (c *Client) BaseURL() string {
 // CheckResponse checks the parsed response.
 // It returns nil if the code is in the successful range,
 // otherwise it tries to parse the body and return a parsed error.
-func CheckResponse(r *http.Response) error {
+func CheckResponse(r *http.Response, err error) error {
+	if err != nil {
+		var aerr *k6cloud.GenericOpenAPIError
+		if !errors.As(err, &aerr) {
+			return err
+		}
+	}
+
 	if r == nil {
 		return errUnknown
 	}

--- a/internal/cloudapi/v6/client.go
+++ b/internal/cloudapi/v6/client.go
@@ -22,7 +22,7 @@ const (
 type Client struct {
 	apiClient *k6cloud.APIClient
 	token     string
-	stackID   int64
+	stackID   int32
 	baseURL   string
 
 	logger logrus.FieldLogger
@@ -62,7 +62,7 @@ func NewClient(logger logrus.FieldLogger, token, host, version string, timeout t
 }
 
 // SetStackID sets the stack ID for the client.
-func (c *Client) SetStackID(stackID int64) {
+func (c *Client) SetStackID(stackID int32) {
 	c.stackID = stackID
 }
 

--- a/internal/cloudapi/v6/client.go
+++ b/internal/cloudapi/v6/client.go
@@ -26,9 +26,6 @@ type Client struct {
 	baseURL   string
 
 	logger logrus.FieldLogger
-
-	retries       int
-	retryInterval time.Duration
 }
 
 // NewClient return a new client for the cloud API
@@ -48,15 +45,15 @@ func NewClient(logger logrus.FieldLogger, token, host, version string, timeout t
 		},
 		OperationServers: map[string]k6cloud.ServerConfigurations{},
 		HTTPClient:       &http.Client{Timeout: timeout},
+		MaxRetries:       MaxRetries,
+		RetryInterval:    RetryInterval,
 	}
 
 	c := &Client{
-		apiClient:     k6cloud.NewAPIClient(cfg),
-		token:         token,
-		baseURL:       fmt.Sprintf("%s/cloud/v6", host),
-		retries:       MaxRetries,
-		retryInterval: RetryInterval,
-		logger:        logger,
+		apiClient: k6cloud.NewAPIClient(cfg),
+		token:     token,
+		baseURL:   fmt.Sprintf("%s/cloud/v6", host),
+		logger:    logger,
 	}
 	return c, nil
 }

--- a/internal/cloudapi/v6/client_test.go
+++ b/internal/cloudapi/v6/client_test.go
@@ -17,6 +17,7 @@ func TestCheckResponse(t *testing.T) {
 	tests := []struct {
 		name                string
 		response            *http.Response
+		inputError          error
 		expectResponseError bool
 		expectedError       string
 	}{
@@ -29,6 +30,12 @@ func TestCheckResponse(t *testing.T) {
 			name:          "successful response 200",
 			response:      &http.Response{StatusCode: http.StatusOK},
 			expectedError: "",
+		},
+		{
+			name:          "non-GenericOpenAPIError is returned directly",
+			response:      nil,
+			inputError:    errors.New("network failure"),
+			expectedError: "network failure",
 		},
 		{
 			name: "unauthorized 401 with invalid JSON",
@@ -75,7 +82,7 @@ func TestCheckResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			err := CheckResponse(tt.response)
+			err := CheckResponse(tt.response, tt.inputError)
 
 			if tt.expectedError == "" && !tt.expectResponseError {
 				assert.NoError(t, err)

--- a/internal/cloudapi/v6/progress.go
+++ b/internal/cloudapi/v6/progress.go
@@ -1,0 +1,163 @@
+package cloudapi
+
+import (
+	"slices"
+	"strings"
+	"time"
+
+	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
+)
+
+// Status represents the status of a test run.
+type Status string
+
+func (s Status) String() string { return string(s) }
+
+// Status values for test run status.
+const (
+	StatusCreated           Status = "created"
+	StatusQueued            Status = "queued"
+	StatusInitializing      Status = "initializing"
+	StatusRunning           Status = "running"
+	StatusProcessingMetrics Status = "processing_metrics"
+	StatusCompleted         Status = "completed"
+	StatusAborted           Status = "aborted"
+)
+
+// Result represents the result of a test run.
+type Result string
+
+func (r Result) String() string { return string(r) }
+
+// Result values for test run result.
+const (
+	ResultPassed Result = "passed"
+	ResultFailed Result = "failed"
+	ResultError  Result = "error"
+)
+
+// TestProgress holds the progress of a test run.
+type TestProgress struct {
+	Status            Status
+	Result            Result
+	EstimatedDuration int32
+	ExecutionDuration int32
+	StatusHistory     []StatusEvent
+}
+
+// Progress returns the fraction of execution completed, from 0 to 1.
+// While running, it uses the status history's running entry timestamp
+// for smooth interpolation between server polls.
+func (tp *TestProgress) Progress() float64 {
+	if tp.IsFinished() || tp.Status == StatusProcessingMetrics {
+		return 1
+	}
+	if tp.Estimated() <= 0 {
+		return 0
+	}
+	if !tp.IsRunning() {
+		return 0
+	}
+	for _, e := range tp.StatusHistory {
+		if e.Status == StatusRunning {
+			return min(float64(time.Since(e.Entered))/float64(tp.Estimated()), 1)
+		}
+	}
+	return 0
+}
+
+// FormatStatus returns a human-readable status string.
+func (tp *TestProgress) FormatStatus() string {
+	if tp.AbortedByUser() {
+		return "Aborted (by user)"
+	}
+	if tp.Status == StatusCompleted {
+		return "Finished" // to match old k6 v1 behavior
+	}
+	ss := strings.Split(tp.Status.String(), "_")
+	for i, s := range ss {
+		ss[i] = strings.ToUpper(s[:1]) + s[1:]
+	}
+	return strings.Join(ss, " ")
+}
+
+// Estimated returns the estimated total duration.
+func (tp *TestProgress) Estimated() time.Duration {
+	return time.Duration(tp.EstimatedDuration) * time.Second
+}
+
+// Elapsed returns the time spent running, derived from Progress and Estimated.
+func (tp *TestProgress) Elapsed() time.Duration {
+	return time.Duration(tp.Progress() * float64(tp.Estimated()))
+}
+
+// IsRunning returns true if the test run is currently running.
+func (tp *TestProgress) IsRunning() bool {
+	return tp.Status == StatusRunning
+}
+
+// IsFinished returns true if the current status is a terminal state.
+func (tp *TestProgress) IsFinished() bool {
+	if tp.Status == StatusCompleted {
+		return true
+	}
+	return tp.Status == StatusAborted
+}
+
+// AbortedByUser returns true if the test was aborted by user.
+func (tp *TestProgress) AbortedByUser() bool {
+	return slices.ContainsFunc(tp.StatusHistory, func(e StatusEvent) bool {
+		return e.Status == StatusAborted && e.ByUser != ""
+	})
+}
+
+// ThresholdsFailed returns true when the test failed due to thresholds.
+func (tp *TestProgress) ThresholdsFailed() bool {
+	return tp.Result == ResultFailed
+}
+
+// TestFailed returns true when the test ended with a non-threshold failure.
+func (tp *TestProgress) TestFailed() bool {
+	return tp.Result == ResultError
+}
+
+// StatusEvent is one entry in a test run's status history.
+type StatusEvent struct {
+	Status  Status
+	Entered time.Time
+	ByUser  string
+	Code    int32
+	Message string
+}
+
+// ToStatusModel encodes status events for the v6 wire format.
+func ToStatusModel(ee []StatusEvent) []k6cloud.StatusApiModel {
+	m := make([]k6cloud.StatusApiModel, len(ee))
+	for i, e := range ee {
+		m[i] = *k6cloud.NewStatusApiModel(e.Status.String(), e.Entered)
+		if e.ByUser == "" && e.Code == 0 && e.Message == "" {
+			continue
+		}
+		m[i].SetExtra(*k6cloud.NewStatusExtraApiModel(
+			*k6cloud.NewNullableString(&e.ByUser),
+			*k6cloud.NewNullableString(&e.Message),
+			*k6cloud.NewNullableInt32(&e.Code),
+		))
+	}
+	return m
+}
+
+// FromStatusModel decodes status events from the v6 wire format.
+func FromStatusModel(mm []k6cloud.StatusApiModel) []StatusEvent {
+	e := make([]StatusEvent, len(mm))
+	for i, m := range mm {
+		e[i].Status = Status(m.GetType())
+		e[i].Entered = m.GetEntered()
+		if extra, ok := m.GetExtraOk(); ok {
+			e[i].ByUser = extra.GetByUser()
+			e[i].Code = extra.GetCode()
+			e[i].Message = extra.GetMessage()
+		}
+	}
+	return e
+}

--- a/internal/cloudapi/v6/v6test/server.go
+++ b/internal/cloudapi/v6/v6test/server.go
@@ -1,0 +1,179 @@
+// Package v6test provides an HTTP test server that simulates the v6
+// cloud API.
+//
+// It keeps v6-specific encoding (nullable fields, status models, SDK
+// types) out of the cmd test files. Cmd tests speak in domain terms
+// (v6.TestProgress, v6.Status*, v6.Result*); this server translates to
+// v6 wire format. When the API moves to v7, only this package changes.
+// The cmd tests stay put.
+package v6test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
+
+	cloudapi "go.k6.io/k6/v2/internal/cloudapi/v6"
+)
+
+const (
+	defaultLoadTestID int32 = 456
+	defaultTestRunID  int32 = 123
+)
+
+// Server is a test HTTP server for the v6 cloud API.
+type Server struct {
+	*httptest.Server
+
+	cfg Config
+}
+
+// Config configures the test server behavior. The zero value is a
+// valid configuration that serves a completed, passing test run.
+type Config struct {
+	// TestRunID is the id reported by the start-test response and used
+	// in the test-run routes. Defaults to [defaultTestRunID] when zero.
+	TestRunID int32
+
+	// ProgressCallback returns the [cloudapi.TestProgress] reported by
+	// each test fetch. When nil, a finished passing run is reported.
+	ProgressCallback func() *cloudapi.TestProgress
+
+	// InspectArchive, when set, is invoked with each create-load-test
+	// request so tests can inspect the uploaded archive before the
+	// server returns its canned response.
+	InspectArchive func(*http.Request)
+}
+
+// NewServer creates a test server that serves v6 API endpoints.
+func NewServer(t *testing.T, cfg Config) *Server {
+	t.Helper()
+
+	if cfg.TestRunID == 0 {
+		cfg.TestRunID = defaultTestRunID
+	}
+
+	s := &Server{cfg: cfg}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /cloud/v6/validate_options", s.handleValidateOptions)
+	mux.HandleFunc("POST /cloud/v6/projects/{projectID}/load_tests", func(w http.ResponseWriter, r *http.Request) {
+		if s.cfg.InspectArchive != nil {
+			s.cfg.InspectArchive(r)
+		}
+		s.handleCreateLoadTest(w, r)
+	})
+	mux.HandleFunc(
+		fmt.Sprintf("POST /cloud/v6/load_tests/%d/start", defaultLoadTestID),
+		s.handleStartTest,
+	)
+	mux.HandleFunc(
+		fmt.Sprintf("GET /cloud/v6/test_runs/%d", cfg.TestRunID),
+		s.handleGetTestRun,
+	)
+	mux.HandleFunc(
+		fmt.Sprintf("POST /cloud/v6/test_runs/%d/abort", cfg.TestRunID),
+		s.handleAbortTestRun,
+	)
+
+	srv := httptest.NewServer(mux)
+	s.Server = srv
+	t.Cleanup(srv.Close)
+
+	return s
+}
+
+func (s *Server) handleValidateOptions(w http.ResponseWriter, _ *http.Request) {
+	vuh, zero := float32(0.5), float32(0)
+	res := k6cloud.NewValidateOptionsResponse(
+		vuh,
+		*k6cloud.NewCostBreakdownApiModel(
+			k6cloud.ProtocolVuh{Float32: &vuh},
+			k6cloud.BrowserVuh{Float32: &zero},
+			k6cloud.BaseTotalVuh{Float32: &vuh},
+			k6cloud.ReductionRate{Float32: &zero},
+			map[string]k6cloud.ReductionRateBreakdownValue{},
+		),
+	)
+	writeJSON(w, http.StatusOK, res)
+}
+
+func (s *Server) handleCreateLoadTest(w http.ResponseWriter, _ *http.Request) {
+	res := k6cloud.NewLoadTestApiModelWithDefaults()
+	res.SetId(defaultLoadTestID)
+	writeJSON(w, http.StatusCreated, res)
+}
+
+func (s *Server) handleStartTest(w http.ResponseWriter, _ *http.Request) {
+	res := k6cloud.NewStartLoadTestResponseWithDefaults()
+	res.SetId(s.cfg.TestRunID)
+	res.SetTestRunDetailsPageUrl(fmt.Sprintf("https://stack.grafana.com/a/k6-app/runs/%d", s.cfg.TestRunID))
+	// SDK decoder requires these keys on the other end even when empty.
+	res.SetDistribution([]k6cloud.DistributionZoneApiModel{})
+	res.SetResultDetails(map[string]any{})
+	res.SetOptions(map[string]any{})
+	writeJSON(w, http.StatusOK, res)
+}
+
+func (s *Server) handleGetTestRun(w http.ResponseWriter, _ *http.Request) {
+	tp := &cloudapi.TestProgress{
+		Status:            cloudapi.StatusCompleted,
+		Result:            cloudapi.ResultPassed,
+		EstimatedDuration: 60,
+		ExecutionDuration: 60,
+	}
+	if s.cfg.ProgressCallback != nil {
+		tp = s.cfg.ProgressCallback()
+	}
+
+	res := k6cloud.NewTestRunApiModelWithDefaults()
+	res.SetStatus(tp.Status.String())
+	res.SetResult(tp.Result.String())
+	res.SetEstimatedDuration(tp.EstimatedDuration)
+	res.SetExecutionDuration(tp.ExecutionDuration)
+	res.SetStatusHistory(cloudapi.ToStatusModel(tp.StatusHistory))
+	// SDK decoder requires these keys on the other end even when empty.
+	res.SetDistribution([]k6cloud.DistributionZoneApiModel{})
+	res.SetResultDetails(map[string]any{})
+	res.SetOptions(map[string]any{})
+	writeJSON(w, http.StatusOK, res)
+}
+
+func (s *Server) handleAbortTestRun(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ResultNone reports a test still in progress (no result yet).
+const ResultNone cloudapi.Result = ""
+
+// Progress returns a progress callback that reports the given status and result.
+func Progress(status cloudapi.Status, result cloudapi.Result) func() *cloudapi.TestProgress {
+	return func() *cloudapi.TestProgress {
+		return &cloudapi.TestProgress{Status: status, Result: result}
+	}
+}
+
+// AbortedByUserProgress returns a progress callback that reports the test as aborted.
+func AbortedByUserProgress(email string) func() *cloudapi.TestProgress {
+	return func() *cloudapi.TestProgress {
+		return &cloudapi.TestProgress{
+			Status: cloudapi.StatusAborted,
+			Result: cloudapi.ResultError,
+			StatusHistory: []cloudapi.StatusEvent{
+				{Status: cloudapi.StatusAborted, ByUser: email},
+			},
+		}
+	}
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		panic(fmt.Errorf("v6test: encoding JSON: %w", err))
+	}
+}

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -213,9 +213,6 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	}
 
 	refID := cloudTestRun.ReferenceID
-	if cloudTestRun.ConfigOverride != nil {
-		cloudConfig = cloudConfig.Apply(*cloudTestRun.ConfigOverride)
-	}
 
 	// Trap Interrupts, SIGINTs and SIGTERMs.
 	gracefulStop := func(sig os.Signal) {

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -186,35 +186,43 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 
 	// Start cloud test run
 	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Validating script options"))
-	client := cloudapi.NewClient(
-		logger, cloudConfig.Token.String, cloudConfig.Host.String, build.Version, cloudConfig.Timeout.TimeDuration())
-	if cloudConfig.StackID.Valid {
-		client.SetStackID(cloudConfig.StackID.Int64)
-	}
-	if err = client.ValidateOptions(arc.Options); err != nil {
+	client, err := cloudapiv6.NewClient(
+		logger, cloudConfig.Token.String, cloudConfig.Hostv6.String, build.Version, cloudConfig.Timeout.TimeDuration())
+	if err != nil {
 		return err
 	}
-
-	if cloudConfig.ProjectID.Int64 == 0 {
-		if err := resolveAndSetProjectID(c.gs, &cloudConfig, tmpCloudConfig, arc); err != nil {
-			return err
-		}
-	}
-
-	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Uploading archive"))
-
-	var cloudTestRun *cloudapi.CreateTestRunResponse
-	if c.uploadOnly {
-		cloudTestRun, err = client.UploadTestOnly(name, cloudConfig.ProjectID.Int64, arc)
-	} else {
-		cloudTestRun, err = client.StartCloudTestRun(name, cloudConfig.ProjectID.Int64, arc)
-	}
-
+	projectID, err := prepCloudTestRun(globalCtx, c.gs, client, &cloudConfig, tmpCloudConfig, arc)
 	if err != nil {
 		return err
 	}
 
-	refID := cloudTestRun.ReferenceID
+	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Uploading archive"))
+
+	loadTest, err := client.UploadTest(globalCtx, name, projectID, arc)
+	if err != nil {
+		return fmt.Errorf("uploading test: %w", err)
+	}
+
+	if c.uploadOnly {
+		et, err := lib.NewExecutionTuple(test.derivedConfig.ExecutionSegment, test.derivedConfig.ExecutionSegmentSequence)
+		if err != nil {
+			return err
+		}
+		executionPlan := test.derivedConfig.Scenarios.GetFullExecutionRequirements(et)
+		testURL := fmt.Sprintf("%s/a/k6-app/tests/%d", strings.TrimSuffix(cloudConfig.StackURL.String, "/"), loadTest.GetId())
+		printExecutionDescription(
+			c.gs, "cloud", test.sourceRootPath, testURL, test.derivedConfig, et, executionPlan, nil,
+		)
+		modifyAndPrintBar(c.gs, progressBar, pb.WithConstLeft("Run "), pb.WithConstProgress(1.0, "Archived"))
+		c.printTestStatus("Archived")
+		return nil
+	}
+
+	run, err := client.StartTest(globalCtx, loadTest.GetId())
+	if err != nil {
+		return fmt.Errorf("starting test: %w", err)
+	}
+	testRunID := run.GetId()
 
 	// Trap Interrupts, SIGINTs and SIGTERMs.
 	gracefulStop := func(sig os.Signal) {
@@ -222,7 +230,7 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 		// Do this in a separate goroutine so that if it blocks, the
 		// second signal can still abort the process execution.
 		go func() {
-			stopErr := client.StopCloudTestRun(refID)
+			stopErr := client.StopTest(context.WithoutCancel(globalCtx), testRunID)
 			if stopErr != nil {
 				logger.WithError(stopErr).Error("Stop cloud test error")
 			} else {
@@ -241,7 +249,7 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	testURL := cloudapi.URLForResults(refID, cloudConfig)
+	testURL := run.GetTestRunDetailsPageUrl()
 	executionPlan := test.derivedConfig.Scenarios.GetFullExecutionRequirements(et)
 	printExecutionDescription(
 		c.gs, "cloud", test.sourceRootPath, testURL, test.derivedConfig, et, executionPlan, nil,
@@ -262,14 +270,8 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 		progressBarWG.Done()
 	}()
 
-	var (
-		startTime   time.Time
-		maxDuration time.Duration
-	)
-	maxDuration, _ = lib.GetEndOffset(executionPlan)
-
 	testProgressLock := &sync.Mutex{}
-	var testProgress *cloudapi.TestProgressResponse
+	var testProgress *cloudapiv6.TestProgress
 	progressBar.Modify(
 		pb.WithProgress(func() (float64, []string) {
 			testProgressLock.Lock()
@@ -278,30 +280,19 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 			if testProgress == nil {
 				return 0, []string{"Waiting..."}
 			}
-
-			statusText := testProgress.RunStatusText
-
-			switch testProgress.RunStatus { //nolint:exhaustive
-			case cloudapi.RunStatusFinished:
-				testProgress.Progress = 1
-			case cloudapi.RunStatusRunning:
-				if startTime.IsZero() {
-					startTime = time.Now()
-				}
-				spent := time.Since(startTime)
-				if spent > maxDuration {
-					statusText = maxDuration.String()
-				} else {
-					statusText = fmt.Sprintf("%s/%s", pb.GetFixedLengthDuration(spent, maxDuration), maxDuration)
+			if testProgress.IsRunning() {
+				est := testProgress.Estimated()
+				return testProgress.Progress(), []string{
+					fmt.Sprintf("%s/%s", pb.GetFixedLengthDuration(testProgress.Elapsed(), est), est),
 				}
 			}
-
-			return testProgress.Progress, []string{statusText}
+			return testProgress.Progress(), []string{testProgress.FormatStatus()}
 		}),
 	)
 
 	ticker := time.NewTicker(time.Millisecond * 2000)
 	if c.showCloudLogs {
+		refID := strconv.FormatInt(int64(testRunID), 10)
 		go func() {
 			logger.Debug("Connecting to cloud logs server...")
 			if err := cloudConfig.StreamLogsToLogger(globalCtx, logger, refID, 0); err != nil {
@@ -311,7 +302,7 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	}
 
 	for range ticker.C {
-		newTestProgress, progressErr := client.GetTestProgress(refID)
+		newTestProgress, progressErr := client.FetchTest(context.WithoutCancel(globalCtx), testRunID)
 		if progressErr != nil {
 			logger.WithError(progressErr).Error("Test progress error")
 			continue
@@ -321,39 +312,31 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 		testProgress = newTestProgress
 		testProgressLock.Unlock()
 
-		if (newTestProgress.RunStatus > cloudapi.RunStatusRunning) ||
-			(c.exitOnRunning && newTestProgress.RunStatus == cloudapi.RunStatusRunning) {
+		if newTestProgress.IsFinished() ||
+			(c.exitOnRunning && newTestProgress.IsRunning()) {
 			globalCancel()
 			break
 		}
 	}
+
+	// Stop progress rendering before printing final status to avoid ghost bars.
+	progressCancel()
+	progressBarWG.Wait()
 
 	if testProgress == nil {
 		//nolint:staticcheck
 		return errext.WithExitCodeIfNone(errors.New("Test progress error"), exitcodes.CloudFailedToGetProgress)
 	}
 
-	if !c.gs.Flags.Quiet {
-		valueColor := getColor(c.gs.Flags.NoColor || !c.gs.Stdout.IsTTY, color.FgCyan)
-		printToStdout(c.gs, fmt.Sprintf(
-			"     test status: %s\n", valueColor.Sprint(testProgress.RunStatusText),
-		))
-	} else {
-		logger.WithField("run_status", testProgress.RunStatusText).Debug("Test finished")
+	c.printTestStatus(testProgress.FormatStatus())
+
+	if testProgress.ThresholdsFailed() {
+		//nolint:staticcheck
+		return errext.WithExitCodeIfNone(errors.New("Thresholds have been crossed"), exitcodes.ThresholdsHaveFailed)
 	}
-
-	if testProgress.ResultStatus == cloudapi.ResultStatusFailed {
-		// Although by looking at [ResultStatus] and [RunStatus] isn't self-explanatory,
-		// the scenario when the test run has finished, but it failed is an exceptional case for those situations
-		// when thresholds have been crossed (failed). So, we report this situation as such.
-		if testProgress.RunStatus == cloudapi.RunStatusFinished ||
-			testProgress.RunStatus == cloudapi.RunStatusAbortedThreshold {
-			//nolint:staticcheck
-			return errext.WithExitCodeIfNone(errors.New("Thresholds have been crossed"), exitcodes.ThresholdsHaveFailed)
-		}
-
-		// TODO: use different exit codes for failed thresholds vs failed test (e.g. aborted by system/limit)
-		return errext.WithExitCodeIfNone(errors.New("The test has failed"), exitcodes.CloudTestRunFailed) //nolint:staticcheck
+	if testProgress.TestFailed() {
+		//nolint:staticcheck
+		return errext.WithExitCodeIfNone(errors.New("The test has failed"), exitcodes.CloudTestRunFailed)
 	}
 
 	return nil

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -19,6 +20,7 @@ import (
 	"go.k6.io/k6/v2/errext"
 	"go.k6.io/k6/v2/errext/exitcodes"
 	"go.k6.io/k6/v2/internal/build"
+	cloudapiv6 "go.k6.io/k6/v2/internal/cloudapi/v6"
 	"go.k6.io/k6/v2/internal/ui/pb"
 	"go.k6.io/k6/v2/lib"
 
@@ -357,6 +359,17 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func (c *cmdCloud) printTestStatus(status string) {
+	if !c.gs.Flags.Quiet {
+		valueColor := getColor(c.gs.Flags.NoColor || !c.gs.Stdout.IsTTY, color.FgCyan)
+		printToStdout(c.gs, fmt.Sprintf(
+			"     test status: %s\n", valueColor.Sprint(status),
+		))
+	} else {
+		c.gs.Logger.WithField("run_status", status).Debug("Test finished")
+	}
+}
+
 func (c *cmdCloud) flagSet() *pflag.FlagSet {
 	flags := pflag.NewFlagSet("", pflag.ContinueOnError)
 	flags.SortFlags = false
@@ -459,6 +472,49 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 	cloudCmd.SetHelpTemplate(cloudTemplate)
 
 	return cloudCmd
+}
+
+// prepCloudTestRun wires stack and project IDs into the client, validates
+// script options, and resolves a default project when none was specified.
+// Returns the project ID as used by subsequent v6 calls.
+func prepCloudTestRun(
+	ctx context.Context, gs *state.GlobalState,
+	client *cloudapiv6.Client,
+	cloudConfig *cloudapi.Config, tmpCloudConfig map[string]any, arc *lib.Archive,
+) (int32, error) {
+	toInt32 := func(v int64) (int32, error) {
+		if v < math.MinInt32 || v > math.MaxInt32 {
+			return 0, fmt.Errorf("value %d overflows int32", v)
+		}
+		return int32(v), nil
+	}
+
+	stackID, err := toInt32(cloudConfig.StackID.Int64)
+	if err != nil {
+		return 0, err
+	}
+	client.SetStackID(stackID)
+
+	projectID, err := toInt32(cloudConfig.ProjectID.Int64)
+	if err != nil {
+		return 0, err
+	}
+
+	if projectID == 0 {
+		if err := resolveAndSetProjectID(gs, cloudConfig, tmpCloudConfig, arc); err != nil {
+			return 0, err
+		}
+		projectID, err = toInt32(cloudConfig.ProjectID.Int64)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	if err := client.ValidateOptions(ctx, projectID, arc.Options); err != nil {
+		return 0, err
+	}
+
+	return projectID, nil
 }
 
 func resolveDefaultProjectID(

--- a/internal/cmd/cloud_login.go
+++ b/internal/cmd/cloud_login.go
@@ -301,7 +301,7 @@ func validateTokenV6(
 		return "", 0, 0, err
 	}
 
-	authResp, err := client.ValidateToken(normalizedURL)
+	authResp, err := client.ValidateToken(gs.Ctx, normalizedURL)
 	if err != nil {
 		return "", 0, 0, err
 	}

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -62,7 +62,7 @@ func TestCloudRunCommandIncompatibleFlags(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ts := getSimpleCloudTestState(t, nil, setupK6CloudRunCmd, tc.cliArgs, nil, nil)
+			ts := getSimpleCloudTestState(t, nil, setupK6CloudRunCmd, tc.cliArgs, nil)
 			ts.ExpectedExitCode = int(exitcodes.InvalidConfig)
 			cmd.ExecuteWithGlobalState(ts.GlobalState)
 

--- a/internal/cmd/tests/cmd_cloud_test.go
+++ b/internal/cmd/tests/cmd_cloud_test.go
@@ -35,7 +35,7 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 	t.Run("TestCloudUserNotAuthenticated", func(t *testing.T) {
 		t.Parallel()
 
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil, nil)
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
 		delete(ts.Env, "K6_CLOUD_TOKEN")
 		ts.ExpectedExitCode = -1 // TODO: use a more specific exit code?
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
@@ -73,7 +73,7 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		export default function() {};
 	`
 
-		ts := getSimpleCloudTestState(t, []byte(script), setupCmd, nil, nil, nil)
+		ts := getSimpleCloudTestState(t, []byte(script), setupCmd, nil, nil)
 		delete(ts.Env, "K6_CLOUD_TOKEN")
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
@@ -95,7 +95,7 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 			}
 		}
 
-		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"}, nil, cs)
+		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"}, cs)
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()
@@ -103,38 +103,6 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		assert.Contains(t, stdout, `execution: cloud`)
 		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
 		assert.Contains(t, stdout, `test status: Running`)
-	})
-
-	t.Run("TestCloudWithConfigOverride", func(t *testing.T) {
-		t.Parallel()
-
-		configOverride := http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
-			resp.WriteHeader(http.StatusOK)
-			_, err := fmt.Fprint(resp, `{
-			"reference_id": "123",
-			"config": {
-				"webAppURL": "https://bogus.url",
-				"testRunDetails": "something from the cloud"
-			},
-			"logs": [
-				{"level": "invalid", "message": "test debug message"},
-				{"level": "warning", "message": "test warning"},
-				{"level": "error", "message": "test error"}
-			]
-		}`)
-			assert.NoError(t, err)
-		})
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, configOverride, nil)
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, "execution: cloud")
-		assert.Contains(t, stdout, "output: something from the cloud")
-		assert.Contains(t, stdout, `level=debug msg="invalid message level 'invalid' for message 'test debug message'`)
-		assert.Contains(t, stdout, `level=error msg="test debug message" source=grafana-k6-cloud`)
-		assert.Contains(t, stdout, `level=warning msg="test warning" source=grafana-k6-cloud`)
-		assert.Contains(t, stdout, `level=error msg="test error" source=grafana-k6-cloud`)
 	})
 
 	// TestCloudWithArchive tests that if k6 uses a static archive with the script inside that has cloud options like:
@@ -236,7 +204,7 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 				Progress:      1.0,
 			}
 		}
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil, progressCallback)
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, progressCallback)
 		ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
@@ -257,7 +225,7 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 				Progress:      1.0,
 			}
 		}
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil, progressCallback)
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, progressCallback)
 		ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
@@ -317,7 +285,7 @@ func getMockCloud(
 	return srv
 }
 
-func getSimpleCloudTestState(t *testing.T, script []byte, setupCmd setupCommandFunc, cliFlags []string, archiveUpload http.Handler, progressCallback func() cloudapi.TestProgressResponse) *GlobalTestState {
+func getSimpleCloudTestState(t *testing.T, script []byte, setupCmd setupCommandFunc, cliFlags []string, progressCallback func() cloudapi.TestProgressResponse) *GlobalTestState {
 	if script == nil {
 		script = []byte(`export default function() {}`)
 	}
@@ -326,7 +294,7 @@ func getSimpleCloudTestState(t *testing.T, script []byte, setupCmd setupCommandF
 		cliFlags = []string{"--verbose", "--log-output=stdout"}
 	}
 
-	srv := getMockCloud(t, 123, archiveUpload, progressCallback)
+	srv := getMockCloud(t, 123, nil, progressCallback)
 
 	ts := NewGlobalTestState(t)
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), script, 0o644))

--- a/internal/cmd/tests/cmd_cloud_test.go
+++ b/internal/cmd/tests/cmd_cloud_test.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"go.k6.io/k6/v2/cloudapi"
 	"go.k6.io/k6/v2/errext/exitcodes"
+	cloudapiv6 "go.k6.io/k6/v2/internal/cloudapi/v6"
+	"go.k6.io/k6/v2/internal/cloudapi/v6/v6test"
 	"go.k6.io/k6/v2/internal/cmd"
 	"go.k6.io/k6/v2/internal/lib/testutils"
 	"go.k6.io/k6/v2/lib/fsext"
@@ -48,7 +48,7 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 	t.Run("TestCloudStackNotConfigured", func(t *testing.T) {
 		t.Parallel()
 
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil, nil)
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
 		delete(ts.Env, "K6_CLOUD_STACK_ID")
 		ts.ExpectedExitCode = -1
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
@@ -56,6 +56,19 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		stdout := ts.Stdout.String()
 		t.Log(stdout)
 		assert.Contains(t, stdout, `must first authenticate`)
+	})
+
+	// TODO: Remove after we remove K6_CLOUD_HOST_V6.
+	t.Run("TestCloudV6ClientUsesV6Host", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+		ts.Env["K6_CLOUD_HOST"] = "http://wrong-host"
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		require.NotContains(t, stdout, "wrong-host", "v6 client should use K6_CLOUD_HOST_V6, not K6_CLOUD_HOST")
 	})
 
 	t.Run("TestCloudLoggedInWithScriptToken", func(t *testing.T) {
@@ -81,28 +94,36 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		t.Log(stdout)
 		assert.NotContains(t, stdout, `not logged in`)
 		assert.Contains(t, stdout, `execution: cloud`)
-		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
 		assert.Contains(t, stdout, `test status: Finished`)
 	})
 
 	t.Run("TestCloudExitOnRunning", func(t *testing.T) {
 		t.Parallel()
 
-		cs := func() cloudapi.TestProgressResponse {
-			return cloudapi.TestProgressResponse{
-				RunStatusText: "Running",
-				RunStatus:     cloudapi.RunStatusRunning,
-			}
-		}
-
-		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"}, cs)
+		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"},
+			v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()
 		t.Log(stdout)
 		assert.Contains(t, stdout, `execution: cloud`)
-		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
 		assert.Contains(t, stdout, `test status: Running`)
+	})
+
+	t.Run("TestCloudURLFromStartResponse", func(t *testing.T) {
+		t.Parallel()
+
+		// v6 returns the run URL in the start response (no ConfigOverride).
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, "execution: cloud")
+		assert.Contains(t, stdout, "output: https://stack.grafana.com/a/k6-app/runs/123")
+		assert.Contains(t, stdout, `test status: Finished`)
 	})
 
 	// TestCloudWithArchive tests that if k6 uses a static archive with the script inside that has cloud options like:
@@ -125,12 +146,11 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 	t.Run("TestCloudWithArchive", func(t *testing.T) {
 		t.Parallel()
 
-		testRunID := 123
 		ts := NewGlobalTestState(t)
 
-		archiveUpload := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
-			// check the archive
-			file, _, err := req.FormFile("file")
+		inspectArchive := func(req *http.Request) {
+			// v6 API uses "script" as the multipart field name (v1 used "file").
+			file, _, err := req.FormFile("script")
 			assert.NoError(t, err)
 			assert.NotNil(t, file)
 
@@ -162,14 +182,11 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 			require.Equal(t, "my load test", metadata.Options.Cloud.Name)
 			require.Equal(t, "lorem ipsum", metadata.Options.Cloud.Note)
 			require.Equal(t, 124, metadata.Options.Cloud.ProjectID)
+		}
 
-			// respond with the test run ID
-			resp.WriteHeader(http.StatusOK)
-			_, err = fmt.Fprintf(resp, `{"reference_id": "%d"}`, testRunID)
-			assert.NoError(t, err)
+		srv := v6test.NewServer(t, v6test.Config{
+			InspectArchive: inspectArchive,
 		})
-
-		srv := getMockCloud(t, testRunID, archiveUpload, nil)
 
 		data, err := os.ReadFile(filepath.Join("testdata/archives", "archive_v1.0.0_with_cloud_option.tar")) //nolint:forbidigo // it's a test
 		require.NoError(t, err)
@@ -178,9 +195,9 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 
 		ts.CmdArgs = []string{"k6", "cloud", "--verbose", "--log-output=stdout", "archive.tar"}
 		ts.Env["K6_SHOW_CLOUD_LOGS"] = "false" // no mock for the logs yet
-		ts.Env["K6_CLOUD_HOST"] = srv.URL
-		ts.Env["K6_CLOUD_TOKEN"] = "foo"     // doesn't matter, we mock the cloud
-		ts.Env["K6_CLOUD_STACK_ID"] = "1234" // doesn't matter, we mock the cloud
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+		ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud
+		ts.Env["K6_CLOUD_STACK_ID"] = "1"
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
@@ -189,22 +206,15 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		assert.NotContains(t, stdout, `not logged in`)
 		assert.Contains(t, stdout, `execution: cloud`)
 		assert.Contains(t, stdout, `hello world from archive`)
-		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
 		assert.Contains(t, stdout, `test status: Finished`)
 	})
 
 	t.Run("TestCloudThresholdsHaveFailed", func(t *testing.T) {
 		t.Parallel()
 
-		progressCallback := func() cloudapi.TestProgressResponse {
-			return cloudapi.TestProgressResponse{
-				RunStatusText: "Finished",
-				RunStatus:     cloudapi.RunStatusFinished,
-				ResultStatus:  cloudapi.ResultStatusFailed,
-				Progress:      1.0,
-			}
-		}
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, progressCallback)
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
+			v6test.Progress(cloudapiv6.StatusCompleted, cloudapiv6.ResultFailed))
 		ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
@@ -217,15 +227,8 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 	t.Run("TestCloudAbortedThreshold", func(t *testing.T) {
 		t.Parallel()
 
-		progressCallback := func() cloudapi.TestProgressResponse {
-			return cloudapi.TestProgressResponse{
-				RunStatusText: "Finished",
-				RunStatus:     cloudapi.RunStatusAbortedThreshold,
-				ResultStatus:  cloudapi.ResultStatusFailed,
-				Progress:      1.0,
-			}
-		}
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, progressCallback)
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
+			v6test.Progress(cloudapiv6.StatusAborted, cloudapiv6.ResultFailed))
 		ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
@@ -233,6 +236,20 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		stdout := ts.Stdout.String()
 		t.Log(stdout)
 		assert.Contains(t, stdout, `Thresholds have been crossed`)
+	})
+
+	t.Run("TestCloudAbortedByUser", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
+			v6test.AbortedByUserProgress("user@example.com"))
+		ts.ExpectedExitCode = int(exitcodes.CloudTestRunFailed)
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `test status: Aborted (by user)`)
 	})
 }
 
@@ -251,59 +268,26 @@ func cloudTestStartSimple(tb testing.TB, testRunID int) http.Handler {
 	})
 }
 
-func getMockCloud(
-	t *testing.T, testRunID int,
-	archiveUpload http.Handler, progressCallback func() cloudapi.TestProgressResponse,
-) *httptest.Server {
-	if archiveUpload == nil {
-		archiveUpload = cloudTestStartSimple(t, testRunID)
-	}
-	testProgressURL := fmt.Sprintf("GET ^/v1/test-progress/%d$", testRunID)
-	defaultProgress := cloudapi.TestProgressResponse{
-		RunStatusText: "Finished",
-		RunStatus:     cloudapi.RunStatusFinished,
-		ResultStatus:  cloudapi.ResultStatusPassed,
-		Progress:      1,
-	}
-
-	srv := getTestServer(t, map[string]http.Handler{
-		"POST ^/v1/archive-upload$": archiveUpload,
-		testProgressURL: http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
-			testProgress := defaultProgress
-			if progressCallback != nil {
-				testProgress = progressCallback()
-			}
-			respBody, err := json.Marshal(testProgress)
-			assert.NoError(t, err)
-			_, err = fmt.Fprint(resp, string(respBody))
-			assert.NoError(t, err)
-		}),
-	})
-
-	t.Cleanup(srv.Close)
-
-	return srv
-}
-
-func getSimpleCloudTestState(t *testing.T, script []byte, setupCmd setupCommandFunc, cliFlags []string, progressCallback func() cloudapi.TestProgressResponse) *GlobalTestState {
+func getSimpleCloudTestState(t *testing.T, script []byte, setupCmd setupCommandFunc, cliFlags []string, progressCallback func() *cloudapiv6.TestProgress) *GlobalTestState {
 	if script == nil {
-		script = []byte(`export default function() {}`)
+		script = []byte("export let options = { cloud: { projectID: 1 } };\nexport default function() {}")
 	}
 
 	if cliFlags == nil {
 		cliFlags = []string{"--verbose", "--log-output=stdout"}
 	}
 
-	srv := getMockCloud(t, 123, nil, progressCallback)
+	srv := v6test.NewServer(t, v6test.Config{
+		ProgressCallback: progressCallback,
+	})
 
 	ts := NewGlobalTestState(t)
 	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), script, 0o644))
 	ts.CmdArgs = setupCmd(cliFlags)
 	ts.Env["K6_SHOW_CLOUD_LOGS"] = "false" // no mock for the logs yet
-	ts.Env["K6_CLOUD_HOST"] = srv.URL
-	ts.Env["K6_CLOUD_TOKEN"] = "foo"       // doesn't matter, we mock the cloud
-	ts.Env["K6_CLOUD_STACK_ID"] = "1234"   // doesn't matter, we mock the cloud
-	ts.Env["K6_CLOUD_PROJECT_ID"] = "1234" // doesn't matter, we mock the cloud
+	ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+	ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud
+	ts.Env["K6_CLOUD_STACK_ID"] = "1"
 
 	return ts
 }

--- a/internal/cmd/tests/cmd_cloud_upload_test.go
+++ b/internal/cmd/tests/cmd_cloud_upload_test.go
@@ -2,14 +2,13 @@ package tests
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"go.k6.io/k6/v2/cloudapi"
+	"go.k6.io/k6/v2/internal/cloudapi/v6/v6test"
 	"go.k6.io/k6/v2/internal/cmd"
 	"go.k6.io/k6/v2/internal/lib/testutils"
 	"go.k6.io/k6/v2/lib/fsext"
@@ -37,20 +36,14 @@ func TestK6CloudUpload(t *testing.T) {
 	t.Run("TestCloudUploadWithScript", func(t *testing.T) {
 		t.Parallel()
 
-		cs := func() cloudapi.TestProgressResponse {
-			return cloudapi.TestProgressResponse{
-				RunStatusText: "Archived",
-				RunStatus:     cloudapi.RunStatusArchived,
-			}
-		}
-
-		ts := getSimpleCloudTestState(t, nil, setupK6CloudUploadCmd, nil, cs)
+		ts := getSimpleCloudTestState(t, nil, setupK6CloudUploadCmd, nil, nil)
+		ts.Env["K6_CLOUD_STACK_URL"] = "https://stack.grafana.com/"
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()
 		t.Log(stdout)
 		assert.Contains(t, stdout, `execution: cloud`)
-		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/tests/456`)
 		assert.Contains(t, stdout, `test status: Archived`)
 	})
 
@@ -74,12 +67,11 @@ func TestK6CloudUpload(t *testing.T) {
 	t.Run("TestCloudUploadWithArchive", func(t *testing.T) {
 		t.Parallel()
 
-		testRunID := 123
 		ts := NewGlobalTestState(t)
 
-		archiveUpload := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		inspectArchive := func(req *http.Request) {
 			// check the archive
-			file, _, err := req.FormFile("file")
+			file, _, err := req.FormFile("script")
 			assert.NoError(t, err)
 			assert.NotNil(t, file)
 
@@ -111,21 +103,11 @@ func TestK6CloudUpload(t *testing.T) {
 			require.Equal(t, "my load test", metadata.Options.Cloud.Name)
 			require.Equal(t, "lorem ipsum", metadata.Options.Cloud.Note)
 			require.Equal(t, 124, metadata.Options.Cloud.ProjectID)
-
-			// respond with the test run ID
-			resp.WriteHeader(http.StatusOK)
-			_, err = fmt.Fprintf(resp, `{"reference_id": "%d"}`, testRunID)
-			assert.NoError(t, err)
-		})
-
-		cs := func() cloudapi.TestProgressResponse {
-			return cloudapi.TestProgressResponse{
-				RunStatusText: "Archived",
-				RunStatus:     cloudapi.RunStatusArchived,
-			}
 		}
 
-		srv := getMockCloud(t, testRunID, archiveUpload, cs)
+		srv := v6test.NewServer(t, v6test.Config{
+			InspectArchive: inspectArchive,
+		})
 
 		data, err := os.ReadFile(filepath.Join("testdata/archives", "archive_v1.0.0_with_cloud_option.tar")) //nolint:forbidigo // it's a test
 		require.NoError(t, err)
@@ -134,9 +116,10 @@ func TestK6CloudUpload(t *testing.T) {
 
 		ts.CmdArgs = []string{"k6", "cloud", "upload", "archive.tar"}
 		ts.Env["K6_SHOW_CLOUD_LOGS"] = "false" // no mock for the logs yet
-		ts.Env["K6_CLOUD_HOST"] = srv.URL
-		ts.Env["K6_CLOUD_TOKEN"] = "foo"
-		ts.Env["K6_CLOUD_STACK_ID"] = "1234"
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+		ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud
+		ts.Env["K6_CLOUD_STACK_ID"] = "1"
+		ts.Env["K6_CLOUD_STACK_URL"] = "https://stack.grafana.com/"
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
@@ -144,7 +127,7 @@ func TestK6CloudUpload(t *testing.T) {
 		t.Log(stdout)
 		assert.NotContains(t, stdout, `not logged in`)
 		assert.Contains(t, stdout, `execution: cloud`)
-		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
+		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/tests/456`)
 		assert.Contains(t, stdout, `test status: Archived`)
 	})
 }

--- a/internal/cmd/tests/cmd_cloud_upload_test.go
+++ b/internal/cmd/tests/cmd_cloud_upload_test.go
@@ -24,7 +24,7 @@ func TestK6CloudUpload(t *testing.T) {
 	t.Run("TestCloudUploadUserNotAuthenticated", func(t *testing.T) {
 		t.Parallel()
 
-		ts := getSimpleCloudTestState(t, nil, setupK6CloudUploadCmd, nil, nil, nil)
+		ts := getSimpleCloudTestState(t, nil, setupK6CloudUploadCmd, nil, nil)
 		delete(ts.Env, "K6_CLOUD_TOKEN")
 		ts.ExpectedExitCode = -1
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
@@ -44,7 +44,7 @@ func TestK6CloudUpload(t *testing.T) {
 			}
 		}
 
-		ts := getSimpleCloudTestState(t, nil, setupK6CloudUploadCmd, nil, nil, cs)
+		ts := getSimpleCloudTestState(t, nil, setupK6CloudUploadCmd, nil, cs)
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()


### PR DESCRIPTION
## What

Implements the 1.9.1 Cloud API (aka V6) for the `k6 cloud run` and `k6 cloud upload` commands and migrates them to the new API. Deletes the v1 code paths they used. Improves existing exit code handling and progress bar issues. 

## Improved exit code handling

Before, most cloud abort scenarios returned an exit code of 0. CI pipelines couldn't distinguish a threshold breach from a successful run. This PR maps V6 statuses to real k6 exit codes to fix those issues, enabling greater control:

| master                             | v6                         |
| ---------------------------------- | -------------------------- |
| exit=0 "Finished"                  | exit=0 "Finished"          |
| exit=99 "Aborted (by threshold)"   | exit=99 "Aborted"          |
| exit=0 "Aborted (by system)"       | exit=97 "Aborted"          |
| exit=0 "Aborted (by limit)"        | exit=97 "Aborted"          |
| exit=0 "Aborted (by script error)" | exit=97 "Aborted"          |
| exit=0 "Aborted (by user)"         | exit=97 "Aborted (by user)"|
| exit=0 "Timed Out"                 | exit=97 "Aborted"          |
| exit=0 "Aborted"                   | exit=97 "Aborted"          |

_Note: v6 reports only "aborted" and "aborted by user". We're working on adding more detailed test results._

## Improved TUI as a side-benefit

Progress bar now actually works. Three visible bugs on `master` fixed:
- Ghost duplicate bar after the run finishes
- Timer stalls at ~x% then jumps to done
- Stale timer races with the status line

This PR now interpolates progress from the cloud's estimated duration and a local timer, fixing the quirks in the previous progress bar. It also eliminates the duplicate ghost bars and stale-timer races. However, estimated duration can drift from actual execution time, so we're working with the backend team to expose it for more accurate tracking.

### Duplicated bars

```
# master
Run    [======================================] Finished
       test status: Finished
Run    [======================================] Finished ← duplicate ghost bar

# v6
Run    [======================================] Finished
       test status: Finished
```

### Progress bar

```
# master: jumps to ~60% immediately, stalls for most of the run.
Run    [=====================>----------------] 01.9s/31s

# v6: Ticks smoothly 0% → ...
Run    [======>-------------------------------] 02.1s/10s
```

### Stale timer race

```
# master: bar shows stale timer, test status prints underneath, then bar duplicates
Run    [====================================>-] 09.5s/31s  ← stale
       test status: Finished
Run    [======================================] Finished   ← catches up
       test status: Finished

# v6: coordinated, no race

Run    [======================================] Finished
       test status: Finished
```

## Testing improvements

Adds a new hand-rolled HTTP test server, `v6test`, that uses the generated OpenAPI types for response bodies. Responses stay in sync with the V6 spec at compile time. Although we tested against a real server, we have also added [a new authentic test server](https://github.com/grafana/k6-cloud-test-server) to make testing the V6 API easier and faster without requiring a real server.

## Request flow changes

- All v6 requests carry `Authorization: Bearer <token>` and `X-Stack-Id`.
- We handle test name conflicts by updating existing scripts, keeping the runs idempotent.

**`cloud run`** goes from a 2-step to a 3-step setup:

```
v1:  validate-options → archive-upload (create+start combined) → poll /v1/test-progress/{id}
v6:  validate_options → projects/{pid}/load_tests → load_tests/{id}/start → poll /cloud/v6/test_runs/{id}
```

**`cloud upload`** no longer polls:

```
v1:  validate-options → archive-upload (upload_only=true) → poll once for Archived
v6:  validate_options → projects/{pid}/load_tests → done
```

**Ctrl+C** abort endpoint changed:

```
v1:  POST /v1/tests/{id}/stop
v6:  POST /cloud/v6/test_runs/{id}/abort
```

## Running

```
export K6_CLOUD_TOKEN=<your-token> \
    K6_CLOUD_STACK_ID=<your-stack-id> \
    K6_SHOW_CLOUD_LOGS=false \ # optional 
    K6_CLOUD_HOST=https://ingest.staging.k6.io \ # for v1
    K6_CLOUD_HOST_V6=https://api.staging.k6.io   # for v6
// build & run
```

## Known follow-ups

- `cloud upload` shows a hostless stack URL in the TUI when the user doesn't configure one; v6 doesn't return it.
- We may have used `execution_duration`, but not required. Agreed with the backend team.

## Related PR(s)/Issue(s)

- Closes #5518
- Closes #5520
- Closes grafana/k6-cloud#4281
- Closes grafana/k6-cloud#4282
- Related grafana/k6-cloud-openapi-client-go#26
- Related #5783
- Supersedes #5592