### PR TITLE
Restore --address name and keep HTTP API disabled-by-default behavior

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -179,7 +179,7 @@ type GlobalFlags struct {
 	ConfigFilePath   string
 	Quiet            bool
 	NoColor          bool
-	HTTPAPIAddr      string
+	Address          string
 	ProfilingEnabled bool
 	LogOutput        string
 	SecretSource     []string
@@ -195,7 +195,7 @@ type GlobalFlags struct {
 // GetDefaultFlags returns the default global flags.
 func GetDefaultFlags(homeDir string, cacheDir string) GlobalFlags {
 	return GlobalFlags{
-		HTTPAPIAddr:             "",
+		Address:                 "",
 		ProfilingEnabled:        false,
 		ConfigFilePath:          filepath.Join(homeDir, "k6", defaultConfigFileName),
 		LogOutput:               "stderr",
@@ -220,8 +220,8 @@ func getFlags(defaultFlags GlobalFlags, env map[string]string, args []string) Gl
 	if val, ok := env["K6_LOG_FORMAT"]; ok {
 		result.LogFormat = val
 	}
-	if val, ok := env["K6_HTTP_API_ADDR"]; ok {
-		result.HTTPAPIAddr = val
+	if val, ok := env["K6_ADDRESS"]; ok {
+		result.Address = val
 	}
 	if env["K6_NO_COLOR"] != "" {
 		result.NoColor = true

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -310,17 +310,17 @@ func rootCmdPersistentFlagSet(gs *state.GlobalState) *pflag.FlagSet {
 	flags.BoolVarP(&gs.Flags.Verbose, "verbose", "v", gs.DefaultFlags.Verbose, "enable verbose logging")
 	flags.BoolVarP(&gs.Flags.Quiet, "quiet", "q", gs.DefaultFlags.Quiet, "disable progress updates")
 	flags.StringVarP(
-		&gs.Flags.HTTPAPIAddr,
-		"http-api-addr", "a",
-		gs.Flags.HTTPAPIAddr,
-		"address for the REST HTTP API server (e.g. localhost:6565); the server is disabled when not set",
+		&gs.Flags.Address,
+		"address", "a",
+		gs.Flags.Address,
+		"address for the REST API server (e.g. localhost:6565); the server is disabled when not set",
 	)
-	flags.Lookup("http-api-addr").DefValue = gs.DefaultFlags.HTTPAPIAddr
+	flags.Lookup("address").DefValue = gs.DefaultFlags.Address
 	flags.BoolVar(
 		&gs.Flags.ProfilingEnabled,
 		"profiling-enabled",
 		gs.DefaultFlags.ProfilingEnabled,
-		"enable profiling (pprof) endpoints, requires the HTTP API to be enabled (--http-api-addr)",
+		"enable profiling (pprof) endpoints, requires the REST API to be enabled (--address)",
 	)
 
 	return flags

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -72,15 +72,15 @@ func TestAddressGlobalOption(t *testing.T) {
 
 	t.Run("default value", func(t *testing.T) {
 		t.Parallel()
-		assert.Equal(t, "", state.GetDefaultFlags(".config", ".cache").HTTPAPIAddr)
+		assert.Equal(t, "", state.GetDefaultFlags(".config", ".cache").Address)
 	})
 
-	t.Run("set via --http-api-addr flag", func(t *testing.T) {
+	t.Run("set via --address flag", func(t *testing.T) {
 		t.Parallel()
 		ts := tests.NewGlobalTestState(t)
 		flagSet := rootCmdPersistentFlagSet(ts.GlobalState)
-		require.NoError(t, flagSet.Parse([]string{"--http-api-addr", "localhost:9090"}))
-		assert.Equal(t, "localhost:9090", ts.Flags.HTTPAPIAddr)
+		require.NoError(t, flagSet.Parse([]string{"--address", "localhost:9090"}))
+		assert.Equal(t, "localhost:9090", ts.Flags.Address)
 	})
 
 	t.Run("set via -a shorthand flag", func(t *testing.T) {
@@ -88,29 +88,29 @@ func TestAddressGlobalOption(t *testing.T) {
 		ts := tests.NewGlobalTestState(t)
 		flagSet := rootCmdPersistentFlagSet(ts.GlobalState)
 		require.NoError(t, flagSet.Parse([]string{"-a", "localhost:9090"}))
-		assert.Equal(t, "localhost:9090", ts.Flags.HTTPAPIAddr)
+		assert.Equal(t, "localhost:9090", ts.Flags.Address)
 	})
 
-	t.Run("set via K6_HTTP_API_ADDR env var", func(t *testing.T) {
+	t.Run("set via K6_ADDRESS env var", func(t *testing.T) {
 		t.Parallel()
 		ts := tests.NewGlobalTestState(t)
-		ts.Env["K6_HTTP_API_ADDR"] = "localhost:9090"
+		ts.Env["K6_ADDRESS"] = "localhost:9090"
 		ts.ReparseFlags()
-		assert.Equal(t, "localhost:9090", ts.Flags.HTTPAPIAddr)
+		assert.Equal(t, "localhost:9090", ts.Flags.Address)
 	})
 }
 
-// TestAddressOptionPrecedence verifies that the CLI flag takes precedence over the K6_HTTP_API_ADDR
+// TestAddressOptionPrecedence verifies that the CLI flag takes precedence over the K6_ADDRESS
 // env var by going through the real cobra command path, reflecting the actual implementation.
 func TestAddressGlobalOptionPrecedence(t *testing.T) {
 	t.Parallel()
 
 	ts := tests.NewGlobalTestState(t)
-	ts.Env["K6_HTTP_API_ADDR"] = "localhost:9090"
-	ts.CmdArgs = []string{"k6", "run", "--http-api-addr", "localhost:9091", "script.js"}
+	ts.Env["K6_ADDRESS"] = "localhost:9090"
+	ts.CmdArgs = []string{"k6", "run", "--address", "localhost:9091", "script.js"}
 
 	rootCmd := newRootCommand(ts.GlobalState)
 	require.NoError(t, rootCmd.cmd.ParseFlags(ts.CmdArgs[1:]))
 
-	assert.Equal(t, "localhost:9091", ts.Flags.HTTPAPIAddr)
+	assert.Equal(t, "localhost:9091", ts.Flags.Address)
 }

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -279,12 +279,12 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 		runAbort(err)
 	})
 	samples := make(chan metrics.SampleContainer, test.derivedConfig.MetricSamplesBufferSize.Int64)
-	if c.gs.Flags.ProfilingEnabled && c.gs.Flags.HTTPAPIAddr == "" {
-		logger.Warn("Profiling is enabled but no HTTP API server is running — " +
-			"profiling endpoints won't be reachable until you enable the HTTP server via --http-api-addr (or K6_HTTP_API_ADDR)")
+	if c.gs.Flags.ProfilingEnabled && c.gs.Flags.Address == "" {
+		logger.Warn("Profiling is enabled but no REST API server is running — " +
+			"profiling endpoints won't be reachable until you enable the REST API server via --address (or K6_ADDRESS)")
 	}
 	// Spin up the REST API server, if enabled.
-	if c.gs.Flags.HTTPAPIAddr != "" { //nolint:nestif
+	if c.gs.Flags.Address != "" { //nolint:nestif
 		initBar.Modify(pb.WithConstProgress(0, "Init API server"))
 
 		// We cannot use backgroundProcesses here, since we need the REST API to
@@ -299,7 +299,7 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 
 		srv := api.GetServer(
 			runCtx,
-			c.gs.Flags.HTTPAPIAddr, c.gs.Flags.ProfilingEnabled,
+			c.gs.Flags.Address, c.gs.Flags.ProfilingEnabled,
 			testRunState,
 			samples,
 			metricsEngine,
@@ -307,13 +307,13 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 		)
 		go func() {
 			defer apiWG.Done()
-			logger.Debugf("Starting the REST API server on %s", c.gs.Flags.HTTPAPIAddr)
+			logger.Debugf("Starting the REST API server on %s", c.gs.Flags.Address)
 			if c.gs.Flags.ProfilingEnabled {
-				logger.Debugf("Profiling exposed on http://%s/debug/pprof/", c.gs.Flags.HTTPAPIAddr)
+				logger.Debugf("Profiling exposed on http://%s/debug/pprof/", c.gs.Flags.Address)
 			}
 			if aerr := srv.ListenAndServe(); aerr != nil && !errors.Is(aerr, http.ErrServerClosed) {
 				// Only exit k6 if the user has explicitly set the REST API address
-				if cmd.Flags().Lookup("http-api-addr").Changed {
+				if cmd.Flags().Lookup("address").Changed {
 					logger.WithError(aerr).Error("Error from API server")
 					c.gs.OSExit(int(exitcodes.CannotStartRESTAPI))
 				} else {

--- a/internal/cmd/stats.go
+++ b/internal/cmd/stats.go
@@ -17,14 +17,14 @@ func getCmdStats(gs *state.GlobalState) *cobra.Command {
 		Hidden: true,
 		Long: `Show test metrics.
 
-  Use the global --http-api-addr flag or the K6_HTTP_API_ADDR environment variable to specify
+  Use the global --address flag or the K6_ADDRESS environment variable to specify
   the URL to the API server.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			if gs.Flags.HTTPAPIAddr == "" {
-				return errors.New("The HTTP API server is disabled, but this command needs" + //nolint:staticcheck
-					" to read metrics from it. Enable it by setting --http-api-addr or K6_HTTP_API_ADDR.")
+			if gs.Flags.Address == "" {
+				return errors.New("The REST API server is disabled, but this command needs" + //nolint:staticcheck
+					" to read metrics from it. Enable it by setting --address or K6_ADDRESS.")
 			}
-			c, err := client.New(gs.Flags.HTTPAPIAddr)
+			c, err := client.New(gs.Flags.Address)
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -670,9 +670,9 @@ func TestSetupTeardownThresholds(t *testing.T) {
 	`)
 
 	addr := getFreeBindAddr(t)
-	cliFlags := []string{"-v", "--log-output=stdout", "--linger", "--http-api-addr", addr}
+	cliFlags := []string{"-v", "--log-output=stdout", "--linger", "--address", addr}
 	ts := getSimpleCloudOutputTestState(t, script, cliFlags, cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed, 0)
-	ts.Flags.HTTPAPIAddr = addr
+	ts.Flags.Address = addr
 
 	sendSignal := injectMockSignalNotifier(ts)
 	asyncWaitForStdoutAndRun(t, ts, 20, 500*time.Millisecond, "waiting for Ctrl+C to continue", func() {
@@ -682,7 +682,7 @@ func TestSetupTeardownThresholds(t *testing.T) {
 		}()
 		t.Logf("Linger reached, running teardown again and stopping the test...")
 		req, err := http.NewRequestWithContext(
-			ts.Ctx, http.MethodPost, fmt.Sprintf("http://%s/v1/teardown", ts.Flags.HTTPAPIAddr), nil,
+			ts.Ctx, http.MethodPost, fmt.Sprintf("http://%s/v1/teardown", ts.Flags.Address), nil,
 		)
 		require.NoError(t, err)
 		resp, err := http.DefaultClient.Do(req)
@@ -933,7 +933,7 @@ func asyncWaitForStdoutAndStopTestFromRESTAPI(
 ) {
 	asyncWaitForStdoutAndRun(t, ts, attempts, interval, expText, func() {
 		req, err := http.NewRequestWithContext(
-			ts.Ctx, http.MethodPatch, fmt.Sprintf("http://%s/v1/status", ts.Flags.HTTPAPIAddr),
+			ts.Ctx, http.MethodPatch, fmt.Sprintf("http://%s/v1/status", ts.Flags.Address),
 			bytes.NewBufferString(`{"data":{"type":"status","id":"default","attributes":{"stopped":true}}}`),
 		)
 		require.NoError(t, err)
@@ -966,10 +966,10 @@ func TestAbortedByUserWithRestAPI(t *testing.T) {
 
 	addr := getFreeBindAddr(t)
 	ts := getSimpleCloudOutputTestState(
-		t, script, []string{"-v", "--log-output=stdout", "--iterations", "20", "--http-api-addr", addr},
+		t, script, []string{"-v", "--log-output=stdout", "--iterations", "20", "--address", addr},
 		cloudapi.RunStatusAbortedUser, cloudapi.ResultStatusPassed, exitcodes.ScriptStoppedFromRESTAPI,
 	)
-	ts.Flags.HTTPAPIAddr = addr
+	ts.Flags.Address = addr
 
 	asyncWaitForStdoutAndStopTestFromRESTAPI(t, ts, 15, time.Second, "a simple iteration")
 

--- a/internal/cmd/tests/cmd_stats_test.go
+++ b/internal/cmd/tests/cmd_stats_test.go
@@ -12,7 +12,7 @@ import (
 	"go.k6.io/k6/v2/internal/lib/testutils"
 )
 
-func TestStatsCommandWithoutHTTPAPIAddrFails(t *testing.T) {
+func TestStatsCommandWithoutAddressFails(t *testing.T) {
 	t.Parallel()
 
 	ts := NewGlobalTestState(t)
@@ -22,7 +22,7 @@ func TestStatsCommandWithoutHTTPAPIAddrFails(t *testing.T) {
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 	logEntries := ts.LoggerHook.Drain()
-	require.True(t, testutils.LogContains(logEntries, logrus.ErrorLevel, "HTTP API server is disabled"))
+	require.True(t, testutils.LogContains(logEntries, logrus.ErrorLevel, "REST API server is disabled"))
 	assert.Empty(t, ts.Stdout.String())
 }
 
@@ -38,7 +38,7 @@ func TestStatsCommand(t *testing.T) {
 	defer srv.Close()
 
 	ts := NewGlobalTestState(t)
-	ts.CmdArgs = []string{"k6", "--http-api-addr", srv.Listener.Addr().String(), "stats"}
+	ts.CmdArgs = []string{"k6", "--address", srv.Listener.Addr().String(), "stats"}
 
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 

--- a/internal/cmd/ui.go
+++ b/internal/cmd/ui.go
@@ -150,8 +150,8 @@ func printExecutionDescription(
 	}
 
 	fmt.Fprintf(buf, "        output: %s\n", valueColor.Sprint(strings.Join(outputDescriptions, ", ")))
-	if gs.Flags.ProfilingEnabled && gs.Flags.HTTPAPIAddr != "" {
-		fmt.Fprintf(buf, "     profiling: %s\n", valueColor.Sprintf("http://%s/debug/pprof/", gs.Flags.HTTPAPIAddr))
+	if gs.Flags.ProfilingEnabled && gs.Flags.Address != "" {
+		fmt.Fprintf(buf, "     profiling: %s\n", valueColor.Sprintf("http://%s/debug/pprof/", gs.Flags.Address))
 	}
 
 	fmt.Fprintf(buf, "\n")


### PR DESCRIPTION
## What?

Restore `--address`/`-a` as the flag name for the REST API server address, and `K6_ADDRESS` as the corresponding env var. The `--http-api-addr` / `K6_HTTP_API_ADDR` names introduced in #5876 are reverted.

## Why?

#5876 bundled two changes: disabling the REST API server by default, and renaming the flag . The renamed flag breaks users scripting against k6, existing docs, and anyone relying on `--address` ([example](https://github.com/grafana/k6/pull/5876#issuecomment-4368954023)). This PR keeps the disabled-by-default behavior while restoring the familiar interface.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Reverts the naming change from #5876 (behavior change is preserved)
- Original issue https://github.com/grafana/k6/issues/5648