### PR TITLE
ci: honor caller-pinned ref in shared lint action

### DIFF
--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -13,12 +13,12 @@ runs:
       shell: bash
       env:
         GITHUB_ACTION_REF: ${{ github.action_ref }}
-        GITHUB_HEAD_REF: ${{  github.head_ref }}
+        GITHUB_HEAD_REF: ${{ github.head_ref }}
         REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
       run: |
-        branch="master"
-        if [ "${REPO_FULL_NAME}" = "grafana/k6" ]; then
-          branch="${GITHUB_ACTION_REF:-${GITHUB_HEAD_REF}}"
+        branch="${GITHUB_HEAD_REF:-master}"
+        if [ "${REPO_FULL_NAME}" != "grafana/k6" ]; then
+          branch="${GITHUB_ACTION_REF:-master}"
         fi
         rules_url="https://raw.githubusercontent.com/grafana/k6/${branch}/.golangci.yml"
         echo "Downloading '${rules_url}' ..."


### PR DESCRIPTION
## What?

Make `.github/actions/lint/` fetch `.golangci.yml` from the caller's pinned `action_ref` when invoked as `grafana/k6/.github/actions/lint@<ref>`. In-repo use is unchanged.

## Why?

The pinned ref was previously ignored for external callers, so downstream repos (xk6 extensions, etc.) always tracked `master` and couldn't pin a stable lint config or golangci-lint version.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)