### PR TITLE
Use synctest in output tests to fix flaky TestOutputFlushWorkersStop

### DIFF
--- a/internal/output/cloud/output.go
+++ b/internal/output/cloud/output.go
@@ -43,6 +43,13 @@ type versionedOutput interface {
 	AddMetricSamples(samples []metrics.SampleContainer)
 }
 
+// cloudClient is the interface used to manage test runs in the Cloud service.
+// It allows tests to inject a mock without starting a real HTTP server.
+type cloudClient interface {
+	CreateTestRun(testRun *cloudapi.TestRun) (*cloudapi.CreateTestRunResponse, error)
+	TestFinished(referenceID string, thresholds cloudapi.ThresholdResult, tainted bool, runStatus cloudapi.RunStatus) error
+}
+
 type apiVersion int64
 
 const (
@@ -71,7 +78,7 @@ type Output struct {
 	// uses the --no-archive-upload flag.
 	testArchive *lib.Archive
 
-	client       *cloudapi.Client
+	client       cloudClient
 	testStopFunc func(error)
 
 	usage *usage.Usage
@@ -384,7 +391,7 @@ func (out *Output) startVersionedOutput() error {
 	case int64(apiVersion1):
 		err = errors.New("v1 is not supported anymore")
 	case int64(apiVersion2):
-		out.versionedOutput, err = cloudv2.New(out.logger, out.config, out.client)
+		out.versionedOutput, err = cloudv2.New(out.logger, out.config, nil)
 	default:
 		err = fmt.Errorf("v%d is an unexpected version", out.config.APIVersion.Int64)
 	}

--- a/internal/output/cloud/output_test.go
+++ b/internal/output/cloud/output_test.go
@@ -3,11 +3,11 @@ package cloud
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -246,59 +246,55 @@ func TestCloudOutputDescription(t *testing.T) {
 
 func TestOutputStopWithTestError(t *testing.T) {
 	t.Parallel()
-
-	done := make(chan struct{})
-
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/v1/tests/1234":
-			b, err := io.ReadAll(r.Body)
-			require.NoError(t, err)
-
-			// aborted by system status
-			expB := `{"result_status":0, "run_status":6, "thresholds":{}}`
-			require.JSONEq(t, expB, string(b))
-
-			w.WriteHeader(http.StatusOK)
-			close(done)
-		default:
-			http.Error(w, "not expected path", http.StatusInternalServerError)
+	synctest.Test(t, func(t *testing.T) {
+		mock := &cloudClientMock{}
+		out := &Output{
+			logger:    testutils.NewLogger(t),
+			testRunID: "1234",
+			client:    mock,
 		}
-	}
-	ts := httptest.NewServer(http.HandlerFunc(handler))
-	defer ts.Close()
 
-	out, err := newOutput(output.Params{
-		Logger: testutils.NewLogger(t),
-		Environment: map[string]string{
-			"K6_CLOUD_HOST": ts.URL,
-		},
-		ScriptOptions: lib.Options{
-			SystemTags: &metrics.DefaultSystemTagSet,
-		},
-		ScriptPath: &url.URL{Path: "/script.js"},
+		calledStopFn := false
+		out.versionedOutput = versionedOutputMock{
+			callback: func(fn string) {
+				if fn == "StopWithTestError" {
+					calledStopFn = true
+				}
+			},
+		}
+
+		fakeErr := errors.New("this is my error")
+		require.NoError(t, out.StopWithTestError(fakeErr))
+		assert.True(t, calledStopFn)
+
+		require.True(t, mock.testFinishedCalled)
+		assert.Equal(t, "1234", mock.testFinishedRefID)
+		assert.Equal(t, cloudapi.ThresholdResult{}, mock.testFinishedThresholds)
+		assert.False(t, mock.testFinishedTainted)
+		assert.Equal(t, cloudapi.RunStatusAbortedSystem, mock.testFinishedRunStatus)
 	})
-	require.NoError(t, err)
+}
 
-	calledStopFn := false
-	out.testRunID = "1234"
-	out.versionedOutput = versionedOutputMock{
-		callback: func(fn string) {
-			if fn == "StopWithTestError" {
-				calledStopFn = true
-			}
-		},
-	}
+// cloudClientMock implements cloudClient for tests without starting a real HTTP server.
+type cloudClientMock struct {
+	testFinishedCalled     bool
+	testFinishedRefID      string
+	testFinishedThresholds cloudapi.ThresholdResult
+	testFinishedTainted    bool
+	testFinishedRunStatus  cloudapi.RunStatus
+}
 
-	fakeErr := errors.New("this is my error")
-	require.NoError(t, out.StopWithTestError(fakeErr))
-	assert.True(t, calledStopFn)
+func (m *cloudClientMock) CreateTestRun(_ *cloudapi.TestRun) (*cloudapi.CreateTestRunResponse, error) {
+	return &cloudapi.CreateTestRunResponse{}, nil
+}
 
-	select {
-	case <-time.After(1 * time.Second):
-		t.Error("timed out")
-	case <-done:
-	}
+func (m *cloudClientMock) TestFinished(referenceID string, thresholds cloudapi.ThresholdResult, tainted bool, runStatus cloudapi.RunStatus) error {
+	m.testFinishedCalled = true
+	m.testFinishedRefID = referenceID
+	m.testFinishedThresholds = thresholds
+	m.testFinishedTainted = tainted
+	m.testFinishedRunStatus = runStatus
+	return nil
 }
 
 func TestOutputGetStatusRun(t *testing.T) {

--- a/output/cloud/expv2/collect_test.go
+++ b/output/cloud/expv2/collect_test.go
@@ -262,21 +262,21 @@ func TestBucketQPopAll(t *testing.T) {
 
 func TestBucketQPushPopConcurrency(t *testing.T) {
 	t.Parallel()
+	const iterations = 1000
 	var (
-		count = 0
-		bq    = bucketQ{}
-		sink  = &counter{}
+		bq   = bucketQ{}
+		sink = &counter{}
 
-		stop = time.After(100 * time.Millisecond)
-		pop  = make(chan struct{}, 10)
-		done = make(chan struct{})
+		pop           = make(chan struct{}, 10)
+		done          = make(chan struct{})
+		goroutineDone = make(chan struct{})
 	)
 
 	go func() {
+		defer close(goroutineDone)
 		for {
 			select {
 			case <-done:
-				close(pop)
 				return
 			case <-pop:
 				b := bq.PopAll()
@@ -286,25 +286,20 @@ func TestBucketQPushPopConcurrency(t *testing.T) {
 	}()
 
 	now := time.Now().Truncate(time.Second).UnixNano()
-	for {
-		select {
-		case <-stop:
-			close(done)
-			return
-		default:
-			count++
-			bq.Push([]timeBucket{
-				{
-					Time: now,
-					Sinks: map[metrics.TimeSeries]metricValue{
-						{}: sink,
-					},
+	for count := range iterations {
+		bq.Push([]timeBucket{
+			{
+				Time: now,
+				Sinks: map[metrics.TimeSeries]metricValue{
+					{}: sink,
 				},
-			})
+			},
+		})
 
-			if count%5 == 0 { // a fixed-arbitrary flush rate
-				pop <- struct{}{}
-			}
+		if count%5 == 0 { // a fixed-arbitrary flush rate
+			pop <- struct{}{}
 		}
 	}
+	close(done)
+	<-goroutineDone
 }

--- a/output/cloud/expv2/metrics_client.go
+++ b/output/cloud/expv2/metrics_client.go
@@ -12,20 +12,26 @@ import (
 	"github.com/klauspost/compress/snappy"
 	"google.golang.org/protobuf/proto"
 
-	"go.k6.io/k6/v2/cloudapi"
 	"go.k6.io/k6/v2/internal/output/cloud/expv2/pbcloud"
 )
+
+// metricsHTTPClient is the interface used by metricsClient to perform HTTP requests.
+// It allows tests to inject a mock that returns immediately without using real HTTP.
+type metricsHTTPClient interface {
+	Do(req *http.Request, v any) error
+	BaseURL() string
+}
 
 // metricsClient is a Protobuf over HTTP client for sending
 // the collected metrics from the Cloud output
 // to the remote service.
 type metricsClient struct {
-	httpClient *cloudapi.Client
+	httpClient metricsHTTPClient
 	url        string
 }
 
 // newMetricsClient creates and initializes a new MetricsClient.
-func newMetricsClient(c *cloudapi.Client, testRunID string) (*metricsClient, error) {
+func newMetricsClient(c metricsHTTPClient, testRunID string) (*metricsClient, error) {
 	// The cloudapi.Client works across different versions of the API, the test
 	// lifecycle management is under /v1 instead the metrics ingestion is /v2.
 	// Unfortunately, the current client has v1 hard-coded so we need to trim the wrong path

--- a/output/cloud/expv2/metrics_client_test.go
+++ b/output/cloud/expv2/metrics_client_test.go
@@ -1,6 +1,7 @@
 package expv2
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"go.k6.io/k6/v2/cloudapi"
 	"go.k6.io/k6/v2/internal/output/cloud/expv2/pbcloud"
 )
@@ -48,16 +50,27 @@ func TestMetricsClientPush(t *testing.T) {
 func TestMetricsClientPushUnexpectedStatus(t *testing.T) {
 	t.Parallel()
 
-	h := func(rw http.ResponseWriter, _ *http.Request) {
-		rw.WriteHeader(http.StatusInternalServerError)
+	// Use a mock that returns immediately without HTTP - no server, no retries.
+	mock := &mockMetricsHTTPClient{
+		doErr: errors.New("500 Internal Server Error"),
 	}
-	ts := httptest.NewServer(http.HandlerFunc(h))
-	defer ts.Close()
-
-	c := cloudapi.NewClient(nil, "fake-token", ts.URL, "k6cloud/v0.4", 1*time.Second)
-	mc, err := newMetricsClient(c, "test-ref-id")
+	mc, err := newMetricsClient(mock, "test-ref-id")
 	require.NoError(t, err)
 
 	err = mc.push(nil)
 	assert.ErrorContains(t, err, "500 Internal Server Error")
+}
+
+// mockMetricsHTTPClient implements metricsHTTPClient for tests.
+// It returns immediately without making HTTP requests.
+type mockMetricsHTTPClient struct {
+	doErr error
+}
+
+func (m *mockMetricsHTTPClient) Do(_ *http.Request, _ any) error {
+	return m.doErr
+}
+
+func (m *mockMetricsHTTPClient) BaseURL() string {
+	return "http://test/v1"
 }

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -306,192 +307,206 @@ func TestOutputStopWithTestError(t *testing.T) {
 
 func TestOutputFlushTicks(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		done := make(chan struct{})
 
-	done := make(chan struct{})
-
-	// It blocks on the first request so it asserts that the flush
-	// operations continues concurrently if one more tick is sent in the meantime.
-	//
-	// The second request unblocks.
-	var requestsCount int64
-	flusherMock := func() {
-		updated := atomic.AddInt64(&requestsCount, 1)
-		if updated == 2 {
-			close(done)
-			return
+		// It blocks on the first request so it asserts that the flush
+		// operations continues concurrently if one more tick is sent in the meantime.
+		//
+		// The second request unblocks.
+		var requestsCount int64
+		flusherMock := func() {
+			updated := atomic.AddInt64(&requestsCount, 1)
+			if updated == 2 {
+				close(done)
+				return
+			}
 		}
-	}
 
-	o := Output{logger: testutils.NewLogger(t)}
-	o.config.MetricPushInterval = types.NullDurationFrom(100 * time.Millisecond) // loop
-	o.flushing = flusherFunc(flusherMock)
-	o.runPeriodicFlush()
+		o := Output{
+			logger: testutils.NewLogger(t),
+			stop:   make(chan struct{}),
+		}
+		o.config.MetricPushInterval = types.NullDurationFrom(100 * time.Millisecond) // loop
+		o.flushing = flusherFunc(flusherMock)
+		o.runPeriodicFlush()
 
-	select {
-	case <-time.After(5 * time.Second):
-		t.Error("timed out")
-	case <-done:
-		assert.NotZero(t, atomic.LoadInt64(&requestsCount))
-	}
+		select {
+		case <-time.After(5 * time.Second):
+			t.Error("timed out")
+		case <-done:
+			assert.NotZero(t, atomic.LoadInt64(&requestsCount))
+		}
+		close(o.stop)
+		synctest.Wait()
+	})
 }
 
 func TestOutputFlushWorkersStop(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		o := Output{
+			logger: testutils.NewLogger(t),
+			stop:   make(chan struct{}),
+		}
+		o.config.MetricPushInterval = types.NullDurationFrom(1 * time.Millisecond)
 
-	t.Skip("test timeouts in CI")
+		once := sync.Once{}
+		flusherMock := func() {
+			// it asserts that flushers are set and the flush is invoked
+			once.Do(func() { close(o.stop) })
+		}
 
-	o := Output{
-		logger: testutils.NewLogger(t),
-		stop:   make(chan struct{}),
-	}
-	o.config.MetricPushInterval = types.NullDurationFrom(1 * time.Millisecond)
+		o.flushing = flusherFunc(flusherMock)
+		o.runPeriodicFlush()
 
-	once := sync.Once{}
-	flusherMock := func() {
-		// it asserts that flushers are set and the flush is invoked
-		once.Do(func() { close(o.stop) })
-	}
-
-	o.flushing = flusherFunc(flusherMock)
-	o.runPeriodicFlush()
-
-	// it asserts that all flushers exit
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		o.wg.Wait()
-	}()
-	select {
-	case <-time.After(time.Second):
-		t.Error("timed out")
-	case <-done:
-	}
+		// it asserts that all flushers exit
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			o.wg.Wait()
+		}()
+		select {
+		case <-time.After(time.Second):
+			t.Error("timed out")
+		case <-done:
+		}
+	})
 }
 
 func TestOutputFlushWorkersAbort(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		o := Output{
+			logger: testutils.NewLogger(t),
+			abort:  make(chan struct{}),
+		}
+		o.config.MetricPushInterval = types.NullDurationFrom(1 * time.Millisecond)
 
-	o := Output{
-		logger: testutils.NewLogger(t),
-		abort:  make(chan struct{}),
-	}
-	o.config.MetricPushInterval = types.NullDurationFrom(1 * time.Millisecond)
+		once := sync.Once{}
+		flusherMock := func() {
+			// it asserts that flushers are set and the flush func is invoked
+			once.Do(func() { close(o.abort) })
+		}
 
-	once := sync.Once{}
-	flusherMock := func() {
-		// it asserts that flushers are set and the flush func is invoked
-		once.Do(func() { close(o.abort) })
-	}
+		o.flushing = flusherFunc(flusherMock)
+		o.runPeriodicFlush()
 
-	o.flushing = flusherFunc(flusherMock)
-	o.runPeriodicFlush()
-
-	// it asserts that all flushers exit
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		o.wg.Wait()
-	}()
-	select {
-	case <-time.After(time.Second):
-		t.Error("timed out")
-	case <-done:
-	}
+		// it asserts that all flushers exit
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			o.wg.Wait()
+		}()
+		select {
+		case <-time.After(time.Second):
+			t.Error("timed out")
+		case <-done:
+		}
+	})
 }
 
 func TestOutputFlushRequestMetadatasConcurrently(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		done := make(chan struct{})
 
-	done := make(chan struct{})
-
-	// It blocks on the first request, so it asserts that the flush
-	// operations continues concurrently if one more tick is sent in the meantime.
-	//
-	// The second request unblocks.
-	var requestsCount int64
-	flusherMock := func() {
-		updated := atomic.AddInt64(&requestsCount, 1)
-		if updated == 2 {
-			close(done)
-			return
+		// It blocks on the first request, so it asserts that the flush
+		// operations continues concurrently if one more tick is sent in the meantime.
+		//
+		// The second request unblocks.
+		var requestsCount int64
+		flusherMock := func() {
+			updated := atomic.AddInt64(&requestsCount, 1)
+			if updated == 2 {
+				close(done)
+				return
+			}
+			<-done
 		}
-		<-done
-	}
 
-	o := Output{logger: testutils.NewLogger(t)}
-	o.config.TracesPushConcurrency = null.IntFrom(2)
-	o.config.TracesPushInterval = types.NullDurationFrom(1) // loop
-	o.requestMetadatasFlusher = flusherFunc(flusherMock)
-	o.runFlushRequestMetadatas()
+		o := Output{
+			logger: testutils.NewLogger(t),
+			stop:   make(chan struct{}),
+		}
+		o.config.TracesPushConcurrency = null.IntFrom(2)
+		o.config.TracesPushInterval = types.NullDurationFrom(1) // loop
+		o.requestMetadatasFlusher = flusherFunc(flusherMock)
+		o.runFlushRequestMetadatas()
 
-	select {
-	case <-time.After(5 * time.Second):
-		t.Error("timed out")
-	case <-done:
-		assert.NotZero(t, atomic.LoadInt64(&requestsCount))
-	}
+		select {
+		case <-time.After(5 * time.Second):
+			t.Error("timed out")
+		case <-done:
+			assert.NotZero(t, atomic.LoadInt64(&requestsCount))
+		}
+		close(o.stop)
+		synctest.Wait()
+	})
 }
 
 func TestOutputFlushRequestMetadatasStop(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		o := Output{
+			logger: testutils.NewLogger(t),
+			stop:   make(chan struct{}),
+		}
+		o.config.TracesPushInterval = types.NullDurationFrom(1 * time.Millisecond)
 
-	o := Output{
-		logger: testutils.NewLogger(t),
-		stop:   make(chan struct{}),
-	}
-	o.config.TracesPushInterval = types.NullDurationFrom(1 * time.Millisecond)
+		once := sync.Once{}
+		flusherMock := func() {
+			// it asserts that flushers are set and the flush is invoked
+			once.Do(func() { close(o.stop) })
+		}
 
-	once := sync.Once{}
-	flusherMock := func() {
-		// it asserts that flushers are set and the flush is invoked
-		once.Do(func() { close(o.stop) })
-	}
+		o.requestMetadatasFlusher = flusherFunc(flusherMock)
+		o.runFlushRequestMetadatas()
 
-	o.requestMetadatasFlusher = flusherFunc(flusherMock)
-	o.runFlushRequestMetadatas()
-
-	// it asserts that all flushers exit
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		o.wg.Wait()
-	}()
-	select {
-	case <-time.After(time.Second):
-		t.Error("timed out")
-	case <-done:
-	}
+		// it asserts that all flushers exit
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			o.wg.Wait()
+		}()
+		select {
+		case <-time.After(time.Second):
+			t.Error("timed out")
+		case <-done:
+		}
+	})
 }
 
 func TestOutputFlushRequestMetadatasAbort(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		o := Output{
+			logger: testutils.NewLogger(t),
+			abort:  make(chan struct{}),
+		}
+		o.config.TracesPushInterval = types.NullDurationFrom(1 * time.Millisecond)
 
-	o := Output{
-		logger: testutils.NewLogger(t),
-		abort:  make(chan struct{}),
-	}
-	o.config.TracesPushInterval = types.NullDurationFrom(1 * time.Millisecond)
+		once := sync.Once{}
+		flusherMock := func() {
+			// it asserts that flushers are set and the flush func is invoked
+			once.Do(func() { close(o.abort) })
+		}
 
-	once := sync.Once{}
-	flusherMock := func() {
-		// it asserts that flushers are set and the flush func is invoked
-		once.Do(func() { close(o.abort) })
-	}
+		o.requestMetadatasFlusher = flusherFunc(flusherMock)
+		o.runFlushRequestMetadatas()
 
-	o.requestMetadatasFlusher = flusherFunc(flusherMock)
-	o.runFlushRequestMetadatas()
-
-	// it asserts that all flushers exit
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		o.wg.Wait()
-	}()
-	select {
-	case <-time.After(time.Second):
-		t.Error("timed out")
-	case <-done:
-	}
+		// it asserts that all flushers exit
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			o.wg.Wait()
+		}()
+		select {
+		case <-time.After(time.Second):
+			t.Error("timed out")
+		case <-done:
+		}
+	})
 }
 
 type flusherFunc func()

--- a/output/helpers_test.go
+++ b/output/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/assert"
@@ -124,20 +125,22 @@ func TestPeriodicFlusherBasics(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, f)
 
-	count := 0
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	f, err = NewPeriodicFlusher(100*time.Millisecond, func() {
-		count++
-		if count == 2 {
-			wg.Done()
-		}
+	synctest.Test(t, func(t *testing.T) {
+		count := 0
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		f, err := NewPeriodicFlusher(100*time.Millisecond, func() {
+			count++
+			if count == 2 {
+				wg.Done()
+			}
+		})
+		assert.NotNil(t, f)
+		assert.Nil(t, err)
+		wg.Wait()
+		f.Stop()
+		assert.Equal(t, 3, count)
 	})
-	assert.NotNil(t, f)
-	assert.Nil(t, err)
-	wg.Wait()
-	f.Stop()
-	assert.Equal(t, 3, count)
 }
 
 func TestPeriodicFlusherConcurrency(t *testing.T) {
@@ -148,30 +151,32 @@ func TestPeriodicFlusherConcurrency(t *testing.T) {
 	randStops := 10 + r.Intn(10)
 	t.Logf("Random source seeded with %d\n", seed)
 
-	count := 0
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-	f, err := NewPeriodicFlusher(1000*time.Microsecond, func() {
-		// Sleep intentionally may be longer than the flush period. Also, this
-		// should never happen concurrently, so it's intentionally not locked.
-		time.Sleep(time.Duration(700+r.Intn(1000)) * time.Microsecond)
-		count++
-		if count == 100 {
-			wg.Done()
-		}
-	})
-	assert.NotNil(t, f)
-	assert.Nil(t, err)
-	wg.Wait()
+	synctest.Test(t, func(t *testing.T) {
+		count := 0
+		wg := &sync.WaitGroup{}
+		wg.Add(1)
+		f, err := NewPeriodicFlusher(1000*time.Microsecond, func() {
+			// Sleep intentionally may be longer than the flush period. Also, this
+			// should never happen concurrently, so it's intentionally not locked.
+			time.Sleep(time.Duration(700+r.Intn(1000)) * time.Microsecond)
+			count++
+			if count == 100 {
+				wg.Done()
+			}
+		})
+		assert.NotNil(t, f)
+		assert.Nil(t, err)
+		wg.Wait()
 
-	stopWG := &sync.WaitGroup{}
-	stopWG.Add(randStops)
-	for range randStops {
-		go func() {
-			f.Stop()
-			stopWG.Done()
-		}()
-	}
-	stopWG.Wait()
-	assert.True(t, count >= 101) // due to the short intervals, we might not get exactly 101
+		stopWG := &sync.WaitGroup{}
+		stopWG.Add(randStops)
+		for range randStops {
+			go func() {
+				f.Stop()
+				stopWG.Done()
+			}()
+		}
+		stopWG.Wait()
+		assert.True(t, count >= 101) // due to the short intervals, we might not get exactly 101
+	})
 }


### PR DESCRIPTION
## What?

Use `testing/synctest` (Go 1.24+) in the output package tests to make time-dependent tests deterministic and fast.

- Wrap time-sensitive tests in `synctest.Test()` across three packages: `output/`, `output/cloud/expv2/`, and `internal/output/cloud/`
- Re-enable `TestOutputFlushWorkersStop`, which had been skipped with `t.Skip("test timeouts in CI")`
- Extract a `metricsHTTPClient` interface in `metrics_client.go` to allow `TestMetricsClientPushUnexpectedStatus` to use an in-process mock instead of an `httptest.Server` (required for synctest compatibility — real HTTP involves retries that would interact badly with fake time)
- Replace a time-bounded concurrency loop (`time.After(100ms)`) in `TestBucketQPushPopConcurrency` with a fixed 1000-iteration loop for determinism

## Why?

`testing/synctest` replaces real wall-clock time with a controllable fake clock inside a bubble. Tests that previously used patterns like:

```go
ticker := time.NewTicker(1 * time.Millisecond)
// ...
select {
case <-time.After(1 * time.Second):
    t.Error("timed out")
case <-done:
}
```

are sensitive to scheduler delays under CI load — the ticker may not fire often enough before the safety timeout. With synctest, fake time advances only when all goroutines in the bubble are blocked, making these tests both deterministic and significantly faster (they no longer spin on real wall-clock intervals).

Closes #5567

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Closes grafana/k6#5567 (`TestOutputFlushWorkersStop` was skipped in grafana/k6#5568 as a workaround)