### PR TITLE
cloudapi/v6: return accurate error on empty name lookup

### DIFF
--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -143,7 +143,7 @@ func (c *Client) findTestByName(
 
 	tests := res.GetValue()
 	if len(tests) == 0 {
-		return nil, errUnknown
+		return nil, errTestNotExists
 	}
 
 	return &tests[0], nil

--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -228,7 +228,7 @@ func TestUploadTest(t *testing.T) {
 			}
 		}))
 		_, err := client.UploadTest(t.Context(), "test", 1, newTestArchive(t))
-		assert.ErrorIs(t, err, errUnknown)
+		assert.ErrorIs(t, err, errTestNotExists)
 	})
 }
 

--- a/internal/cloudapi/v6/errors.go
+++ b/internal/cloudapi/v6/errors.go
@@ -12,6 +12,7 @@ import (
 var (
 	errNotAuthorized    = errors.New("not allowed to upload result to k6 Cloud")
 	errNotAuthenticated = errors.New("failed to authenticate with k6 Cloud")
+	errTestNotExists    = errors.New("load test not found")
 	errUnknown          = errors.New("an error occurred communicating with k6 Cloud")
 )
 


### PR DESCRIPTION
## What?

Return `errTestNotExists` instead of `errUnknown` when the name query returns no tests. The user sees `uploading test: load test not found` instead of `uploading test: an error occurred communicating with k6 Cloud`.

## Why?

The API responded correctly, but the test just wasn't there. The old message pointed users and support toward network issues when nothing was wrong with communication.

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/pull/5769#discussion_r3124948396