### PR TITLE
chore: Make TestExternallyControlledRun less flaky

### DIFF
--- a/lib/executor/externally_controlled_test.go
+++ b/lib/executor/externally_controlled_test.go
@@ -30,8 +30,11 @@ func TestExternallyControlledRun(t *testing.T) {
 
 	synctest.Test(t, func(t *testing.T) {
 		doneIters := new(uint64)
-		runner := simpleRunner(func(_ context.Context, _ *lib.State) error {
-			time.Sleep(200 * time.Millisecond)
+		runner := simpleRunner(func(ctx context.Context, _ *lib.State) error {
+			select {
+			case <-ctx.Done():
+			case <-time.After(200 * time.Millisecond):
+			}
 			atomic.AddUint64(doneIters, 1)
 			return nil
 		})


### PR DESCRIPTION
## What?

The test sometimes might get stuck on the sleep for a while longer, instead of as expected stopping hte VU fast. This fixes this issue

## Why?
Flakiness in tests is bad
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
