### PR TITLE
Configure branch v1 to get security updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     "**/vendor/**",
     ".github/workflows/xk6-tests/**"
   ],
-  "baseBranches": ["master", "v1"],
+  "baseBranches": ["master", "v1.x"],
   "prConcurrentLimit": 50,
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -100,13 +100,13 @@
       ]
     },
 	{
-      "matchBaseBranches": ["v1"],
+      "matchBaseBranches": ["v1.x"],
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "enabled": false,
       "description": "Disable all standard updates for v1"
     },
     {
-      "matchBaseBranches": ["v1"],
+      "matchBaseBranches": ["v1.x"],
       "matchUpdateTypes": ["security"],
       "enabled": true,
       "dependencyDashboardApproval": false,

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "**/vendor/**",
     ".github/workflows/xk6-tests/**"
   ],
+  "baseBranches": ["master", "v1"],
   "prConcurrentLimit": 50,
   "packageRules": [
     {
@@ -97,6 +98,19 @@
       "extends": [
         "schedule:quarterly"
       ]
+    },
+	{
+      "matchBaseBranches": ["v1"],
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "enabled": false,
+      "description": "Disable all standard updates for v1"
+    },
+    {
+      "matchBaseBranches": ["v1"],
+      "matchUpdateTypes": ["security"],
+      "enabled": true,
+      "dependencyDashboardApproval": false,
+      "description": "Override and enable only security updates for v1"
     }
   ]
 }


### PR DESCRIPTION
## What?

Configure v1 branch to get security updates only

## Why?

We do intend on supporting k6 v1 for a whole year. Not having security updates enabled by default will make this harder. 

I am not currently enabling other updates as that likely is going to give us quite a lot more work. And if needed we can do them manually.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
