### PR TITLE
Bump k6 to 2.0.0-rc1

### DIFF
--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -3,4 +3,4 @@ package build
 
 // Version contains the current version of k6
 // represented using Semantic Versioning expression.
-const Version = "1.7.1"
+const Version = "2.0.0-rc1"

--- a/internal/cmd/archive_test.go
+++ b/internal/cmd/archive_test.go
@@ -109,28 +109,28 @@ export default function () { http.get("https://example.com"); }
 		},
 		{
 			name: "use directive sets k6 constraint",
-			script: []byte(`"use k6 >= 0.50.0";
+			script: []byte(`"use k6 >= 2.0.0-0";
 import http from "k6/http";
 export default function () {}
 `),
-			expectedDeps: map[string]string{"k6": ">=0.50.0"},
+			expectedDeps: map[string]string{"k6": ">=2.0.0-0"},
 		},
 		{
 			name: "manifest overrides star constraint but pre-manifest deps are stored",
 			script: []byte(`import http from "k6/http";
 export default function () {}
 `),
-			manifest:     `{"k6": ">=1.0.0"}`,
+			manifest:     `{"k6": ">=2.0.0-0"}`,
 			expectedDeps: map[string]string{"k6": "*"}, // pre-manifest: still "*"
 		},
 		{
 			name: "manifest does not override explicit use directive constraint",
-			script: []byte(`"use k6 >= 0.9.0";
+			script: []byte(`"use k6 >= 2.0.0-0";
 import http from "k6/http";
 export default function () {}
 `),
-			manifest:     `{"k6": ">=1.0.0"}`,
-			expectedDeps: map[string]string{"k6": ">=0.9.0"}, // pre-manifest: explicit constraint preserved
+			manifest:     `{"k6": ">=2.2.0"}`,
+			expectedDeps: map[string]string{"k6": ">=2.0.0-0"}, // pre-manifest: explicit constraint preserved
 		},
 	}
 

--- a/internal/cmd/deps_test.go
+++ b/internal/cmd/deps_test.go
@@ -140,9 +140,9 @@ export default function () {
 }
 `),
 			},
-			manifest:          `{"k6": ">=1.6.0"}`,
-			expectedDeps:      map[string]string{"k6": ">=1.6.0"},
-			expectCustomBuild: false, // current k6 version satisfies >=1.6.0
+			manifest:          `{"k6": ">=2.0.0-0"}`, // using -0 to match prereleases
+			expectedDeps:      map[string]string{"k6": ">=2.0.0-0"},
+			expectCustomBuild: false, // current k6 version satisfies >=2.0.0-0
 			expectedImports:   []string{"/main.js", "k6/http"},
 		},
 	}


### PR DESCRIPTION
## What?

Bump k6 version to 2.0.0-rc1

## Why?
We need to do this to align the release version with what k6 reports.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
