### PR TITLE
fix: respect K6_CLOUD_PUSH_REF_ID in cloud local execution

### DIFF
--- a/internal/cmd/outputs_cloud.go
+++ b/internal/cmd/outputs_cloud.go
@@ -25,13 +25,12 @@ const (
 	testRunIDKey    = "K6_CLOUDRUN_TEST_RUN_ID"
 )
 
-// createCloudTest performs some test and Cloud configuration validations and if everything
-// looks good, then it creates a test run in the k6 Cloud, using the Cloud API, meant to be used
-// for streaming test results.
+// createCloudTest performs test and Cloud configuration validations and prepares the test run.
+// It creates a new test run in the k6 Cloud backend unless a PushRefID is provided,
+// in which case it reuses an existing test run.
 //
-// This method is also responsible for filling the test run id on the test environment, so it can be used later,
-// and to populate the Cloud configuration back in case the Cloud API returned some overrides,
-// as expected by the Cloud output.
+// This method also sets the test run ID in the environment so it can be used later,
+// and applies any Cloud configuration overrides returned by the API.
 //
 //nolint:funlen
 func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error {
@@ -92,6 +91,12 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 	if conf.MaxTimeSeriesInBatch.Int64 < 1 {
 		return fmt.Errorf("max allowed number of time series in a single batch must be a positive number but is %d",
 			conf.MaxTimeSeriesInBatch.Int64)
+	}
+
+	if conf.PushRefID.Valid && conf.PushRefID.String != "" {
+		test.preInitState.RuntimeOptions.Env[testRunIDKey] = conf.PushRefID.String
+		gs.Logger.Debug("using PushRefID, skipping CreateTestRun")
+		return nil
 	}
 
 	var testArchive *lib.Archive

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -213,32 +213,46 @@ export default function() {
 		assert.Contains(t, stdout, "The test run id is "+strconv.Itoa(testRunID))
 	})
 
-	t.Run("should error when no stack is configured", func(t *testing.T) {
+	t.Run("reuses existing test run when K6_CLOUD_PUSH_REF_ID is set", func(t *testing.T) {
 		t.Parallel()
 
 		script := `
 export const options = {
   cloud: {
-      name: 'Hello k6 Cloud!',
-      projectID: 123456,
+	  name: 'Hello k6 Cloud!',
+	  projectID: 123456,
   },
 };
 
-export default function() {};`
+export default function() {
+    ` + "console.log(`The test run id is ${__ENV.K6_CLOUDRUN_TEST_RUN_ID}`);" + `
+};`
 
-		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"})
-		ts.ExpectedExitCode = -1
-		delete(ts.Env, "K6_CLOUD_STACK_ID")
+		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"}, 0)
+
+		const pushRefID = "99999"
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = pushRefID
+
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^/v1/tests$": http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				require.Fail(t, "CreateTestRun must not be called when K6_CLOUD_PUSH_REF_ID is set")
+			}),
+		})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()
 		t.Log(stdout)
-		assert.Contains(t, stdout, "must first authenticate")
+
+		assert.Contains(t, stdout, "execution: local")
+		assert.Contains(t, stdout, "output: cloud (https://app.k6.io/runs/"+pushRefID+")")
+		assert.Contains(t, stdout, "The test run id is "+pushRefID)
 	})
 }
 
-func makeTestState(tb testing.TB, script string, cliFlags []string) *GlobalTestState {
+func makeTestState(tb testing.TB, script string, cliFlags []string, expExitCode exitcodes.ExitCode) *GlobalTestState {
 	if cliFlags == nil {
 		cliFlags = []string{"-v", "--log-output=stdout"}
 	}

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -228,13 +228,13 @@ export default function() {
     ` + "console.log(`The test run id is ${__ENV.K6_CLOUDRUN_TEST_RUN_ID}`);" + `
 };`
 
-		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"}, 0)
+		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"})
 
 		const pushRefID = "99999"
 		ts.Env["K6_CLOUD_PUSH_REF_ID"] = pushRefID
 
 		srv := getTestServer(t, map[string]http.Handler{
-			"POST ^/v1/tests$": http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			"POST ^/v1/tests$": http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 				require.Fail(t, "CreateTestRun must not be called when K6_CLOUD_PUSH_REF_ID is set")
 			}),
 		})
@@ -252,7 +252,7 @@ export default function() {
 	})
 }
 
-func makeTestState(tb testing.TB, script string, cliFlags []string, expExitCode exitcodes.ExitCode) *GlobalTestState {
+func makeTestState(tb testing.TB, script string, cliFlags []string) *GlobalTestState {
 	if cliFlags == nil {
 		cliFlags = []string{"-v", "--log-output=stdout"}
 	}


### PR DESCRIPTION
## What?

This PR fixes inconsistent behavior between:

`k6 run --out cloud`
`k6 cloud run --local-execution`

Previously, `k6 cloud run --local-execution` always created a new test run, even when `K6_CLOUD_PUSH_REF_ID` was set.

## Why?

`createCloudTest()` unconditionally called `CreateTestRun()`, ignoring the provided `K6_CLOUD_PUSH_REF_ID`.

This caused:

- unnecessary creation of new test runs
- mismatch in run IDs between execution paths
- orphaned test runs in Grafana Cloud

This change ensures that when `K6_CLOUD_PUSH_REF_ID` is provided, the existing test run is reused instead of creating a new one, aligning behavior with the cloud output path.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

Closes #5813 

<!-- Thanks for your contribution! 🙏🏼 -->
