### PR TITLE
Handle Go module pseudo-versions in dependency constraint checking

### DIFF
--- a/internal/cmd/deps.go
+++ b/internal/cmd/deps.go
@@ -12,7 +12,6 @@ import (
 
 	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/ext"
-	"go.k6.io/k6/v2/internal/build"
 )
 
 type depsCmd struct {
@@ -55,7 +54,11 @@ func (c *depsCmd) run(cmd *cobra.Command, args []string) error {
 	imports := test.Imports()
 	slices.Sort(imports)
 
-	customBuildRequired := isCustomBuildRequired(deps, build.Version, ext.GetAll())
+	checkErr := checkBuiltinDependencies(deps, runtimeK6Version(), ext.GetAll())
+	if checkErr != nil {
+		c.gs.Logger.WithError(checkErr).Debug("Current binary does not satisfy all dependencies, custom build required")
+	}
+	customBuildRequired := checkErr != nil
 
 	if c.isJSON {
 		return c.outputJSON(depsMap, imports, customBuildRequired)

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -275,12 +275,21 @@ func checkVersionConstraint(name, version string, constraint *semver.Constraints
 // checkConstraintBySHA checks if vSHA matches the SHA embedded in constraint.
 // Returns (satisfied, definitive): definitive=false means the constraint has no
 // embedded SHA and normal semver comparison should be used instead.
+// SHA matching is only applied to exact-version constraints (operator "=" or no
+// operator); all other operators fall back to normal semver comparison.
 func checkConstraintBySHA(vSHA string, constraint *semver.Constraints) (bool, bool) {
 	cs := constraint.String()
+	// Compound constraints cannot be matched by SHA alone; refuse definitively
+	// so the caller does not fall back to semver, which mishandles pseudo-versions.
 	if strings.ContainsAny(cs, " ,") {
+		return false, true
+	}
+	versionStr := constraintVersionStr(cs)
+	operator := cs[:len(cs)-len(versionStr)]
+	if operator != "" && operator != "=" {
 		return false, false
 	}
-	cv, err := semver.NewVersion(constraintVersionStr(cs))
+	cv, err := semver.NewVersion(versionStr)
 	if err != nil {
 		return false, false
 	}

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -120,14 +120,99 @@ func (b *customBinary) run(gs *state.GlobalState) error {
 // used just to signal we shouldn't print error again
 var errAlreadyReported = fmt.Errorf("already reported error")
 
-// isCustomBuildRequired checks if there is at least one dependency that are not satisfied by the binary
-// considering the version of k6 and any built-in extension
-func isCustomBuildRequired(deps dependencies, k6Version string, exts []*ext.Extension) bool {
-	if len(deps) == 0 {
+// isHexString reports whether s is non-empty and contains only lowercase hex digits.
+func isHexString(s string) bool {
+	return s != "" && strings.IndexFunc(s, func(r rune) bool {
+		return (r < '0' || r > '9') && (r < 'a' || r > 'f')
+	}) < 0
+}
+
+// versionSHA extracts the commit SHA from an already-parsed semver Version.
+// It handles two forms:
+//
+//	build metadata:  v0.0.0+sha   → v.Metadata() = "sha"
+//	pseudo-version:  v0.0.0-YYYYMMDDHHMMSS-sha → last segment of v.Prerelease()
+func versionSHA(v *semver.Version) (string, bool) {
+	if m := v.Metadata(); isHexString(m) {
+		return m, true
+	}
+	if pre := v.Prerelease(); pre != "" {
+		parts := strings.Split(pre, "-")
+		if len(parts) > 1 {
+			if last := parts[len(parts)-1]; isHexString(last) {
+				return last, true
+			}
+		}
+	}
+	return "", false
+}
+
+// extractVersionSHA parses version and returns any embedded commit SHA.
+//
+//	v0.0.0-20241015123456-abcdef123456  → "abcdef123456", true
+//	v0.0.0+abc123                       → "abc123",       true
+//	v1.2.3                              → "",             false
+func extractVersionSHA(version string) (string, bool) {
+	v, err := semver.NewVersion(version)
+	if err != nil {
+		return "", false
+	}
+	return versionSHA(v)
+}
+
+// constraintVersionStr returns the bare version token from a single constraint
+// string by skipping any leading operator characters. Module versions always
+// start with 'v', so the first 'v' marks the start of the version.
+func constraintVersionStr(cs string) string {
+	if i := strings.IndexByte(cs, 'v'); i >= 0 {
+		return cs[i:]
+	}
+	return ""
+}
+
+// pseudoVersionSatisfies reports whether version satisfies c by comparing the
+// commit SHAs embedded in both strings. It only applies when:
+//   - version contains a recognisable SHA (pseudo-version or build-metadata form)
+//   - c is a single exact-version constraint whose version also contains a SHA
+//   - one SHA is a prefix of the other (handles 7-char vs 12-char short SHAs)
+func pseudoVersionSatisfies(version string, c *semver.Constraints) bool {
+	sv, err := semver.NewVersion(version)
+	if err != nil {
 		return false
 	}
+	vSHA, ok := versionSHA(sv)
+	if !ok {
+		return false
+	}
+	satisfied, definitive := checkConstraintBySHA(vSHA, c)
+	return definitive && satisfied
+}
 
-	// collect modules that this binary contain, including k6 itself
+// unsatisfiedDependencyError describes the first dependency that the current
+// binary cannot satisfy. version is empty when the dependency is absent entirely.
+type unsatisfiedDependencyError struct {
+	name       string
+	version    string // built-in version; empty if not present
+	constraint string // required constraint
+}
+
+func (e unsatisfiedDependencyError) Error() string {
+	if e.version == "" {
+		return fmt.Sprintf("dependency %q is not present in the current binary", e.name)
+	}
+	return fmt.Sprintf("dependency %q: version %q does not satisfy constraint %q",
+		e.name, e.version, e.constraint)
+}
+
+// checkBuiltinDependencies returns the first dependency from deps that is not
+// satisfied by the built-in modules of the current binary (k6 itself plus any
+// compiled-in extensions). Returns nil when all dependencies are satisfied.
+func checkBuiltinDependencies(deps dependencies, k6Version string, exts []*ext.Extension) error {
+	if len(deps) == 0 {
+		return nil
+	}
+
+	// collect modules that this binary contains, including k6 itself
 	builtIn := map[string]string{"k6": k6Version}
 	for _, e := range exts {
 		builtIn[e.Name] = e.Version
@@ -135,31 +220,75 @@ func isCustomBuildRequired(deps dependencies, k6Version string, exts []*ext.Exte
 
 	for name, constraint := range deps {
 		version, provided := builtIn[name]
-		// if the binary does not contain a required module, we need a custom
 		if !provided {
-			return true
+			return unsatisfiedDependencyError{name: name}
 		}
-
-		// If dependency's constraint is null, assume it is "*" and consider it satisfied.
-		// See https://github.com/grafana/k6deps/issues/91
-		if constraint == nil {
-			continue
-		}
-
-		semver, err := semver.NewVersion(version)
-		if err != nil {
-			// ignore built in module if version is not a valid sem ver (e.g. a development version)
-			// if user wants to use this built-in, must disable the automatic extension resolution
-			return true
-		}
-
-		// if the current version does not satisfies the constrains, binary provisioning is required
-		if !constraint.Check(semver) {
-			return true
+		if err := checkVersionConstraint(name, version, constraint); err != nil {
+			return err
 		}
 	}
 
-	return false
+	return nil
+}
+
+// checkVersionConstraint checks whether version satisfies constraint for a named dependency.
+func checkVersionConstraint(name, version string, constraint *semver.Constraints) error {
+	// If dependency's constraint is null, assume it is "*" and consider it satisfied.
+	// See https://github.com/grafana/k6deps/issues/91
+	if constraint == nil {
+		return nil
+	}
+
+	sv, err := semver.NewVersion(version)
+	if err != nil {
+		// version is not valid semver (e.g. a pseudo-version); try SHA comparison.
+		if pseudoVersionSatisfies(version, constraint) {
+			return nil
+		}
+		return unsatisfiedDependencyError{name: name, version: version, constraint: constraint.String()}
+	}
+
+	// Semver ignores build metadata (v0.0.0+sha) in comparisons per the spec,
+	// so a plain constraint.Check would treat v0.0.0+abc and v0.0.0+xyz as
+	// equal. When both sides embed a commit SHA, compare them directly.
+	if vSHA, ok := versionSHA(sv); ok {
+		if satisfied, definitive := checkConstraintBySHA(vSHA, constraint); definitive {
+			if satisfied {
+				return nil
+			}
+			return unsatisfiedDependencyError{name: name, version: version, constraint: constraint.String()}
+		}
+	}
+
+	if !constraint.Check(sv) {
+		// Pre-release pseudo-versions (v0.0.0-timestamp-sha) parse as semver but
+		// may fail range checks even when the constraint names the exact same
+		// commit. Try SHA comparison as a last resort.
+		if pseudoVersionSatisfies(version, constraint) {
+			return nil
+		}
+		return unsatisfiedDependencyError{name: name, version: version, constraint: constraint.String()}
+	}
+	return nil
+}
+
+// checkConstraintBySHA checks if vSHA matches the SHA embedded in constraint.
+// Returns (satisfied, definitive): definitive=false means the constraint has no
+// embedded SHA and normal semver comparison should be used instead.
+func checkConstraintBySHA(vSHA string, constraint *semver.Constraints) (bool, bool) {
+	cs := constraint.String()
+	if strings.ContainsAny(cs, " ,") {
+		return false, false
+	}
+	cv, err := semver.NewVersion(constraintVersionStr(cs))
+	if err != nil {
+		return false, false
+	}
+	cSHA, ok := versionSHA(cv)
+	if !ok {
+		return false, false
+	}
+	return strings.HasPrefix(vSHA, cSHA) || strings.HasPrefix(cSHA, vSHA), true
 }
 
 // k6buildProvisioner provisions a k6 binary that satisfies the dependencies using the k6build service

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -14,77 +14,139 @@ import (
 	"go.k6.io/k6/v2/internal/cmd/tests"
 )
 
-func TestIsCustomBuildRequired(t *testing.T) {
+func TestCheckBuiltinDependencies(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		title  string
-		deps   map[string]string
-		exts   []*ext.Extension
-		expect bool
+		name      string
+		k6Version string
+		deps      map[string]string
+		exts      []*ext.Extension
+		wantErr   bool
 	}{
 		{
-			title:  "k6 satisfied",
-			deps:   map[string]string{"k6": "=v1.0.0"},
-			exts:   []*ext.Extension{},
-			expect: false,
+			name:    "k6 satisfied",
+			deps:    map[string]string{"k6": "=v1.0.0"},
+			exts:    []*ext.Extension{},
+			wantErr: false,
 		},
 		{
-			title:  "k6 not satisfied",
-			deps:   map[string]string{"k6": ">v1.0.0"},
-			exts:   []*ext.Extension{},
-			expect: true,
+			name:    "k6 not satisfied",
+			deps:    map[string]string{"k6": ">v1.0.0"},
+			exts:    []*ext.Extension{},
+			wantErr: true,
 		},
 		{
-			title:  "extension not present",
-			deps:   map[string]string{"k6": "*", "k6/x/faker": "*"},
-			exts:   []*ext.Extension{},
-			expect: true,
+			name:    "extension not present",
+			deps:    map[string]string{"k6": "*", "k6/x/faker": "*"},
+			exts:    []*ext.Extension{},
+			wantErr: true,
 		},
 		{
-			title: "extension satisfied",
-			deps:  map[string]string{"k6/x/faker": "=v0.4.0"},
+			name: "extension satisfied",
+			deps: map[string]string{"k6/x/faker": "=v0.4.0"},
 			exts: []*ext.Extension{
 				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
 			},
-			expect: false,
+			wantErr: false,
 		},
 		{
-			title: "extension not satisfied",
-			deps:  map[string]string{"k6/x/faker": ">v0.4.0"},
+			name: "extension not satisfied",
+			deps: map[string]string{"k6/x/faker": ">v0.4.0"},
 			exts: []*ext.Extension{
 				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
 			},
-			expect: true,
+			wantErr: true,
 		},
 		{
-			title: "k6 and extension satisfied",
-			deps:  map[string]string{"k6": "=v1.0.0", "k6/x/faker": "=v0.4.0"},
+			name: "k6 and extension satisfied",
+			deps: map[string]string{"k6": "=v1.0.0", "k6/x/faker": "=v0.4.0"},
 			exts: []*ext.Extension{
 				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
 			},
-			expect: false,
+			wantErr: false,
 		},
 		{
-			title: "k6 satisfied, extension not satisfied",
-			deps:  map[string]string{"k6": "=v1.0.0", "k6/x/faker": ">v0.4.0"},
+			name: "k6 satisfied, extension not satisfied",
+			deps: map[string]string{"k6": "=v1.0.0", "k6/x/faker": ">v0.4.0"},
 			exts: []*ext.Extension{
 				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
 			},
-			expect: true,
+			wantErr: true,
 		},
 		{
-			title: "k6 not satisfied, extension satisfied",
-			deps:  map[string]string{"k6": ">v1.0.0", "k6/x/faker": "=v0.4.0"},
+			name: "k6 not satisfied, extension satisfied",
+			deps: map[string]string{"k6": ">v1.0.0", "k6/x/faker": "=v0.4.0"},
 			exts: []*ext.Extension{
 				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
 			},
-			expect: true,
+			wantErr: true,
+		},
+		// Pseudo-version cases
+		{
+			name:      "k6 build-metadata pseudo-version matches exact constraint",
+			k6Version: "v0.0.0+abc123456789",
+			deps:      map[string]string{"k6": "=v0.0.0+abc123456789"},
+			exts:      []*ext.Extension{},
+			wantErr:   false,
+		},
+		{
+			name:      "k6 go pseudo-version matches exact constraint",
+			k6Version: "v0.0.0-20241015123456-abc123456789",
+			deps:      map[string]string{"k6": "=v0.0.0-20241015123456-abc123456789"},
+			exts:      []*ext.Extension{},
+			wantErr:   false,
+		},
+		{
+			name:      "k6 build-metadata pseudo-version matches constraint with same SHA",
+			k6Version: "v0.0.0+abc123456789",
+			deps:      map[string]string{"k6": "=v0.0.0-20241015123456-abc123456789"},
+			exts:      []*ext.Extension{},
+			wantErr:   false,
+		},
+		{
+			name:      "k6 go pseudo-version matches constraint with build-metadata SHA",
+			k6Version: "v0.0.0-20241015123456-abc123456789",
+			deps:      map[string]string{"k6": "=v0.0.0+abc123456789"},
+			exts:      []*ext.Extension{},
+			wantErr:   false,
+		},
+		{
+			name:      "k6 pseudo-version does not match different SHA",
+			k6Version: "v0.0.0+abc123456789",
+			deps:      map[string]string{"k6": "=v0.0.0+def456789012"},
+			exts:      []*ext.Extension{},
+			wantErr:   true,
+		},
+		{
+			name:      "k6 pseudo-version does not satisfy range constraint",
+			k6Version: "v0.0.0+abc123456789",
+			deps:      map[string]string{"k6": ">=v1.0.0"},
+			exts:      []*ext.Extension{},
+			wantErr:   true,
+		},
+		{
+			name:      "extension build-metadata pseudo-version matches exact constraint",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6/x/sql": "=v0.0.0+abc123456789"},
+			exts: []*ext.Extension{
+				{Name: "k6/x/sql", Module: "github.com/grafana/xk6-sql", Version: "v0.0.0+abc123456789"},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "extension go pseudo-version matches exact constraint",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6/x/sql": "=v0.0.0-20241015123456-abc123456789"},
+			exts: []*ext.Extension{
+				{Name: "k6/x/sql", Module: "github.com/grafana/xk6-sql", Version: "v0.0.0-20241015123456-abc123456789"},
+			},
+			wantErr: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		t.Run(tc.title, func(t *testing.T) {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			deps := make(map[string]*semver.Constraints)
@@ -96,9 +158,74 @@ func TestIsCustomBuildRequired(t *testing.T) {
 				deps[name] = constraint
 			}
 
-			k6Version := "v1.0.0"
-			required := isCustomBuildRequired(deps, k6Version, tc.exts)
-			assert.Equal(t, tc.expect, required)
+			k6Version := tc.k6Version
+			if k6Version == "" {
+				k6Version = "v1.0.0"
+			}
+			err := checkBuiltinDependencies(deps, k6Version, tc.exts)
+			assert.Equal(t, tc.wantErr, err != nil)
+		})
+	}
+}
+
+func TestExtractVersionSHA(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		version string
+		sha     string
+		ok      bool
+	}{
+		{"v0.0.0-20241015123456-abc123456789", "abc123456789", true},
+		{"v1.2.3-0.20241015123456-abc123456789", "abc123456789", true},
+		{"v0.0.0+abc123456789", "abc123456789", true},
+		{"v0.0.0+abc123", "abc123", true},
+		{"v1.0.0", "", false},
+		{"v0.0.0-alpha", "", false},
+		{"1.0.0", "", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.version, func(t *testing.T) {
+			t.Parallel()
+			sha, ok := extractVersionSHA(tc.version)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.sha, sha)
+		})
+	}
+}
+
+func TestPseudoVersionSatisfies(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		version    string
+		constraint string
+		satisfies  bool
+	}{
+		{"v0.0.0+abc123456789", "=v0.0.0+abc123456789", true},
+		{"v0.0.0-20241015123456-abc123456789", "=v0.0.0-20241015123456-abc123456789", true},
+		// cross-format: same SHA, different pseudo-version style
+		{"v0.0.0+abc123456789", "=v0.0.0-20241015123456-abc123456789", true},
+		{"v0.0.0-20241015123456-abc123456789", "=v0.0.0+abc123456789", true},
+		// short SHA prefix match
+		{"v0.0.0+abc123456789", "=v0.0.0+abc123", true},
+		// different SHA
+		{"v0.0.0+abc123456789", "=v0.0.0+def456789012", false},
+		// range constraint — no SHA comparison
+		{"v0.0.0+abc123456789", ">=v1.0.0", false},
+		// compound constraint — no SHA comparison
+		{"v0.0.0+abc123456789", ">=v0.0.0 <v1.0.0", false},
+		// version has no SHA
+		{"v1.0.0", "=v0.0.0+abc123456789", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.version+"/"+tc.constraint, func(t *testing.T) {
+			t.Parallel()
+			c, err := semver.NewConstraint(tc.constraint)
+			require.NoError(t, err)
+			assert.Equal(t, tc.satisfies, pseudoVersionSatisfies(tc.version, c))
 		})
 	}
 }

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -25,58 +25,66 @@ func TestCheckBuiltinDependencies(t *testing.T) {
 		wantErr   bool
 	}{
 		{
-			name:    "k6 satisfied",
-			deps:    map[string]string{"k6": "=v1.0.0"},
-			exts:    []*ext.Extension{},
+			name:      "k6 satisfied",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": "=v1.0.0"},
+
 			wantErr: false,
 		},
 		{
-			name:    "k6 not satisfied",
-			deps:    map[string]string{"k6": ">v1.0.0"},
-			exts:    []*ext.Extension{},
+			name:      "k6 not satisfied",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": ">v1.0.0"},
+
 			wantErr: true,
 		},
 		{
-			name:    "extension not present",
-			deps:    map[string]string{"k6": "*", "k6/x/faker": "*"},
-			exts:    []*ext.Extension{},
+			name:      "extension not present",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": "*", "k6/x/faker": "*"},
+
 			wantErr: true,
 		},
 		{
-			name: "extension satisfied",
-			deps: map[string]string{"k6/x/faker": "=v0.4.0"},
-			exts: []*ext.Extension{
-				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
-			},
-			wantErr: false,
-		},
-		{
-			name: "extension not satisfied",
-			deps: map[string]string{"k6/x/faker": ">v0.4.0"},
-			exts: []*ext.Extension{
-				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
-			},
-			wantErr: true,
-		},
-		{
-			name: "k6 and extension satisfied",
-			deps: map[string]string{"k6": "=v1.0.0", "k6/x/faker": "=v0.4.0"},
+			name:      "extension satisfied",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6/x/faker": "=v0.4.0"},
 			exts: []*ext.Extension{
 				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
 			},
 			wantErr: false,
 		},
 		{
-			name: "k6 satisfied, extension not satisfied",
-			deps: map[string]string{"k6": "=v1.0.0", "k6/x/faker": ">v0.4.0"},
+			name:      "extension not satisfied",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6/x/faker": ">v0.4.0"},
 			exts: []*ext.Extension{
 				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
 			},
 			wantErr: true,
 		},
 		{
-			name: "k6 not satisfied, extension satisfied",
-			deps: map[string]string{"k6": ">v1.0.0", "k6/x/faker": "=v0.4.0"},
+			name:      "k6 and extension satisfied",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": "=v1.0.0", "k6/x/faker": "=v0.4.0"},
+			exts: []*ext.Extension{
+				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "k6 satisfied, extension not satisfied",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": "=v1.0.0", "k6/x/faker": ">v0.4.0"},
+			exts: []*ext.Extension{
+				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
+			},
+			wantErr: true,
+		},
+		{
+			name:      "k6 not satisfied, extension satisfied",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": ">v1.0.0", "k6/x/faker": "=v0.4.0"},
 			exts: []*ext.Extension{
 				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
 			},
@@ -87,43 +95,57 @@ func TestCheckBuiltinDependencies(t *testing.T) {
 			name:      "k6 build-metadata pseudo-version matches exact constraint",
 			k6Version: "v0.0.0+abc123456789",
 			deps:      map[string]string{"k6": "=v0.0.0+abc123456789"},
-			exts:      []*ext.Extension{},
-			wantErr:   false,
+
+			wantErr: false,
 		},
 		{
 			name:      "k6 go pseudo-version matches exact constraint",
 			k6Version: "v0.0.0-20241015123456-abc123456789",
 			deps:      map[string]string{"k6": "=v0.0.0-20241015123456-abc123456789"},
-			exts:      []*ext.Extension{},
-			wantErr:   false,
+
+			wantErr: false,
 		},
 		{
 			name:      "k6 build-metadata pseudo-version matches constraint with same SHA",
 			k6Version: "v0.0.0+abc123456789",
 			deps:      map[string]string{"k6": "=v0.0.0-20241015123456-abc123456789"},
-			exts:      []*ext.Extension{},
-			wantErr:   false,
+
+			wantErr: false,
 		},
 		{
 			name:      "k6 go pseudo-version matches constraint with build-metadata SHA",
 			k6Version: "v0.0.0-20241015123456-abc123456789",
 			deps:      map[string]string{"k6": "=v0.0.0+abc123456789"},
-			exts:      []*ext.Extension{},
-			wantErr:   false,
+
+			wantErr: false,
 		},
 		{
 			name:      "k6 pseudo-version does not match different SHA",
 			k6Version: "v0.0.0+abc123456789",
 			deps:      map[string]string{"k6": "=v0.0.0+def456789012"},
-			exts:      []*ext.Extension{},
-			wantErr:   true,
+
+			wantErr: true,
+		},
+		{
+			name:      "k6 pseudo-version does not satisfy strict greater-than constraint with same SHA",
+			k6Version: "v0.0.0+abc123456789",
+			deps:      map[string]string{"k6": ">v0.0.0+abc123456789"},
+
+			wantErr: true,
+		},
+		{
+			name:      "k6 pseudo-version does not satisfy not-equal constraint with same SHA",
+			k6Version: "v0.0.0+abc123456789",
+			deps:      map[string]string{"k6": "!=v0.0.0+abc123456789"},
+
+			wantErr: true,
 		},
 		{
 			name:      "k6 pseudo-version does not satisfy range constraint",
 			k6Version: "v0.0.0+abc123456789",
 			deps:      map[string]string{"k6": ">=v1.0.0"},
-			exts:      []*ext.Extension{},
-			wantErr:   true,
+
+			wantErr: true,
 		},
 		{
 			name:      "extension build-metadata pseudo-version matches exact constraint",
@@ -143,6 +165,155 @@ func TestCheckBuiltinDependencies(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		// Pseudo-versions with non-zero base version against a plain semver range.
+		// go pseudo-versions (pre-release form) do not satisfy non-pre-release constraints
+		// per Masterminds semver semantics, regardless of whether the base version is higher.
+		// build-metadata pseudo-versions (+sha) behave like normal releases because metadata
+		// is stripped before comparison.
+		// Using >=vX.Y.Z-0 as the constraint lower bound opts pre-release versions back in.
+		{
+			name:      "k6 go pseudo-version with lower base version does not satisfy range constraint",
+			k6Version: "v1.4.0-20241015123456-abc123456789",
+			deps:      map[string]string{"k6": ">=v1.5.0"},
+
+			wantErr: true,
+		},
+		{
+			name:      "k6 go pseudo-version with higher base version does not satisfy non-pre-release range constraint",
+			k6Version: "v1.6.0-20241015123456-abc123456789",
+			deps:      map[string]string{"k6": ">=v1.5.0"},
+
+			wantErr: true,
+		},
+		{
+			name:      "k6 go pseudo-version with higher base version satisfies pre-release range constraint",
+			k6Version: "v1.6.0-20241015123456-abc123456789",
+			deps:      map[string]string{"k6": ">=v1.5.0-0"},
+
+			wantErr: false,
+		},
+		{
+			name:      "k6 go pseudo-version with lower base version does not satisfy pre-release range constraint",
+			k6Version: "v1.4.0-20241015123456-abc123456789",
+			deps:      map[string]string{"k6": ">=v1.5.0-0"},
+
+			wantErr: true,
+		},
+		{
+			name:      "k6 build-metadata pseudo-version with lower base version does not satisfy range constraint",
+			k6Version: "v1.4.0+abc123456789",
+			deps:      map[string]string{"k6": ">=v1.5.0"},
+
+			wantErr: true,
+		},
+		{
+			name:      "k6 build-metadata pseudo-version with higher base version satisfies range constraint",
+			k6Version: "v1.6.0+abc123456789",
+			deps:      map[string]string{"k6": ">=v1.5.0"},
+
+			wantErr: false,
+		},
+		// Pseudo-version constraints (the constraint itself is a pseudo-version)
+		{
+			name:      "normal k6 version does not match pseudo-version exact constraint",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": "=v0.0.0+abc123456789"},
+			wantErr:   true,
+		},
+		{
+			name:      "normal k6 version satisfies pseudo-version lower-bound range",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": ">=v0.0.0-20241015123456-abc123456789"},
+			wantErr:   false,
+		},
+		{
+			name:      "k6 pseudo-version satisfies matching pseudo-version lower-bound range",
+			k6Version: "v0.0.0+abc123456789",
+			deps:      map[string]string{"k6": ">=v0.0.0-20241015123456-abc123456789"},
+			wantErr:   false,
+		},
+		{
+			name:      "extension go pseudo-version matches build-metadata pseudo-version exact constraint",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6/x/sql": "=v0.0.0+abc123456789"},
+			exts: []*ext.Extension{
+				{Name: "k6/x/sql", Module: "github.com/grafana/xk6-sql", Version: "v0.0.0-20241015123456-abc123456789"},
+			},
+			wantErr: false,
+		},
+		// Multiple constraints (compound range)
+		{
+			name:      "k6 satisfies compound range constraint",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": ">=v0.9.0 <v2.0.0"},
+			wantErr:   false,
+		},
+		{
+			name:      "k6 below compound range constraint",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": ">=v1.1.0 <v2.0.0"},
+			wantErr:   true,
+		},
+		{
+			name:      "k6 above compound range constraint",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6": ">=v0.9.0 <v1.0.0"},
+			wantErr:   true,
+		},
+		{
+			name:      "k6 build-metadata pseudo-version does not satisfy compound range constraint",
+			k6Version: "v0.0.0+abc123456789",
+			deps:      map[string]string{"k6": ">=v0.9.0 <v2.0.0"},
+			wantErr:   true,
+		},
+		{
+			name:      "k6 go pseudo-version does not satisfy compound range constraint",
+			k6Version: "v0.0.0-20241015123456-abc123456789",
+			deps:      map[string]string{"k6": ">=v0.9.0 <v2.0.0"},
+			wantErr:   true,
+		},
+		// Compound constraint: exact pseudo-version SHA plus an upper limit.
+		// Note: compound constraints (containing spaces) bypass SHA comparison and
+		// rely entirely on semver, so cross-format SHA matching does not apply.
+		{
+			name:      "k6 go pseudo-version does not satisfy exact-sha-plus-upper-limit compound constraint",
+			k6Version: "v1.6.0-20241015123456-abc123456789",
+			deps:      map[string]string{"k6": "=v1.6.0-20241015123456-abc123456789 <v2.0.0"},
+
+			wantErr: true,
+		},
+		{
+			name:      "k6 go pseudo-version with different SHA does not satisfy exact-sha-plus-upper-limit compound constraint",
+			k6Version: "v1.7.0-20241015123456-def456789012",
+			deps:      map[string]string{"k6": "=v1.6.0-20241015123456-abc123456789 <v2.0.0"},
+
+			wantErr: true,
+		},
+		{
+			name:      "k6 build-metadata pseudo-version does not match go pseudo-version in compound constraint",
+			k6Version: "v1.6.0+abc123456789",
+			deps:      map[string]string{"k6": "=v1.6.0-20241015123456-abc123456789 <v2.0.0"},
+
+			wantErr: true,
+		},
+		{
+			name:      "extension satisfies compound range constraint",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6/x/faker": ">=v0.3.0 <v1.0.0"},
+			exts: []*ext.Extension{
+				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
+			},
+			wantErr: false,
+		},
+		{
+			name:      "extension does not satisfy compound range constraint",
+			k6Version: "v1.0.0",
+			deps:      map[string]string{"k6/x/faker": ">=v0.5.0 <v1.0.0"},
+			exts: []*ext.Extension{
+				{Name: "k6/x/faker", Module: "github.com/grafana/xk6-faker", Version: "v0.4.0"},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -158,11 +329,7 @@ func TestCheckBuiltinDependencies(t *testing.T) {
 				deps[name] = constraint
 			}
 
-			k6Version := tc.k6Version
-			if k6Version == "" {
-				k6Version = "v1.0.0"
-			}
-			err := checkBuiltinDependencies(deps, k6Version, tc.exts)
+			err := checkBuiltinDependencies(deps, tc.k6Version, tc.exts)
 			assert.Equal(t, tc.wantErr, err != nil)
 		})
 	}
@@ -212,6 +379,9 @@ func TestPseudoVersionSatisfies(t *testing.T) {
 		{"v0.0.0+abc123456789", "=v0.0.0+abc123", true},
 		// different SHA
 		{"v0.0.0+abc123456789", "=v0.0.0+def456789012", false},
+		// non-exact operators with matching SHA — SHA comparison should not apply
+		{"v0.0.0+abc123456789", ">v0.0.0+abc123456789", false},
+		{"v0.0.0+abc123456789", "!=v0.0.0+abc123456789", false},
 		// range constraint — no SHA comparison
 		{"v0.0.0+abc123456789", ">=v1.0.0", false},
 		// compound constraint — no SHA comparison

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -24,7 +24,6 @@ import (
 	"go.k6.io/k6/v2/errext"
 	"go.k6.io/k6/v2/errext/exitcodes"
 	"go.k6.io/k6/v2/ext"
-	"go.k6.io/k6/v2/internal/build"
 	"go.k6.io/k6/v2/internal/js"
 	"go.k6.io/k6/v2/internal/loader"
 	"go.k6.io/k6/v2/js/modules"
@@ -277,7 +276,9 @@ func resolveModulesDependencies(
 		return deps, preDeps, originalError
 	}
 
-	if !isCustomBuildRequired(deps, build.Version, ext.GetAll()) {
+	if err := checkBuiltinDependencies(deps, runtimeK6Version(), ext.GetAll()); err != nil {
+		logger.WithError(err).Debug("Current binary does not satisfy all dependencies, custom build required")
+	} else {
 		logger.
 			Debug("The current k6 binary already satisfies all the required dependencies," +
 				" it isn't required to provision a new binary.")

--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -20,6 +20,82 @@ const (
 	mainK6Path     = "go.k6.io/k6/v2"
 )
 
+// k6VersionInfo holds the version and VCS metadata for the running k6 binary,
+// as read from Go build info.
+type k6VersionInfo struct {
+	version string // effective version string, always with "v" prefix
+	commit  string // short VCS hash, "devel" for plain go-build, "" if unknown
+	dirty   bool   // true when the working tree was modified at build time
+}
+
+// readK6VersionInfo reads Go build info once and returns everything needed by
+// both the version display and the dependency constraint check. This is the
+// single source of truth so that what k6 prints and what it compares against
+// are always the same string.
+func readK6VersionInfo() k6VersionInfo {
+	v := build.Version
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return k6VersionInfo{version: v}
+	}
+
+	if bi.Main.Path == mainK6Path {
+		return readMainK6VersionInfo(bi, v)
+	}
+	return readLibK6VersionInfo(bi, v)
+}
+
+func readMainK6VersionInfo(bi *debug.BuildInfo, fallback string) k6VersionInfo {
+	var info k6VersionInfo
+	if bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+		info.version = bi.Main.Version
+	} else {
+		info.version = fallback
+		if bi.Main.Version == "(devel)" {
+			info.commit = "devel"
+		}
+	}
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			commitLen := min(len(s.Value), 10)
+			info.commit = s.Value[:commitLen]
+		case "vcs.modified":
+			info.dirty = s.Value == "true"
+		}
+	}
+	return info
+}
+
+// readLibK6VersionInfo handles the case where k6 is used as a library inside another binary.
+func readLibK6VersionInfo(bi *debug.BuildInfo, fallback string) k6VersionInfo {
+	var info k6VersionInfo
+	for _, dep := range bi.Deps {
+		if dep.Path == mainK6Path {
+			if dep.Replace != nil {
+				info.version = dep.Replace.Version
+			} else {
+				info.version = dep.Version
+			}
+			break
+		}
+	}
+	if info.version == "" {
+		info.version = fallback
+	}
+	return info
+}
+
+// runtimeK6Version returns the effective k6 version for dependency constraint
+// checking. It is guaranteed to match details["version"] from versionDetails().
+func runtimeK6Version() string {
+	return readK6VersionInfo().version
+}
+
 // fullVersion returns the maximally full version and build information for
 // the currently running k6 executable.
 func fullVersion() string {
@@ -47,48 +123,20 @@ func fullVersion() string {
 
 // versionDetails returns the structured details about version
 func versionDetails() map[string]any {
-	v := build.Version
-	if !strings.HasPrefix(v, "v") {
-		v = "v" + v
-	}
+	info := readK6VersionInfo()
 
 	details := map[string]any{
-		"version":    v,
+		"version":    info.version,
 		"go_version": runtime.Version(),
 		"go_os":      runtime.GOOS,
 		"go_arch":    runtime.GOARCH,
 	}
 
-	buildInfo, ok := debug.ReadBuildInfo()
-	if !ok {
-		return details
+	if info.commit != "" {
+		details[commitKey] = info.commit
 	}
-
-	if buildInfo.Main.Path == mainK6Path {
-		details["version"] = buildInfo.Main.Version
-		if buildInfo.Main.Version == "(devel)" {
-			details["version"] = v
-			details[commitKey] = "devel"
-		}
-		for _, s := range buildInfo.Settings {
-			switch s.Key {
-			case "vcs.revision":
-				commitLen := min(len(s.Value), 10)
-				details[commitKey] = s.Value[:commitLen]
-			case "vcs.modified":
-				if s.Value == "true" {
-					details[commitDirtyKey] = true
-				}
-			default:
-			}
-		}
-	} else {
-		for _, dep := range buildInfo.Deps {
-			if dep.Path == mainK6Path {
-				details["version"] = dep.Version
-				break
-			}
-		}
+	if info.dirty {
+		details[commitDirtyKey] = true
 	}
 
 	return details


### PR DESCRIPTION
## What?

When a script manifest specifies a dependency as a Go module pseudo-version (`v0.0.0+somesha` or `v0.0.0-20241015123456-abcdef123456`), k6 was always triggering binary provisioning even when the running binary already satisfied the constraint. This PR fixes two root causes and ensures the version k6 compares against constraints matches what it displays in `version` output.

## Why?

**Build metadata is invisible to semver comparison.** The semver spec ignores build metadata, so `v0.0.0+abc` and `v0.0.0+xyz` are treated as equal — a mismatched SHA would silently pass, and a matching SHA would also pass, but for the wrong reason.

**Pre-release pseudo-versions always fail range checks.** `v0.0.0-timestamp-sha` is less than `v0.0.0` in semver ordering, so any range constraint fails even when the constraint names the exact same commit.

**The compared version didn't match the displayed version.** `checkBuiltinDependencies` was comparing against the static `build.Version` constant, while the `version` command was printing the actual build-info version, which may be a pseudo-version when k6 is installed via `go install go.k6.io/k6@<sha>`.

## Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- https://github.com/grafana/k6deps/pull/44

🤖 Generated with [Claude Code](https://claude.com/claude-code)