### PR TITLE
Do not startup the HTTP server by default

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -175,7 +175,7 @@ type GlobalFlags struct {
 	ConfigFilePath   string
 	Quiet            bool
 	NoColor          bool
-	Address          string
+	HTTPAPIAddr   string
 	ProfilingEnabled bool
 	LogOutput        string
 	SecretSource     []string
@@ -191,7 +191,7 @@ type GlobalFlags struct {
 // GetDefaultFlags returns the default global flags.
 func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 	return GlobalFlags{
-		Address:                 "localhost:6565",
+		HTTPAPIAddr:          "localhost:6565",
 		ProfilingEnabled:        false,
 		ConfigFilePath:          filepath.Join(homeDir, "k6", defaultConfigFileName),
 		LogOutput:               "stderr",
@@ -216,8 +216,8 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 	if val, ok := env["K6_LOG_FORMAT"]; ok {
 		result.LogFormat = val
 	}
-	if val, ok := env["K6_ADDRESS"]; ok {
-		result.Address = val
+	if val, ok := env["K6_HTTP_API_ADDR"]; ok {
+		result.HTTPAPIAddr = val
 	}
 	if env["K6_NO_COLOR"] != "" {
 		result.NoColor = true

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -216,6 +216,9 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 	if val, ok := env["K6_LOG_FORMAT"]; ok {
 		result.LogFormat = val
 	}
+	if val, ok := env["K6_ADDRESS"]; ok {
+		result.Address = val
+	}
 	if env["K6_NO_COLOR"] != "" {
 		result.NoColor = true
 	}

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -175,7 +175,7 @@ type GlobalFlags struct {
 	ConfigFilePath   string
 	Quiet            bool
 	NoColor          bool
-	HTTPAPIAddr   string
+	HTTPAPIAddr      string
 	ProfilingEnabled bool
 	LogOutput        string
 	SecretSource     []string
@@ -191,7 +191,7 @@ type GlobalFlags struct {
 // GetDefaultFlags returns the default global flags.
 func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 	return GlobalFlags{
-		HTTPAPIAddr:          "localhost:6565",
+		HTTPAPIAddr:             "",
 		ProfilingEnabled:        false,
 		ConfigFilePath:          filepath.Join(homeDir, "k6", defaultConfigFileName),
 		LogOutput:               "stderr",

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -289,8 +289,8 @@ func rootCmdPersistentFlagSet(gs *state.GlobalState) *pflag.FlagSet {
 	// either with croconf or through the hack above...
 	flags.BoolVarP(&gs.Flags.Verbose, "verbose", "v", gs.DefaultFlags.Verbose, "enable verbose logging")
 	flags.BoolVarP(&gs.Flags.Quiet, "quiet", "q", gs.DefaultFlags.Quiet, "disable progress updates")
-	flags.StringVarP(&gs.Flags.Address, "address", "a", gs.Flags.Address, "address for the HTTP API server address")
-	flags.Lookup("address").DefValue = gs.DefaultFlags.Address
+	flags.StringVarP(&gs.Flags.HTTPAPIAddr, "http-api-addr", "a", gs.Flags.HTTPAPIAddr, "address for the HTTP API server")
+	flags.Lookup("http-api-addr").DefValue = gs.DefaultFlags.HTTPAPIAddr
 	flags.BoolVar(
 		&gs.Flags.ProfilingEnabled,
 		"profiling-enabled",

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -289,13 +289,18 @@ func rootCmdPersistentFlagSet(gs *state.GlobalState) *pflag.FlagSet {
 	// either with croconf or through the hack above...
 	flags.BoolVarP(&gs.Flags.Verbose, "verbose", "v", gs.DefaultFlags.Verbose, "enable verbose logging")
 	flags.BoolVarP(&gs.Flags.Quiet, "quiet", "q", gs.DefaultFlags.Quiet, "disable progress updates")
-	flags.StringVarP(&gs.Flags.HTTPAPIAddr, "http-api-addr", "a", gs.Flags.HTTPAPIAddr, "address for the HTTP API server")
+	flags.StringVarP(
+		&gs.Flags.HTTPAPIAddr,
+		"http-api-addr", "a",
+		gs.Flags.HTTPAPIAddr,
+		"address for the REST HTTP API server (e.g. localhost:6565); the server is disabled when not set",
+	)
 	flags.Lookup("http-api-addr").DefValue = gs.DefaultFlags.HTTPAPIAddr
 	flags.BoolVar(
 		&gs.Flags.ProfilingEnabled,
 		"profiling-enabled",
 		gs.DefaultFlags.ProfilingEnabled,
-		"enable profiling (pprof) endpoints, k6's HTTP API should be enabled as well",
+		"enable profiling (pprof) endpoints, requires the HTTP API to be enabled (--http-api-addr)",
 	)
 
 	return flags

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -289,12 +289,13 @@ func rootCmdPersistentFlagSet(gs *state.GlobalState) *pflag.FlagSet {
 	// either with croconf or through the hack above...
 	flags.BoolVarP(&gs.Flags.Verbose, "verbose", "v", gs.DefaultFlags.Verbose, "enable verbose logging")
 	flags.BoolVarP(&gs.Flags.Quiet, "quiet", "q", gs.DefaultFlags.Quiet, "disable progress updates")
-	flags.StringVarP(&gs.Flags.Address, "address", "a", gs.DefaultFlags.Address, "address for the REST API server")
+	flags.StringVarP(&gs.Flags.Address, "address", "a", gs.Flags.Address, "address for the HTTP API server address")
+	flags.Lookup("address").DefValue = gs.DefaultFlags.Address
 	flags.BoolVar(
 		&gs.Flags.ProfilingEnabled,
 		"profiling-enabled",
 		gs.DefaultFlags.ProfilingEnabled,
-		"enable profiling (pprof) endpoints, k6's REST API should be enabled as well",
+		"enable profiling (pprof) endpoints, k6's HTTP API should be enabled as well",
 	)
 
 	return flags

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -75,7 +75,7 @@ func TestAddressGlobalOption(t *testing.T) {
 		assert.Equal(t, "", state.GetDefaultFlags(".config", ".cache").HTTPAPIAddr)
 	})
 
-	t.Run("set via --address flag", func(t *testing.T) {
+	t.Run("set via --http-api-addr flag", func(t *testing.T) {
 		t.Parallel()
 		ts := tests.NewGlobalTestState(t)
 		flagSet := rootCmdPersistentFlagSet(ts.GlobalState)

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -72,7 +72,7 @@ func TestAddressGlobalOption(t *testing.T) {
 
 	t.Run("default value", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "localhost:6565", state.GetDefaultFlags(".config", ".cache").HTTPAPIAddr)
+		assert.Equal(t, "", state.GetDefaultFlags(".config", ".cache").HTTPAPIAddr)
 	})
 
 	t.Run("set via --address flag", func(t *testing.T) {

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -72,15 +72,15 @@ func TestAddressGlobalOption(t *testing.T) {
 
 	t.Run("default value", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "localhost:6565", state.GetDefaultFlags(".config", ".cache").Address)
+		assert.Equal(t, "localhost:6565", state.GetDefaultFlags(".config", ".cache").HTTPAPIAddr)
 	})
 
 	t.Run("set via --address flag", func(t *testing.T) {
 		t.Parallel()
 		ts := tests.NewGlobalTestState(t)
 		flagSet := rootCmdPersistentFlagSet(ts.GlobalState)
-		require.NoError(t, flagSet.Parse([]string{"--address", "localhost:9090"}))
-		assert.Equal(t, "localhost:9090", ts.GlobalState.Flags.Address)
+		require.NoError(t, flagSet.Parse([]string{"--http-api-addr", "localhost:9090"}))
+		assert.Equal(t, "localhost:9090", ts.Flags.HTTPAPIAddr)
 	})
 
 	t.Run("set via -a shorthand flag", func(t *testing.T) {
@@ -88,29 +88,29 @@ func TestAddressGlobalOption(t *testing.T) {
 		ts := tests.NewGlobalTestState(t)
 		flagSet := rootCmdPersistentFlagSet(ts.GlobalState)
 		require.NoError(t, flagSet.Parse([]string{"-a", "localhost:9090"}))
-		assert.Equal(t, "localhost:9090", ts.GlobalState.Flags.Address)
+		assert.Equal(t, "localhost:9090", ts.Flags.HTTPAPIAddr)
 	})
 
-	t.Run("set via K6_ADDRESS env var", func(t *testing.T) {
+	t.Run("set via K6_HTTP_API_ADDR env var", func(t *testing.T) {
 		t.Parallel()
 		ts := tests.NewGlobalTestState(t)
-		ts.Env["K6_ADDRESS"] = "localhost:9090"
+		ts.Env["K6_HTTP_API_ADDR"] = "localhost:9090"
 		ts.ReparseFlags()
-		assert.Equal(t, "localhost:9090", ts.GlobalState.Flags.Address)
+		assert.Equal(t, "localhost:9090", ts.Flags.HTTPAPIAddr)
 	})
 }
 
-// TestAddressOptionPrecedence verifies that the CLI flag takes precedence over the K6_ADDRESS
+// TestAddressOptionPrecedence verifies that the CLI flag takes precedence over the K6_HTTP_API_ADDR
 // env var by going through the real cobra command path, reflecting the actual implementation.
 func TestAddressGlobalOptionPrecedence(t *testing.T) {
 	t.Parallel()
 
 	ts := tests.NewGlobalTestState(t)
-	ts.Env["K6_ADDRESS"] = "localhost:9090"
-	ts.CmdArgs = []string{"k6", "run", "--address", "localhost:9091", "script.js"}
+	ts.Env["K6_HTTP_API_ADDR"] = "localhost:9090"
+	ts.CmdArgs = []string{"k6", "run", "--http-api-addr", "localhost:9091", "script.js"}
 
 	rootCmd := newRootCommand(ts.GlobalState)
 	require.NoError(t, rootCmd.cmd.ParseFlags(ts.CmdArgs[1:]))
 
-	assert.Equal(t, "localhost:9091", ts.GlobalState.Flags.Address)
+	assert.Equal(t, "localhost:9091", ts.Flags.HTTPAPIAddr)
 }

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/errext/exitcodes"
 	"go.k6.io/k6/v2/internal/cmd/tests"
 )
@@ -63,4 +65,52 @@ func TestRootCommandHelpDisplayCommands(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAddressGlobalOption(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default value", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, "localhost:6565", state.GetDefaultFlags(".config", ".cache").Address)
+	})
+
+	t.Run("set via --address flag", func(t *testing.T) {
+		t.Parallel()
+		ts := tests.NewGlobalTestState(t)
+		flagSet := rootCmdPersistentFlagSet(ts.GlobalState)
+		require.NoError(t, flagSet.Parse([]string{"--address", "localhost:9090"}))
+		assert.Equal(t, "localhost:9090", ts.GlobalState.Flags.Address)
+	})
+
+	t.Run("set via -a shorthand flag", func(t *testing.T) {
+		t.Parallel()
+		ts := tests.NewGlobalTestState(t)
+		flagSet := rootCmdPersistentFlagSet(ts.GlobalState)
+		require.NoError(t, flagSet.Parse([]string{"-a", "localhost:9090"}))
+		assert.Equal(t, "localhost:9090", ts.GlobalState.Flags.Address)
+	})
+
+	t.Run("set via K6_ADDRESS env var", func(t *testing.T) {
+		t.Parallel()
+		ts := tests.NewGlobalTestState(t)
+		ts.Env["K6_ADDRESS"] = "localhost:9090"
+		ts.ReparseFlags()
+		assert.Equal(t, "localhost:9090", ts.GlobalState.Flags.Address)
+	})
+}
+
+// TestAddressOptionPrecedence verifies that the CLI flag takes precedence over the K6_ADDRESS
+// env var by going through the real cobra command path, reflecting the actual implementation.
+func TestAddressGlobalOptionPrecedence(t *testing.T) {
+	t.Parallel()
+
+	ts := tests.NewGlobalTestState(t)
+	ts.Env["K6_ADDRESS"] = "localhost:9090"
+	ts.CmdArgs = []string{"k6", "run", "--address", "localhost:9091", "script.js"}
+
+	rootCmd := newRootCommand(ts.GlobalState)
+	require.NoError(t, rootCmd.cmd.ParseFlags(ts.CmdArgs[1:]))
+
+	assert.Equal(t, "localhost:9091", ts.GlobalState.Flags.Address)
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -280,7 +280,7 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 	})
 	samples := make(chan metrics.SampleContainer, test.derivedConfig.MetricSamplesBufferSize.Int64)
 	// Spin up the REST API server, if not disabled.
-	if c.gs.Flags.Address != "" { //nolint:nestif
+	if c.gs.Flags.HTTPAPIAddr != "" { //nolint:nestif
 		initBar.Modify(pb.WithConstProgress(0, "Init API server"))
 
 		// We cannot use backgroundProcesses here, since we need the REST API to
@@ -295,7 +295,7 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 
 		srv := api.GetServer(
 			runCtx,
-			c.gs.Flags.Address, c.gs.Flags.ProfilingEnabled,
+			c.gs.Flags.HTTPAPIAddr, c.gs.Flags.ProfilingEnabled,
 			testRunState,
 			samples,
 			metricsEngine,
@@ -303,13 +303,13 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 		)
 		go func() {
 			defer apiWG.Done()
-			logger.Debugf("Starting the REST API server on %s", c.gs.Flags.Address)
+			logger.Debugf("Starting the REST API server on %s", c.gs.Flags.HTTPAPIAddr)
 			if c.gs.Flags.ProfilingEnabled {
-				logger.Debugf("Profiling exposed on http://%s/debug/pprof/", c.gs.Flags.Address)
+				logger.Debugf("Profiling exposed on http://%s/debug/pprof/", c.gs.Flags.HTTPAPIAddr)
 			}
 			if aerr := srv.ListenAndServe(); aerr != nil && !errors.Is(aerr, http.ErrServerClosed) {
 				// Only exit k6 if the user has explicitly set the REST API address
-				if cmd.Flags().Lookup("address").Changed {
+				if cmd.Flags().Lookup("http-api-addr").Changed {
 					logger.WithError(aerr).Error("Error from API server")
 					c.gs.OSExit(int(exitcodes.CannotStartRESTAPI))
 				} else {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -279,7 +279,7 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 		runAbort(err)
 	})
 	samples := make(chan metrics.SampleContainer, test.derivedConfig.MetricSamplesBufferSize.Int64)
-	// Spin up the REST API server, if not disabled.
+	// Spin up the REST API server, if enabled.
 	if c.gs.Flags.HTTPAPIAddr != "" { //nolint:nestif
 		initBar.Modify(pb.WithConstProgress(0, "Init API server"))
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -279,6 +279,10 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 		runAbort(err)
 	})
 	samples := make(chan metrics.SampleContainer, test.derivedConfig.MetricSamplesBufferSize.Int64)
+	if c.gs.Flags.ProfilingEnabled && c.gs.Flags.HTTPAPIAddr == "" {
+		logger.Warn("Profiling is enabled but no HTTP API server is running — " +
+			"profiling endpoints won't be reachable until you enable the HTTP server via --http-api-addr (or K6_HTTP_API_ADDR)")
+	}
 	// Spin up the REST API server, if enabled.
 	if c.gs.Flags.HTTPAPIAddr != "" { //nolint:nestif
 		initBar.Modify(pb.WithConstProgress(0, "Init API server"))

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -15,9 +15,10 @@ func getCmdStats(gs *state.GlobalState) *cobra.Command {
 		Hidden: true,
 		Long: `Show test metrics.
 
-  Use the global --address flag or the K6_ADDRESS environment variable to specify the URL to the API server.`,
+  Use the global --http-api-addr flag or the K6_HTTP_API_ADDR environment variable to specify
+  the URL to the API server.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			c, err := client.New(gs.Flags.Address)
+			c, err := client.New(gs.Flags.HTTPAPIAddr)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -15,7 +15,7 @@ func getCmdStats(gs *state.GlobalState) *cobra.Command {
 		Hidden: true,
 		Long: `Show test metrics.
 
-  Use the global --address flag to specify the URL to the API server.`,
+  Use the global --address flag or the K6_ADDRESS environment variable to specify the URL to the API server.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			c, err := client.New(gs.Flags.Address)
 			if err != nil {

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"go.k6.io/k6/v2/api/v1/client"
@@ -18,6 +20,10 @@ func getCmdStats(gs *state.GlobalState) *cobra.Command {
   Use the global --http-api-addr flag or the K6_HTTP_API_ADDR environment variable to specify
   the URL to the API server.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
+			if gs.Flags.HTTPAPIAddr == "" {
+				return errors.New("The HTTP API server is disabled, but this command needs" + //nolint:staticcheck
+					" to read metrics from it. Enable it by setting --http-api-addr or K6_HTTP_API_ADDR.")
+			}
 			c, err := client.New(gs.Flags.HTTPAPIAddr)
 			if err != nil {
 				return err

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -637,7 +637,7 @@ func TestSetupTeardownThresholds(t *testing.T) {
 		}()
 		t.Logf("Linger reached, running teardown again and stopping the test...")
 		req, err := http.NewRequestWithContext(
-			ts.Ctx, http.MethodPost, fmt.Sprintf("http://%s/v1/teardown", ts.Flags.Address), nil,
+			ts.Ctx, http.MethodPost, fmt.Sprintf("http://%s/v1/teardown", ts.Flags.HTTPAPIAddr), nil,
 		)
 		require.NoError(t, err)
 		resp, err := http.DefaultClient.Do(req)
@@ -888,7 +888,7 @@ func asyncWaitForStdoutAndStopTestFromRESTAPI(
 ) {
 	asyncWaitForStdoutAndRun(t, ts, attempts, interval, expText, func() {
 		req, err := http.NewRequestWithContext(
-			ts.Ctx, http.MethodPatch, fmt.Sprintf("http://%s/v1/status", ts.Flags.Address),
+			ts.Ctx, http.MethodPatch, fmt.Sprintf("http://%s/v1/status", ts.Flags.HTTPAPIAddr),
 			bytes.NewBufferString(`{"data":{"type":"status","id":"default","attributes":{"stopped":true}}}`),
 		)
 		require.NoError(t, err)

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -68,14 +68,21 @@ func TestHTTPAPIServerAddr(t *testing.T) {
 
 	testCases := []struct {
 		name          string
+		args          []string
 		expectStarted bool
 	}{
 		{
-			name:          "server is not started when addr is empty",
+			name:          "addr flag not set",
 			expectStarted: false,
 		},
 		{
-			name:          "server is started when addr is set",
+			name:          "addr flag explicitly empty",
+			args:          []string{"-a", ""},
+			expectStarted: false,
+		},
+		{
+			name:          "addr flag set",
+			args:          []string{"-a", getFreeBindAddr(t)},
 			expectStarted: true,
 		},
 	}
@@ -84,12 +91,9 @@ func TestHTTPAPIServerAddr(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			addr := ""
-			if tc.expectStarted {
-				addr = getFreeBindAddr(t)
-			}
 			ts := NewGlobalTestState(t)
-			ts.CmdArgs = []string{"k6", "run", "-v", "--log-output=stdout", "-a", addr, "-"}
+			ts.CmdArgs = append([]string{"k6", "run", "-v", "--log-output=stdout"}, tc.args...)
+			ts.CmdArgs = append(ts.CmdArgs, "-")
 			ts.Stdin = bytes.NewBufferString(`export default function() {};`)
 
 			cmd.ExecuteWithGlobalState(ts.GlobalState)

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -63,6 +63,45 @@ func TestVersion(t *testing.T) {
 	assert.Empty(t, ts.LoggerHook.Drain())
 }
 
+func TestHTTPAPIServerAddr(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		expectStarted bool
+	}{
+		{
+			name:          "server is not started when addr is empty",
+			expectStarted: false,
+		},
+		{
+			name:          "server is started when addr is set",
+			expectStarted: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			addr := ""
+			if tc.expectStarted {
+				addr = getFreeBindAddr(t)
+			}
+			ts := NewGlobalTestState(t)
+			ts.CmdArgs = []string{"k6", "run", "-v", "--log-output=stdout", "-a", addr, "-"}
+			ts.Stdin = bytes.NewBufferString(`export default function() {};`)
+
+			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			logEntries := ts.LoggerHook.Drain()
+			assert.Equal(t,
+				tc.expectStarted,
+				testutils.LogContains(logEntries, logrus.DebugLevel, "Starting the REST API server"))
+		})
+	}
+}
+
 func TestSimpleTestStdin(t *testing.T) {
 	t.Parallel()
 
@@ -626,8 +665,10 @@ func TestSetupTeardownThresholds(t *testing.T) {
 		};
 	`)
 
-	cliFlags := []string{"-v", "--log-output=stdout", "--linger"}
+	addr := getFreeBindAddr(t)
+	cliFlags := []string{"-v", "--log-output=stdout", "--linger", "--http-api-addr", addr}
 	ts := getSimpleCloudOutputTestState(t, script, cliFlags, cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed, 0)
+	ts.Flags.HTTPAPIAddr = addr
 
 	sendSignal := injectMockSignalNotifier(ts)
 	asyncWaitForStdoutAndRun(t, ts, 20, 500*time.Millisecond, "waiting for Ctrl+C to continue", func() {
@@ -919,10 +960,12 @@ func TestAbortedByUserWithRestAPI(t *testing.T) {
 		}
 	`
 
+	addr := getFreeBindAddr(t)
 	ts := getSimpleCloudOutputTestState(
-		t, script, []string{"-v", "--log-output=stdout", "--iterations", "20"},
+		t, script, []string{"-v", "--log-output=stdout", "--iterations", "20", "--http-api-addr", addr},
 		cloudapi.RunStatusAbortedUser, cloudapi.ResultStatusPassed, exitcodes.ScriptStoppedFromRESTAPI,
 	)
+	ts.Flags.HTTPAPIAddr = addr
 
 	asyncWaitForStdoutAndStopTestFromRESTAPI(t, ts, 15, time.Second, "a simple iteration")
 

--- a/internal/cmd/tests/cmd_stats_test.go
+++ b/internal/cmd/tests/cmd_stats_test.go
@@ -1,0 +1,47 @@
+package tests
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/internal/lib/testutils"
+)
+
+func TestStatsCommandWithoutHTTPAPIAddrFails(t *testing.T) {
+	t.Parallel()
+
+	ts := NewGlobalTestState(t)
+	ts.CmdArgs = []string{"k6", "stats"}
+	ts.ExpectedExitCode = -1
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	logEntries := ts.LoggerHook.Drain()
+	require.True(t, testutils.LogContains(logEntries, logrus.ErrorLevel, "HTTP API server is disabled"))
+	assert.Empty(t, ts.Stdout.String())
+}
+
+func TestStatsCommand(t *testing.T) {
+	t.Parallel()
+
+	srv := getTestServer(t, map[string]http.Handler{
+		`GET ^/v1/metrics$`: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":[{"type":"metrics","id":"http_reqs","attributes":{"type":"counter","contains":"default","tainted":null,"sample":{"count":1,"rate":0.5}}}]}`))
+		}),
+	})
+	defer srv.Close()
+
+	ts := NewGlobalTestState(t)
+	ts.CmdArgs = []string{"k6", "--http-api-addr", srv.Listener.Addr().String(), "stats"}
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Contains(t, ts.Stdout.String(), "http_reqs")
+	assert.Contains(t, ts.Stdout.String(), "counter")
+}

--- a/internal/cmd/tests/test_state.go
+++ b/internal/cmd/tests/test_state.go
@@ -88,7 +88,7 @@ func NewGlobalTestState(tb testing.TB) *GlobalTestState {
 
 	outMutex := &sync.Mutex{}
 	defaultFlags := state.GetDefaultFlags(".config", ".cache")
-	defaultFlags.Address = getFreeBindAddr(tb)
+	defaultFlags.HTTPAPIAddr = getFreeBindAddr(tb)
 
 	ts.GlobalState = &state.GlobalState{
 		Ctx:          ctx,

--- a/internal/cmd/tests/test_state.go
+++ b/internal/cmd/tests/test_state.go
@@ -88,7 +88,6 @@ func NewGlobalTestState(tb testing.TB) *GlobalTestState {
 
 	outMutex := &sync.Mutex{}
 	defaultFlags := state.GetDefaultFlags(".config", ".cache")
-	defaultFlags.HTTPAPIAddr = getFreeBindAddr(tb)
 
 	ts.GlobalState = &state.GlobalState{
 		Ctx:          ctx,

--- a/internal/cmd/ui.go
+++ b/internal/cmd/ui.go
@@ -150,8 +150,8 @@ func printExecutionDescription(
 	}
 
 	fmt.Fprintf(buf, "        output: %s\n", valueColor.Sprint(strings.Join(outputDescriptions, ", ")))
-	if gs.Flags.ProfilingEnabled && gs.Flags.Address != "" {
-		fmt.Fprintf(buf, "     profiling: %s\n", valueColor.Sprintf("http://%s/debug/pprof/", gs.Flags.Address))
+	if gs.Flags.ProfilingEnabled && gs.Flags.HTTPAPIAddr != "" {
+		fmt.Fprintf(buf, "     profiling: %s\n", valueColor.Sprintf("http://%s/debug/pprof/", gs.Flags.HTTPAPIAddr))
 	}
 
 	fmt.Fprintf(buf, "\n")


### PR DESCRIPTION
## What?

The k6 HTTP API server no longer starts automatically. Previously, k6 always listened on `localhost:6565` unless the address was explicitly opt-out. Now the server only starts when an address is explicitly provided via the `--http-api-addr` flag or the `K6_HTTP_API_ADDR` environment variable.

Additionally:
- The `--address` / `-a` flag has been renamed to `--http-api-addr` / `-a` (shorthand preserved because it might be useful for internal operations).
- A new `K6_ADDRESS` has been added as a first step in this pull request and next commits renamed renamed to stay consistently `K6_HTTP_API_ADDR`.

Closes #5648