### PR TITLE
Warn when http.get or http.head receive extra arguments

### DIFF
--- a/internal/js/runner_test.go
+++ b/internal/js/runner_test.go
@@ -2054,7 +2054,7 @@ func runMultiFileTestCase(t *testing.T, tc multiFileTestCase, tb *httpmultibin.H
 	options := runner.GetOptions()
 	require.Empty(t, options.Validate())
 
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	vu, err := runner.NewVU(ctx, 1, 1, tc.samples)

--- a/internal/js/runner_test.go
+++ b/internal/js/runner_test.go
@@ -2054,7 +2054,7 @@ func runMultiFileTestCase(t *testing.T, tc multiFileTestCase, tb *httpmultibin.H
 	options := runner.GetOptions()
 	require.Empty(t, options.Validate())
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
 	vu, err := runner.NewVU(ctx, 1, 1, tc.samples)

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -69,12 +69,24 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	// wrappers (facades) that convert the old k6 idiosyncratic APIs to the new
 	// proper Client ones that accept Request objects and don't suck
 	mustExport("get", func(url sobek.Value, args ...sobek.Value) (*Response, error) {
+		// http.get should not have more than one additional argument
+		if len(args) > 1 {
+			if state := mi.vu.State(); state != nil {
+				state.Logger.Warnf("http.get only accepts a url and a params argument (2 arguments), but %d were given", len(args)+1)
+			}
+		}
 		// http.get(url, params) doesn't have a body argument, so we add undefined
 		// as the third argument to http.request(method, url, body, params)
 		args = append([]sobek.Value{sobek.Undefined()}, args...)
 		return mi.defaultClient.Request(http.MethodGet, url, args...)
 	})
 	mustExport("head", func(url sobek.Value, args ...sobek.Value) (*Response, error) {
+		// http.head should not have more than one additional argument
+		if len(args) > 1 {
+			if state := mi.vu.State(); state != nil {
+				state.Logger.Warnf("http.head only accepts a url and a params argument (2 arguments), but %d were given", len(args)+1)
+			}
+		}
 		// http.head(url, params) doesn't have a body argument, so we add undefined
 		// as the third argument to http.request(method, url, body, params)
 		args = append([]sobek.Value{sobek.Undefined()}, args...)

--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -72,7 +72,10 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 		// http.get should not have more than one additional argument
 		if len(args) > 1 {
 			if state := mi.vu.State(); state != nil {
-				state.Logger.Warnf("http.get only accepts a url and a params argument (2 arguments), but %d were given", len(args)+1)
+				state.Logger.Warnf(
+					"http.get only accepts a url and a params argument (2 arguments), but %d were given",
+					len(args)+1,
+				)
 			}
 		}
 		// http.get(url, params) doesn't have a body argument, so we add undefined
@@ -84,7 +87,10 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 		// http.head should not have more than one additional argument
 		if len(args) > 1 {
 			if state := mi.vu.State(); state != nil {
-				state.Logger.Warnf("http.head only accepts a url and a params argument (2 arguments), but %d were given", len(args)+1)
+				state.Logger.Warnf(
+					"http.head only accepts a url and a params argument (2 arguments), but %d were given",
+					len(args)+1,
+				)
 			}
 		}
 		// http.head(url, params) doesn't have a body argument, so we add undefined

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1175,6 +1175,38 @@ func TestRequest(t *testing.T) {
 		assertRequestMetricsEmitted(t, metrics.GetBufferedSamples(samples), "HEAD", sr("HTTPBIN_URL/get?a=1&b=2"), 200, "")
 	})
 
+	t.Run("GETExtraArgs", func(t *testing.T) {
+		ts := newTestCase(t)
+		rt := ts.runtime.VU.Runtime()
+
+		ts.hook.Reset()
+		_, err := rt.RunString(ts.tb.Replacer.Replace(`
+		var res = http.get("HTTPBIN_URL/get", null, {headers: {"X-We-Want-This": "value"}});
+		`))
+		require.NoError(t, err)
+
+		logEntry := ts.hook.LastEntry()
+		require.NotNil(t, logEntry)
+		assert.Equal(t, logrus.WarnLevel, logEntry.Level)
+		assert.Contains(t, logEntry.Message, "http.get only accepts a url and a params argument")
+	})
+
+	t.Run("HEADExtraArgs", func(t *testing.T) {
+		ts := newTestCase(t)
+		rt := ts.runtime.VU.Runtime()
+
+		ts.hook.Reset()
+		_, err := rt.RunString(ts.tb.Replacer.Replace(`
+		var res = http.head("HTTPBIN_URL/get", null, {headers: {"X-We-Want-This": "value"}});
+		`))
+		require.NoError(t, err)
+
+		logEntry := ts.hook.LastEntry()
+		require.NotNil(t, logEntry)
+		assert.Equal(t, logrus.WarnLevel, logEntry.Level)
+		assert.Contains(t, logEntry.Message, "http.head only accepts a url and a params argument")
+	})
+
 	t.Run("OPTIONS", func(t *testing.T) {
 		_, err := rt.RunString(sr(`
 		var res = http.options("HTTPBIN_URL/?a=1&b=2", null, {headers: {"X-We-Want-This": "value"}});


### PR DESCRIPTION
## What?

Emit a warning log when `http.get` or `http.head` are called with more than 2 arguments (url + params).

## Why?

`http.get` and `http.head` only accept `(url, params)`, unlike `http.post` and other HTTP methods which accept `(url, body, params)`. Users commonly write
`http.get(url, null, params)` expecting the same 3-argument signature, which silently ignores the extra params. This warning helps users notice the mistake.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Previous attempt: #3974 (closed due to unaddressed feedback)

Closes #2823