### PR TITLE
Machine-readable summary respects SUMMARY_TREND_STATS

### DIFF
--- a/internal/lib/summary/machine_readable.go
+++ b/internal/lib/summary/machine_readable.go
@@ -168,6 +168,18 @@ func machineReadableMetricValues(m Metric) (any, error) {
 			Rate:    m.Values["rate"],
 		}, nil
 	case string(machinereadable.MetricTypeTrend):
+		known := map[string]bool{"avg": true, "min": true, "max": true, "med": true, "p(90)": true, "p(95)": true}
+		for k := range m.Values {
+			if !known[k] {
+				// return a map with all present values so dynamic percentiles are preserved
+				vals := make(map[string]float64, len(m.Values))
+				for kk, vv := range m.Values {
+					vals[kk] = vv
+				}
+				return vals, nil
+			}
+		}
+
 		var values machinereadable.TrendValues
 		if avgVal, ok := m.Values["avg"]; ok {
 			values.Avg = &avgVal

--- a/internal/output/summary/summary_test.go
+++ b/internal/output/summary/summary_test.go
@@ -14,6 +14,7 @@ import (
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
 	"go.k6.io/k6/output"
+	"encoding/json"
 )
 
 func TestOutput_Summary(t *testing.T) {
@@ -342,4 +343,60 @@ func TestOutput_AddMetricSamples(t *testing.T) {
 
 		assert.Equal(t, []string{"something", "auth"}, o.dataModel.groupsOrder)
 	})
+}
+
+func TestMachineReadable_IncludesP99(t *testing.T) {
+	t.Parallel()
+
+	s := summary.New()
+
+	m := summary.Metric{
+		MetricInfo: summary.MetricInfo{
+			Name:     "request_duration",
+			Type:     "trend",
+			Contains: "default",
+		},
+		Values: map[string]float64{
+			"avg":   50,
+			"p(95)": 95,
+			"p(99)": 99, // 👈 critical for test
+		},
+	}
+
+	s.Group.Metrics.Custom = map[string]summary.Metric{
+		"request_duration": m,
+	}
+
+	meta := summary.Meta{}
+
+	mr, err := summary.ToMachineReadable(s, meta)
+	require.NoError(t, err)
+
+	b, err := json.Marshal(mr)
+	require.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(b, &result)
+	require.NoError(t, err)
+
+	// Navigate safely
+	results, ok := result["results"].(map[string]interface{})
+	require.True(t, ok)
+
+	metrics, ok := results["metrics"].([]interface{})
+	require.True(t, ok)
+	require.NotEmpty(t, metrics)
+
+	metric, ok := metrics[0].(map[string]interface{})
+	require.True(t, ok)
+
+	values, ok := metric["values"].(map[string]interface{})
+	require.True(t, ok)
+
+	// ❌ This should FAIL before fix
+	assert.Contains(t, values, "p(99)")
+
+	// sanity checks
+	assert.Contains(t, values, "avg")
+	assert.Contains(t, values, "p(95)")
 }

--- a/internal/output/summary/summary_test.go
+++ b/internal/output/summary/summary_test.go
@@ -359,7 +359,7 @@ func TestMachineReadable_IncludesP99(t *testing.T) {
 		Values: map[string]float64{
 			"avg":   50,
 			"p(95)": 95,
-			"p(99)": 99, // 👈 critical for test
+			"p(99)": 99, 
 		},
 	}
 


### PR DESCRIPTION
## What?

This PR updates the machine-readable summary output to respect the values specified in `SUMMARY_TREND_STATS`.

When additional trend statistics such as `p(99)` are configured, they are currently computed but not included in the machine-readable output. This change preserves such values by falling back to a dynamic representation when unsupported fields are present.

## Why?

The current implementation only supports a fixed set of trend statistics (`avg`, `min`, `max`, `med`, `p(90)`, `p(95)`) via the generated `TrendValues` struct.

However, `SUMMARY_TREND_STATS` allows specifying additional percentiles like `p(99)`. These values are silently dropped in the machine-readable output, leading to inconsistency between computed metrics and exported results.

This PR ensures that all computed trend statistics are preserved without modifying the generated schema.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable


## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #5736 

<!-- Thanks for your contribution! 🙏🏼 -->
