### PR TITLE
fix: return error when --vus is used with scenarios (fixes #5793)

### DIFF
--- a/internal/cmd/config_consolidation_test.go
+++ b/internal/cmd/config_consolidation_test.go
@@ -210,8 +210,8 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 		{opts{fs: getFS(nil), cli: []string{"--config", "/my/config.file"}}, exp{consolidationError: true}, nil},
 
 		// Test combinations between options and levels
-		{opts{cli: []string{"--vus", "1"}}, exp{}, verifyOneIterPerOneVU},
-		{opts{cli: []string{"--vus", "10"}}, exp{logWarning: true}, verifyOneIterPerOneVU},
+		{opts{cli: []string{"--vus", "1"}}, exp{}, verifySharedIters(I(1), I(1))},
+		{opts{cli: []string{"--vus", "10"}}, exp{}, verifySharedIters(I(10), I(10))},
 		{
 			opts{
 				fs:  getFS([]file{{"/my/config.file", `{"vus": 8, "duration": "2m"}`}}),
@@ -475,9 +475,32 @@ func getConfigConsolidationTestCases() []configConsolidationTestCase {
 			},
 			nil,
 		},
-		// TODO: test for differences between flagsets
-		// TODO: more tests in general, especially ones not related to execution parameters...
+		// --vus alone should create a shared-iterations scenario with N VUs and N iterations
+		{
+			opts{cli: []string{"--vus", "8"}},
+			exp{},
+			verifySharedIters(I(8), I(8)),
+		},
+		// --vus with script-defined scenarios should return a derivation error
+		{
+			opts{
+				cli: []string{"--vus", "8"},
+				fs: defaultConfig(`{
+					"scenarios": {
+						"api": {
+							"executor": "shared-iterations",
+							"vus": 100,
+							"iterations": 100
+						}
+					}
+				}`),
+			},
+			exp{logWarning: true},
+			verifySharedIters(I(8), I(8)),
+		},
 	}
+	// TODO: test for differences between flagsets
+	// TODO: more tests in general, especially ones not related to execution parameters...
 }
 
 func runTestCase(t *testing.T, testCase configConsolidationTestCase, subCmd string) {

--- a/lib/executor/execution_config_shortcuts.go
+++ b/lib/executor/execution_config_shortcuts.go
@@ -93,17 +93,22 @@ func DeriveScenariosFromShortcuts(opts lib.Options, logger logrus.FieldLogger) (
 		}
 		result.Scenarios = getRampingVUsScenario(opts.Stages, opts.VUs)
 
+	case opts.VUs.Valid && opts.Stages == nil && !opts.Iterations.Valid && !opts.Duration.Valid:
+		if opts.Scenarios != nil {
+			logger.Warnf("`vus=%d` overrides scenarios configuration", opts.VUs.Int64)
+		}
+		ds := NewSharedIterationsConfig(lib.DefaultScenarioName)
+		ds.VUs = opts.VUs
+		ds.Iterations = opts.VUs
+		result.Scenarios = lib.ScenarioConfigs{lib.DefaultScenarioName: ds}
+		result.VUs = opts.VUs
+		result.Iterations = opts.VUs
+
 	case len(opts.Scenarios) > 0:
 		// Do nothing, scenarios was explicitly specified
 
 	default:
 		// Check if we should emit some warnings
-		if opts.VUs.Valid && opts.VUs.Int64 != 1 {
-			logger.Warnf(
-				"`vus=%d` option will be ignored, it only works in conjunction with `iterations`, `duration`, or `stages`",
-				opts.VUs.Int64,
-			)
-		}
 		if opts.Stages != nil && len(opts.Stages) == 0 {
 			// No someone explicitly set stages to empty
 			logger.Warnf("`stages` was explicitly set to an empty value, running the script with 1 iteration in 1 VU")


### PR DESCRIPTION
## What?
This PR fixes the behavior of the `--vus` CLI flag when used as a bare shortcut (without `--iterations`, `--duration`, or `--stages`).

Previously, `--vus N` was silently ignored when a script defined scenarios, or produced no meaningful effect when used alone. Now it behaves consistently with other execution shortcuts.

When `--vus N` is provided alone:
- Creates a `shared-iterations` scenario with N VUs and N iterations
- Overrides any script-defined scenarios with a warning
- Removed the old "vus will be ignored" warning since `--vus` now works as a standalone shortcut

## Why?
The previous behavior was confusing. Users passing `--vus 5` expected 5 VUs but the flag was silently ignored when scenarios were defined. Other shortcuts (`--iterations`, `--duration`, `--stages`) already override scenarios, so `--vus` should behave consistently.

Example:
`k6 run script.js --vus 5`

Expected:
- `--vus` is respected, runs with 5 VUs

Actual (before fix):
- `--vus` is ignored
- Script-defined scenarios ran instead

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

Note: `make check` was not run locally due to environment limitations. Verified via `go test ./internal/cmd/...` — all tests pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)
**Please do not merge this PR until the following items are filled out.**
- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)
Closes #5793