### PR TITLE
Bump ubuntu runners to 24.04

### DIFF
--- a/.github/actions/test-common/action.yml
+++ b/.github/actions/test-common/action.yml
@@ -34,8 +34,6 @@ runs:
         unzip go.zip -d $HOME/sdk
 
     - name: Install chromium
-      # This is only needed on arm images, chromium comes preinstalled on amd64 runner images.
-      if: ${{contains(inputs.platform, 'arm') }}
       shell: bash
       run: |
         sudo apt update && sudo apt install chromium-browser

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         go-version: [1.25.x]
         platform:
-          [ubuntu-22.04, ubuntu-arm64-large, github-hosted-windows-x64-large]
+          [ubuntu-24.04, ubuntu-arm64-large, github-hosted-windows-x64-large]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -46,8 +46,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-22.04
-            gotip_platform: ubuntu-22.04
+          - platform: ubuntu-24.04
+            gotip_platform: ubuntu-24.04
           - platform: ubuntu-arm64-large
             gotip_platform: ubuntu-24.04-arm
           - platform: github-hosted-windows-x64-large
@@ -76,7 +76,7 @@ jobs:
       matrix:
         go-version: [1.26.x]
         platform:
-          [ubuntu-22.04, ubuntu-arm64-large, github-hosted-windows-x64-large]
+          [ubuntu-24.04, ubuntu-arm64-large, github-hosted-windows-x64-large]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.25.x]
-        platform: [ubuntu-22.04, ubuntu-24.04-arm, windows-latest]
+        platform: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu-22.04, ubuntu-24.04-arm, windows-latest]
+        platform: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.platform }}
     continue-on-error: true
     steps:
@@ -65,13 +65,13 @@ jobs:
         with:
           use_gotip: "true"
           platform: ${{ matrix.platform }}
-  
+
   test-latest:
     strategy:
       fail-fast: false
       matrix:
         go-version: [1.26.x]
-        platform: [ubuntu-22.04, ubuntu-24.04-arm, windows-latest]
+        platform: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What?

Bumped runners to ubuntu 24.04 - as 22.04 started to have problems with browser. Also installed browser specifically as apparently what comes with the image has problems.

## Why?
CI is once again failing for browser related issues. 
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
