### PR TITLE
[feat] Add headless=new argument

### DIFF
--- a/internal/js/modules/k6/browser/chromium/browser_type.go
+++ b/internal/js/modules/k6/browser/chromium/browser_type.go
@@ -392,6 +392,10 @@ func prepareFlags(lopts *common.BrowserOptions, k6opts *k6lib.Options) (map[stri
 		f["mute-audio"] = true
 		f["blink-settings"] = "primaryHoverType=2,availableHoverTypes=2,primaryPointerType=4,availablePointerTypes=4"
 	}
+	if lopts.HeadlessNew {
+		f["headless"] = "new"
+	}
+
 	ignoreDefaultArgsFlags(f, lopts.IgnoreDefaultArgs)
 
 	setFlagsFromArgs(f, lopts.Args)

--- a/internal/js/modules/k6/browser/chromium/browser_type_test.go
+++ b/internal/js/modules/k6/browser/chromium/browser_type_test.go
@@ -153,6 +153,25 @@ func TestBrowserTypePrepareFlags(t *testing.T) {
 	}
 }
 
+func TestBrowserTypePrepareHeadlessNewMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("headless_new_sets_headless_new_flag", func(t *testing.T) {
+		t.Parallel()
+
+		opts := &common.BrowserOptions{
+			Headless:    true,
+			HeadlessNew: true,
+		}
+		flags, err := prepareFlags(opts, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "new", flags["headless"])
+		// headless-only flags should still be set
+		assert.Contains(t, flags, "hide-scrollbars")
+		assert.Contains(t, flags, "mute-audio")
+	})
+}
+
 func TestExecutablePath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/browser_options.go
+++ b/internal/js/modules/k6/browser/common/browser_options.go
@@ -23,6 +23,7 @@ type BrowserOptions struct {
 	Debug             bool
 	ExecutablePath    string
 	Headless          bool
+	HeadlessNew       bool // use --headless=new (Chrome 112+) instead of --headless
 	IgnoreDefaultArgs []string
 	LogCategoryFilter string
 	// TODO: Do not expose slowMo option by now.
@@ -99,7 +100,12 @@ func (bo *BrowserOptions) Parse(
 		case env.BrowserExecutablePath:
 			bo.ExecutablePath = ev
 		case env.BrowserHeadless:
-			bo.Headless, err = parseBoolOpt(e, ev)
+			if ev == "new" {
+				bo.Headless = true
+				bo.HeadlessNew = true
+			} else {
+				bo.Headless, err = parseBoolOpt(e, ev)
+			}
 		case env.BrowserIgnoreDefaultArgs:
 			bo.IgnoreDefaultArgs = parseListOpt(ev)
 		case env.LogCategoryFilter:

--- a/internal/js/modules/k6/browser/common/browser_options_test.go
+++ b/internal/js/modules/k6/browser/common/browser_options_test.go
@@ -155,6 +155,17 @@ func TestBrowserOptionsParse(t *testing.T) {
 				assert.False(t, lo.Headless)
 			},
 		},
+		"headless_new": {
+			opts: map[string]any{
+				"type": "chromium",
+			},
+			envLookupper: env.ConstLookup(env.BrowserHeadless, "new"),
+			assert: func(tb testing.TB, lo *BrowserOptions) {
+				tb.Helper()
+				assert.True(tb, lo.Headless)
+				assert.True(tb, lo.HeadlessNew)
+			},
+		},
 		"headless_err": {
 			opts: map[string]any{
 				"type": "chromium",

--- a/internal/js/modules/k6/browser/common/kill_other.go
+++ b/internal/js/modules/k6/browser/common/kill_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package common
 


### PR DESCRIPTION
## What?

This PR adds the ability to set headless mode for the k6 browser to "new." The new headless mode runs Chrome almost exactly like a regular browser. It uses the same rendering engine, compositor, and code paths as normal Chrome.

## Why?

1. More accurate behaviour (The new mode behaves much closer to what real users see)
  - Better CSS/layout rendering
  - More accurate JavaScript execution
  - Fewer “works in browser but not in headless” bugs

2. Fewer compatibility issues (Old headless had lots of edge cases)
  - Missing APIs
  - Rendering differences
  - Issues with things like WebGL, fonts, media

3. Better support for modern web features
- WebGPU / WebGL
- Advanced animations
- Video playback
- Extensions (to some extent)

4. Closer to real-user environments (important for automation)
- End-to-end testing (Playwright, Puppeteer, Selenium)
- Web scraping
- Bot automation

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable