### PR TITLE
feat: pass k6ModPath v2 to build service via k6provider

### DIFF
--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -351,6 +351,7 @@ func getProviderConfig(gs *state.GlobalState) k6provider.Config {
 	config := k6provider.Config{
 		BuildServiceURL: gs.Flags.BuildServiceURL,
 		BinaryCacheDir:  gs.Flags.BinaryCache,
+		K6ModPath:       "go.k6.io/k6/v2",
 	}
 
 	token, err := extractToken(gs)

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -419,6 +419,7 @@ func TestGetProviderConfig(t *testing.T) {
 				BuildServiceURL:  "https://ingest.k6.io/builder/api/v1",
 				BinaryCacheDir:   filepath.Join(".cache", "k6", "builds"),
 				BuildServiceAuth: "",
+				K6ModPath:        "go.k6.io/k6/v2",
 			},
 		},
 		{
@@ -428,6 +429,7 @@ func TestGetProviderConfig(t *testing.T) {
 				BuildServiceURL:  "https://ingest.k6.io/builder/api/v1",
 				BinaryCacheDir:   filepath.Join(".cache", "k6", "builds"),
 				BuildServiceAuth: "K6CLOUDTOKEN",
+				K6ModPath:        "go.k6.io/k6/v2",
 			},
 		},
 	}


### PR DESCRIPTION
## What?

Set `K6ModPath: "go.k6.io/k6/v2"` in the k6provider config so that this binary signals to the build service which k6 module to resolve and build against when requesting a custom binary.

## Why?

k6build routes build requests to the correct per-version catalog based on the `k6_mod_path` field in the request (see grafana/k6build#318 and grafana/k6provider#120). Without this field the build service has no way to distinguish a v2 build request from a v1 one and will route to the v1 catalog, producing a binary built against `go.k6.io/k6` instead of `go.k6.io/k6/v2`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): N/A
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): N/A

## Related PR(s)/Issue(s)

- grafana/k6provider#120 — adds `Config.K6ModPath` to k6provider; forwards `k6_mod_path` in build service requests (direct dependency of this PR)
- grafana/k6build#318 — adds `k6_mod_path` routing to the build service