### PR TITLE
cloud: keep a stuck upload from blocking shutdown

### DIFF
--- a/cloudapi/api_test.go
+++ b/cloudapi/api_test.go
@@ -3,6 +3,7 @@ package cloudapi
 import (
 	"archive/tar"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -416,4 +417,40 @@ func fprint(t *testing.T, w io.Writer, format string) int {
 	n, err := fmt.Fprint(w, format)
 	require.NoError(t, err)
 	return n
+}
+
+func TestClientDoStopsRetryingOnCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	firstReq := make(chan struct{}, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		select {
+		case firstReq <- struct{}{}:
+		default:
+		}
+		w.WriteHeader(http.StatusInternalServerError) // always retryable
+	}))
+	defer server.Close()
+
+	client := NewClient(testutils.NewLogger(t), "token", server.URL, "1.0", 1*time.Second)
+	// A long interval makes the test pass only if cancellation short-circuits
+	// the wait between retries instead of sleeping through it.
+	client.retryInterval = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL+"/v1/whatever", nil)
+	require.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- client.Do(req, nil) }()
+
+	<-firstReq // the first attempt landed, so Do is now waiting to retry
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Do kept waiting to retry after the context was canceled")
+	}
 }

--- a/cloudapi/client.go
+++ b/cloudapi/client.go
@@ -110,7 +110,14 @@ func (c *Client) Do(req *http.Request, v any) error {
 		retry, err := c.do(req, v, i)
 
 		if retry {
-			time.Sleep(c.retryInterval)
+			// Wait before retrying, but give up as soon as the request's
+			// context is done so a canceled or timed-out call returns at once
+			// instead of sleeping through the remaining attempts.
+			select {
+			case <-req.Context().Done():
+				return req.Context().Err()
+			case <-time.After(c.retryInterval):
+			}
 			if req.GetBody != nil {
 				req.Body, _ = req.GetBody()
 			}

--- a/internal/output/cloud/insights/flush.go
+++ b/internal/output/cloud/insights/flush.go
@@ -14,7 +14,7 @@ type Client interface {
 
 // RequestMetadatasFlusher is an interface for flushing data to the cloud.
 type RequestMetadatasFlusher interface {
-	Flush() error
+	Flush(ctx context.Context) error
 }
 
 // Flusher is an implementation of RequestMetadatasFlusher.
@@ -34,11 +34,11 @@ func NewFlusher(client Client, collector RequestMetadatasCollector) *Flusher {
 }
 
 // Flush retrieves data from the collector and sends it to the insights backend.
-func (f *Flusher) Flush() error {
+func (f *Flusher) Flush(ctx context.Context) error {
 	requestMetadatas := f.collector.PopAll()
 	if len(requestMetadatas) < 1 {
 		return nil
 	}
 
-	return f.client.IngestRequestMetadatasBatch(context.Background(), requestMetadatas)
+	return f.client.IngestRequestMetadatasBatch(ctx, requestMetadatas)
 }

--- a/internal/output/cloud/insights/flush_test.go
+++ b/internal/output/cloud/insights/flush_test.go
@@ -90,7 +90,7 @@ func Test_tracesFlusher_Flush_ReturnsNoErrorWithWorkingInsightsClientAndNonCance
 	flusher := NewFlusher(cli, col)
 
 	// When
-	err := flusher.Flush()
+	err := flusher.Flush(t.Context())
 
 	// Then
 	require.NoError(t, err)
@@ -109,7 +109,7 @@ func Test_tracesFlusher_Flush_ReturnsNoErrorWithWorkingInsightsClientAndNonCance
 	flusher := NewFlusher(cli, col)
 
 	// When
-	err := flusher.Flush()
+	err := flusher.Flush(t.Context())
 
 	// Then
 	require.NoError(t, err)
@@ -129,7 +129,7 @@ func Test_tracesFlusher_Flush_ReturnsErrorWithFailingInsightsClientAndNonCancell
 	flusher := NewFlusher(cli, col)
 
 	// When
-	err := flusher.Flush()
+	err := flusher.Flush(t.Context())
 
 	// Then
 	require.ErrorIs(t, err, testErr)

--- a/output/cloud/expv2/flush.go
+++ b/output/cloud/expv2/flush.go
@@ -1,6 +1,7 @@
 package expv2
 
 import (
+	"context"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -10,7 +11,7 @@ import (
 )
 
 type pusher interface {
-	push(samples *pbcloud.MetricSet) error
+	push(ctx context.Context, samples *pbcloud.MetricSet) error
 }
 
 type metricsFlusher struct {
@@ -27,7 +28,7 @@ type metricsFlusher struct {
 // flush flushes the queued buckets sending them to the remote Cloud service.
 // If the number of time series collected is bigger than maximum batch size
 // then it splits in chunks.
-func (f *metricsFlusher) flush() error {
+func (f *metricsFlusher) flush(ctx context.Context) error {
 	// drain the buffer
 	buckets := f.bq.PopAll()
 	if len(buckets) < 1 {
@@ -82,10 +83,10 @@ func (f *metricsFlusher) flush() error {
 		f.reportDiscardedLabels(msb.discardedLabels)
 	}
 
-	return f.flushBatches(batches)
+	return f.flushBatches(ctx, batches)
 }
 
-func (f *metricsFlusher) flushBatches(batches []*pbcloud.MetricSet) error {
+func (f *metricsFlusher) flushBatches(ctx context.Context, batches []*pbcloud.MetricSet) error {
 	var (
 		workers  = min(len(batches), f.batchPushConcurrency)
 		errs     = make(chan error, workers)
@@ -96,7 +97,7 @@ func (f *metricsFlusher) flushBatches(batches []*pbcloud.MetricSet) error {
 	for i := 0; i < workers; i++ {
 		go func() {
 			for chunk := range feed {
-				if err := f.client.push(chunk); err != nil {
+				if err := f.client.push(ctx, chunk); err != nil {
 					errs <- err
 					return
 				}

--- a/output/cloud/expv2/flush_test.go
+++ b/output/cloud/expv2/flush_test.go
@@ -1,11 +1,13 @@
 package expv2
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -81,7 +83,7 @@ func TestMetricsFlusherFlushInBatchWithinBucket(t *testing.T) {
 		require.Len(t, sinks, tc.series)
 
 		bq.Push([]timeBucket{{Time: 1, Sinks: sinks}})
-		err := mf.flush()
+		err := mf.flush(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, tc.expFlushCalls, pm.timesCalled())
 	}
@@ -131,7 +133,7 @@ func TestMetricsFlusherFlushInBatchAcrossBuckets(t *testing.T) {
 		}
 		require.Len(t, bq.buckets, tc.series)
 
-		err := mf.flush()
+		err := mf.flush(t.Context())
 		require.NoError(t, err)
 		assert.Equal(t, tc.expPushCalls, pm.timesCalled())
 	}
@@ -192,7 +194,7 @@ func TestFlushWithReservedLabels(t *testing.T) {
 		},
 	})
 
-	err := mf.flush()
+	err := mf.flush(t.Context())
 	require.NoError(t, err)
 
 	loglines := hook.Drain()
@@ -282,7 +284,7 @@ func TestFlushMaxSeriesInBatch(t *testing.T) {
 			},
 		},
 	})
-	err := mf.flush()
+	err := mf.flush(t.Context())
 	require.NoError(t, err)
 
 	require.Len(t, collected, 2)
@@ -327,7 +329,7 @@ func (pm *pusherMock) timesCalled() int {
 	return int(atomic.LoadInt64(&pm.pushCalled))
 }
 
-func (pm *pusherMock) push(ms *pbcloud.MetricSet) error {
+func (pm *pusherMock) push(_ context.Context, ms *pbcloud.MetricSet) error {
 	if pm.hook != nil {
 		pm.hook(ms)
 	}
@@ -339,6 +341,81 @@ func (pm *pusherMock) push(ms *pbcloud.MetricSet) error {
 	}
 
 	return nil
+}
+
+// TestMetricsFlusherFlushReturnsOnContextCancel ensures a flush returns promptly
+// when its context is cancelled, even while a metric push is blocked on an
+// unresponsive connection. Without this, the final flush at shutdown could keep
+// k6 from exiting.
+func TestMetricsFlusherFlushReturnsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	r := metrics.NewRegistry()
+	m1 := r.MustNewMetric("metric1", metrics.Counter)
+
+	logger, _ := testutils.NewLoggerWithHook(t)
+
+	released := make(chan struct{})
+	defer close(released)
+	pm := &blockingPusher{released: released}
+
+	bq := &bucketQ{}
+	mf := metricsFlusher{
+		bq:                   bq,
+		client:               pm,
+		logger:               logger,
+		discardedLabels:      make(map[string]struct{}),
+		maxSeriesInBatch:     1,
+		batchPushConcurrency: 1,
+	}
+
+	for i := range 5 {
+		ts := metrics.TimeSeries{
+			Metric: m1,
+			Tags:   r.RootTagSet().With("key1", "val"+strconv.Itoa(i)),
+		}
+		bq.Push([]timeBucket{
+			{
+				Time: int64(i) + 1,
+				Sinks: map[metrics.TimeSeries]metricValue{
+					ts: &counter{Sum: 1},
+				},
+			},
+		})
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	done := make(chan error, 1)
+	go func() { done <- mf.flush(ctx) }()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("flush did not return after context was cancelled (production hang reproduced)")
+	}
+}
+
+// blockingPusher blocks push() until released is closed. It honours context
+// cancellation so flush can interrupt a stuck push.
+type blockingPusher struct {
+	released chan struct{}
+	called   atomic.Int64
+}
+
+func (bp *blockingPusher) push(ctx context.Context, _ *pbcloud.MetricSet) error {
+	bp.called.Add(1)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-bp.released:
+		return nil
+	}
 }
 
 func TestMetricsFlusherErrorCase(t *testing.T) {
@@ -383,7 +460,7 @@ func TestMetricsFlusherErrorCase(t *testing.T) {
 	}
 	require.Len(t, bq.buckets, series)
 
-	err := mf.flush()
+	err := mf.flush(t.Context())
 	require.Error(t, err)
 	// since the push happens concurrently the number of the calls could vary,
 	// but at least one call should happen and it should be less than the

--- a/output/cloud/expv2/metrics_client.go
+++ b/output/cloud/expv2/metrics_client.go
@@ -52,15 +52,16 @@ func newMetricsClient(c metricsHTTPClient, testRunID string) (*metricsClient, er
 	}, nil
 }
 
-// Push the provided metrics for the given test run ID.
-func (mc *metricsClient) push(samples *pbcloud.MetricSet) error {
+// Push the provided metrics for the given test run ID. The context cancels the
+// underlying HTTP request so a stuck push cannot block k6 shutdown.
+func (mc *metricsClient) push(ctx context.Context, samples *pbcloud.MetricSet) error {
 	b, err := newRequestBody(samples)
 	if err != nil {
 		return err
 	}
 
 	req, err := http.NewRequestWithContext(
-		context.Background(), http.MethodPost, mc.url, io.NopCloser(bytes.NewReader(b)))
+		ctx, http.MethodPost, mc.url, io.NopCloser(bytes.NewReader(b)))
 	if err != nil {
 		return err
 	}

--- a/output/cloud/expv2/metrics_client_test.go
+++ b/output/cloud/expv2/metrics_client_test.go
@@ -42,7 +42,7 @@ func TestMetricsClientPush(t *testing.T) {
 	require.NoError(t, err)
 
 	mset := pbcloud.MetricSet{}
-	err = mc.push(&mset)
+	err = mc.push(t.Context(), &mset)
 	require.NoError(t, err)
 	assert.Equal(t, 1, reqs)
 }
@@ -57,7 +57,7 @@ func TestMetricsClientPushUnexpectedStatus(t *testing.T) {
 	mc, err := newMetricsClient(mock, "test-ref-id")
 	require.NoError(t, err)
 
-	err = mc.push(nil)
+	err = mc.push(t.Context(), nil)
 	assert.ErrorContains(t, err, "500 Internal Server Error")
 }
 

--- a/output/cloud/expv2/output.go
+++ b/output/cloud/expv2/output.go
@@ -23,9 +23,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// stopFlushTimeout bounds how long shutdown waits on in-flight uploads before
+// canceling them, so a stalled upload can't keep the process from exiting.
+const stopFlushTimeout = 15 * time.Second
+
 // flusher is an interface for flushing data to the cloud.
 type flusher interface {
-	flush() error
+	flush(ctx context.Context) error
 }
 
 // Output sends result data to the k6 Cloud service.
@@ -54,6 +58,9 @@ type Output struct {
 	abort        chan struct{}
 	abortOnce    sync.Once
 	testStopFunc func(error)
+
+	// cancelFlush interrupts in-flight uploads when shutdown can no longer wait.
+	cancelFlush context.CancelFunc
 }
 
 // New creates a new cloud output.
@@ -116,7 +123,10 @@ func (o *Output) Start() error {
 		batchPushConcurrency: int(o.config.MetricPushConcurrency.Int64),
 	}
 
-	o.runPeriodicFlush()
+	flushCtx, cancelFlush := context.WithCancel(context.Background())
+	o.cancelFlush = cancelFlush
+
+	o.runPeriodicFlush(flushCtx)
 	o.periodicInvoke(o.config.AggregationPeriod.TimeDuration(), o.collectSamples)
 
 	if insightsOutput.Enabled(o.config) {
@@ -139,7 +149,7 @@ func (o *Output) Start() error {
 
 		o.insightsClient = insightsClient
 		o.requestMetadatasFlusher = insightsOutput.NewFlusher(insightsClient, o.requestMetadatasCollector)
-		o.runFlushRequestMetadatas()
+		o.runFlushRequestMetadatas(flushCtx)
 	}
 
 	o.logger.WithField("config", printableConfig(o.config)).Debug("Started!")
@@ -152,8 +162,25 @@ func (o *Output) StopWithTestError(_ error) error {
 	o.logger.Debug("Stopping...")
 	defer o.logger.Debug("Stopped!")
 
+	defer o.cancelFlush()
+
 	close(o.stop)
-	o.wg.Wait()
+
+	// Wait for the background flushers, but don't let a stuck upload pin the
+	// process: once the budget is spent, cancel any in-flight push so wg.Wait
+	// returns, and skip the final flush since the connection is unhealthy.
+	flushersDone := make(chan struct{})
+	go func() {
+		o.wg.Wait()
+		close(flushersDone)
+	}()
+	select {
+	case <-flushersDone:
+	case <-time.After(stopFlushTimeout):
+		o.cancelFlush()
+		<-flushersDone
+		return nil
+	}
 
 	select {
 	case <-o.abort:
@@ -166,11 +193,14 @@ func (o *Output) StopWithTestError(_ error) error {
 	// wait period.
 	o.collector.DropExpiringDelay()
 	o.collectSamples()
-	o.flushMetrics()
+
+	stopCtx, cancel := context.WithTimeout(context.Background(), stopFlushTimeout)
+	defer cancel()
+	o.flushMetrics(stopCtx)
 
 	// Flush all the remaining request metadatas.
 	if insightsOutput.Enabled(o.config) {
-		o.flushRequestMetadatas()
+		o.flushRequestMetadatas(stopCtx)
 		if err := o.insightsClient.Close(); err != nil {
 			o.logger.WithError(err).Error("Failed to close the insights client")
 		}
@@ -179,7 +209,7 @@ func (o *Output) StopWithTestError(_ error) error {
 	return nil
 }
 
-func (o *Output) runPeriodicFlush() {
+func (o *Output) runPeriodicFlush(ctx context.Context) {
 	t := time.NewTicker(o.config.MetricPushInterval.TimeDuration())
 
 	o.wg.Add(1)
@@ -193,7 +223,7 @@ func (o *Output) runPeriodicFlush() {
 		for {
 			select {
 			case <-t.C:
-				o.flushMetrics()
+				o.flushMetrics(ctx)
 			case <-o.stop:
 				return
 			case <-o.abort:
@@ -254,10 +284,10 @@ func (o *Output) collectSamples() {
 }
 
 // flushMetrics receives a set of metric samples.
-func (o *Output) flushMetrics() {
+func (o *Output) flushMetrics(ctx context.Context) {
 	start := time.Now()
 
-	err := o.flushing.flush()
+	err := o.flushing.flush(ctx)
 	if err != nil {
 		o.handleFlushError(err)
 		return
@@ -266,7 +296,7 @@ func (o *Output) flushMetrics() {
 	o.logger.WithField("t", time.Since(start)).Trace("Successfully flushed buffered samples to the cloud")
 }
 
-func (o *Output) runFlushRequestMetadatas() {
+func (o *Output) runFlushRequestMetadatas(ctx context.Context) {
 	t := time.NewTicker(o.config.TracesPushInterval.TimeDuration())
 
 	for i := int64(0); i < o.config.TracesPushConcurrency.Int64; i++ {
@@ -276,7 +306,7 @@ func (o *Output) runFlushRequestMetadatas() {
 			for {
 				select {
 				case <-t.C:
-					o.flushRequestMetadatas()
+					o.flushRequestMetadatas(ctx)
 				case <-o.stop:
 					return
 				case <-o.abort:
@@ -288,10 +318,10 @@ func (o *Output) runFlushRequestMetadatas() {
 }
 
 // flushRequestMetadatas periodically flushes traces collected in RequestMetadatasCollector using flusher.
-func (o *Output) flushRequestMetadatas() {
+func (o *Output) flushRequestMetadatas(ctx context.Context) {
 	start := time.Now()
 
-	err := o.requestMetadatasFlusher.Flush()
+	err := o.requestMetadatasFlusher.Flush(ctx)
 	if err != nil {
 		o.logger.WithError(err).WithField("t", time.Since(start)).Error("Failed to push trace samples to the cloud")
 

--- a/output/cloud/expv2/output_test.go
+++ b/output/cloud/expv2/output_test.go
@@ -1,6 +1,7 @@
 package expv2
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -315,7 +316,7 @@ func TestOutputFlushTicks(t *testing.T) {
 		//
 		// The second request unblocks.
 		var requestsCount int64
-		flusherMock := func() {
+		flusherMock := func(context.Context) {
 			updated := atomic.AddInt64(&requestsCount, 1)
 			if updated == 2 {
 				close(done)
@@ -329,7 +330,7 @@ func TestOutputFlushTicks(t *testing.T) {
 		}
 		o.config.MetricPushInterval = types.NullDurationFrom(100 * time.Millisecond) // loop
 		o.flushing = flusherFunc(flusherMock)
-		o.runPeriodicFlush()
+		o.runPeriodicFlush(t.Context())
 
 		select {
 		case <-time.After(5 * time.Second):
@@ -352,13 +353,13 @@ func TestOutputFlushWorkersStop(t *testing.T) {
 		o.config.MetricPushInterval = types.NullDurationFrom(1 * time.Millisecond)
 
 		once := sync.Once{}
-		flusherMock := func() {
+		flusherMock := func(context.Context) {
 			// it asserts that flushers are set and the flush is invoked
 			once.Do(func() { close(o.stop) })
 		}
 
 		o.flushing = flusherFunc(flusherMock)
-		o.runPeriodicFlush()
+		o.runPeriodicFlush(t.Context())
 
 		// it asserts that all flushers exit
 		done := make(chan struct{})
@@ -384,13 +385,13 @@ func TestOutputFlushWorkersAbort(t *testing.T) {
 		o.config.MetricPushInterval = types.NullDurationFrom(1 * time.Millisecond)
 
 		once := sync.Once{}
-		flusherMock := func() {
+		flusherMock := func(context.Context) {
 			// it asserts that flushers are set and the flush func is invoked
 			once.Do(func() { close(o.abort) })
 		}
 
 		o.flushing = flusherFunc(flusherMock)
-		o.runPeriodicFlush()
+		o.runPeriodicFlush(t.Context())
 
 		// it asserts that all flushers exit
 		done := make(chan struct{})
@@ -416,7 +417,7 @@ func TestOutputFlushRequestMetadatasConcurrently(t *testing.T) {
 		//
 		// The second request unblocks.
 		var requestsCount int64
-		flusherMock := func() {
+		flusherMock := func(context.Context) {
 			updated := atomic.AddInt64(&requestsCount, 1)
 			if updated == 2 {
 				close(done)
@@ -431,8 +432,8 @@ func TestOutputFlushRequestMetadatasConcurrently(t *testing.T) {
 		}
 		o.config.TracesPushConcurrency = null.IntFrom(2)
 		o.config.TracesPushInterval = types.NullDurationFrom(1) // loop
-		o.requestMetadatasFlusher = flusherFunc(flusherMock)
-		o.runFlushRequestMetadatas()
+		o.requestMetadatasFlusher = requestMetadatasFlusherFunc(flusherMock)
+		o.runFlushRequestMetadatas(t.Context())
 
 		select {
 		case <-time.After(5 * time.Second):
@@ -455,13 +456,13 @@ func TestOutputFlushRequestMetadatasStop(t *testing.T) {
 		o.config.TracesPushInterval = types.NullDurationFrom(1 * time.Millisecond)
 
 		once := sync.Once{}
-		flusherMock := func() {
+		flusherMock := func(context.Context) {
 			// it asserts that flushers are set and the flush is invoked
 			once.Do(func() { close(o.stop) })
 		}
 
-		o.requestMetadatasFlusher = flusherFunc(flusherMock)
-		o.runFlushRequestMetadatas()
+		o.requestMetadatasFlusher = requestMetadatasFlusherFunc(flusherMock)
+		o.runFlushRequestMetadatas(t.Context())
 
 		// it asserts that all flushers exit
 		done := make(chan struct{})
@@ -487,13 +488,13 @@ func TestOutputFlushRequestMetadatasAbort(t *testing.T) {
 		o.config.TracesPushInterval = types.NullDurationFrom(1 * time.Millisecond)
 
 		once := sync.Once{}
-		flusherMock := func() {
+		flusherMock := func(context.Context) {
 			// it asserts that flushers are set and the flush func is invoked
 			once.Do(func() { close(o.abort) })
 		}
 
-		o.requestMetadatasFlusher = flusherFunc(flusherMock)
-		o.runFlushRequestMetadatas()
+		o.requestMetadatasFlusher = requestMetadatasFlusherFunc(flusherMock)
+		o.runFlushRequestMetadatas(t.Context())
 
 		// it asserts that all flushers exit
 		done := make(chan struct{})
@@ -509,14 +510,56 @@ func TestOutputFlushRequestMetadatasAbort(t *testing.T) {
 	})
 }
 
-type flusherFunc func()
+func TestOutputStopCancelsStuckFlush(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		o := Output{
+			logger: testutils.NewLogger(t),
+			stop:   make(chan struct{}),
+			abort:  make(chan struct{}),
+		}
+		o.config.MetricPushInterval = types.NullDurationFrom(time.Millisecond)
 
-func (ff flusherFunc) Flush() error {
-	return ff.flush()
+		// A flush that only returns once its context is canceled mimics an
+		// upload stuck on an unresponsive connection.
+		inflight := make(chan struct{})
+		var once sync.Once
+		o.flushing = flusherFunc(func(ctx context.Context) {
+			once.Do(func() { close(inflight) })
+			<-ctx.Done()
+		})
+
+		flushCtx, cancel := context.WithCancel(context.Background())
+		o.cancelFlush = cancel
+		o.runPeriodicFlush(flushCtx)
+
+		<-inflight // a periodic flush is now stuck mid-upload
+
+		stopped := make(chan struct{})
+		go func() {
+			defer close(stopped)
+			_ = o.StopWithTestError(nil)
+		}()
+
+		select {
+		case <-stopped:
+		case <-time.After(time.Minute):
+			t.Fatal("StopWithTestError hung on a stuck flush (production hang reproduced)")
+		}
+	})
 }
 
-func (ff flusherFunc) flush() error {
-	ff()
+type flusherFunc func(context.Context)
+
+func (ff flusherFunc) flush(ctx context.Context) error {
+	ff(ctx)
+	return nil
+}
+
+type requestMetadatasFlusherFunc func(context.Context)
+
+func (ff requestMetadatasFlusherFunc) Flush(ctx context.Context) error {
+	ff(ctx)
 	return nil
 }
 


### PR DESCRIPTION
## What?

A `k6 cloud` test no longer hangs at exit when its final uploads can't reach the server.

## Why?

When a test ends, k6 makes a last upload of the metrics and traces still held in memory before exiting. Those uploads couldn't be canceled, so an unresponsive connection left k6 waiting for each request to time out on its own. The test had already finished and earlier data was delivered, yet the process kept hanging at shutdown.

Shutdown is now bounded:

- It waits a fixed budget for in-flight uploads, then abandons them if they overrun.
- The final metrics and traces uploads run under that same budget.
- Cloud requests stop retrying the moment the budget passes, instead of waiting out the full retry schedule.

A stalled upload is dropped in time for k6 to exit on its own.

## Note

The end-of-test run-status notification, sent after the uploads, still uses the shared cloud client's request timeout rather than the shutdown budget. Bounding it cleanly means adding a context to a public `cloudapi` client method that other tools (e.g. k6-operator) depend on, so it's left as a follow-up. It isn't part of the observed hangs, which are all in the metrics upload path.

## Related

- Closes grafana/k6-cloud-agent#291
- Partially fixes grafana/k6-cloud-agent#341
