### PR TITLE
Cancel hung cloud pushes on output shutdown

### DIFF
--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -1,6 +1,7 @@
 package expv2
 
 import (
+	"context"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -10,7 +11,7 @@ import (
 )
 
 type pusher interface {
-	push(samples *pbcloud.MetricSet) error
+	push(ctx context.Context, samples *pbcloud.MetricSet) error
 }
 
 type metricsFlusher struct {
@@ -27,7 +28,7 @@ type metricsFlusher struct {
 // flush flushes the queued buckets sending them to the remote Cloud service.
 // If the number of time series collected is bigger than maximum batch size
 // then it splits in chunks.
-func (f *metricsFlusher) flush() error {
+func (f *metricsFlusher) flush(ctx context.Context) error {
 	// drain the buffer
 	buckets := f.bq.PopAll()
 	if len(buckets) < 1 {
@@ -82,10 +83,10 @@ func (f *metricsFlusher) flush() error {
 		f.reportDiscardedLabels(msb.discardedLabels)
 	}
 
-	return f.flushBatches(batches)
+	return f.flushBatches(ctx, batches)
 }
 
-func (f *metricsFlusher) flushBatches(batches []*pbcloud.MetricSet) error {
+func (f *metricsFlusher) flushBatches(ctx context.Context, batches []*pbcloud.MetricSet) error {
 	var (
 		workers  = min(len(batches), f.batchPushConcurrency)
 		errs     = make(chan error, workers)
@@ -96,7 +97,7 @@ func (f *metricsFlusher) flushBatches(batches []*pbcloud.MetricSet) error {
 	for i := 0; i < workers; i++ {
 		go func() {
 			for chunk := range feed {
-				if err := f.client.push(chunk); err != nil {
+				if err := f.client.push(ctx, chunk); err != nil {
 					errs <- err
 					return
 				}

--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -1,6 +1,7 @@
 package expv2
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"sync"
@@ -81,7 +82,7 @@ func TestMetricsFlusherFlushInBatchWithinBucket(t *testing.T) {
 		require.Len(t, sinks, tc.series)
 
 		bq.Push([]timeBucket{{Time: 1, Sinks: sinks}})
-		err := mf.flush()
+		err := mf.flush(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, tc.expFlushCalls, pm.timesCalled())
 	}
@@ -131,7 +132,7 @@ func TestMetricsFlusherFlushInBatchAcrossBuckets(t *testing.T) {
 		}
 		require.Len(t, bq.buckets, tc.series)
 
-		err := mf.flush()
+		err := mf.flush(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, tc.expPushCalls, pm.timesCalled())
 	}
@@ -192,7 +193,7 @@ func TestFlushWithReservedLabels(t *testing.T) {
 		},
 	})
 
-	err := mf.flush()
+	err := mf.flush(context.Background())
 	require.NoError(t, err)
 
 	loglines := hook.Drain()
@@ -282,7 +283,7 @@ func TestFlushMaxSeriesInBatch(t *testing.T) {
 			},
 		},
 	})
-	err := mf.flush()
+	err := mf.flush(context.Background())
 	require.NoError(t, err)
 
 	require.Len(t, collected, 2)
@@ -327,7 +328,7 @@ func (pm *pusherMock) timesCalled() int {
 	return int(atomic.LoadInt64(&pm.pushCalled))
 }
 
-func (pm *pusherMock) push(ms *pbcloud.MetricSet) error {
+func (pm *pusherMock) push(_ context.Context, ms *pbcloud.MetricSet) error {
 	if pm.hook != nil {
 		pm.hook(ms)
 	}
@@ -383,7 +384,7 @@ func TestMetricsFlusherErrorCase(t *testing.T) {
 	}
 	require.Len(t, bq.buckets, series)
 
-	err := mf.flush()
+	err := mf.flush(context.Background())
 	require.Error(t, err)
 	// since the push happens concurrently the number of the calls could vary,
 	// but at least one call should happen and it should be less than the

--- a/output/cloud/expv2/metrics_client.go
+++ b/output/cloud/expv2/metrics_client.go
@@ -53,14 +53,19 @@ func newMetricsClient(c metricsHTTPClient, testRunID string) (*metricsClient, er
 }
 
 // Push the provided metrics for the given test run ID.
-func (mc *metricsClient) push(samples *pbcloud.MetricSet) error {
+//
+// The context bounds the lifetime of the in-flight HTTP request: when
+// the cloud Output is shutting down it cancels the context so a slow
+// or hung response cannot pin (*Output).StopWithTestError on its
+// WaitGroup (k6-cloud-agent issue #341).
+func (mc *metricsClient) push(ctx context.Context, samples *pbcloud.MetricSet) error {
 	b, err := newRequestBody(samples)
 	if err != nil {
 		return err
 	}
 
 	req, err := http.NewRequestWithContext(
-		context.Background(), http.MethodPost, mc.url, io.NopCloser(bytes.NewReader(b)))
+		ctx, http.MethodPost, mc.url, io.NopCloser(bytes.NewReader(b)))
 	if err != nil {
 		return err
 	}

--- a/output/cloud/expv2/metrics_client_test.go
+++ b/output/cloud/expv2/metrics_client_test.go
@@ -1,6 +1,7 @@
 package expv2
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/http"
@@ -42,7 +43,7 @@ func TestMetricsClientPush(t *testing.T) {
 	require.NoError(t, err)
 
 	mset := pbcloud.MetricSet{}
-	err = mc.push(&mset)
+	err = mc.push(context.Background(), &mset)
 	require.NoError(t, err)
 	assert.Equal(t, 1, reqs)
 }
@@ -57,7 +58,7 @@ func TestMetricsClientPushUnexpectedStatus(t *testing.T) {
 	mc, err := newMetricsClient(mock, "test-ref-id")
 	require.NoError(t, err)
 
-	err = mc.push(nil)
+	err = mc.push(context.Background(), nil)
 	assert.ErrorContains(t, err, "500 Internal Server Error")
 }
 

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -25,7 +25,7 @@ import (
 
 // flusher is an interface for flushing data to the cloud.
 type flusher interface {
-	flush() error
+	flush(ctx context.Context) error
 }
 
 // Output sends result data to the k6 Cloud service.
@@ -50,6 +50,12 @@ type Output struct {
 	// stop signal to graceful stop
 	stop chan struct{}
 
+	// flushCtx scopes the lifetime of in-flight flush HTTP requests.
+	// Canceling it during shutdown unblocks pushes whose response
+	// is hanging on the network so wg.Wait() can return promptly.
+	flushCtx    context.Context
+	flushCancel context.CancelFunc
+
 	// abort signal to interrupt immediately all background goroutines
 	abort        chan struct{}
 	abortOnce    sync.Once
@@ -63,14 +69,25 @@ func New(logger logrus.FieldLogger, conf cloudapi.Config, _ *cloudapi.Client) (*
 	//
 	// It creates a new client because in the case the backend has overwritten
 	// the config we need to use the new set.
-	return &Output{
+	o := &Output{
 		config: conf,
 		logger: logger.WithField("output", "cloudv2"),
 		abort:  make(chan struct{}),
 		stop:   make(chan struct{}),
 		cloudClient: cloudapi.NewClient(
 			logger, conf.Token.String, conf.Host.String, build.Version, conf.Timeout.TimeDuration()),
-	}, nil
+	}
+	o.flushCtx, o.flushCancel = context.WithCancel(context.Background())
+	return o, nil
+}
+
+// ensureFlushCtx initializes flushCtx and flushCancel lazily. It exists
+// because some tests construct Output{} directly without going through
+// New() and still exercise flushMetrics via the periodic flush path.
+func (o *Output) ensureFlushCtx() {
+	if o.flushCtx == nil {
+		o.flushCtx, o.flushCancel = context.WithCancel(context.Background())
+	}
 }
 
 // SetTestRunID sets the Cloud's test run id.
@@ -152,8 +169,30 @@ func (o *Output) StopWithTestError(_ error) error {
 	o.logger.Debug("Stopping...")
 	defer o.logger.Debug("Stopped!")
 
+	o.ensureFlushCtx()
 	close(o.stop)
-	o.wg.Wait()
+
+	// Wait for background flush loops to exit. If a flush is hung on a
+	// network request, give it a short grace period and then cancel
+	// flushCtx so the in-flight HTTP push returns and the wait group
+	// can complete. Otherwise k6 may hang on shutdown long enough that
+	// k6agent forcefully terminates the process with SIGQUIT
+	// (k6-cloud-agent issue #341).
+	const inflightFlushGrace = 5 * time.Second
+	wgDone := make(chan struct{})
+	go func() {
+		o.wg.Wait()
+		close(wgDone)
+	}()
+	flushCanceledOnTimeout := false
+	select {
+	case <-wgDone:
+	case <-time.After(inflightFlushGrace):
+		o.logger.Warn("Cloud output flush did not return in time on shutdown, canceling in-flight requests")
+		o.flushCancel()
+		flushCanceledOnTimeout = true
+		<-wgDone
+	}
 
 	select {
 	case <-o.abort:
@@ -161,12 +200,22 @@ func (o *Output) StopWithTestError(_ error) error {
 	default:
 	}
 
+	// If we had to cancel an in-flight push to escape the wait group,
+	// the network is unhealthy. Skip the final flush (which would also
+	// hang) and let the caller proceed to testFinished.
+	if flushCanceledOnTimeout {
+		return nil
+	}
+
 	// Drain the SampleBuffer and force the aggregation for flushing
 	// all the queued samples even if they haven't yet passed the
-	// wait period.
+	// wait period. Use a fresh context so the final flush is not
+	// poisoned by a previously canceled flushCtx.
+	finalCtx, finalCancel := context.WithTimeout(context.Background(), o.config.Timeout.TimeDuration())
+	defer finalCancel()
 	o.collector.DropExpiringDelay()
 	o.collectSamples()
-	o.flushMetrics()
+	o.flushMetrics(finalCtx)
 
 	// Flush all the remaining request metadatas.
 	if insightsOutput.Enabled(o.config) {
@@ -180,6 +229,7 @@ func (o *Output) StopWithTestError(_ error) error {
 }
 
 func (o *Output) runPeriodicFlush() {
+	o.ensureFlushCtx()
 	t := time.NewTicker(o.config.MetricPushInterval.TimeDuration())
 
 	o.wg.Add(1)
@@ -193,7 +243,7 @@ func (o *Output) runPeriodicFlush() {
 		for {
 			select {
 			case <-t.C:
-				o.flushMetrics()
+				o.flushMetrics(o.flushCtx)
 			case <-o.stop:
 				return
 			case <-o.abort:
@@ -254,11 +304,14 @@ func (o *Output) collectSamples() {
 }
 
 // flushMetrics receives a set of metric samples.
-func (o *Output) flushMetrics() {
+func (o *Output) flushMetrics(ctx context.Context) {
 	start := time.Now()
 
-	err := o.flushing.flush()
+	err := o.flushing.flush(ctx)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			return
+		}
 		o.handleFlushError(err)
 		return
 	}

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -1,6 +1,7 @@
 package expv2
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -374,6 +375,60 @@ func TestOutputFlushWorkersStop(t *testing.T) {
 	})
 }
 
+// TestOutputStopWithTestErrorDoesNotHangOnInflightFlush asserts that
+// StopWithTestError returns promptly even if a flush is currently in
+// flight when stop is requested.
+//
+// Reproduces production test run 7400202 (k6-cloud-agent issue #341):
+// a hung HTTP push to the metrics ingest endpoint pinned
+// (*Output).StopWithTestError on wg.Wait() for ~60 seconds, exceeding
+// k6agent's StopTimeout. k6agent then forcefully terminated the k6
+// process with SIGQUIT.
+//
+// The fix propagates cancellation from StopWithTestError into the
+// in-flight flush so it returns instead of pinning the wait group.
+func TestOutputStopWithTestErrorDoesNotHangOnInflightFlush(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		flushStarted := make(chan struct{})
+
+		o := Output{
+			logger: testutils.NewLogger(t),
+			stop:   make(chan struct{}),
+			abort:  make(chan struct{}),
+		}
+		o.config.MetricPushInterval = types.NullDurationFrom(1 * time.Millisecond)
+
+		once := sync.Once{}
+		flusherMock := flusherCtxFunc(func(ctx context.Context) error {
+			// Simulate an in-flight HTTP push that does not respond.
+			// It must unblock when StopWithTestError signals shutdown.
+			once.Do(func() { close(flushStarted) })
+			<-ctx.Done()
+			return ctx.Err()
+		})
+		o.flushing = flusherMock
+		o.runPeriodicFlush()
+
+		<-flushStarted
+
+		stopReturned := make(chan error, 1)
+		go func() {
+			stopReturned <- o.StopWithTestError(nil)
+		}()
+
+		// The fix gives in-flight flushes a short grace period before
+		// canceling them. 30 seconds is well past that grace period
+		// while still being far below k6agent's 60-second hard timeout.
+		select {
+		case <-stopReturned:
+			// success: stop returned without waiting indefinitely.
+		case <-time.After(30 * time.Second):
+			t.Fatal("StopWithTestError blocked on an in-flight flush")
+		}
+	})
+}
+
 func TestOutputFlushWorkersAbort(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
@@ -512,12 +567,24 @@ func TestOutputFlushRequestMetadatasAbort(t *testing.T) {
 type flusherFunc func()
 
 func (ff flusherFunc) Flush() error {
-	return ff.flush()
+	return ff.flush(context.Background())
 }
 
-func (ff flusherFunc) flush() error {
+func (ff flusherFunc) flush(_ context.Context) error {
 	ff()
 	return nil
+}
+
+// flusherCtxFunc is a context-aware flusher used by tests that need
+// to verify cancellation-driven shutdown behavior.
+type flusherCtxFunc func(ctx context.Context) error
+
+func (ff flusherCtxFunc) Flush() error {
+	return ff(context.Background())
+}
+
+func (ff flusherCtxFunc) flush(ctx context.Context) error {
+	return ff(ctx)
 }
 
 func TestPrintableConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

The cloud Output's `StopWithTestError` could pin `wg.Wait()` for ~60 seconds whenever an HTTP push to the v2 metrics ingest endpoint stopped responding. Once that wait exceeded k6agent's `StopTimeout` (also 1 minute by default), k6agent escalated to SIGQUIT and forcefully killed k6 even when the load test itself had finished cleanly.

## Root cause

`output/cloud/expv2/metrics_client.go` builds its push request with `context.Background()`, so `cloudapi.Client.Do` cannot be canceled by anything other than its own 1-minute HTTP timeout. While that push hangs:

- `runPeriodicFlush` is stuck inside `flushBatches` and never re-enters its `select` to observe `<-o.stop`.
- `StopWithTestError` calls `close(o.stop)` then `o.wg.Wait()`, which cannot return until the periodic flush goroutine returns.
- The default Cloud HTTP timeout (`cloudapi.Config.Timeout`, 1 minute) equals the k6agent `StopTimeout`. The race is unwinnable: k6agent SIGTERMs k6, k6 calls `StopWithTestError`, that blocks for ~60s, k6agent times out and SIGQUITs.

Reproduced from production test run 7400202 (release 2.116.0): the SIGQUIT goroutine dump shows goroutine 1 at `expv2.(*Output).StopWithTestError` waiting on `sync.WaitGroup.Wait` for "1 minutes". This pattern matches the chronic [k6-cloud-agent issue #341](https://github.com/grafana/k6-cloud-agent/issues/341) (55 occurrences, "Process wait error").

## Fix

- Thread a context through `flusher.flush`, `metricsFlusher.flushBatches`, and `metricsClient.push`, then use it in `http.NewRequestWithContext`.
- Maintain a long-lived `flushCtx` on the `Output` that the periodic flush passes to each push.
- On shutdown: close `o.stop`, then wait up to 5 seconds for the wait group. If it does not return in time, log a warning, cancel `flushCtx` so any hung HTTP request returns immediately, and skip the post-stop final flush (the network is unhealthy anyway). The final flush, when it does run, uses a fresh time-bounded context.

The signature change is internal to `output/cloud/expv2`. Existing tests are updated to match.

## Reproduction

`TestOutputStopWithTestErrorDoesNotHangOnInflightFlush` exercises the failure path: a flusher mock blocks until its context is canceled. Without the shutdown cancel, `StopWithTestError` blocks indefinitely on `wg.Wait()`. With the fix, it returns within the 5-second grace period.

Verified: removing only the timeout-cancel block in `StopWithTestError` causes the new test to fail with `StopWithTestError blocked on an in-flight flush`. Restoring it makes it pass under `-race -count=20`.

## Test plan

- [x] `go test ./output/cloud/expv2/...`
- [x] `go test ./internal/output/...`
- [x] `go test -race -count=20 -run TestOutputStopWithTestErrorDoesNotHangOnInflightFlush ./output/cloud/expv2/`
- [x] `golangci-lint run ./output/cloud/expv2/ ./internal/output/cloud/...`