### PR TITLE
Remove deprecated --upload-only flag

### DIFF
--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -70,16 +70,6 @@ func (c *cmdCloud) preRun(cmd *cobra.Command, _ []string) error {
 			c.exitOnRunning = exitOnRunningValue
 		}
 	}
-	if uploadOnlyEnv, ok := c.gs.Env["K6_CLOUD_UPLOAD_ONLY"]; ok {
-		uploadOnlyValue, err := strconv.ParseBool(uploadOnlyEnv)
-		if err != nil {
-			return fmt.Errorf("parsing K6_CLOUD_UPLOAD_ONLY returned an error: %w", err)
-		}
-		if !cmd.Flags().Changed("upload-only") {
-			c.uploadOnly = uploadOnlyValue
-		}
-	}
-
 	return nil
 }
 
@@ -370,12 +360,6 @@ func (c *cmdCloud) flagSet() *pflag.FlagSet {
 		"exits when test reaches the running status")
 	flags.BoolVar(&c.showCloudLogs, "show-logs", c.showCloudLogs,
 		"enable showing of logs when a test is executed in the cloud")
-	flags.BoolVar(&c.uploadOnly, "upload-only", c.uploadOnly,
-		"only upload the test to the cloud without actually starting a test run")
-	if err := flags.MarkDeprecated("upload-only", "use \"k6 cloud upload\" instead"); err != nil {
-		panic(err) // Should never happen
-	}
-
 	return flags
 }
 
@@ -384,7 +368,6 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 		gs:            gs,
 		showCloudLogs: true,
 		exitOnRunning: false,
-		uploadOnly:    false,
 	}
 
 	exampleText := getExampleText(gs, `

--- a/internal/cmd/tests/cmd_cloud_test.go
+++ b/internal/cmd/tests/cmd_cloud_test.go
@@ -92,26 +92,6 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		assert.Contains(t, stdout, `test status: Running`)
 	})
 
-	t.Run("TestCloudUploadOnly", func(t *testing.T) {
-		t.Parallel()
-
-		cs := func() cloudapi.TestProgressResponse {
-			return cloudapi.TestProgressResponse{
-				RunStatusText: "Archived",
-				RunStatus:     cloudapi.RunStatusArchived,
-			}
-		}
-
-		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--upload-only", "--log-output=stdout"}, nil, cs)
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, `execution: cloud`)
-		assert.Contains(t, stdout, `output: https://app.k6.io/runs/123`)
-		assert.Contains(t, stdout, `test status: Archived`)
-	})
-
 	t.Run("TestCloudWithConfigOverride", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
## What?

Remove the deprecated `--upload-only` CLI flag and `K6_CLOUD_UPLOAD_ONLY` environment variable from the `k6 cloud` command.

## Why?

The `--upload-only` flag was deprecated in #3906 (August 2024) in favor of the `k6 cloud upload` subcommand. v2 is the appropriate semver boundary for removing this deprecated flag.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Closes #5843
- Original deprecation: #3906
- Cloud subcommands restructuring: #3813