### PR TITLE
feat: add pre-manifest dependencies to archive metadata

### DIFF
--- a/internal/cmd/archive.go
+++ b/internal/cmd/archive.go
@@ -26,14 +26,12 @@ func (c *cmdArchive) run(cmd *cobra.Command, args []string) error {
 	// an execution shortcut option (e.g. `iterations` or `duration`),
 	// we will have multiple conflicting execution options since the
 	// derivation will set `scenarios` as well.
-	testRunState, err := test.buildTestRunState(test.consolidatedConfig.Options)
-	if err != nil {
+	if err := test.initRunner.SetOptions(test.consolidatedConfig.Options); err != nil {
 		return err
 	}
 
 	// Archive.
-	arc := testRunState.Runner.MakeArchive()
-	arc.Dependencies = test.preManifestDependencies.toStringMap()
+	arc := test.makeArchive()
 
 	if c.excludeEnvVars {
 		c.gs.Logger.Debug("environment variables will be excluded from the archive")

--- a/internal/cmd/archive.go
+++ b/internal/cmd/archive.go
@@ -33,6 +33,7 @@ func (c *cmdArchive) run(cmd *cobra.Command, args []string) error {
 
 	// Archive.
 	arc := testRunState.Runner.MakeArchive()
+	arc.Dependencies = test.preManifestDependencies.toStringMap()
 
 	if c.excludeEnvVars {
 		c.gs.Logger.Debug("environment variables will be excluded from the archive")

--- a/internal/cmd/archive_test.go
+++ b/internal/cmd/archive_test.go
@@ -91,6 +91,74 @@ func TestArchiveThresholds(t *testing.T) {
 	}
 }
 
+func TestArchiveContainsDependencies(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		script       []byte
+		manifest     string
+		expectedDeps map[string]string
+	}{
+		{
+			name: "no external deps, only k6",
+			script: []byte(`import http from "k6/http";
+export default function () { http.get("https://example.com"); }
+`),
+			expectedDeps: map[string]string{"k6": "*"},
+		},
+		{
+			name: "use directive sets k6 constraint",
+			script: []byte(`"use k6 >= 0.50.0";
+import http from "k6/http";
+export default function () {}
+`),
+			expectedDeps: map[string]string{"k6": ">=0.50.0"},
+		},
+		{
+			name: "manifest overrides star constraint but pre-manifest deps are stored",
+			script: []byte(`import http from "k6/http";
+export default function () {}
+`),
+			manifest:     `{"k6": ">=1.0.0"}`,
+			expectedDeps: map[string]string{"k6": "*"}, // pre-manifest: still "*"
+		},
+		{
+			name: "manifest does not override explicit use directive constraint",
+			script: []byte(`"use k6 >= 0.9.0";
+import http from "k6/http";
+export default function () {}
+`),
+			manifest:     `{"k6": ">=1.0.0"}`,
+			expectedDeps: map[string]string{"k6": ">=0.9.0"}, // pre-manifest: explicit constraint preserved
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fileName := "script.js"
+			ts := tests.NewGlobalTestState(t)
+			require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, fileName), tc.script, 0o644))
+			ts.Flags.DependenciesManifest = tc.manifest
+			ts.CmdArgs = []string{"k6", "archive", fileName}
+
+			newRootCommand(ts.GlobalState).execute()
+			require.NoError(t, testutils.Untar(t, ts.FS, "archive.tar", "tmp/"))
+
+			data, err := fsext.ReadFile(ts.FS, "tmp/metadata.json")
+			require.NoError(t, err)
+
+			metadata := struct {
+				Dependencies map[string]string `json:"dependencies"`
+			}{}
+			require.NoError(t, json.Unmarshal(data, &metadata))
+			require.Equal(t, tc.expectedDeps, metadata.Dependencies)
+		})
+	}
+}
+
 func TestArchiveContainsEnv(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -111,8 +111,7 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	// an execution shortcut option (e.g. `iterations` or `duration`),
 	// we will have multiple conflicting execution options since the
 	// derivation will set `scenarios` as well.
-	testRunState, err := test.buildTestRunState(test.consolidatedConfig.Options)
-	if err != nil {
+	if err := test.initRunner.SetOptions(test.consolidatedConfig.Options); err != nil {
 		return err
 	}
 
@@ -128,8 +127,7 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 	printBar(c.gs, progressBar)
 
 	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Building the archive..."))
-	arc := testRunState.Runner.MakeArchive()
-	arc.Dependencies = test.preManifestDependencies.toStringMap()
+	arc := test.makeArchive()
 
 	tmpCloudConfig, err := cloudapi.GetTemporaryCloudConfig(arc.Options.Cloud)
 	if err != nil {

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -129,6 +129,7 @@ func (c *cmdCloud) run(cmd *cobra.Command, args []string) error {
 
 	modifyAndPrintBar(c.gs, progressBar, pb.WithConstProgress(0, "Building the archive..."))
 	arc := testRunState.Runner.MakeArchive()
+	arc.Dependencies = test.preManifestDependencies.toStringMap()
 
 	tmpCloudConfig, err := cloudapi.GetTemporaryCloudConfig(arc.Options.Cloud)
 	if err != nil {

--- a/internal/cmd/deps.go
+++ b/internal/cmd/deps.go
@@ -51,14 +51,7 @@ func (c *depsCmd) run(cmd *cobra.Command, args []string) error {
 	}
 
 	deps := test.Dependencies()
-	depsMap := map[string]string{}
-	for name, constraint := range test.Dependencies() {
-		if constraint == nil {
-			depsMap[name] = "*"
-			continue
-		}
-		depsMap[name] = constraint.String()
-	}
+	depsMap := deps.toStringMap()
 	imports := test.Imports()
 	slices.Sort(imports)
 

--- a/internal/cmd/deps_test.go
+++ b/internal/cmd/deps_test.go
@@ -14,6 +14,13 @@ import (
 	"go.k6.io/k6/internal/lib/testutils"
 )
 
+// TestGetCmdDeps exercises k6 deps against the standard (non-custom) binary, so
+// every k6/x/ import is unregistered and surfaces via extractUnknownModules.
+// The additional path — where a k6/x/ extension is already registered in the
+// binary and is therefore only captured by the k6/x/ import loop in
+// collectTestDependencies — cannot be exercised end-to-end without a custom
+// binary. That path is covered at unit level by
+// TestCollectTestDependenciesRegisteredExtensions.
 func TestGetCmdDeps(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
@@ -106,6 +113,22 @@ export default function () {
 			expectedDeps:      map[string]string{"k6": "*", "k6/x/alpha": ">=1.2.3", "k6/x/beta": "*"},
 			expectCustomBuild: true,
 			expectedImports:   []string{"/main.js", "/modules/util.js", "/modules/with-directive.js", "k6/x/beta"},
+		},
+		{
+			// k6/x/foo is both directly imported (captured via the k6/x/ import loop,
+			// or via extractUnknownModules on the standard binary) and constrained by
+			// a use directive. The use directive constraint must win over the bare "*".
+			name: "use directive constraint wins over bare import of same extension",
+			files: map[string][]byte{
+				"/main.js": []byte(`"use k6 with k6/x/foo >= 1.2.3";
+import foo from "k6/x/foo";
+
+export default function () { foo(); }
+`),
+			},
+			expectedDeps:      map[string]string{"k6": "*", "k6/x/foo": ">=1.2.3"},
+			expectCustomBuild: true,
+			expectedImports:   []string{"/main.js", "k6/x/foo"},
 		},
 		{
 			name: "manifest overrides default k6 constraint without use directive",

--- a/internal/cmd/outputs.go
+++ b/internal/cmd/outputs.go
@@ -173,9 +173,7 @@ func createOutputs(
 		// with building an archive and setting it on the output instance.
 		if !test.derivedConfig.NoArchiveUpload.Bool {
 			if archiveOut, ok := out.(output.WithArchive); ok {
-				arc := test.initRunner.MakeArchive()
-				arc.Dependencies = test.preManifestDependencies.toStringMap()
-				archiveOut.SetArchive(arc)
+				archiveOut.SetArchive(test.makeArchive())
 			}
 		}
 

--- a/internal/cmd/outputs.go
+++ b/internal/cmd/outputs.go
@@ -173,7 +173,9 @@ func createOutputs(
 		// with building an archive and setting it on the output instance.
 		if !test.derivedConfig.NoArchiveUpload.Bool {
 			if archiveOut, ok := out.(output.WithArchive); ok {
-				archiveOut.SetArchive(test.initRunner.MakeArchive())
+				arc := test.initRunner.MakeArchive()
+				arc.Dependencies = test.preManifestDependencies.toStringMap()
+				archiveOut.SetArchive(arc)
 			}
 		}
 

--- a/internal/cmd/outputs_cloud.go
+++ b/internal/cmd/outputs_cloud.go
@@ -114,8 +114,7 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 
 	var testArchive *lib.Archive
 	if !test.derivedConfig.NoArchiveUpload.Bool {
-		testArchive = test.initRunner.MakeArchive()
-		testArchive.Dependencies = test.preManifestDependencies.toStringMap()
+		testArchive = test.makeArchive()
 	}
 
 	testRun := &cloudapi.TestRun{

--- a/internal/cmd/outputs_cloud.go
+++ b/internal/cmd/outputs_cloud.go
@@ -115,6 +115,7 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 	var testArchive *lib.Archive
 	if !test.derivedConfig.NoArchiveUpload.Bool {
 		testArchive = test.initRunner.MakeArchive()
+		testArchive.Dependencies = test.preManifestDependencies.toStringMap()
 	}
 
 	testRun := &cloudapi.TestRun{

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -50,10 +50,11 @@ type loadedTest struct {
 	initRunner     lib.Runner // TODO: rename to something more appropriate
 	keyLogger      io.Closer
 
-	dependencies       dependencies
-	imports            []string
-	runnerContinuation func() (lib.Runner, error)
-	dependencyErr      error
+	dependencies            dependencies
+	preManifestDependencies dependencies
+	imports                 []string
+	runnerContinuation      func() (lib.Runner, error)
+	dependencyErr           error
 }
 
 func loadLocalTestWithoutRunner(gs *state.GlobalState, cmd *cobra.Command, args []string) (*loadedTest, error) {
@@ -172,8 +173,9 @@ func (lt *loadedTest) prepareFirstRunner(gs *state.GlobalState) error {
 			moduleResolver.LoadMainModule(pwd, specifier, lt.source.Data),
 			exitcodes.ScriptException)
 		lt.imports = moduleResolver.Imported()
-		deps, depErr := resolveModulesDependencies(err, lt.imports, logger, lt.fileSystems, lt.source, gs)
+		deps, preDeps, depErr := resolveModulesDependencies(err, lt.imports, logger, lt.fileSystems, lt.source, gs)
 		lt.dependencies = deps
+		lt.preManifestDependencies = preDeps
 		if depErr != nil {
 			return fmt.Errorf("could not load JS test '%s': %w", testPath, depErr)
 		}
@@ -205,8 +207,9 @@ func (lt *loadedTest) prepareFirstRunner(gs *state.GlobalState) error {
 				moduleResolver.LoadMainModule(pwd, specifier, arc.Data),
 				exitcodes.ScriptException)
 			lt.imports = moduleResolver.Imported()
-			deps, depErr := resolveModulesDependencies(loadErr, lt.imports, logger, arc.Filesystems, lt.source, gs)
+			deps, preDeps, depErr := resolveModulesDependencies(loadErr, lt.imports, logger, arc.Filesystems, lt.source, gs)
 			lt.dependencies = deps
+			lt.preManifestDependencies = preDeps
 			if depErr != nil {
 				return fmt.Errorf("could not load JS test '%s': %w", testPath, depErr)
 			}
@@ -258,42 +261,42 @@ func (lt *loadedTest) Imports() []string {
 func resolveModulesDependencies(
 	originalError error, imports []string, logger logrus.FieldLogger,
 	fileSystems map[string]fsext.Fs, source *loader.SourceData, gs *state.GlobalState,
-) (dependencies, error) {
-	deps, err := collectTestDependencies(originalError, imports, fileSystems, gs.Flags.DependenciesManifest)
+) (dependencies, dependencies, error) {
+	deps, preDeps, err := collectTestDependencies(originalError, imports, fileSystems, gs.Flags.DependenciesManifest)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if !gs.Flags.AutoExtensionResolution {
-		return deps, originalError
+		return deps, preDeps, originalError
 	}
 
 	if len(deps) == 0 {
-		return deps, nil
+		return deps, preDeps, nil
 	}
 
 	if !isCustomBuildRequired(deps, build.Version, ext.GetAll()) {
 		logger.
 			Debug("The current k6 binary already satisfies all the required dependencies," +
 				" it isn't required to provision a new binary.")
-		return deps, nil
+		return deps, preDeps, nil
 	}
 
 	if source.URL.Path == "/-" {
 		gs.Stdin = bytes.NewBuffer(source.Data)
 	}
 
-	return deps, binaryIsNotSatisfyingDependenciesError{
+	return deps, preDeps, binaryIsNotSatisfyingDependenciesError{
 		deps: deps,
 	}
 }
 
 func collectTestDependencies(
 	originalError error, imports []string, fileSystems map[string]fsext.Fs, manifest string,
-) (dependencies, error) {
+) (dependencies, dependencies, error) {
 	deps, err := extractUnknownModules(originalError)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Ensure k6 is always a dependency with "*" constraint by default.
@@ -302,20 +305,40 @@ func collectTestDependencies(
 		deps["k6"] = nil
 	}
 
-	if err := analyseUseContraints(imports, fileSystems, deps); err != nil {
-		return nil, err
+	// Add every k6/x/ import as a dep regardless of whether it is registered in the
+	// current binary. ModuleResolver.Imported() returns all k6/x/ specifiers that were
+	// encountered during loading — both unknown ones (already caught by extractUnknownModules
+	// above) and ones that loaded successfully because they are built into the binary.
+	// The latter case matters for auto-extension-resolution: the first run detects an
+	// unknown k6/x/foo, provisions a custom binary, and re-executes. On the second run
+	// k6/x/foo is registered so extractUnknownModules never fires, but we still need it
+	// in the archive's dependency metadata so downstream consumers know to provision it.
+	for _, imported := range imports {
+		if strings.HasPrefix(imported, "k6/x/") {
+			if _, ok := deps[imported]; !ok {
+				deps[imported] = nil
+			}
+		}
 	}
+
+	if err := analyseUseContraints(imports, fileSystems, deps); err != nil {
+		return nil, nil, err
+	}
+
+	// Snapshot deps before the manifest is applied so callers can record
+	// the script's own declared constraints independently of any external policy.
+	preDeps := maps.Clone(deps)
 
 	m, err := parseManifest(manifest)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	err = deps.applyManifest(m)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return deps, nil
+	return deps, preDeps, nil
 }
 
 func analyseUseContraints(imports []string, fileSystems map[string]fsext.Fs, deps dependencies) error {
@@ -396,6 +419,18 @@ func (d dependencies) String() string {
 		}
 	}
 	return buf.String()
+}
+
+func (d dependencies) toStringMap() map[string]string {
+	m := make(map[string]string, len(d))
+	for k, v := range d {
+		if v == nil {
+			m[k] = "*"
+		} else {
+			m[k] = v.String()
+		}
+	}
+	return m
 }
 
 func dependenciesFromMap(input map[string]string) (dependencies, error) {

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -258,21 +258,23 @@ func (lt *loadedTest) Imports() []string {
 	return append([]string(nil), lt.imports...)
 }
 
+func (lt *loadedTest) makeArchive() *lib.Archive {
+	arc := lt.initRunner.MakeArchive()
+	arc.Dependencies = lt.preManifestDependencies.toStringMap()
+	return arc
+}
+
 func resolveModulesDependencies(
 	originalError error, imports []string, logger logrus.FieldLogger,
 	fileSystems map[string]fsext.Fs, source *loader.SourceData, gs *state.GlobalState,
-) (dependencies, dependencies, error) {
-	deps, preDeps, err := collectTestDependencies(originalError, imports, fileSystems, gs.Flags.DependenciesManifest)
+) (deps, preDeps dependencies, err error) {
+	deps, preDeps, err = collectTestDependencies(originalError, imports, fileSystems, gs.Flags.DependenciesManifest)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	if !gs.Flags.AutoExtensionResolution {
 		return deps, preDeps, originalError
-	}
-
-	if len(deps) == 0 {
-		return deps, preDeps, nil
 	}
 
 	if !isCustomBuildRequired(deps, build.Version, ext.GetAll()) {
@@ -315,9 +317,9 @@ func resolveModulesDependencies(
 // then the external manifest is applied.
 func collectTestDependencies(
 	originalError error, imports []string, fileSystems map[string]fsext.Fs, manifest string,
-) (dependencies, dependencies, error) {
+) (deps, preDeps dependencies, err error) {
 	// Step 1: modules that failed to load.
-	deps, err := extractUnknownModules(originalError)
+	deps, err = extractUnknownModules(originalError)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -337,13 +339,13 @@ func collectTestDependencies(
 	}
 
 	// Step 3: explicit version constraints from "use k6" directives in script files.
-	if err := analyseUseContraints(imports, fileSystems, deps); err != nil {
+	if err = analyseUseContraints(imports, fileSystems, deps); err != nil {
 		return nil, nil, err
 	}
 
 	// Snapshot before the manifest so callers can distinguish what the script
 	// declared from what an external policy required.
-	preDeps := maps.Clone(deps)
+	preDeps = maps.Clone(deps)
 
 	m, err := parseManifest(manifest)
 	if err != nil {

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -291,28 +291,43 @@ func resolveModulesDependencies(
 	}
 }
 
+// collectTestDependencies builds the complete set of build dependencies for a
+// script in three ordered steps, then snapshots them before applying any
+// external manifest override.
+//
+// Step 1 — failed imports (extractUnknownModules): modules that the resolver
+// could not find are the primary signal that an extension is needed.
+//
+// Step 2 — k6/x/ import scan: ModuleResolver.Imported() contains every k6/x/
+// specifier the resolver touched, including ones that loaded successfully
+// because they are already built into the binary. Step 1 misses those.
+// This matters for auto-extension-resolution: on the re-execution with the
+// provisioned binary the extension is registered, so step 1 never fires for
+// it. Step 2 must run before step 3 so that a "use k6 with k6/x/foo >= 1.0"
+// directive found in step 3 can override the nil constraint added here.
+//
+// Step 3 — "use k6" directives (analyseUseContraints): explicit version
+// constraints declared inside script files. These take precedence over the
+// unconstrained entries added by steps 1 and 2 because deps.update only
+// overwrites nil/"*" constraints.
+//
+// After the three steps the map is cloned to preserve the pre-manifest state,
+// then the external manifest is applied.
 func collectTestDependencies(
 	originalError error, imports []string, fileSystems map[string]fsext.Fs, manifest string,
 ) (dependencies, dependencies, error) {
+	// Step 1: modules that failed to load.
 	deps, err := extractUnknownModules(originalError)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	// Ensure k6 is always a dependency with "*" constraint by default.
-	// This can be overridden by "use k6" or "use k6 with k6/x/..." directives in the script.
+	// k6 itself is always a dependency; directives in the script can tighten this.
 	if _, ok := deps["k6"]; !ok {
 		deps["k6"] = nil
 	}
 
-	// Add every k6/x/ import as a dep regardless of whether it is registered in the
-	// current binary. ModuleResolver.Imported() returns all k6/x/ specifiers that were
-	// encountered during loading — both unknown ones (already caught by extractUnknownModules
-	// above) and ones that loaded successfully because they are built into the binary.
-	// The latter case matters for auto-extension-resolution: the first run detects an
-	// unknown k6/x/foo, provisions a custom binary, and re-executes. On the second run
-	// k6/x/foo is registered so extractUnknownModules never fires, but we still need it
-	// in the archive's dependency metadata so downstream consumers know to provision it.
+	// Step 2: all k6/x/ imports, registered or not.
 	for _, imported := range imports {
 		if strings.HasPrefix(imported, "k6/x/") {
 			if _, ok := deps[imported]; !ok {
@@ -321,20 +336,20 @@ func collectTestDependencies(
 		}
 	}
 
+	// Step 3: explicit version constraints from "use k6" directives in script files.
 	if err := analyseUseContraints(imports, fileSystems, deps); err != nil {
 		return nil, nil, err
 	}
 
-	// Snapshot deps before the manifest is applied so callers can record
-	// the script's own declared constraints independently of any external policy.
+	// Snapshot before the manifest so callers can distinguish what the script
+	// declared from what an external policy required.
 	preDeps := maps.Clone(deps)
 
 	m, err := parseManifest(manifest)
 	if err != nil {
 		return nil, nil, err
 	}
-	err = deps.applyManifest(m)
-	if err != nil {
+	if err = deps.applyManifest(m); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/cmd/test_load_test.go
+++ b/internal/cmd/test_load_test.go
@@ -31,6 +31,177 @@ export default () => {
 `
 )
 
+func TestCollectTestDependenciesPreManifestSnapshot(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pre-manifest deps reflect script constraints before override", func(t *testing.T) {
+		t.Parallel()
+
+		// manifest overrides the default "*" k6 constraint
+		manifest := `{"k6": ">=1.0.0"}`
+		deps, preDeps, err := collectTestDependencies(nil, nil, nil, manifest)
+		require.NoError(t, err)
+
+		// post-manifest: k6 constraint is overridden to ">=1.0.0"
+		require.Equal(t, ">=1.0.0", deps["k6"].String())
+		// pre-manifest: k6 constraint is still "*" (nil)
+		require.Nil(t, preDeps["k6"])
+	})
+
+	t.Run("pre-manifest deps are independent from post-manifest deps", func(t *testing.T) {
+		t.Parallel()
+
+		// manifest overrides k6's nil constraint to ">=0.9.0"
+		manifest := `{"k6": ">=0.9.0"}`
+		deps, preDeps, err := collectTestDependencies(nil, nil, nil, manifest)
+		require.NoError(t, err)
+
+		// post-manifest has the constraint; mutating it must not affect the pre-manifest snapshot
+		require.Equal(t, ">=0.9.0", deps["k6"].String())
+		require.Nil(t, preDeps["k6"], "pre-manifest snapshot should still be nil/unconstrained")
+
+		// Mutate the post-manifest map and verify the snapshot is unaffected.
+		delete(deps, "k6")
+		require.Nil(t, preDeps["k6"], "deleting from deps must not affect preDeps")
+		require.Contains(t, preDeps, "k6", "preDeps should still contain k6 after mutation of deps")
+	})
+
+	t.Run("explicit use directive constraint is preserved in pre-manifest deps", func(t *testing.T) {
+		t.Parallel()
+
+		fs := testutils.MakeMemMapFs(t, map[string][]byte{
+			"/script.js": []byte(`"use k6 >= 0.9.0";
+export default function () {}
+`),
+		})
+
+		manifest := `{"k6": ">=1.0.0"}`
+		deps, preDeps, err := collectTestDependencies(nil, []string{"file:///script.js"}, map[string]fsext.Fs{"file": fs}, manifest)
+		require.NoError(t, err)
+
+		// manifest does not override an explicit constraint — both pre and post should match
+		require.Equal(t, ">=0.9.0", deps["k6"].String())
+		require.Equal(t, ">=0.9.0", preDeps["k6"].String())
+	})
+
+	t.Run("pre-manifest deps include use-directive extension constraints", func(t *testing.T) {
+		t.Parallel()
+
+		fs := testutils.MakeMemMapFs(t, map[string][]byte{
+			"/script.js": []byte(`"use k6 with k6/x/sql >= 0.4.0";
+export default function () {}
+`),
+		})
+
+		manifest := `{"k6/x/sql": ">=1.0.0"}`
+		deps, preDeps, err := collectTestDependencies(nil, []string{"file:///script.js"}, map[string]fsext.Fs{"file": fs}, manifest)
+		require.NoError(t, err)
+
+		// The explicit ">=0.4.0" constraint from use directive is not overridden by manifest
+		require.Equal(t, ">=0.4.0", deps["k6/x/sql"].String())
+		require.Equal(t, ">=0.4.0", preDeps["k6/x/sql"].String())
+	})
+
+	t.Run("pre-manifest snapshot has nil constraint for unconstrained star dep", func(t *testing.T) {
+		t.Parallel()
+
+		// no manifest, no use directives — k6 gets the default nil/"*" constraint
+		deps, preDeps, err := collectTestDependencies(nil, nil, nil, "")
+		require.NoError(t, err)
+
+		require.Nil(t, deps["k6"])
+		require.Nil(t, preDeps["k6"])
+	})
+}
+
+func TestCollectTestDependenciesRegisteredExtensions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("k6/x/ import with no error is still captured as dep", func(t *testing.T) {
+		t.Parallel()
+		// Simulate the second run of auto-extension-resolution: k6/x/foo is now registered
+		// so LoadMainModule succeeds (originalError = nil), but k6/x/foo still appears in
+		// the imports list returned by moduleResolver.Imported().
+		deps, preDeps, err := collectTestDependencies(nil, []string{"k6/x/foo", "k6/http"}, nil, "")
+		require.NoError(t, err)
+
+		require.Nil(t, deps["k6/x/foo"], "registered extension should be in deps with nil constraint")
+		require.Nil(t, preDeps["k6/x/foo"], "registered extension should be in pre-manifest deps")
+		require.NotContains(t, deps, "k6/http", "built-in k6 modules should not be added as deps")
+	})
+
+	t.Run("multiple k6/x/ imports are all captured", func(t *testing.T) {
+		t.Parallel()
+		// All k6/x/ imports from Imported() should appear in deps,
+		// even when originalError is nil (registered extensions).
+		deps, preDeps, err := collectTestDependencies(nil, []string{"k6/x/foo", "k6/x/bar"}, nil, "")
+		require.NoError(t, err)
+
+		require.Nil(t, deps["k6/x/foo"])
+		require.Nil(t, deps["k6/x/bar"])
+		require.Nil(t, preDeps["k6/x/foo"])
+		require.Nil(t, preDeps["k6/x/bar"])
+		require.Len(t, deps, 3, "should have k6, k6/x/foo, k6/x/bar")
+	})
+
+	t.Run("k6/x/ import with use directive constraint is preserved", func(t *testing.T) {
+		t.Parallel()
+		// The new loop adds k6/x/foo with nil, then analyseUseContraints overrides it
+		// with the explicit constraint from the use directive.
+		fs := testutils.MakeMemMapFs(t, map[string][]byte{
+			"/script.js": []byte(`"use k6 with k6/x/foo >= 1.0.0";
+export default function () {}
+`),
+		})
+		deps, preDeps, err := collectTestDependencies(
+			nil,
+			[]string{"file:///script.js", "k6/x/foo"},
+			map[string]fsext.Fs{"file": fs},
+			"",
+		)
+		require.NoError(t, err)
+
+		require.Equal(t, ">=1.0.0", deps["k6/x/foo"].String(), "use directive should set the constraint")
+		require.Equal(t, ">=1.0.0", preDeps["k6/x/foo"].String())
+	})
+}
+
+func TestDependenciesToStringMap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil constraint becomes star", func(t *testing.T) {
+		t.Parallel()
+		d := dependencies{"k6": nil}
+		m := d.toStringMap()
+		require.Equal(t, map[string]string{"k6": "*"}, m)
+	})
+
+	t.Run("constraint string is preserved", func(t *testing.T) {
+		t.Parallel()
+		c, err := semver.NewConstraint(">=0.4.0")
+		require.NoError(t, err)
+		d := dependencies{"k6/x/sql": c}
+		m := d.toStringMap()
+		require.Equal(t, map[string]string{"k6/x/sql": ">=0.4.0"}, m)
+	})
+
+	t.Run("empty dependencies produces empty map", func(t *testing.T) {
+		t.Parallel()
+		d := dependencies{}
+		m := d.toStringMap()
+		require.Empty(t, m)
+	})
+
+	t.Run("mixed nil and constrained", func(t *testing.T) {
+		t.Parallel()
+		c, err := semver.NewConstraint(">=1.2.3")
+		require.NoError(t, err)
+		d := dependencies{"k6": nil, "k6/x/foo": c}
+		m := d.toStringMap()
+		require.Equal(t, map[string]string{"k6": "*", "k6/x/foo": ">=1.2.3"}, m)
+	})
+}
+
 func TestAnalyseUseConstraints(t *testing.T) {
 	t.Parallel()
 

--- a/lib/archive.go
+++ b/lib/archive.go
@@ -72,6 +72,11 @@ type Archive struct {
 
 	K6Version string `json:"k6version"`
 	Goos      string `json:"goos"`
+
+	// Dependencies contains the script's declared build dependencies before any manifest overrides.
+	// Keys are dependency names (e.g. "k6", "k6/x/sql"), values are semver constraint strings
+	// or "*" for unconstrained. This field is omitted for archives created by older k6 versions.
+	Dependencies map[string]string `json:"dependencies,omitempty"`
 }
 
 func (arc *Archive) getFs(name string) fsext.Fs {

--- a/lib/archive_test.go
+++ b/lib/archive_test.go
@@ -154,6 +154,69 @@ func TestArchiveReadWrite(t *testing.T) {
 		diffMapFilesystems(t, arc1Filesystems, arc2Filesystems)
 	})
 
+	t.Run("RoundtripWithDependencies", func(t *testing.T) {
+		t.Parallel()
+		arc1 := &Archive{
+			Type:      "js",
+			K6Version: build.Version,
+			Options: Options{
+				VUs:        null.IntFrom(1),
+				SystemTags: &metrics.DefaultSystemTagSet,
+			},
+			FilenameURL: &url.URL{Scheme: "file", Path: "/path/to/a.js"},
+			Data:        []byte(`// a contents`),
+			PwdURL:      &url.URL{Scheme: "file", Path: "/path/to"},
+			Filesystems: map[string]fsext.Fs{
+				"file": testutils.MakeMemMapFs(t, map[string][]byte{
+					"/path/to/a.js": []byte(`// a contents`),
+				}),
+				"https": testutils.MakeMemMapFs(t, map[string][]byte{}),
+			},
+			Dependencies: map[string]string{
+				"k6":       "*",
+				"k6/x/sql": ">=0.4.0",
+			},
+		}
+
+		buf := bytes.NewBuffer(nil)
+		require.NoError(t, arc1.Write(buf))
+
+		arc2, err := ReadArchive(buf)
+		require.NoError(t, err)
+
+		assert.Equal(t, arc1.Dependencies, arc2.Dependencies)
+	})
+
+	t.Run("RoundtripNilDependencies", func(t *testing.T) {
+		t.Parallel()
+		arc1 := &Archive{
+			Type:      "js",
+			K6Version: build.Version,
+			Options: Options{
+				VUs:        null.IntFrom(1),
+				SystemTags: &metrics.DefaultSystemTagSet,
+			},
+			FilenameURL: &url.URL{Scheme: "file", Path: "/path/to/a.js"},
+			Data:        []byte(`// a contents`),
+			PwdURL:      &url.URL{Scheme: "file", Path: "/path/to"},
+			Filesystems: map[string]fsext.Fs{
+				"file": testutils.MakeMemMapFs(t, map[string][]byte{
+					"/path/to/a.js": []byte(`// a contents`),
+				}),
+				"https": testutils.MakeMemMapFs(t, map[string][]byte{}),
+			},
+			Dependencies: nil,
+		}
+
+		buf := bytes.NewBuffer(nil)
+		require.NoError(t, arc1.Write(buf))
+
+		arc2, err := ReadArchive(buf)
+		require.NoError(t, err)
+
+		assert.Nil(t, arc2.Dependencies)
+	})
+
 	t.Run("Anonymized", func(t *testing.T) {
 		t.Parallel()
 		testdata := []struct {


### PR DESCRIPTION
## What?

Add a `dependencies` field to the archive's `metadata.json`. The field records the script's declared build dependencies — via unknown module imports and `"use k6"` directives — **before any external manifest overrides** are applied.

The field is populated at all four archive-creation paths: `k6 archive`, `k6 cloud`, `k6 run --out cloud`, and `k6 cloud run --local-execution`. It is omitted (`omitempty`) for backwards compatibility with archives created by older k6 versions.

## Why?

Cloud consumers need to know what a script itself requires, independently of any org-level manifest policies that may have been applied locally. Storing the pre-manifest snapshot lets the cloud apply its own constraints without losing the script's original intent.

Additionally, `k6/x/` imports are now captured regardless of whether the extension is registered in the current binary. Without this, auto-extension-resolution would silently drop an extension from the archive metadata on the second execution (when the extension is registered and no longer "unknown" to the loader).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

<!-- Closes #ISSUE-ID -->