### PR TITLE
`k6 x explore` in help output

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -64,6 +64,9 @@ Examples:
 Documentation:
   # Look up the JavaScript API, examples, and best practices
   $ {{.CommandPath}} x docs
+
+  # Discover available k6 extensions
+  $ {{.CommandPath}} x explore
 {{if .HasAvailableSubCommands}}
 Use "{{.CommandPath}} [command] --help" for more information about a command.{{end}}
 `


### PR DESCRIPTION
## What?

Makes `k6 x explore` discoverable by adding it to the `k6` help output.

## Why?

Same gap that #5748 addressed for `k6 x docs`. The `explore` subcommand lets users browse the extension registry from the CLI, but the help output doesn't mention it, making it harder for users to find.

## Related PR(s)/Issue(s)

Closes #5787
Related to #5758