### PR TITLE
chore(deps): bump k6provider to v0.5.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/grafana/k6-cloud-openapi-client-go v0.0.2
-	github.com/grafana/k6provider v0.4.0
+	github.com/grafana/k6provider v0.5.0
 	github.com/grafana/sobek v0.0.0-20260331145705-2272ac4993ef
 	github.com/grafana/xk6-dashboard-assets v0.1.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -92,8 +92,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/k6-cloud-openapi-client-go v0.0.2 h1:YzMFCaKiLA8UFQjCrrhrtkxvkzcRt8ENMeo+f7ndV7k=
 github.com/grafana/k6-cloud-openapi-client-go v0.0.2/go.mod h1:RBPBP7qIR/K6qzQEQYESVhp/XJspiBTOyBEBCbPXrvI=
-github.com/grafana/k6provider v0.4.0 h1:pbocygBjY3BpSwQn01Nagl2ngQmv0aWr6mmq50PTyuI=
-github.com/grafana/k6provider v0.4.0/go.mod h1:R9WKthnwk96E47m6w/mnC13hhBYTn5iMdP5caFt/t5k=
+github.com/grafana/k6provider v0.5.0 h1:SwItWPOMQHfRytezQBKpeXLxjNmcyD/x9PTA28pEbwg=
+github.com/grafana/k6provider v0.5.0/go.mod h1:R9WKthnwk96E47m6w/mnC13hhBYTn5iMdP5caFt/t5k=
 github.com/grafana/sobek v0.0.0-20260331145705-2272ac4993ef h1:onLtCR9w3Iqn57s39rYf1PtRl89uSznaM36TKcepxn4=
 github.com/grafana/sobek v0.0.0-20260331145705-2272ac4993ef/go.mod h1:YtuqiJX1W3XvRSilL/kUZzduJG3phPJWyzM9DiIEfBo=
 github.com/grafana/xk6-dashboard-assets v0.1.2 h1:n2wqytPICn2ZYsKa9HE6GlvFXk+WjByMfT4eM+ms3gE=

--- a/vendor/github.com/grafana/k6provider/client.go
+++ b/vendor/github.com/grafana/k6provider/client.go
@@ -31,6 +31,7 @@ type buildArtifact struct {
 
 // buildRequest defines a request to the build service
 type buildRequest struct {
+	K6ModPath     string       `json:"k6_mod_path,omitempty"`
 	K6Constraints string       `json:"k6,omitempty"`
 	Dependencies  []dependency `json:"dependencies,omitempty"`
 	Platform      string       `json:"platform,omitempty"`
@@ -74,10 +75,12 @@ func newBuildServiceClient(
 func (r *buildClient) Build(
 	ctx context.Context,
 	platform string,
+	k6ModPath string,
 	k6Constraints string,
 	deps []dependency,
 ) (buildArtifact, error) {
 	req := buildRequest{
+		K6ModPath:     k6ModPath,
 		Platform:      platform,
 		K6Constraints: k6Constraints,
 		Dependencies:  deps,

--- a/vendor/github.com/grafana/k6provider/provider.go
+++ b/vendor/github.com/grafana/k6provider/provider.go
@@ -96,6 +96,10 @@ type Config struct {
 	PruneInterval time.Duration
 	// Download configuration
 	DownloadConfig DownloadConfig
+	// K6ModPath is the Go module path for k6. If empty, k6_mod_path is omitted from
+	// build requests and the build service defaults to go.k6.io/k6 (v1).
+	// Set to "go.k6.io/k6/v2" for k6 v2 builds.
+	K6ModPath string
 }
 
 // Dependencies defines a group of dependencies with their version constrains
@@ -112,6 +116,7 @@ type Provider struct {
 	binDir     string
 	buildSrv   *buildClient
 	platform   string
+	k6ModPath  string
 	pruner     *Pruner
 	logger     *slog.Logger
 }
@@ -210,6 +215,7 @@ func NewProviderWithLogger(config Config, logger *slog.Logger) (*Provider, error
 		binDir:     binDir,
 		buildSrv:   buildSrv,
 		platform:   platform,
+		k6ModPath:  config.K6ModPath,
 		pruner:     pruner,
 		logger:     logger,
 	}, nil
@@ -242,7 +248,7 @@ func (p *Provider) GetArtifact(
 		"deps", deps,
 		"platform", p.platform,
 	)
-	artifact, err := p.buildSrv.Build(ctx, p.platform, k6Constrains, buildDeps)
+	artifact, err := p.buildSrv.Build(ctx, p.platform, p.k6ModPath, k6Constrains, buildDeps)
 	if err != nil {
 		if !errors.Is(err, ErrInvalidParameters) {
 			return Artifact{}, NewWrappedError(ErrBuild, err)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -180,7 +180,7 @@ github.com/gorilla/websocket
 # github.com/grafana/k6-cloud-openapi-client-go v0.0.2
 ## explicit; go 1.23.4
 github.com/grafana/k6-cloud-openapi-client-go/k6
-# github.com/grafana/k6provider v0.4.0
+# github.com/grafana/k6provider v0.5.0
 ## explicit; go 1.24.0
 github.com/grafana/k6provider
 # github.com/grafana/sobek v0.0.0-20260331145705-2272ac4993ef


### PR DESCRIPTION
Bumps `github.com/grafana/k6provider` from v0.4.0 to v0.5.0.

v0.5.0 adds `K6ModPath` support for k6 v2 build routing (grafana/k6provider#120).

🤖 Generated with [Claude Code](https://claude.com/claude-code)