### PR TITLE
Release notes for v1.7.2 (v1.x)

### DIFF
--- a/release notes/v1.7.2.md
+++ b/release notes/v1.7.2.md
@@ -1,0 +1,7 @@
+k6 `v1.7.2` is here! This patch release resolves a critical Go compiler vulnerability.
+
+- Bumps the Go toolchain to 1.25.9 and the Docker builder image to `golang:1.26.2-alpine`.
+
+## Maintenance and security updates
+
+- [#5916](https://github.com/grafana/k6/pull/5916) Resolves [CVE-2026-27143](https://nvd.nist.gov/vuln/detail/CVE-2026-27143) by bumping the Go toolchain to `go1.25.9` and the Docker builder image to `golang:1.26.2-alpine`. The previous toolchain (`go1.25.8`) and builder image (`golang:1.26.1-alpine`) were within the affected range (Go before 1.25.9 and 1.26.0 to 1.26.1).


### PR DESCRIPTION
Mirror of the v1.7.2 release notes onto `v1.x`.