### PR TITLE
chore: Use synctest within eventloop and timer tests

### DIFF
--- a/internal/js/eventloop/eventloop_test.go
+++ b/internal/js/eventloop/eventloop_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/grafana/sobek"
@@ -36,118 +37,130 @@ func TestBasicEventLoop(t *testing.T) {
 
 func TestEventLoopRegistered(t *testing.T) {
 	t.Parallel()
-	loop := eventloop.New(&modulestest.VU{RuntimeField: sobek.New()})
-	var ran int
-	f := func() error {
-		ran++
-		r := loop.RegisterCallback()
-		go func() {
-			time.Sleep(time.Second)
-			r(func() error {
-				ran++
-				return nil
-			})
-		}()
-		return nil
-	}
-	start := time.Now()
-	require.NoError(t, loop.Start(f))
-	took := time.Since(start)
-	require.Equal(t, 2, ran)
-	require.Less(t, time.Second, took)
-	require.Greater(t, time.Second+time.Millisecond*100, took)
+	synctest.Test(t, func(t *testing.T) {
+		loop := eventloop.New(&modulestest.VU{RuntimeField: sobek.New()})
+		var ran int
+		f := func() error {
+			ran++
+			r := loop.RegisterCallback()
+			go func() {
+				time.Sleep(time.Second)
+				r(func() error {
+					ran++
+					return nil
+				})
+			}()
+			return nil
+		}
+		start := time.Now()
+		require.NoError(t, loop.Start(f))
+		synctest.Wait()
+		took := time.Since(start)
+		require.Equal(t, 2, ran)
+		require.GreaterOrEqual(t, took, time.Second, "should have waited for goroutine sleep")
+		require.LessOrEqual(t, took, time.Second+time.Millisecond*100)
+	})
 }
 
 func TestEventLoopWaitOnRegistered(t *testing.T) {
 	t.Parallel()
-	var ran int
-	loop := eventloop.New(&modulestest.VU{RuntimeField: sobek.New()})
-	f := func() error {
-		ran++
-		r := loop.RegisterCallback()
-		go func() {
-			time.Sleep(time.Second)
-			r(func() error {
-				ran++
-				return nil
-			})
-		}()
-		return fmt.Errorf("expected")
-	}
-	start := time.Now()
-	require.Error(t, loop.Start(f))
-	took := time.Since(start)
-	loop.WaitOnRegistered()
-	took2 := time.Since(start)
-	require.Equal(t, 2, ran)
-	require.Greater(t, time.Millisecond*50, took)
-	require.Less(t, time.Second, took2)
-	require.Greater(t, time.Second+time.Millisecond*100, took2)
-}
-
-func TestEventLoopAllCallbacksGetCalled(t *testing.T) {
-	t.Parallel()
-	sleepTime := time.Millisecond * 500
-	loop := eventloop.New(&modulestest.VU{RuntimeField: sobek.New()})
-	var called int64
-	f := func() error {
-		for i := range 100 {
-			bad := i == 99
+	synctest.Test(t, func(t *testing.T) {
+		var ran int
+		loop := eventloop.New(&modulestest.VU{RuntimeField: sobek.New()})
+		f := func() error {
+			ran++
 			r := loop.RegisterCallback()
-
 			go func() {
-				if !bad {
-					time.Sleep(sleepTime)
-				}
+				time.Sleep(time.Second)
 				r(func() error {
-					if bad {
-						return errors.New("something")
-					}
-					atomic.AddInt64(&called, 1)
+					ran++
 					return nil
 				})
 			}()
+			return fmt.Errorf("expected")
 		}
-		return fmt.Errorf("expected")
-	}
-	for range 3 {
-		called = 0
 		start := time.Now()
 		require.Error(t, loop.Start(f))
 		took := time.Since(start)
 		loop.WaitOnRegistered()
+		synctest.Wait()
 		took2 := time.Since(start)
+		require.Equal(t, 2, ran)
 		require.Greater(t, time.Millisecond*50, took)
-		require.Less(t, sleepTime, took2)
-		require.Greater(t, sleepTime+time.Millisecond*100, took2)
-		require.EqualValues(t, 99, called)
-	}
+		require.GreaterOrEqual(t, took2, time.Second, "WaitOnRegistered should have waited for goroutine")
+		require.LessOrEqual(t, took2, time.Second+time.Millisecond*100)
+	})
+}
+
+func TestEventLoopAllCallbacksGetCalled(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		sleepTime := time.Millisecond * 500
+		loop := eventloop.New(&modulestest.VU{RuntimeField: sobek.New()})
+		var called int64
+		f := func() error {
+			for i := range 100 {
+				bad := i == 99
+				r := loop.RegisterCallback()
+
+				go func() {
+					if !bad {
+						time.Sleep(sleepTime)
+					}
+					r(func() error {
+						if bad {
+							return errors.New("something")
+						}
+						atomic.AddInt64(&called, 1)
+						return nil
+					})
+				}()
+			}
+			return fmt.Errorf("expected")
+		}
+		for range 3 {
+			called = 0
+			start := time.Now()
+			require.Error(t, loop.Start(f))
+			took := time.Since(start)
+			loop.WaitOnRegistered()
+			synctest.Wait()
+			took2 := time.Since(start)
+			require.Greater(t, time.Millisecond*50, took)
+			require.GreaterOrEqual(t, took2, sleepTime, "WaitOnRegistered should have waited for goroutines")
+			require.LessOrEqual(t, took2, sleepTime+time.Millisecond*100)
+			require.EqualValues(t, 99, called)
+		}
+	})
 }
 
 func TestEventLoopPanicOnDoubleCallback(t *testing.T) {
 	t.Parallel()
-	loop := eventloop.New(&modulestest.VU{RuntimeField: sobek.New()})
-	var ran int
-	f := func() error {
-		ran++
-		r := loop.RegisterCallback()
-		go func() {
-			time.Sleep(time.Second)
-			r(func() error {
-				ran++
-				return nil
-			})
+	synctest.Test(t, func(t *testing.T) {
+		loop := eventloop.New(&modulestest.VU{RuntimeField: sobek.New()})
+		var ran int
+		f := func() error {
+			ran++
+			r := loop.RegisterCallback()
+			go func() {
+				time.Sleep(time.Second)
+				r(func() error {
+					ran++
+					return nil
+				})
 
-			require.Panics(t, func() { r(func() error { return nil }) })
-		}()
-		return nil
-	}
-	start := time.Now()
-	require.NoError(t, loop.Start(f))
-	took := time.Since(start)
-	require.Equal(t, 2, ran)
-	require.Less(t, time.Second, took)
-	require.Greater(t, time.Second+time.Millisecond*100, took)
+				require.Panics(t, func() { r(func() error { return nil }) })
+			}()
+			return nil
+		}
+		start := time.Now()
+		require.NoError(t, loop.Start(f))
+		synctest.Wait()
+		took := time.Since(start)
+		require.Equal(t, 2, ran)
+		require.GreaterOrEqual(t, took, time.Second, "should have waited for goroutine sleep")
+		require.LessOrEqual(t, took, time.Second+time.Millisecond*100)
+	})
 }
 
 func TestEventLoopRejectUndefined(t *testing.T) {

--- a/internal/js/tc55/timers/timers_test.go
+++ b/internal/js/tc55/timers/timers_test.go
@@ -3,6 +3,7 @@ package timers_test
 import (
 	"context"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -47,97 +48,103 @@ func TestSetUndefinedFunction(t *testing.T) {
 
 func TestSetInterval(t *testing.T) {
 	t.Parallel()
-	runtime := newRuntime(t)
+	synctest.Test(t, func(t *testing.T) {
+		runtime := newRuntime(t)
 
-	rt := runtime.VU.Runtime()
-	var log []string
-	require.NoError(t, rt.Set("print", func(s string) { log = append(log, s) }))
-	require.NoError(t, rt.Set("sleep10", func() { time.Sleep(10 * time.Millisecond) }))
+		rt := runtime.VU.Runtime()
+		var log []string
+		require.NoError(t, rt.Set("print", func(s string) { log = append(log, s) }))
+		require.NoError(t, rt.Set("sleep10", func() { time.Sleep(10 * time.Millisecond) }))
 
-	_, err := runtime.RunOnEventLoop(`
-		var i = 0;
-		let s = setInterval(()=> {
-			sleep10();
-			if (i>1) {
-			  print("in setInterval");
-			  clearInterval(s);
-			}
-			i++;
-		}, 1);
-		print("outside setInterval")
-	`)
-	require.NoError(t, err)
-	require.Len(t, log, 2)
-	require.Equal(t, "outside setInterval", log[0])
-	for i, l := range log[1:] {
-		require.Equal(t, "in setInterval", l, i)
-	}
+		_, err := runtime.RunOnEventLoop(`
+			var i = 0;
+			let s = setInterval(()=> {
+				sleep10();
+				if (i>1) {
+				  print("in setInterval");
+				  clearInterval(s);
+				}
+				i++;
+			}, 1);
+			print("outside setInterval")
+		`)
+		require.NoError(t, err)
+		require.Len(t, log, 2)
+		require.Equal(t, "outside setInterval", log[0])
+		for i, l := range log[1:] {
+			require.Equal(t, "in setInterval", l, i)
+		}
+	})
 }
 
 func TestSetTimeoutOrder(t *testing.T) {
 	t.Parallel()
-	runtime := newRuntime(t)
+	synctest.Test(t, func(t *testing.T) {
+		runtime := newRuntime(t)
 
-	rt := runtime.VU.Runtime()
-	var log []string
-	require.NoError(t, rt.Set("print", func(s string) { log = append(log, s) }))
+		rt := runtime.VU.Runtime()
+		var log []string
+		require.NoError(t, rt.Set("print", func(s string) { log = append(log, s) }))
 
-	for i := range 100 {
-		_, err := runtime.RunOnEventLoop(`
-			setTimeout((_) => print("one"), 1);
-			setTimeout((_) => print("two"), 1);
-			setTimeout((_) => print("three"), 1);
-			setTimeout((_) => print("last"), 20);
-			setTimeout((_) => print("four"), 1);
-			setTimeout((_) => print("five"), 1);
-			setTimeout((_) => print("six"), 1);
-			print("outside setTimeout");
-		`)
-		require.NoError(t, err)
-		require.Equal(t, []string{"outside setTimeout", "one", "two", "three", "four", "five", "six", "last"}, log, i)
-		log = log[:0]
-	}
+		for i := range 100 {
+			_, err := runtime.RunOnEventLoop(`
+				setTimeout((_) => print("one"), 1);
+				setTimeout((_) => print("two"), 1);
+				setTimeout((_) => print("three"), 1);
+				setTimeout((_) => print("last"), 20);
+				setTimeout((_) => print("four"), 1);
+				setTimeout((_) => print("five"), 1);
+				setTimeout((_) => print("six"), 1);
+				print("outside setTimeout");
+			`)
+			require.NoError(t, err)
+			require.Equal(t, []string{"outside setTimeout", "one", "two", "three", "four", "five", "six", "last"}, log, i)
+			log = log[:0]
+		}
+	})
 }
 
 func TestSetIntervalOrder(t *testing.T) {
 	t.Parallel()
-	runtime := newRuntime(t)
+	synctest.Test(t, func(t *testing.T) {
+		runtime := newRuntime(t)
 
-	rt := runtime.VU.Runtime()
-	var log []string
-	require.NoError(t, rt.Set("print", func(s string) { log = append(log, s) }))
+		rt := runtime.VU.Runtime()
+		var log []string
+		require.NoError(t, rt.Set("print", func(s string) { log = append(log, s) }))
 
-	for range 100 {
-		_, err := runtime.RunOnEventLoop(`
-			var one = setInterval((_) => print("one"), 1);
-			var two = setInterval((_) => print("two"), 1);
-			var last = setInterval((_) => {
-				print("last")
-				clearInterval(one);
-				clearInterval(two);
-				clearInterval(three);
-				clearInterval(last);
-			}, 10);
-			var three = setInterval((_) => print("three"), 1);
-			print("outside");
-		`)
-		require.NoError(t, err)
-		runtime.EventLoop.WaitOnRegistered()
-		require.GreaterOrEqual(t, len(log), 5)
-		require.Equal(t, "outside", log[0])
-		for i := 1; i < len(log)-1; i += 3 {
-			switch len(log) - i {
-			case 2:
-				require.Equal(t, []string{"one"}, log[i:i+1])
-			case 3:
-				require.Equal(t, []string{"one", "two"}, log[i:i+2])
-			default:
-				require.Equal(t, []string{"one", "two", "three"}, log[i:i+3])
+		for range 100 {
+			_, err := runtime.RunOnEventLoop(`
+				var one = setInterval((_) => print("one"), 1);
+				var two = setInterval((_) => print("two"), 1);
+				var last = setInterval((_) => {
+					print("last")
+					clearInterval(one);
+					clearInterval(two);
+					clearInterval(three);
+					clearInterval(last);
+				}, 10);
+				var three = setInterval((_) => print("three"), 1);
+				print("outside");
+			`)
+			require.NoError(t, err)
+			runtime.EventLoop.WaitOnRegistered()
+			require.GreaterOrEqual(t, len(log), 5)
+			require.Equal(t, "outside", log[0])
+			for i := 1; i < len(log)-1; i += 3 {
+				switch len(log) - i {
+				case 2:
+					require.Equal(t, []string{"one"}, log[i:i+1])
+				case 3:
+					require.Equal(t, []string{"one", "two"}, log[i:i+2])
+				default:
+					require.Equal(t, []string{"one", "two", "three"}, log[i:i+3])
+				}
 			}
+			require.Equal(t, "last", log[len(log)-1])
+			log = log[:0]
 		}
-		require.Equal(t, "last", log[len(log)-1])
-		log = log[:0]
-	}
+	})
 }
 
 func TestSetTimeoutContextCancel(t *testing.T) {
@@ -199,21 +206,22 @@ func TestSetTimeoutContextCancel(t *testing.T) {
 
 func TestClearFirstTimeoutWhenMultiple(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runtime := newRuntime(t)
+		rt := runtime.VU.Runtime()
+		var log []time.Time
 
-	runtime := newRuntime(t)
-	rt := runtime.VU.Runtime()
-	var log []time.Time
-
-	start := time.Now()
-	require.NoError(t, rt.Set("time", func() { log = append(log, time.Now()) }))
-	_, err := runtime.RunOnEventLoop(`
-		setTimeout(() => {
-		   time();
-		}, 1000);
-		const cancelTimeout = setTimeout(() => {}, 200);
-		clearTimeout(cancelTimeout);
-	`)
-	require.NoError(t, err)
-	require.Len(t, log, 1)
-	require.Greater(t, log[0].Sub(start), time.Second)
+		start := time.Now()
+		require.NoError(t, rt.Set("time", func() { log = append(log, time.Now()) }))
+		_, err := runtime.RunOnEventLoop(`
+			setTimeout(() => {
+			   time();
+			}, 1000);
+			const cancelTimeout = setTimeout(() => {}, 200);
+			clearTimeout(cancelTimeout);
+		`)
+		require.NoError(t, err)
+		require.Len(t, log, 1)
+		require.GreaterOrEqual(t, log[0].Sub(start), time.Second)
+	})
 }


### PR DESCRIPTION
## What?

Add `testing/synctest` to tests in `internal/js/eventloop` and `internal/js/tc55/timers` to virtualize time, making the tests faster and deterministic.

**Eventloop tests** — wrap `TestEventLoopRegistered`, `TestEventLoopWaitOnRegistered`, `TestEventLoopAllCallbacksGetCalled`, and `TestEventLoopPanicOnDoubleCallback` in `synctest.Test`.

**Timer tests** — wrap `TestSetInterval`, `TestSetTimeoutOrder`, `TestSetIntervalOrder`, and `TestClearFirstTimeoutWhenMultiple` in `synctest.Test`. Also fixes a `require.Greater` → `require.GreaterOrEqual` assertion in `TestClearFirstTimeoutWhenMultiple` since under the virtual clock the 1s timer fires at exactly 1s, not slightly after.

`TestSetTimeoutContextCancel` is intentionally left out: its 2000-iteration loop accumulates goroutines with deferred cleanup across iterations while sharing a single `interruptChannel`; inside a synctest bubble goroutines from earlier iterations fire `Interrupt` into later iterations' event loops, causing a deadlock.

## Why?

The timer and eventloop tests previously waited on real-time delays (1ms–1s `setTimeout`/`setInterval` durations, `time.Sleep` calls), making them slow and potentially flaky on loaded machines. Using `testing/synctest` virtualizes these delays so tests complete near-instantly without changing what is being tested.

Speedups:

| Test | Before | After |
|---|---|---|
| `TestEventLoopRegistered` + 3 related | ~5.7s total | ~1s total |
| `TestSetTimeoutOrder` (100 iter × 20ms) | ~2050ms | ~10ms |
| `TestSetIntervalOrder` (100 iter × 10ms) | ~1050ms | ~20ms |
| `TestClearFirstTimeoutWhenMultiple` (1s timer) | ~1000ms | <1ms |
| `TestSetInterval` (3 iter × 10ms sleep) | ~30ms | <1ms |

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable