### PR TITLE
Bump go in xk6-tests to appease security scanners

### DIFF
--- a/.github/workflows/xk6-tests/xk6-js-test/go.mod
+++ b/.github/workflows/xk6-tests/xk6-js-test/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/xk6-js-test
 
-go 1.25.0
+go 1.25.10
 
 require go.k6.io/k6/v2 v2.0.0-20260424133653-c3427b0487c8
 

--- a/.github/workflows/xk6-tests/xk6-output-test/go.mod
+++ b/.github/workflows/xk6-tests/xk6-output-test/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/xk6-output-test
 
-go 1.25.0
+go 1.25.10
 
 require go.k6.io/k6/v2 v2.0.0-20260424133653-c3427b0487c8
 


### PR DESCRIPTION
## What?

Bump go version in purely tests modules.

## Why?
Some securyti scanners keep reporting this which is quite noisy 
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
