### PR TITLE
fix(deps): bump go toolchain to resolve CVE-2026-27143 (v1.7.x)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 as builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 as builder
 WORKDIR $GOPATH/src/go.k6.io/k6
 COPY . .
 ARG TARGETOS TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.k6.io/k6
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.36.11-20251118093737-4105057cc7d4.1


### PR DESCRIPTION
Cherry-pick of #5915 onto `v1.7.x` so we can cut a v1.7.2 patch release. [CVE-2026-27143](https://nvd.nist.gov/vuln/detail/CVE-2026-27143) is a bug fixed in Go 1.25.9 and 1.26.2. v1.7.1 was built with `toolchain go1.25.8` + `golang:1.26.1-alpine`, both within the affected range.