### PR TITLE
websockets: fix shutdown deadlock on server pings

### DIFF
--- a/internal/js/modules/k6/websockets/websockets.go
+++ b/internal/js/modules/k6/websockets/websockets.go
@@ -369,11 +369,28 @@ func (w *webSocket) emitConnectionMetrics(ctx context.Context, start time.Time, 
 const writeWait = 10 * time.Second
 
 func (w *webSocket) loop() {
-	// Pass ping/pong events through the main control loop
+	// Pass ping/pong events through the main control loop.
+	// The handlers below run synchronously inside ReadMessage (via advanceFrame),
+	// so a blocking send here stalls the entire readPump goroutine.
+	// The select on w.done lets them bail out when the loop has already exited,
+	// preventing a deadlock where readPump blocks forever on an unbuffered send
+	// that nobody will receive.
 	pingChan := make(chan string)
 	pongChan := make(chan string)
-	w.conn.SetPingHandler(func(msg string) error { pingChan <- msg; return nil })
-	w.conn.SetPongHandler(func(pingID string) error { pongChan <- pingID; return nil })
+	w.conn.SetPingHandler(func(msg string) error {
+		select {
+		case pingChan <- msg:
+		case <-w.done:
+		}
+		return nil
+	})
+	w.conn.SetPongHandler(func(pingID string) error {
+		select {
+		case pongChan <- pingID:
+		case <-w.done:
+		}
+		return nil
+	})
 
 	ctx := w.vu.Context()
 	wg := new(sync.WaitGroup)

--- a/internal/js/modules/k6/websockets/websockets_test.go
+++ b/internal/js/modules/k6/websockets/websockets_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/sirupsen/logrus"
@@ -1707,4 +1708,53 @@ func TestRemoteCloseWithCodeAndReason(t *testing.T) {
 	samples := metrics.GetBufferedSamples(ts.samples)
 	assertSessionMetricsEmitted(t, samples, "", sr("WSBIN_URL/ws-remote-close"), http.StatusSwitchingProtocols, "")
 	assert.Equal(t, []string{"remote closed"}, ts.callRecorder.Recorded())
+}
+
+// TestPingHandlerDeadlock verifies that server pings arriving during connection
+// teardown don't deadlock the readPump goroutine. The server sends aggressive
+// pings then abruptly kills the TCP connection. Without the fix, the ping
+// handler blocks forever on an unbuffered channel send after the loop exits.
+// The goleak check in TestMain catches the leaked goroutine.
+func TestPingHandlerDeadlock(t *testing.T) {
+	t.Parallel()
+	ts := newTestState(t)
+
+	ts.tb.Mux.HandleFunc("/ws-ping-deadlock", func(w http.ResponseWriter, req *http.Request) {
+		conn, upgErr := (&websocket.Upgrader{}).Upgrade(w, req, w.Header())
+		if !assert.NoError(t, upgErr) {
+			return
+		}
+
+		// Drain reads so the server doesn't block on unread messages.
+		// ReadMessage errors are expected here because we kill TCP below.
+		go func() {
+			for {
+				if _, _, err := conn.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}()
+
+		// Send a burst of pings to fill the receive buffer.
+		for range 20 {
+			assert.NoError(t, conn.WriteControl(
+				websocket.PingMessage, []byte("p"), time.Now().Add(time.Second),
+			))
+		}
+
+		// Abruptly kill TCP so the client's writePump fails,
+		// triggering connectionClosedWithError -> close(w.done)
+		// while the readPump may still be in the ping handler.
+		assert.NoError(t, conn.UnderlyingConn().Close())
+	})
+
+	sr := ts.tb.Replacer.Replace
+	_, err := ts.runtime.RunOnEventLoop(sr(`
+		var ws = new WebSocket("WSBIN_URL/ws-ping-deadlock")
+		ws.onerror = (e) => { call("error: " + e.error) }
+		ws.onopen = () => {
+			ws.send("keepalive")
+		}
+	`))
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## What?

Fixes a deadlock where WebSocket connections hang forever during teardown when the server sends pings.

## Why?

WebSocket connections should shut down cleanly when a test ends or the server drops the connection. A server ping arriving during that window could permanently stall the k6 process. Observed on cloud test run 7385826.

## How to reproduce

The included test sends 20 pings in a burst and drops the TCP connection. Without the fix, the test hangs until timeout.

## Related PR(s)/Issue(s)

Closes #4598