### PR TITLE
fix(packaging): install s3cmd via apt to fix k6packager image build

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -5,9 +5,7 @@ LABEL maintainer="k6 Developers <developers@k6.io>"
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
-    apt-get install -y apt-utils createrepo-c curl git gnupg2 python3-pip unzip rpm
-
-RUN pip3 install "s3cmd==2.4.0"
+    apt-get install -y apt-utils createrepo-c curl git gnupg2 s3cmd unzip rpm
 
 # Download awscli, check GPG signature and install.
 COPY ./awscli-key.gpg .


### PR DESCRIPTION
## What?

In `packaging/Dockerfile`, install `s3cmd` from the Debian repository instead
of via `pip3`, and drop the now-unnecessary `python3-pip` dependency.

## Why?

The `k6packager` workflow has been failing since the base image was bumped to
`debian:trixie`. Trixie ships Python 3.13, which enforces PEP 668, so
`pip3 install s3cmd==2.4.0` is rejected with
`error: externally-managed-environment`.

Debian trixie packages `s3cmd 2.4.0-3` — the same upstream version previously
pinned via pip — so installing it through `apt` keeps the version constant and
sidesteps PEP 668.

Failing run for reference:
https://github.com/grafana/k6/actions/runs/25266283376/job/74081274422

Locally verified:
- The previous Dockerfile reproduces the CI failure.
- The updated Dockerfile builds end-to-end.
- `s3cmd --version` in the resulting image reports `2.4.0`.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)