### PR TITLE
Remove SingleCounterForRate option from OTEL output

### DIFF
--- a/internal/output/opentelemetry/config.go
+++ b/internal/output/opentelemetry/config.go
@@ -68,11 +68,6 @@ type Config struct {
 	// GRPCExporterInsecure disables client transport security for the Exporter's gRPC
 	// connection.
 	GRPCExporterInsecure null.Bool `json:"grpcExporterInsecure" envconfig:"K6_OTEL_GRPC_EXPORTER_INSECURE"`
-
-	// SingleCounterForRate sets the feature flag defining how to export metrics defined as Rate type.
-	// When it is set to true, metrics are exported as a single counter, using an attribute as discriminator.
-	// When the opposite, the old method is used generating two different counters.
-	SingleCounterForRate null.Bool `json:"singleCounterForRate" envconfig:"K6_OTEL_SINGLE_COUNTER_FOR_RATE"`
 }
 
 // GetConsolidatedConfig combines the options' values from the different sources
@@ -123,8 +118,6 @@ func newDefaultConfig() Config {
 
 		ExportInterval: types.NewNullDuration(10*time.Second, false),
 		FlushInterval:  types.NewNullDuration(1*time.Second, false),
-
-		SingleCounterForRate: null.NewBool(true, false),
 	}
 }
 
@@ -192,10 +185,6 @@ func (cfg Config) Apply(v Config) Config {
 
 	if v.Headers.Valid {
 		cfg.Headers = v.Headers
-	}
-
-	if v.SingleCounterForRate.Valid {
-		cfg.SingleCounterForRate = v.SingleCounterForRate
 	}
 
 	return cfg

--- a/internal/output/opentelemetry/config_test.go
+++ b/internal/output/opentelemetry/config_test.go
@@ -33,7 +33,6 @@ func TestConfig(t *testing.T) {
 				GRPCExporterEndpoint: null.NewString("localhost:4317", false),
 				ExportInterval:       types.NewNullDuration(10*time.Second, false),
 				FlushInterval:        types.NewNullDuration(1*time.Second, false),
-				SingleCounterForRate: null.NewBool(true, false),
 			},
 		},
 
@@ -50,7 +49,6 @@ func TestConfig(t *testing.T) {
 				GRPCExporterEndpoint: null.NewString("else", true),
 				ExportInterval:       types.NewNullDuration(4*time.Millisecond, true),
 				FlushInterval:        types.NewNullDuration(1*time.Second, false),
-				SingleCounterForRate: null.NewBool(true, false),
 			},
 		},
 
@@ -71,7 +69,6 @@ func TestConfig(t *testing.T) {
 				"K6_OTEL_TLS_CLIENT_CERTIFICATE":   "client_cert_path",
 				"K6_OTEL_TLS_CLIENT_KEY":           "client_key_path",
 				"K6_OTEL_HEADERS":                  "key1=value1,key2=value2",
-				"K6_OTEL_SINGLE_COUNTER_FOR_RATE":  "false",
 			},
 			expectedConfig: Config{
 				ServiceName:           null.NewString("foo", true),
@@ -89,7 +86,6 @@ func TestConfig(t *testing.T) {
 				TLSClientCertificate:  null.NewString("client_cert_path", true),
 				TLSClientKey:          null.NewString("client_key_path", true),
 				Headers:               null.NewString("key1=value1,key2=value2", true),
-				SingleCounterForRate:  null.NewBool(false, true),
 			},
 		},
 
@@ -108,7 +104,6 @@ func TestConfig(t *testing.T) {
 				GRPCExporterEndpoint: null.NewString("localhost:4317", false),
 				ExportInterval:       types.NewNullDuration(10*time.Second, false),
 				FlushInterval:        types.NewNullDuration(1*time.Second, false),
-				SingleCounterForRate: null.NewBool(true, false),
 			},
 		},
 
@@ -129,8 +124,7 @@ func TestConfig(t *testing.T) {
 					`"tlsCertificate":"cert_path",` +
 					`"tlsClientCertificate":"client_cert_path",` +
 					`"tlsClientKey":"client_key_path",` +
-					`"headers":"key1=value1,key2=value2",` +
-					`"singleCounterForRate":false` +
+					`"headers":"key1=value1,key2=value2"` +
 					`}`,
 			),
 			expectedConfig: Config{
@@ -149,7 +143,6 @@ func TestConfig(t *testing.T) {
 				TLSClientCertificate:  null.NewString("client_cert_path", true),
 				TLSClientKey:          null.NewString("client_key_path", true),
 				Headers:               null.NewString("key1=value1,key2=value2", true),
-				SingleCounterForRate:  null.NewBool(false, true),
 			},
 		},
 
@@ -166,7 +159,6 @@ func TestConfig(t *testing.T) {
 				GRPCExporterEndpoint: null.NewString("localhost:4317", false), // default
 				ExportInterval:       types.NewNullDuration(15*time.Millisecond, true),
 				FlushInterval:        types.NewNullDuration(1*time.Second, false),
-				SingleCounterForRate: null.NewBool(true, false),
 			},
 		},
 		"no scheme in http exporter protocol": {

--- a/internal/output/opentelemetry/output.go
+++ b/internal/output/opentelemetry/output.go
@@ -72,11 +72,6 @@ func (o *Output) Stop() error {
 func (o *Output) Start() error {
 	o.logger.Debug("Starting output...")
 
-	if !o.config.SingleCounterForRate.Bool {
-		o.logger.Warn("Exporting rate metrics as a pair of counters is deprecated" +
-			" and will be removed in future releases. Please migrate to the new format.")
-	}
-
 	exp, err := getExporter(o.config)
 	if err != nil {
 		return fmt.Errorf("failed to create OpenTelemetry exporter: %w", err)
@@ -179,36 +174,12 @@ func (o *Output) dispatch(entry metrics.Sample) error {
 
 		trend.Record(ctx, entry.Value, attributeSetOpt)
 	case metrics.Rate:
-		var err error
-		if o.config.SingleCounterForRate.Bool {
-			err = o.singleCounterForRate(ctx, name, attributeSetOpt, entry)
-		} else {
-			// Deprecated path, remove with https://github.com/grafana/k6/issues/5185
-			err = o.pairOfCountersForRate(ctx, name, attributeSetOpt, entry)
-		}
-		if err != nil {
+		if err := o.singleCounterForRate(ctx, name, attributeSetOpt, entry); err != nil {
 			return err
 		}
 	default:
 		return fmt.Errorf("metric %q has unsupported metric type", entry.Metric.Name)
 	}
-	return nil
-}
-
-func (o *Output) pairOfCountersForRate(
-	ctx context.Context,
-	metricName string,
-	attributeSetOpt otelMetric.MeasurementOption,
-	entry metrics.Sample,
-) error {
-	nonZero, total, err := o.metricsRegistry.getOrCreateCountersForRate(metricName)
-	if err != nil {
-		return fmt.Errorf("get or create counter for Rate metric %q: %w", metricName, err)
-	}
-	if entry.Value != 0 {
-		nonZero.Add(ctx, 1, attributeSetOpt)
-	}
-	total.Add(ctx, 1, attributeSetOpt)
 	return nil
 }
 

--- a/internal/output/opentelemetry/registry.go
+++ b/internal/output/opentelemetry/registry.go
@@ -107,56 +107,6 @@ func (r *registry) getOrCreateCounterForRate(name string) (otelMetric.Int64Count
 	return totalCounter, nil
 }
 
-// Deprecated: Metrics of Rate type are now exported using a single counter,
-// we want to remove the support for exporting via the pair of counters on k6 v1.4.0.
-func (r *registry) getOrCreateCountersForRate(name string) (otelMetric.Int64Counter, otelMetric.Int64Counter, error) {
-	// k6's rate metric tracks how frequently a non-zero value occurs.
-	// so to correctly calculate the rate in a metrics backend
-	// we need to split the rate metric into two counters:
-	// 2. number of non-zero occurrences
-	// 1. the total number of occurrences
-
-	nonZeroName := name + ".occurred"
-	totalName := name + ".total"
-
-	var err error
-	var nonZeroCounter, totalCounter otelMetric.Int64Counter
-
-	storedNonZeroCounter, ok := r.rateCounters.Load(nonZeroName)
-	if !ok {
-		nonZeroCounter, err = r.meter.Int64Counter(nonZeroName)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create counter for %q: %w", nonZeroName, err)
-		}
-
-		r.rateCounters.Store(nonZeroName, nonZeroCounter)
-		r.logger.Debugf("registered counter metric %q", nonZeroName)
-	} else {
-		nonZeroCounter, ok = storedNonZeroCounter.(otelMetric.Int64Counter)
-		if !ok {
-			return nil, nil, fmt.Errorf("metric %q stored not as counter", nonZeroName)
-		}
-	}
-
-	storedTotalCounter, ok := r.rateCounters.Load(totalName)
-	if !ok {
-		totalCounter, err = r.meter.Int64Counter(totalName)
-		if err != nil {
-			return nil, nil, fmt.Errorf("failed to create counter for %q: %w", totalName, err)
-		}
-
-		r.rateCounters.Store(totalName, totalCounter)
-		r.logger.Debugf("registered counter metric %q", totalName)
-	} else {
-		totalCounter, ok = storedTotalCounter.(otelMetric.Int64Counter)
-		if !ok {
-			return nil, nil, fmt.Errorf("metric %q stored not as counter", totalName)
-		}
-	}
-
-	return nonZeroCounter, totalCounter, nil
-}
-
 func (r *registry) getOrCreateGauge(name, unit string) (otelMetric.Float64Gauge, error) {
 	if gauge, ok := r.gauges.Load(name); ok {
 		if v, ok := gauge.(otelMetric.Float64Gauge); ok {


### PR DESCRIPTION
## What?

Remove the deprecated `SingleCounterForRate` config option and all supporting code from the OpenTelemetry output. Rate metrics are now always exported as a single counter with a `condition` attribute (`nonzero`/`zero`).

## Why?

The `SingleCounterForRate` option was added in PR #5164 as a temporary escape hatch so users could revert to the old pair-of-counters behavior (`<metric>.occurred` + `<metric>.total`) for one release cycle. The old method had a cold-startup bug where `.occurred` was never created if the rate never fired (see #4573).

The issue explicitly stated: *"This option is temporary and will be removed in the release following its introduction."* v2 is the appropriate semver boundary for this removal.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Feature flag introduction: https://github.com/grafana/k6/pull/5164
- Original rate metric issue: https://github.com/grafana/k6/issues/4573

Closes #5185