### PR TITLE
Add 'k6 x docs' hint in help output

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -20,7 +20,6 @@ import (
 	"go.k6.io/k6/errext"
 	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/ext"
-	"go.k6.io/k6/internal/build"
 	"go.k6.io/k6/internal/log"
 	"go.k6.io/k6/secretsource"
 
@@ -29,18 +28,8 @@ import (
 
 const waitLoggerCloseTimeout = time.Second * 5
 
-func getDocsURL() string {
-	version := build.Version
-	version = strings.TrimPrefix(version, "v")
-	parts := strings.SplitN(version, ".", 3)
-	if len(parts) >= 2 {
-		return fmt.Sprintf("https://grafana.com/docs/k6/v%s.%s.x/", parts[0], parts[1])
-	}
-	return "https://grafana.com/docs/k6/latest/"
-}
-
 func getRootUsageTemplate() string {
-	return fmt.Sprintf(`{{.Short}}
+	return `{{.Short}}
 
 Usage:{{if .Runnable}}
   {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
@@ -51,7 +40,7 @@ Core Commands:{{range .Commands}}{{if eq .Name "new"}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{range .Commands}}{{if eq .Name "cloud"}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}
 
-Additional Commands:{{range .Commands}}{{if and .IsAvailableCommand (ne .Name "new") (ne .Name "run") `+
+Additional Commands:{{range .Commands}}{{if and .IsAvailableCommand (ne .Name "new") (ne .Name "run") ` +
 		`(ne .Name "cloud") (ne .Name "help")}}
   {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}
 
@@ -71,10 +60,13 @@ Examples:
 
   # Run locally, stream results to Grafana Cloud
   $ {{.CommandPath}} cloud run --local-execution test.js
+
+Documentation:
+  # Look up the JavaScript API, examples, and best practices
+  $ {{.CommandPath}} x docs
 {{if .HasAvailableSubCommands}}
-Use "{{.CommandPath}} [command] --help" for more information about a command.
-Full CLI documentation: %s{{end}}
-`, getDocsURL())
+Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`
 }
 
 // ExecuteWithGlobalState runs the root command with an existing GlobalState.


### PR DESCRIPTION
## What?

Adds a single-line hint in the CLI help output to improve discoverability of the `k6 x docs` 

## Why?

This helps users discover built-in documentation and best practices directly from the CLI help output, as suggested in the issue.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

Closes #5748 

