### PR TITLE
Skip shell completions provisioning on cache miss

### DIFF
--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"strings"
 	"syscall"
+	"time"
 	"unicode"
 	"unicode/utf8"
 
@@ -467,4 +469,35 @@ func parseManifest(manifestString string) (dependencies, error) {
 		return nil, fmt.Errorf("invalid dependencies manifest %w", err)
 	}
 	return dependenciesFromMap(manifestMap)
+}
+
+// completionTimeout bounds the cache lookup for shell completion requests.
+// The build service is reachable but not guaranteed responsive; without a
+// deadline a stall would hang the shell on every TAB.
+const completionTimeout = 3 * time.Second
+
+// completeExtension handles a shell completion request for an unregistered
+// extension subcommand. If the matching provisioned binary is already cached
+// locally, it delegates the completion request to that binary. Otherwise it
+// returns nil (no completions) so the shell does not hang waiting on a build.
+func completeExtension(gs *state.GlobalState, extName string, prov provisioner) error {
+	deps, err := dependenciesFromSubcommand(gs, extName)
+	if err != nil {
+		gs.Logger.WithError(err).Debug("Failed to build completion deps")
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(gs.Ctx, completionTimeout)
+	defer cancel()
+
+	bin, err := prov.provision(ctx, constraintsMapToProvisionDependency(deps))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		gs.Logger.WithError(err).Debug("Failed to check provisioner cache for completion request")
+		return nil
+	}
+
+	return bin.run(ctx, gs)
 }

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -303,11 +303,18 @@ func checkConstraintBySHA(vSHA string, constraint *semver.Constraints) (bool, bo
 
 // buildProvisioner provisions a k6 binary that satisfies the dependencies using the k6build service.
 type buildProvisioner struct {
-	gs *state.GlobalState
+	gs         *state.GlobalState
+	cachedOnly bool // if true, only looks up already-cached binaries
 }
 
 func newBuildProvisioner(gs *state.GlobalState) provisioner {
 	return &buildProvisioner{gs: gs}
+}
+
+// newCacheProvisioner returns a provisioner that only looks up already-cached binaries.
+// A cache miss surfaces as [fs.ErrNotExist]; the build service is never asked to build.
+func newCacheProvisioner(gs *state.GlobalState) provisioner {
+	return &buildProvisioner{gs: gs, cachedOnly: true}
 }
 
 func (p *buildProvisioner) provision(ctx context.Context, deps map[string]string) (commandExecutor, error) {
@@ -318,13 +325,19 @@ func (p *buildProvisioner) provision(ctx context.Context, deps map[string]string
 		return nil, err
 	}
 
-	binary, err := provider.GetBinary(ctx, deps)
+	getBinary := provider.GetBinary
+	if p.cachedOnly {
+		getBinary = provider.GetCachedBinary
+	}
+
+	binary, err := getBinary(ctx, deps)
 	if err != nil {
 		return nil, err
 	}
-
-	p.gs.Logger.
-		Info("A new k6 binary has been provisioned with version(s): ", formatDependencies(binary.Dependencies))
+	if !p.cachedOnly {
+		p.gs.Logger.Info("A new k6 binary has been provisioned with version(s): ",
+			formatDependencies(binary.Dependencies))
+	}
 
 	return &customBinary{binary.Path}, nil
 }

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,12 +26,12 @@ import (
 // commandExecutor executes the requested k6 command line command.
 // It abstract the execution path from the concrete binary.
 type commandExecutor interface {
-	run(*state.GlobalState) error
+	run(ctx context.Context, gs *state.GlobalState) error
 }
 
 // provisioner defines the interface for provisioning a commandExecutor for a set of dependencies
 type provisioner interface {
-	provision(map[string]string) (commandExecutor, error)
+	provision(ctx context.Context, deps map[string]string) (commandExecutor, error)
 }
 
 func constraintsMapToProvisionDependency(deps map[string]*semver.Constraints) k6provider.Dependencies {
@@ -57,8 +58,8 @@ type customBinary struct {
 }
 
 //nolint:forbidigo
-func (b *customBinary) run(gs *state.GlobalState) error {
-	cmd := exec.CommandContext(gs.Ctx, b.path, gs.CmdArgs[1:]...) //nolint:gosec
+func (b *customBinary) run(ctx context.Context, gs *state.GlobalState) error {
+	cmd := exec.CommandContext(ctx, b.path, gs.CmdArgs[1:]...) //nolint:gosec
 
 	// we pass os stdout, err, in because passing them from GlobalState changes how
 	// the subprocess detects the type of terminal
@@ -300,16 +301,16 @@ func checkConstraintBySHA(vSHA string, constraint *semver.Constraints) (bool, bo
 	return strings.HasPrefix(vSHA, cSHA) || strings.HasPrefix(cSHA, vSHA), true
 }
 
-// k6buildProvisioner provisions a k6 binary that satisfies the dependencies using the k6build service
-type k6buildProvisioner struct {
+// buildProvisioner provisions a k6 binary that satisfies the dependencies using the k6build service.
+type buildProvisioner struct {
 	gs *state.GlobalState
 }
 
-func newK6BuildProvisioner(gs *state.GlobalState) provisioner {
-	return &k6buildProvisioner{gs: gs}
+func newBuildProvisioner(gs *state.GlobalState) provisioner {
+	return &buildProvisioner{gs: gs}
 }
 
-func (p *k6buildProvisioner) provision(deps map[string]string) (commandExecutor, error) {
+func (p *buildProvisioner) provision(ctx context.Context, deps map[string]string) (commandExecutor, error) {
 	config := getProviderConfig(p.gs)
 
 	provider, err := k6provider.NewProvider(config)
@@ -317,7 +318,7 @@ func (p *k6buildProvisioner) provision(deps map[string]string) (commandExecutor,
 		return nil, err
 	}
 
-	binary, err := provider.GetBinary(p.gs.Ctx, deps)
+	binary, err := provider.GetBinary(ctx, deps)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"context"
+	"errors"
+	"io/fs"
 	"path/filepath"
 	"testing"
 
@@ -9,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/ext"
 
 	"go.k6.io/k6/v2/internal/cmd/tests"
@@ -696,6 +700,85 @@ func TestDependenciesApplyManifest(t *testing.T) {
 				require.ErrorContains(t, err, test.expectedError)
 			} else {
 				require.EqualValues(t, test.expected, (map[string]string)(constraintsMapToProvisionDependency(deps)))
+			}
+		})
+	}
+}
+
+type fakeCommandExecutor struct {
+	runCalled bool
+	runErr    error
+}
+
+func (f *fakeCommandExecutor) run(_ context.Context, _ *state.GlobalState) error {
+	f.runCalled = true
+	return f.runErr
+}
+
+type fakeProvisioner struct {
+	gotDeps map[string]string
+	bin     commandExecutor
+	err     error
+}
+
+func (f *fakeProvisioner) provision(_ context.Context, deps map[string]string) (commandExecutor, error) {
+	f.gotDeps = deps
+	return f.bin, f.err
+}
+
+func Test_completeExtension(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name          string
+		manifest      string
+		provisionErr  error
+		runErr        error
+		wantRunCalled bool
+		wantDepsKey   string
+	}{
+		{
+			name:          "cache hit runs the binary",
+			wantRunCalled: true,
+			wantDepsKey:   "subcommand:docs",
+		},
+		{
+			name:         "cache miss returns nil without running",
+			provisionErr: fs.ErrNotExist,
+		},
+		{
+			name:         "provisioner error is swallowed",
+			provisionErr: errors.New("provider boom"),
+		},
+		{
+			name:     "deps build error is swallowed",
+			manifest: `{not valid json`,
+		},
+		{
+			name:          "binary run error propagates",
+			runErr:        errors.New("subprocess failed"),
+			wantRunCalled: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := tests.NewGlobalTestState(t)
+			if tt.manifest != "" {
+				ts.Flags.DependenciesManifest = tt.manifest
+			}
+			exec := &fakeCommandExecutor{runErr: tt.runErr}
+			prov := &fakeProvisioner{bin: exec, err: tt.provisionErr}
+
+			err := completeExtension(ts.GlobalState, "docs", prov)
+			if tt.runErr != nil {
+				require.ErrorIs(t, err, tt.runErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantRunCalled, exec.runCalled)
+			if tt.wantDepsKey != "" {
+				require.Contains(t, prov.gotDeps, tt.wantDepsKey)
 			}
 		})
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -216,9 +216,9 @@ func handleUnsatisfiedDependencies(err error, c *rootCommand) (exitcodes.ExitCod
 		WithField("deps", deps).
 		Info("Automatic extension resolution is enabled. The current k6 binary doesn't satisfy all dependencies," +
 			" it's required to provision a custom binary.")
-	provisioner := newK6BuildProvisioner(c.globalState)
+	provisioner := newBuildProvisioner(c.globalState)
 	var customBinary commandExecutor
-	customBinary, err = provisioner.provision(constraintsMapToProvisionDependency(deps))
+	customBinary, err = provisioner.provision(c.globalState.Ctx, constraintsMapToProvisionDependency(deps))
 	if err != nil {
 		err = errext.WithExitCodeIfNone(err, exitcodes.ScriptException)
 		c.globalState.Logger.
@@ -228,7 +228,7 @@ func handleUnsatisfiedDependencies(err error, c *rootCommand) (exitcodes.ExitCod
 		return 0, err
 	}
 
-	err = customBinary.run(c.globalState)
+	err = customBinary.run(c.globalState.Ctx, c.globalState)
 	// this only happens if we actually ran the binary and it exited afterwads, in which case we propagate the exit code
 	var ecerr errext.HasExitCode
 	if errors.As(err, &ecerr) {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -175,7 +175,7 @@ func (c *rootCommand) execute() {
 	// provisioned binary's output would append to it, producing double output.
 	var err error
 	if ext, ok := detectExtensionCompletion(c.cmd, c.globalState); ok {
-		err = buildExtensionDeps(c.globalState, ext)
+		err = completeExtension(c.globalState, ext, newCacheProvisioner(c.globalState))
 	} else {
 		err = c.cmd.Execute()
 	}


### PR DESCRIPTION
## What?

Skips completions for uncached provisioned extensions. The cache-only provisioner skips the build on cache miss and times out on service slowness. Once `k6provider` moves to fully offline lookups, this code will pick up that improvement without any changes in k6.

## Why?

Completions for uncached extensions may hang users without feedback because of provisioning.

## Related PR(s)/Issue(s)

- grafana/k6provider#119
- #5880
- Closes #5768