### PR TITLE
ci: avoid promoting pre-releases and old majors to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
       major: ${{ steps.classify_release.outputs.major }}
       is_prerelease: ${{ steps.classify_release.outputs.is_prerelease }}
       is_latest_stable: ${{ steps.classify_release.outputs.is_latest_stable }}
+      is_latest_in_major: ${{ steps.classify_release.outputs.is_latest_in_major }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -114,6 +115,7 @@ jobs:
           MAJOR=""
           IS_PRERELEASE=false
           IS_LATEST_STABLE=false
+          IS_LATEST_IN_MAJOR=false
           if [[ "${GITHUB_REF}" =~ ^refs/tags/v.+$ ]]; then
             MAJOR=$(echo "${VERSION}" | sed -E 's/^v([0-9]+).*/\1/')
             if [[ "${VERSION}" == *-* ]]; then
@@ -125,10 +127,22 @@ jobs:
             if [[ "${IS_PRERELEASE}" == "false" && "${VERSION}" == "${MAX_STABLE}" ]]; then
               IS_LATEST_STABLE=true
             fi
+            # Highest stable tag within this tag's major. Needed because
+            # we can ship multiple bugfix releases on an older major
+            # (e.g. v1.4.2 after v1.5.0 is already out on the v1 line):
+            # only the newest one on that major should move :vN.
+            MAX_STABLE_IN_MAJOR=$(git tag --sort=-v:refname \
+              | grep -vE '-' \
+              | grep -E "^v${MAJOR}\." \
+              | head -n1 || true)
+            if [[ "${IS_PRERELEASE}" == "false" && "${VERSION}" == "${MAX_STABLE_IN_MAJOR}" ]]; then
+              IS_LATEST_IN_MAJOR=true
+            fi
           fi
           echo "major=${MAJOR}" >> ${GITHUB_OUTPUT}
           echo "is_prerelease=${IS_PRERELEASE}" >> ${GITHUB_OUTPUT}
           echo "is_latest_stable=${IS_LATEST_STABLE}" >> ${GITHUB_OUTPUT}
+          echo "is_latest_in_major=${IS_LATEST_IN_MAJOR}" >> ${GITHUB_OUTPUT}
 
   build:
     runs-on: ubuntu-latest
@@ -268,10 +282,12 @@ jobs:
             --platform linux/amd64,linux/arm64 \
             -t $DOCKER_IMAGE_ID:$VERSION-with-browser \
             -t ghcr.io/$GHCR_IMAGE_ID:$VERSION-with-browser .
-      # Move the floating major tag (e.g. :v1, :v2) for any stable release on
-      # that major. Pre-releases (-rc, -beta, ...) do not move it.
+      # Move the floating major tag (e.g. :v1, :v2) only when this tag is
+      # the highest stable tag on its major. Pre-releases never move it,
+      # and a bugfix released on an older line within the same major
+      # (e.g. v1.4.2 after v1.5.0) does not regress :vN.
       - name: Publish floating major tag
-        if: ${{ startsWith(github.ref, 'refs/tags/v') && needs.configure.outputs.is_prerelease == 'false' }}
+        if: ${{ needs.configure.outputs.is_latest_in_major == 'true' }}
         env:
           MAJOR: ${{ needs.configure.outputs.major }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
       k6_version: ${{ steps.get_k6_version.outputs.k6_version }}
       go_version: ${{ steps.get_go_version.outputs.go_version }}
       sign_windows_artifacts: ${{ steps.determine_windows_signing.outputs.sign_windows_artifacts }}
+      major: ${{ steps.classify_release.outputs.major }}
+      is_prerelease: ${{ steps.classify_release.outputs.is_prerelease }}
+      is_latest_stable: ${{ steps.classify_release.outputs.is_latest_stable }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -95,6 +98,37 @@ jobs:
             sign_windows_artifacts="false"
           fi
           echo "sign_windows_artifacts=${sign_windows_artifacts}" >> ${GITHUB_OUTPUT}
+
+      # Classify the release so we can decide whether this build should:
+      #  - move the Docker :latest tag (only the highest stable tag overall)
+      #  - move the Docker :vN floating major tag (any stable tag, per major)
+      #  - be marked as the GitHub "Latest release" or as a pre-release
+      # This prevents pre-releases (e.g. -rc) and maintenance releases on
+      # older majors (e.g. v1.x after v2.0.0 ships) from claiming "latest".
+      - name: Classify release
+        id: classify_release
+        env:
+          VERSION: ${{ steps.get_k6_version.outputs.k6_version }}
+        run: |
+          set -x
+          MAJOR=""
+          IS_PRERELEASE=false
+          IS_LATEST_STABLE=false
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/v.+$ ]]; then
+            MAJOR=$(echo "${VERSION}" | sed -E 's/^v([0-9]+).*/\1/')
+            if [[ "${VERSION}" == *-* ]]; then
+              IS_PRERELEASE=true
+            fi
+            # Highest stable tag in the repo (excludes anything with a
+            # pre-release identifier like -rc, -beta, -dev).
+            MAX_STABLE=$(git tag --sort=-v:refname | grep -vE '-' | head -n1 || true)
+            if [[ "${IS_PRERELEASE}" == "false" && "${VERSION}" == "${MAX_STABLE}" ]]; then
+              IS_LATEST_STABLE=true
+            fi
+          fi
+          echo "major=${MAJOR}" >> ${GITHUB_OUTPUT}
+          echo "is_prerelease=${IS_PRERELEASE}" >> ${GITHUB_OUTPUT}
+          echo "is_latest_stable=${IS_LATEST_STABLE}" >> ${GITHUB_OUTPUT}
 
   build:
     runs-on: ubuntu-latest
@@ -234,7 +268,30 @@ jobs:
             --platform linux/amd64,linux/arm64 \
             -t $DOCKER_IMAGE_ID:$VERSION-with-browser \
             -t ghcr.io/$GHCR_IMAGE_ID:$VERSION-with-browser .
-          # We also want to tag the latest stable version as latest
+      # Move the floating major tag (e.g. :v1, :v2) for any stable release on
+      # that major. Pre-releases (-rc, -beta, ...) do not move it.
+      - name: Publish floating major tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && needs.configure.outputs.is_prerelease == 'false' }}
+        env:
+          MAJOR: ${{ needs.configure.outputs.major }}
+        run: |
+          echo "Publish $GHCR_IMAGE_ID:v$MAJOR images"
+          docker buildx build --push \
+            --target release \
+            --platform linux/amd64,linux/arm64 \
+            -t $DOCKER_IMAGE_ID:v$MAJOR \
+            -t ghcr.io/$GHCR_IMAGE_ID:v$MAJOR .
+          docker buildx build --push \
+            --target with-browser \
+            --platform linux/amd64,linux/arm64 \
+            -t $DOCKER_IMAGE_ID:v$MAJOR-with-browser \
+            -t ghcr.io/$GHCR_IMAGE_ID:v$MAJOR-with-browser .
+      # Only the highest stable tag in the repo gets :latest. Maintenance
+      # releases on older majors (e.g. v1.x after v2.0.0 ships) and any
+      # pre-release must not move :latest.
+      - name: Publish :latest
+        if: ${{ needs.configure.outputs.is_latest_stable == 'true' }}
+        run: |
           echo "Publish $GHCR_IMAGE_ID:latest"
           docker buildx build --push \
             --target release \
@@ -488,13 +545,24 @@ jobs:
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_LATEST_STABLE: ${{ needs.configure.outputs.is_latest_stable }}
+          IS_PRERELEASE: ${{ needs.configure.outputs.is_prerelease }}
         run: |
           set -x
           assets=()
           for asset in ./dist/*; do
             assets+=("$asset")
           done
-          gh release create "$VERSION" "${assets[@]}" --target "$GITHUB_SHA" -F "./release notes/${VERSION}.md"
+          # --latest=false prevents pre-releases and maintenance releases on
+          # older majors from being shown as the "Latest release" on GitHub.
+          extra_args=( "--latest=${IS_LATEST_STABLE}" )
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            extra_args+=( "--prerelease" )
+          fi
+          gh release create "$VERSION" "${assets[@]}" \
+            --target "$GITHUB_SHA" \
+            -F "./release notes/${VERSION}.md" \
+            "${extra_args[@]}"
 
   submit-winget-manifest:
     needs: [configure, publish-github]


### PR DESCRIPTION
## What?

Reworks the release section of `.github/workflows/build.yml` so that
publishing a tag no longer unconditionally claims the `:latest` Docker
tag and the GitHub "Latest release" marker.

A new "Classify release" step in the `configure` job derives four
outputs from the tag and the repository's tag history:

- `major` — the major version number from the tag (e.g. `1` for `v1.4.2`).
- `is_prerelease` — true when the tag contains a `-` (e.g. `-rc1`, `-beta.2`).
- `is_latest_stable` — true only when the tag is the highest stable tag
  in the repository.
- `is_latest_in_major` — true only when the tag is the highest stable
  tag within its own major (e.g. `v1.5.0` is true, but `v1.4.2`
  released afterwards as a v1.4 bugfix is false).

These outputs are then consumed in two places:

- `build-docker`: the previous unconditional `:latest` block is split
  into two steps:
  - "Publish floating major tag" pushes `:vN` (and `:vN-with-browser`)
    only when `is_latest_in_major` is true, so users can pin to e.g.
    `grafana/k6:v1`. This guards against bugfix releases on an older
    line of the same major (e.g. v1.4.2 after v1.5.0) regressing `:vN`.
  - "Publish :latest" runs only when `is_latest_stable` is true.
- `publish-github`: `gh release create` now receives
  `--latest=<is_latest_stable>` and `--prerelease` when applicable.

Behaviour matrix:

| Release | GH "Latest" | Docker `:latest` | Docker `:vN` | Docker `:X.Y.Z` |
|---|---|---|---|---|
| `v2.3.0` (current major, stable) | ✅ | ✅ | ✅ `:v2` | ✅ |
| `v2.3.0-rc1` (pre-release) | ❌ | ❌ | ❌ | ✅ |
| `v1.5.0` (older-major maintenance, top of v1) | ❌ | ❌ | ✅ `:v1` | ✅ |
| `v1.4.2` (older-major bugfix, behind v1.5.0) | ❌ | ❌ | ❌ | ✅ |
| `v1.4.2-rc1` | ❌ | ❌ | ❌ | ✅ |

## Why?

Today, every tagged build on `refs/tags/v*` overwrites Docker's
`:latest` and is shown as the GitHub "Latest release". That was fine
while k6 only had a single live major and no public release
candidates, but it breaks down for three cases we care about now:

1. Release candidates (`-rc`) are intended for early adopters but
   currently advertise themselves as the latest stable build.
2. Once v2 ships, maintenance releases on v1.x must keep flowing to
   users still on v1 without claiming "latest" — both for Docker users
   pulling `:latest` and for users browsing GitHub releases.
3. Within an older major we may still ship bugfixes on multiple lines
   (e.g. v1.4.2 long after v1.5.0). Only the highest stable tag on a
   given major should move `:vN`; otherwise `:v1` would silently regress
   to an older release.

Adding a `:vN` floating major tag lets users pin to a major line
(`grafana/k6:v1`) without committing to a specific patch.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

(Workflow change only; no Go code touched. The change cannot be
exercised end-to-end without pushing a real tag, so I'd suggest dry-running
on a fork or with a throwaway tag before relying on it for an actual release.)

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

Closes #5906
