### PR TITLE
Deliver  k6 version to subcommands

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -31,6 +31,10 @@ const (
 	// DependenciesManifest defines the default values for dependency resolution
 	DependenciesManifest = "K6_DEPENDENCIES_MANIFEST"
 
+	// ProvisionHostVersion is the k6 version of the binary that provisioned a subprocess.
+	// Subcommand extensions can read it to know which k6 version launched them.
+	ProvisionHostVersion = "K6_PROVISION_HOST_VERSION"
+
 	// defaultBuildServiceURL defines the URL to the default (grafana hosted) build service
 	defaultBuildServiceURL = "https://ingest.k6.io/builder/api/v1"
 

--- a/internal/cmd/launcher.go
+++ b/internal/cmd/launcher.go
@@ -72,18 +72,7 @@ func (b *customBinary) run(ctx context.Context, gs *state.GlobalState) error {
 	// in `gs.Stdin` and should be passed to the command
 	cmd.Stdin = gs.Stdin
 
-	// Copy environment variables to the k6 process skipping auto extension resolution feature flag.
-	env := []string{}
-	for k, v := range gs.Env {
-		if k == state.AutoExtensionResolution {
-			continue
-		}
-		env = append(env, fmt.Sprintf("%s=%s", k, v))
-	}
-	// If auto extension resolution is enabled then
-	// this avoids unnecessary re-processing of dependencies in the sub-process.
-	env = append(env, state.AutoExtensionResolution+"=false")
-	cmd.Env = env
+	cmd.Env = buildSubprocessEnv(gs.Env)
 
 	// handle signals
 	sigC := make(chan os.Signal, 2)
@@ -118,6 +107,22 @@ func (b *customBinary) run(ctx context.Context, gs *state.GlobalState) error {
 				Debug("Signal received, waiting for the subprocess to handle it and return.")
 		}
 	}
+}
+
+// buildSubprocessEnv prepares environment variables for a provisioned k6 subprocess.
+func buildSubprocessEnv(src map[string]string) []string {
+	env := []string{}
+	for k, v := range src {
+		if k == state.AutoExtensionResolution {
+			continue
+		}
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
+	}
+	// Disable auto extension resolution in the subprocess to avoid
+	// unnecessary re-processing of dependencies.
+	env = append(env, state.AutoExtensionResolution+"=false")
+	env = append(env, state.ProvisionHostVersion+"="+runtimeK6Version())
+	return env
 }
 
 // used just to signal we shouldn't print error again

--- a/internal/cmd/launcher_test.go
+++ b/internal/cmd/launcher_test.go
@@ -705,6 +705,26 @@ func TestDependenciesApplyManifest(t *testing.T) {
 	}
 }
 
+func TestBuildSubprocessEnv(t *testing.T) {
+	t.Parallel()
+
+	env := map[string]string{
+		"HOME":                        "/home/user",
+		"K6_NO_USAGE_REPORT":          "true",
+		state.AutoExtensionResolution: "true",
+	}
+
+	result := buildSubprocessEnv(env)
+
+	assert.Contains(t, result, state.AutoExtensionResolution+"=false")
+	assert.Contains(t, result, state.ProvisionHostVersion+"="+runtimeK6Version())
+	assert.Contains(t, result, "HOME=/home/user")
+	assert.Contains(t, result, "K6_NO_USAGE_REPORT=true")
+
+	// AutoExtensionResolution from the original env should not be forwarded.
+	assert.NotContains(t, result, state.AutoExtensionResolution+"=true")
+}
+
 type fakeCommandExecutor struct {
 	runCalled bool
 	runErr    error


### PR DESCRIPTION
## What?

Provisioned subcommands receive the k6 version through the `K6_PROVISION_HOST_VERSION` environment variable. 

## Why?

Like [`xk6-docs`](https://github.com/grafana/xk6-docs), [`mcp-k6`](https://github.com/grafana/mcp-k6) is soon [becoming](https://github.com/grafana/xk6-mcp-subcommand) a subcommand. These can use the host's k6 version to display docs that match a user's k6 version. However, provisioning picks the latest k6 major version, not the user's (e.g., a user on k6 2.0 gets 2.2 docs). So, the docs can drift and mention options or APIs that the user's k6 lacks, or miss behavior that exists in that version. For AI agents, this is worse. They can write broken scripts using APIs that aren't there.