### PR TITLE
browser: prevent nil pointer panic in ElementHandle.DefaultTimeout

### DIFF
--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -226,7 +226,13 @@ func (h *ElementHandle) dblclick(p *Position, opts *MouseClickOptions) error {
 }
 
 // DefaultTimeout returns the default timeout for this element handle.
+// If the receiver or any of the chained fields are nil (which can happen
+// when the element handle is no longer attached to a live frame), the
+// package-level DefaultTimeout constant is returned instead of panicking.
 func (h *ElementHandle) DefaultTimeout() time.Duration {
+	if h == nil || h.frame == nil || h.frame.manager == nil || h.frame.manager.timeoutSettings == nil {
+		return DefaultTimeout
+	}
 	return h.frame.manager.timeoutSettings.timeout()
 }
 

--- a/internal/js/modules/k6/browser/common/element_handle_test.go
+++ b/internal/js/modules/k6/browser/common/element_handle_test.go
@@ -12,6 +12,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestElementHandleDefaultTimeoutNilSafe(t *testing.T) {
+	t.Parallel()
+
+	// A nil receiver must return the package-level DefaultTimeout instead of
+	// panicking. See https://github.com/grafana/k6/issues/4957.
+	var h *ElementHandle
+	assert.Equal(t, DefaultTimeout, h.DefaultTimeout())
+
+	// Partially-initialized handles with nil intermediate fields must also
+	// fall back to DefaultTimeout rather than dereferencing a nil pointer.
+	assert.Equal(t, DefaultTimeout, (&ElementHandle{}).DefaultTimeout())
+}
+
 func TestErrorFromDOMError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What?

Guard `(*ElementHandle).DefaultTimeout` against a nil receiver and nil intermediate fields, falling back to the package-level `DefaultTimeout` constant.

## Why?

When `ElementHandle.GetAttribute` (and any of the other methods that call `DefaultTimeout` to build options) is invoked on a nil or partially-initialized handle, the method panics with a SIGSEGV while dereferencing `h.frame.manager.timeoutSettings`. This matches the stack trace reported in #4957:

```
panic: runtime error: invalid memory address or nil pointer dereference
go.k6.io/k6/internal/js/modules/k6/browser/common.(*ElementHandle).DefaultTimeout(0x2?)
go.k6.io/k6/internal/js/modules/k6/browser/common.(*ElementHandle).GetAttribute(0x0, ...)
```

The defensive guard preserves all existing behaviour for fully-initialized handles while preventing the runner from crashing the whole script.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

Closes #4957