### PR TITLE
Add a dedicated cloud auth error type

### DIFF
--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -29,30 +29,24 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// cloudAuthError is an authentication error whose describes the cause. Typically used
-// for user-facing error messages. Callers can use errors.As to detect any Grafana Cloud authentication
-// failure regardless of the specific cause.
-type cloudAuthError struct{ reason string }
-
-func (e *cloudAuthError) Error() string { return e.reason }
+var (
+	errCloudAuth = errors.New( //nolint:staticcheck // user-facing error message, capitalization is intentional
+		"Run `k6 cloud login` to authenticate, or check the docs for other options at" +
+			" https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication",
+	)
+	errMissingToken   = errors.New("access token not configured")
+	errMissingStackID = errors.New("stack ID not configured")
+)
 
 // checkCloudLogin verifies that both a token and a stack are configured.
 // Together they represent a complete Grafana Cloud login.
 func checkCloudLogin(conf cloudapi.Config) error {
-	const requiredErrFormat = "To run tests in Grafana Cloud, you must first authenticate" +
-		" setting %s. Run `k6 cloud login` providing the stack and token," +
-		" or check the docs for other options:" +
-		" https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication"
-
+	const prefix = "Running cloud tests requires auth settings"
 	if !conf.Token.Valid || conf.Token.String == "" {
-		return &cloudAuthError{
-			reason: fmt.Sprintf(requiredErrFormat, "an access token"),
-		}
+		return fmt.Errorf("%s: %w.\n%w", prefix, errMissingToken, errCloudAuth)
 	}
 	if !conf.StackID.Valid || conf.StackID.Int64 == 0 {
-		return &cloudAuthError{
-			reason: fmt.Sprintf(requiredErrFormat, "a stack ID"),
-		}
+		return fmt.Errorf("%s: %w.\n%w", prefix, errMissingStackID, errCloudAuth)
 	}
 	return nil
 }
@@ -412,7 +406,7 @@ func getCmdCloud(gs *state.GlobalState) *cobra.Command {
 
   # Run a test archive in Grafana Cloud
   $ {{.}} cloud run archive.tar
-  
+
   # [deprecated] Run a test script in Grafana Cloud
   $ {{.}} cloud script.js
 

--- a/internal/cmd/cloud.go
+++ b/internal/cmd/cloud.go
@@ -29,23 +29,30 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// errUserUnauthenticated represents an authentication error when trying to use
-// Grafana Cloud without being logged in or having a valid token.
-//
-//nolint:staticcheck // the error is shown to the user so here punctuation and capital are required
-var errUserUnauthenticated = errors.New("You must first authenticate to run tests in Grafana Cloud." +
-	" Run the `k6 cloud login` command providing the stack and token, or check the docs" +
-	" https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication" +
-	" for additional methods.")
+// cloudAuthError is an authentication error whose describes the cause. Typically used
+// for user-facing error messages. Callers can use errors.As to detect any Grafana Cloud authentication
+// failure regardless of the specific cause.
+type cloudAuthError struct{ reason string }
+
+func (e *cloudAuthError) Error() string { return e.reason }
 
 // checkCloudLogin verifies that both a token and a stack are configured.
 // Together they represent a complete Grafana Cloud login.
 func checkCloudLogin(conf cloudapi.Config) error {
+	const requiredErrFormat = "To run tests in Grafana Cloud, you must first authenticate" +
+		" setting %s. Run `k6 cloud login` providing the stack and token," +
+		" or check the docs for other options:" +
+		" https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication"
+
 	if !conf.Token.Valid || conf.Token.String == "" {
-		return errUserUnauthenticated
+		return &cloudAuthError{
+			reason: fmt.Sprintf(requiredErrFormat, "an access token"),
+		}
 	}
 	if !conf.StackID.Valid || conf.StackID.Int64 == 0 {
-		return errUserUnauthenticated
+		return &cloudAuthError{
+			reason: fmt.Sprintf(requiredErrFormat, "a stack ID"),
+		}
 	}
 	return nil
 }

--- a/internal/cmd/cloud_run.go
+++ b/internal/cmd/cloud_run.go
@@ -140,7 +140,7 @@ func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
 			}
 
 			if err := createCloudTest(c.runCmd.gs, test); err != nil {
-				if errors.Is(err, errUserUnauthenticated) {
+				if errors.As(err, new(*cloudAuthError)) {
 					return nil, nil, err
 				}
 				return nil, nil, fmt.Errorf("could not create the cloud test run: %w", err)

--- a/internal/cmd/cloud_run.go
+++ b/internal/cmd/cloud_run.go
@@ -140,7 +140,7 @@ func (c *cmdCloudRun) run(cmd *cobra.Command, args []string) error {
 			}
 
 			if err := createCloudTest(c.runCmd.gs, test); err != nil {
-				if errors.As(err, new(*cloudAuthError)) {
+				if errors.Is(err, errCloudAuth) {
 					return nil, nil, err
 				}
 				return nil, nil, fmt.Errorf("could not create the cloud test run: %w", err)

--- a/internal/cmd/cloud_test.go
+++ b/internal/cmd/cloud_test.go
@@ -116,9 +116,11 @@ func TestCheckCloudLogin(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name    string
-		conf    cloudapi.Config
-		wantErr error
+		name                string
+		conf                cloudapi.Config
+		expectedAuthError   bool
+		expectedTokenReason bool
+		expectedStackReason bool
 	}{
 		{
 			name: "valid token and stack passes",
@@ -126,29 +128,31 @@ func TestCheckCloudLogin(t *testing.T) {
 				Token:   null.StringFrom("valid-token"),
 				StackID: null.IntFrom(1234),
 			},
-			wantErr: nil,
 		},
 		{
-			name: "missing token returns unauthenticated error",
+			name: "missing token returns token not configured error",
 			conf: cloudapi.Config{
 				StackID: null.IntFrom(1234),
 			},
-			wantErr: errUserUnauthenticated,
+			expectedAuthError:   true,
+			expectedTokenReason: true,
 		},
 		{
-			name: "empty token string returns unauthenticated error",
+			name: "empty token string returns token not configured error",
 			conf: cloudapi.Config{
 				Token:   null.StringFrom(""),
 				StackID: null.IntFrom(1234),
 			},
-			wantErr: errUserUnauthenticated,
+			expectedAuthError:   true,
+			expectedTokenReason: true,
 		},
 		{
 			name: "missing stack returns stack not configured error",
 			conf: cloudapi.Config{
 				Token: null.StringFrom("valid-token"),
 			},
-			wantErr: errUserUnauthenticated,
+			expectedAuthError:   true,
+			expectedStackReason: true,
 		},
 		{
 			name: "zero stack ID returns stack not configured error",
@@ -156,7 +160,8 @@ func TestCheckCloudLogin(t *testing.T) {
 				Token:   null.StringFrom("valid-token"),
 				StackID: null.IntFrom(0),
 			},
-			wantErr: errUserUnauthenticated,
+			expectedAuthError:   true,
+			expectedStackReason: true,
 		},
 	}
 
@@ -164,11 +169,22 @@ func TestCheckCloudLogin(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := checkCloudLogin(tc.conf)
-			if tc.wantErr == nil {
-				require.NoError(t, err)
-			} else {
-				require.ErrorIs(t, err, tc.wantErr)
+
+			if tc.expectedAuthError {
+				var authErr *cloudAuthError
+				require.ErrorAs(t, err, &authErr)
+				switch {
+				case tc.expectedTokenReason:
+					require.ErrorContains(t, err, "an access token")
+				case tc.expectedStackReason:
+					require.ErrorContains(t, err, "a stack ID")
+				default:
+					t.Fatal("if an auth error is expected then an expected reason must be defined")
+				}
+				return
 			}
+
+			require.NoError(t, err)
 		})
 	}
 }

--- a/internal/cmd/cloud_test.go
+++ b/internal/cmd/cloud_test.go
@@ -116,11 +116,9 @@ func TestCheckCloudLogin(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
-		name                string
-		conf                cloudapi.Config
-		expectedAuthError   bool
-		expectedTokenReason bool
-		expectedStackReason bool
+		name        string
+		conf        cloudapi.Config
+		expectedErr error
 	}{
 		{
 			name: "valid token and stack passes",
@@ -134,8 +132,7 @@ func TestCheckCloudLogin(t *testing.T) {
 			conf: cloudapi.Config{
 				StackID: null.IntFrom(1234),
 			},
-			expectedAuthError:   true,
-			expectedTokenReason: true,
+			expectedErr: errMissingToken,
 		},
 		{
 			name: "empty token string returns token not configured error",
@@ -143,16 +140,14 @@ func TestCheckCloudLogin(t *testing.T) {
 				Token:   null.StringFrom(""),
 				StackID: null.IntFrom(1234),
 			},
-			expectedAuthError:   true,
-			expectedTokenReason: true,
+			expectedErr: errMissingToken,
 		},
 		{
 			name: "missing stack returns stack not configured error",
 			conf: cloudapi.Config{
 				Token: null.StringFrom("valid-token"),
 			},
-			expectedAuthError:   true,
-			expectedStackReason: true,
+			expectedErr: errMissingStackID,
 		},
 		{
 			name: "zero stack ID returns stack not configured error",
@@ -160,8 +155,7 @@ func TestCheckCloudLogin(t *testing.T) {
 				Token:   null.StringFrom("valid-token"),
 				StackID: null.IntFrom(0),
 			},
-			expectedAuthError:   true,
-			expectedStackReason: true,
+			expectedErr: errMissingStackID,
 		},
 	}
 
@@ -169,21 +163,11 @@ func TestCheckCloudLogin(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			err := checkCloudLogin(tc.conf)
-
-			if tc.expectedAuthError {
-				var authErr *cloudAuthError
-				require.ErrorAs(t, err, &authErr)
-				switch {
-				case tc.expectedTokenReason:
-					require.ErrorContains(t, err, "an access token")
-				case tc.expectedStackReason:
-					require.ErrorContains(t, err, "a stack ID")
-				default:
-					t.Fatal("if an auth error is expected then an expected reason must be defined")
-				}
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
+				require.ErrorIs(t, err, errCloudAuth)
 				return
 			}
-
 			require.NoError(t, err)
 		})
 	}

--- a/internal/cmd/tests/cmd_cloud_test.go
+++ b/internal/cmd/tests/cmd_cloud_test.go
@@ -42,7 +42,7 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 
 		stdout := ts.Stdout.String()
 		t.Log(stdout)
-		assert.Contains(t, stdout, `must first authenticate`)
+		assert.Contains(t, stdout, `access token not configured`)
 	})
 
 	t.Run("TestCloudStackNotConfigured", func(t *testing.T) {
@@ -55,7 +55,7 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 
 		stdout := ts.Stdout.String()
 		t.Log(stdout)
-		assert.Contains(t, stdout, `must first authenticate`)
+		assert.Contains(t, stdout, `stack ID not configured`)
 	})
 
 	// TODO: Remove after we remove K6_CLOUD_HOST_V6.

--- a/internal/cmd/tests/cmd_cloud_upload_test.go
+++ b/internal/cmd/tests/cmd_cloud_upload_test.go
@@ -30,7 +30,7 @@ func TestK6CloudUpload(t *testing.T) {
 
 		stdout := ts.Stdout.String()
 		t.Log(stdout)
-		assert.Contains(t, stdout, `must first authenticate`)
+		assert.Contains(t, stdout, `access token not configured`)
 	})
 
 	t.Run("TestCloudUploadWithScript", func(t *testing.T) {


### PR DESCRIPTION
## What?

Refactor the returned authentication errors. Instead of using a single static error for all authentication failures, it introduces a custom error type that provides more specific error messages depending on the missing configuration (token or stack ID).

## Why?

Hopefully, it improves the UX.