### PR TITLE
Merge v1.7.x into v1.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.1-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 as builder
+FROM --platform=$BUILDPLATFORM golang:1.26.2-alpine@sha256:c2a1f7b2095d046ae14b286b18413a05bb82c9bca9b25fe7ff5efef0f0826166 as builder
 WORKDIR $GOPATH/src/go.k6.io/k6
 COPY . .
 ARG TARGETOS TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module go.k6.io/k6
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.36.11-20251118093737-4105057cc7d4.1

--- a/release notes/v1.7.2.md
+++ b/release notes/v1.7.2.md
@@ -1,0 +1,7 @@
+k6 `v1.7.2` is here! This patch release resolves a critical Go compiler vulnerability.
+
+- Bumps the Go toolchain to 1.25.9 and the Docker builder image to `golang:1.26.2-alpine`.
+
+## Maintenance and security updates
+
+- [#5916](https://github.com/grafana/k6/pull/5916) Resolves [CVE-2026-27143](https://nvd.nist.gov/vuln/detail/CVE-2026-27143) by bumping the Go toolchain to `go1.25.9` and the Docker builder image to `golang:1.26.2-alpine`. The previous toolchain (`go1.25.8`) and builder image (`golang:1.26.1-alpine`) were within the affected range (Go before 1.25.9 and 1.26.0 to 1.26.1).


### PR DESCRIPTION
Restore the invariant after the v1.7.2 patches land on v1.7.x.