### PR TITLE
Preserve module source on API errors

### DIFF
--- a/errext/fields.go
+++ b/errext/fields.go
@@ -1,0 +1,36 @@
+package errext
+
+import (
+	"errors"
+	"maps"
+)
+
+type fieldsError struct {
+	error
+	fields map[string]any
+}
+
+func (e fieldsError) Unwrap() error { return e.error }
+
+// WithFields attaches structured log fields to err.
+func WithFields(err error, fields map[string]any) error {
+	if err == nil {
+		return nil
+	}
+	if len(fields) == 0 {
+		return err
+	}
+	merged := FieldsFromErr(err)
+	maps.Copy(merged, fields)
+	return fieldsError{error: err, fields: merged}
+}
+
+// FieldsFromErr returns structured log fields attached to err.
+func FieldsFromErr(err error) map[string]any {
+	fields := map[string]any{}
+	var ferr fieldsError
+	if errors.As(err, &ferr) {
+		maps.Copy(fields, ferr.fields)
+	}
+	return fields
+}

--- a/errext/fields_test.go
+++ b/errext/fields_test.go
@@ -1,0 +1,49 @@
+package errext_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.k6.io/k6/v2/errext"
+)
+
+func TestWithFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("NilError", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, errext.WithFields(nil, map[string]any{"k": "v"}))
+	})
+
+	t.Run("EmptyFields", func(t *testing.T) {
+		t.Parallel()
+		orig := errors.New("plain")
+		assert.Equal(t, orig, errext.WithFields(orig, nil))
+		assert.Equal(t, orig, errext.WithFields(orig, map[string]any{}))
+	})
+
+	t.Run("AttachesFields", func(t *testing.T) {
+		t.Parallel()
+		wrapped := errext.WithFields(errors.New("boom"), map[string]any{"module": "browser"})
+		fields := errext.FieldsFromErr(wrapped)
+		assert.Equal(t, map[string]any{"module": "browser"}, fields)
+	})
+
+	t.Run("PreservesChain", func(t *testing.T) {
+		t.Parallel()
+		orig := errors.New("root")
+		wrapped := errext.WithFields(orig, map[string]any{"k": "v"})
+		assert.True(t, errors.Is(wrapped, orig))
+		assert.Equal(t, "root", wrapped.Error())
+	})
+
+	t.Run("MergesFields", func(t *testing.T) {
+		t.Parallel()
+		inner := errext.WithFields(errors.New("err"), map[string]any{"a": "1"})
+		outer := errext.WithFields(inner, map[string]any{"b": "2"})
+		fields := errext.FieldsFromErr(outer)
+		assert.Equal(t, map[string]any{"a": "1", "b": "2"}, fields)
+	})
+}

--- a/errext/format.go
+++ b/errext/format.go
@@ -13,12 +13,12 @@ func Format(err error) (string, map[string]any) {
 	}
 
 	errText := err.Error()
+	fields := FieldsFromErr(err)
 	var xerr Exception
 	if errors.As(err, &xerr) {
 		errText = xerr.StackTrace()
+		fields["source"] = "stacktrace"
 	}
-
-	fields := make(map[string]any)
 	var herr HasHint
 	if errors.As(err, &herr) {
 		fields["hint"] = herr.Hint()

--- a/errext/format_test.go
+++ b/errext/format_test.go
@@ -31,7 +31,7 @@ func TestFormat(t *testing.T) {
 		err := fakeExceptionError{error: errors.New("simple error"), stack: "stack trace"}
 		errorText, fields := errext.Format(err)
 		assert.Equal(t, "stack trace", errorText)
-		assert.Empty(t, fields)
+		assert.Equal(t, map[string]any{"source": "stacktrace"}, fields)
 	})
 
 	t.Run("Hint", func(t *testing.T) {
@@ -42,12 +42,20 @@ func TestFormat(t *testing.T) {
 		assert.Equal(t, map[string]any{"hint": "hint message"}, fields)
 	})
 
+	t.Run("Fields", func(t *testing.T) {
+		t.Parallel()
+		err := errext.WithFields(errors.New("browser error"), map[string]any{"module": "browser"})
+		errorText, fields := errext.Format(err)
+		assert.Equal(t, "browser error", errorText)
+		assert.Equal(t, map[string]any{"module": "browser"}, fields)
+	})
+
 	t.Run("ExceptionWithHint", func(t *testing.T) {
 		t.Parallel()
 		err := fakeExceptionError{error: errext.WithHint(errors.New("error with hint"), "hint message"), stack: "stack trace"}
 		errorText, fields := errext.Format(err)
 		assert.Equal(t, "stack trace", errorText)
-		assert.Equal(t, map[string]any{"hint": "hint message"}, fields)
+		assert.Equal(t, map[string]any{"hint": "hint message", "source": "stacktrace"}, fields)
 	})
 }
 

--- a/internal/js/eventloop/eventloop.go
+++ b/internal/js/eventloop/eventloop.go
@@ -2,7 +2,7 @@
 package eventloop
 
 import (
-	"fmt"
+	"errors"
 	"sync"
 
 	"github.com/grafana/sobek"
@@ -194,11 +194,33 @@ func (e *EventLoop) Start(firstCallback func() error) error {
 					}
 				}
 			}
-			// this is the de facto wording in both firefox and deno at least
-			return fmt.Errorf("Uncaught (in promise) %s", value) //nolint:staticcheck
+			return newRejectionError(promise.Result(), value)
 		}
 	}
 }
+
+func newRejectionError(res, v sobek.Value) error {
+	var s string
+	if v != nil {
+		s = v.String()
+	}
+	// this is the de facto wording in both firefox and deno at least
+	msg := "Uncaught (in promise) " + s
+	if !common.IsNullish(res) {
+		if cause, ok := res.Export().(error); ok {
+			return &rejectionError{msg: msg, cause: cause}
+		}
+	}
+	return errors.New(msg)
+}
+
+type rejectionError struct {
+	msg   string
+	cause error
+}
+
+func (e *rejectionError) Error() string { return e.msg }
+func (e *rejectionError) Unwrap() error { return e.cause }
 
 // WaitOnRegistered waits on all registered callbacks so we know nothing is still doing work.
 // This does call back the callbacks and more can be queued over time.

--- a/internal/js/eventloop/eventloop_test.go
+++ b/internal/js/eventloop/eventloop_test.go
@@ -199,6 +199,23 @@ func TestEventLoopRejectSyntaxError(t *testing.T) {
 	require.EqualError(t, err, "Uncaught (in promise) ReferenceError: some is not defined\n\tat <eval>:1:30(1)\n")
 }
 
+func TestEventLoopRejectPreservesErrorChain(t *testing.T) {
+	t.Parallel()
+	vu := &modulestest.VU{RuntimeField: sobek.New()}
+	loop := eventloop.New(vu)
+	rt := vu.Runtime()
+	original := fmt.Errorf("connection refused")
+	require.NoError(t, rt.Set("reason", rt.ToValue(original)))
+	err := loop.Start(func() error {
+		_, err := rt.RunString("Promise.reject(reason)")
+		return err
+	})
+	loop.WaitOnRegistered()
+	require.ErrorContains(t, err, "Uncaught (in promise)")
+	require.ErrorContains(t, err, "connection refused")
+	require.ErrorIs(t, err, original)
+}
+
 func TestEventLoopRejectGoError(t *testing.T) {
 	t.Parallel()
 	vu := &modulestest.VU{RuntimeField: sobek.New()}

--- a/internal/js/modules/k6/browser/browser/helpers.go
+++ b/internal/js/modules/k6/browser/browser/helpers.go
@@ -93,7 +93,7 @@ func promise(vu moduleVU, fn func() (result any, reason error)) *sobek.Promise {
 	go func() {
 		v, err := fn()
 		if err != nil {
-			reject(err)
+			reject(k6ext.BrowserError(err))
 			return
 		}
 		resolve(v)

--- a/internal/js/modules/k6/browser/browser/mapping.go
+++ b/internal/js/modules/k6/browser/browser/mapping.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/sobek"
 
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/common"
+	"go.k6.io/k6/v2/internal/js/modules/k6/browser/k6ext"
 
 	k6common "go.k6.io/k6/v2/js/common"
 )
@@ -30,7 +31,7 @@ func mapBrowserToSobek(vu moduleVU) *sobek.Object {
 	for k, v := range mapBrowser(vu) {
 		err := obj.Set(k, rt.ToValue(v))
 		if err != nil {
-			k6common.Throw(rt, fmt.Errorf("mapping: %w", err))
+			k6common.Throw(rt, k6ext.BrowserError(fmt.Errorf("mapping: %w", err)))
 		}
 	}
 

--- a/internal/js/modules/k6/browser/k6ext/panic.go
+++ b/internal/js/modules/k6/browser/k6ext/panic.go
@@ -32,7 +32,7 @@ func Abortf(ctx context.Context, format string, a ...any) {
 // TODO: test.
 func Panicf(ctx context.Context, format string, a ...any) {
 	failFunc := func(rt *sobek.Runtime, a ...any) {
-		k6common.Throw(rt, fmt.Errorf(format, a...))
+		k6common.Throw(rt, BrowserError(fmt.Errorf(format, a...)))
 	}
 	sharedPanic(ctx, failFunc, a...)
 }
@@ -99,4 +99,9 @@ func (e *UserFriendlyError) Error() string {
 	case errors.Is(e.Err, context.Canceled):
 		return "canceled"
 	}
+}
+
+// BrowserError tags err as originating from the browser module.
+func BrowserError(err error) error {
+	return errext.WithFields(err, map[string]any{"module": "browser"})
 }

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"go.k6.io/k6/v2/errext"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/common"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/k6ext/k6test"
 	k6metrics "go.k6.io/k6/v2/metrics"
@@ -297,6 +298,24 @@ func TestPageEvaluateMappingError(t *testing.T) { //nolint:tparallel
 			assert.ErrorContains(t, err, tt.wantErr)
 		})
 	}
+}
+
+func TestPageEvaluateErrorHasBrowserModule(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t)
+	tb.vu.ActivateVU()
+	tb.vu.StartIteration(t)
+	defer tb.vu.EndIteration(t)
+
+	_, err := tb.vu.RunAsync(t, `
+		const page = await browser.newPage();
+		await page.evaluate("() => { throw new Error('expected'); }");
+	`)
+	require.ErrorContains(t, err, "evaluating JS: Error: expected")
+
+	_, fields := errext.Format(err)
+	assert.Equal(t, "browser", fields["module"])
 }
 
 func TestPageGoto(t *testing.T) {

--- a/internal/js/summary_test.go
+++ b/internal/js/summary_test.go
@@ -697,5 +697,5 @@ func TestExceptionInHandleSummaryFallsBackToTextSummary(t *testing.T) {
 	errMsg, err := logErrors[0].String()
 	require.NoError(t, err)
 	assert.Contains(t, errMsg, "\"Error: intentional error\\n\\tat file:///script.js:4:11(3)\\n")
-	assert.Equal(t, logrus.Fields{"hint": "script exception"}, logErrors[0].Data)
+	assert.Equal(t, logrus.Fields{"hint": "script exception", "source": "stacktrace"}, logErrors[0].Data)
 }

--- a/lib/executor/helpers.go
+++ b/lib/executor/helpers.go
@@ -2,7 +2,6 @@ package executor
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"time"
@@ -96,13 +95,9 @@ func getIterationRunner(
 					return false
 				}
 
-				var exception errext.Exception
-				if errors.As(err, &exception) {
-					// TODO don't count this as a full iteration?
-					logger.WithField("source", "stacktrace").Error(exception.StackTrace())
-				} else {
-					logger.Error(err.Error())
-				}
+				// TODO don't count this as a full iteration?
+				errText, fields := errext.Format(err)
+				logger.WithFields(logrus.Fields(fields)).Error(errText)
 				// TODO: investigate context cancelled errors
 			}
 


### PR DESCRIPTION
## What?

Browser API failures now log the browser module as `module=browser`.

- This solution makes it ready to use even after we switch to `slog` for logging.
- Browser failures that surface as iteration errors can be filtered as browser logs.
- We don't override `source` as it's being used by other things, like `stacktrace`, `console`, `http-debug`, `grafana-k6-cloud`, etc. Some systems are parsing those, and we should not change them like so. So, we use `module`.

## Why?

Users should be able to filter Cloud Logs for failures separately. A browser operation that failed during a test has already reached Cloud Logs, but it arrived without a label, so the source could not classify it as a browser op.

## Note

Failing CI runs [are not related](https://github.com/grafana/k6/pull/6003) to this PR.

## Related PR(s)/Issue(s)

- Related to grafana/k6-cloud#1318
- Related to grafana/xk6-browser#1553
