### PR TITLE
cloudapi/v6: fix request body on SDK retry

### DIFF
--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -104,16 +104,6 @@ func TestValidateToken(t *testing.T) {
 	})
 }
 
-func TestClientRetry(t *testing.T) {
-	t.Parallel()
-
-	client, err := NewClient(testutils.NewLogger(t), "test-token", "http://example.com", "1.0", 1*time.Second)
-	require.NoError(t, err)
-	// the client already tests retries. we just verify we set it up correctly.
-	assert.Equal(t, MaxRetries, client.apiClient.GetConfig().MaxRetries)
-	assert.Equal(t, RetryInterval, client.apiClient.GetConfig().RetryInterval)
-}
-
 func TestValidateOptions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cloudapi/v6/api_test.go
+++ b/internal/cloudapi/v6/api_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -102,6 +103,43 @@ func TestValidateToken(t *testing.T) {
 		assert.Nil(t, resp)
 		assert.Contains(t, err.Error(), "invalid stack URL")
 	})
+}
+
+func TestRetryWithConnectionClose(t *testing.T) {
+	t.Parallel()
+
+	var attempts atomic.Int32
+	var body []byte
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			w.Header().Set("Connection", "close")
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		var err error
+		body, err = io.ReadAll(r.Body)
+		assert.NoError(t, err)
+		writeJSON(t, w, http.StatusOK, map[string]any{})
+	}))
+	defer srv.Close()
+
+	client, err := NewClient(testutils.NewLogger(t), "test-token", srv.URL, "1.0", 5*time.Second)
+	require.NoError(t, err)
+	client.SetStackID(1)
+
+	opts := lib.Options{VUs: null.IntFrom(10)}
+	require.NoError(t, client.ValidateOptions(t.Context(), 1, opts))
+
+	assert.Equal(t, int32(2), attempts.Load(), "expected exactly 2 attempts")
+
+	var got struct {
+		Options json.RawMessage `json:"options"`
+	}
+	require.NoError(t, json.Unmarshal(body, &got))
+	want, err := json.Marshal(opts)
+	require.NoError(t, err)
+	assert.JSONEq(t, string(want), string(got.Options))
 }
 
 func TestValidateOptions(t *testing.T) {

--- a/internal/cloudapi/v6/client.go
+++ b/internal/cloudapi/v6/client.go
@@ -45,9 +45,12 @@ func NewClient(logger logrus.FieldLogger, token, host, version string, timeout t
 			},
 		},
 		OperationServers: map[string]k6cloud.ServerConfigurations{},
-		HTTPClient:       &http.Client{Timeout: timeout},
-		MaxRetries:       MaxRetries,
-		RetryInterval:    RetryInterval,
+		HTTPClient: &http.Client{
+			Timeout:   timeout,
+			Transport: &bodyResetTransport{base: http.DefaultTransport},
+		},
+		MaxRetries:    MaxRetries,
+		RetryInterval: RetryInterval,
 	}
 
 	c := &Client{
@@ -67,6 +70,24 @@ func (c *Client) SetStackID(stackID int32) {
 // BaseURL returns configured host.
 func (c *Client) BaseURL() string {
 	return c.baseURL
+}
+
+// bodyResetTransport resets req.Body from GetBody before each round trip.
+// The vendored SDK retries 5xx/429 by re-calling Do on the same request
+// without resetting its Body. After Connection: close the drained body
+// causes "ContentLength=N with Body length 0".
+type bodyResetTransport struct{ base http.RoundTripper }
+
+func (rt *bodyResetTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.GetBody == nil {
+		return rt.base.RoundTrip(req)
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	req.Body = body
+	return rt.base.RoundTrip(req)
 }
 
 // CheckResponse checks the parsed response.


### PR DESCRIPTION
## What?

The v6 client can lose the request body when the SDK retries a failed request. A transport wrapper now resets the body before each round trip. Also removes `TestClientRetry`, which only asserted that config values were set.

## Why?

When the server sends `Connection: close`, the next attempt fails with `ContentLength=N with Body length 0`. On keep-alive connections, `net/http` internally resets, so the bug only surfaces on connection-close responses.

## Related PR(s)/Issue(s)

Follow-up from https://github.com/grafana/k6/pull/5769#discussion_r3124982405