### PR TITLE
Normalize cloud login stack URLs

### DIFF
--- a/internal/cmd/cloud_login.go
+++ b/internal/cmd/cloud_login.go
@@ -282,7 +282,8 @@ func authenticateUserToken(
 
 // validateTokenV6 validates a token and a stack URL/slug and returns the normalized URL, stack ID,
 // and default project ID.
-// The stackInput can be either a full URL (e.g., https://my-team.grafana.net) or just a slug (e.g., my-team).
+// The stackInput can be either a full URL (e.g., https://my-team.grafana.net)
+// or just a slug (e.g., my-team).
 func validateTokenV6(
 	gs *state.GlobalState,
 	config cloudapi.Config,
@@ -309,14 +310,18 @@ func validateTokenV6(
 	return normalizedURL, int64(authResp.StackId), int64(authResp.DefaultProjectId), nil
 }
 
-// normalizeStackURL converts a stack slug to a full URL if needed.
-// The stackInput can be either a full URL (e.g., https://my-team.grafana.net) or just a slug (e.g., my-team).
+// normalizeStackURL converts a stack slug to a full URL if needed and removes trailing slashes.
+// The stackInput can be either a full URL (e.g., https://my-team.grafana.net)
+// or just a slug (e.g., my-team).
 func normalizeStackURL(stackInput string) string {
-	// If it's already a full URL, return it as is
+	stackInput = strings.TrimRight(stackInput, "/")
+
+	// If it's already a full URL, return it as is.
 	if strings.HasPrefix(stackInput, "http://") || strings.HasPrefix(stackInput, "https://") {
 		return stackInput
 	}
-	// Otherwise, treat it as a slug and construct the URL
+
+	// Otherwise, treat it as a slug and construct the URL.
 	slug := stripGrafanaNetSuffix(stackInput)
 	return fmt.Sprintf("https://%s.grafana.net", slug)
 }

--- a/internal/cmd/cloud_login_test.go
+++ b/internal/cmd/cloud_login_test.go
@@ -96,3 +96,57 @@ func TestPrintConfigTokenOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeStackURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "slug",
+			input:    "my-team",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "slug with grafana net suffix",
+			input:    "my-team.grafana.net",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "slug with grafana net suffix and trailing slash",
+			input:    "my-team.grafana.net/",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "full https URL",
+			input:    "https://my-team.grafana.net",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "full https URL with trailing slash",
+			input:    "https://my-team.grafana.net/",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "full https URL with multiple trailing slashes",
+			input:    "https://my-team.grafana.net///",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "full http URL with trailing slash",
+			input:    "http://my-team.grafana.net/",
+			expected: "http://my-team.grafana.net",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, normalizeStackURL(tc.input))
+		})
+	}
+}

--- a/internal/cmd/tests/cmd_cloud_login_test.go
+++ b/internal/cmd/tests/cmd_cloud_login_test.go
@@ -45,6 +45,19 @@ func TestCloudLoginWithArgs(t *testing.T) {
 			},
 		},
 		{
+			name:    "valid token and valid stack URL with trailing slash",
+			token:   validToken,
+			stack:   validStackURL + "/",
+			wantErr: false,
+			wantStdoutContains: []string{
+				"Logged in successfully",
+				fmt.Sprintf("token: %s", strings.Repeat("*", 11)),
+				fmt.Sprintf("stack-id: %d", validStackID),
+				fmt.Sprintf("stack-url: %s", validStackURL),
+				fmt.Sprintf("default-project-id: %d", defaultProjectID),
+			},
+		},
+		{
 			name:    "valid token without stack fails",
 			token:   validToken,
 			wantErr: true,


### PR DESCRIPTION
## What?

Normalize `k6 cloud login --stack` stack inputs by removing trailing `/` characters before validating them with Grafana Cloud. This keeps copied stack URLs like `https://my-team.grafana.net/` equivalent to `https://my-team.grafana.net`.

Added focused unit coverage for stack URL normalization and command coverage for login with a trailing-slash stack URL.

## Why?

A trailing slash was sent to the Cloud auth API as part of `X-Stack-Url`, which could make an otherwise valid stack fail authentication as not found.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass. (Ran `go test ./internal/cmd/... -count=1`.)

## Checklist: Documentation (only for k6 maintainers and if relevant)

Not applicable; this is a CLI bug fix.

## Related PR(s)/Issue(s)

Fixes #5894
