### PR TITLE
refactor(browser): move PageReloadOptions parsing to mapping layer

### DIFF
--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -368,8 +368,9 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 			}), nil
 		},
 		"reload": func(opts sobek.Value) (*sobek.Promise, error) {
-			popts := common.NewPageReloadOptions(common.LifecycleEventLoad, p.NavigationTimeout())
-			if err := popts.Parse(vu.Context(), opts); err != nil {
+			defaults := common.NewPageReloadOptions(common.LifecycleEventLoad, p.NavigationTimeout())
+			popts, err := parsePageReloadOptions(rt, opts, defaults)
+			if err != nil {
 				return nil, fmt.Errorf("parsing reload options: %w", err)
 			}
 			return promise(vu, func() (any, error) {
@@ -1147,6 +1148,29 @@ func parsePageEmulateMediaOptions(
 			defaults.Media = common.MediaType(obj.Get(k).String())
 		case "reducedMotion":
 			defaults.ReducedMotion = common.ReducedMotion(obj.Get(k).String())
+		}
+	}
+
+	return defaults, nil
+}
+
+// parsePageReloadOptions parses the page reload options from a Sobek value.
+func parsePageReloadOptions(
+	rt *sobek.Runtime, opts sobek.Value, defaults *common.PageReloadOptions,
+) (*common.PageReloadOptions, error) {
+	if k6common.IsNullish(opts) {
+		return defaults, nil
+	}
+
+	obj := opts.ToObject(rt)
+	for _, k := range obj.Keys() {
+		switch k {
+		case "waitUntil":
+			if err := defaults.WaitUntil.UnmarshalText([]byte(obj.Get(k).String())); err != nil {
+				return nil, err
+			}
+		case "timeout":
+			defaults.Timeout = time.Duration(obj.Get(k).ToInteger()) * time.Millisecond
 		}
 	}
 

--- a/internal/js/modules/k6/browser/browser/page_mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping_test.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"testing"
+	"time"
 
 	"github.com/grafana/sobek"
 	"github.com/stretchr/testify/assert"
@@ -180,6 +181,75 @@ func TestParsePageEmulateMediaOptions(t *testing.T) {
 			require.NoError(t, err)
 
 			opts, err := parsePageEmulateMediaOptions(vu.Runtime(), v, newDefaults())
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, opts)
+		})
+	}
+}
+
+func TestParsePageReloadOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    *common.PageReloadOptions
+		wantErr string
+	}{
+		{
+			name:  "defaults_on_null",
+			input: `null`,
+			want: &common.PageReloadOptions{
+				WaitUntil: common.LifecycleEventLoad,
+				Timeout:   30 * time.Second,
+			},
+		},
+		{
+			name:  "all_options",
+			input: `({waitUntil: "networkidle", timeout: 5000})`,
+			want: &common.PageReloadOptions{
+				WaitUntil: common.LifecycleEventNetworkIdle,
+				Timeout:   5 * time.Second,
+			},
+		},
+		{
+			name:  "partial_waitUntil_only",
+			input: `({waitUntil: "domcontentloaded"})`,
+			want: &common.PageReloadOptions{
+				WaitUntil: common.LifecycleEventDOMContentLoad,
+				Timeout:   30 * time.Second,
+			},
+		},
+		{
+			name:  "partial_timeout_only",
+			input: `({timeout: 10000})`,
+			want: &common.PageReloadOptions{
+				WaitUntil: common.LifecycleEventLoad,
+				Timeout:   10 * time.Second,
+			},
+		},
+		{
+			name:    "invalid_lifecycle",
+			input:   `({waitUntil: "invalid"})`,
+			wantErr: "invalid lifecycle event",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			vu := k6test.NewVU(t)
+			v, err := vu.Runtime().RunString(tt.input)
+			require.NoError(t, err)
+
+			opts, err := parsePageReloadOptions(vu.Runtime(), v, common.NewPageReloadOptions(common.LifecycleEventLoad, common.DefaultTimeout))
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, opts)
 		})

--- a/internal/js/modules/k6/browser/common/page_options.go
+++ b/internal/js/modules/k6/browser/common/page_options.go
@@ -89,28 +89,6 @@ func (o *PageGoBackForwardOptions) Parse(ctx context.Context, opts sobek.Value) 
 	return nil
 }
 
-// Parse parses the page reload options.
-func (o *PageReloadOptions) Parse(ctx context.Context, opts sobek.Value) error {
-	rt := k6ext.Runtime(ctx)
-	if !common.IsNullish(opts) {
-		opts := opts.ToObject(rt)
-		for _, k := range opts.Keys() {
-			switch k {
-			case "waitUntil":
-				lifeCycle := opts.Get(k).String()
-				if l, ok := lifecycleEventToID[lifeCycle]; ok {
-					o.WaitUntil = l
-				} else {
-					return fmt.Errorf("%q is not a valid lifecycle", lifeCycle)
-				}
-			case "timeout":
-				o.Timeout = time.Duration(opts.Get(k).ToInteger()) * time.Millisecond
-			}
-		}
-	}
-	return nil
-}
-
 func NewPageScreenshotOptions() *PageScreenshotOptions {
 	return &PageScreenshotOptions{
 		Clip:           nil,


### PR DESCRIPTION
## What?

Move `PageReloadOptions` parsing from `common` into the browser mapping layer.

## Why?

`PageReloadOptions.Parse` uses Sobek and is only needed for browser option parsing, so I moved it to the mapping layer.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- https://github.com/grafana/k6/issues/5305