### PR TITLE
Discover subcommands in `k6 x`

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -35,9 +35,9 @@ const (
 	// Subcommand extensions can read it to know which k6 version launched them.
 	ProvisionHostVersion = "K6_PROVISION_HOST_VERSION"
 
-	// ProvisionCatalogCacheAge overrides how long the on-disk k6 extension
+	// ProvisionCatalogTTL overrides how long the on-disk k6 extension
 	// registry catalog is considered fresh before `k6 x` refetches it.
-	ProvisionCatalogCacheAge = "K6_PROVISION_CATALOG_CACHE_AGE"
+	ProvisionCatalogTTL = "K6_PROVISION_CATALOG_TTL"
 
 	// ProvisionCatalogURL overrides the k6 extension registry catalog endpoint
 	// fetched by `k6 x`. Tests point this at httptest or an unreachable address

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -35,6 +35,10 @@ const (
 	// Subcommand extensions can read it to know which k6 version launched them.
 	ProvisionHostVersion = "K6_PROVISION_HOST_VERSION"
 
+	// ProvisionCatalogCacheAge overrides how long the on-disk k6 extension
+	// registry catalog is considered fresh before `k6 x` refetches it.
+	ProvisionCatalogCacheAge = "K6_PROVISION_CATALOG_CACHE_AGE"
+
 	// defaultBuildServiceURL defines the URL to the default (grafana hosted) build service
 	defaultBuildServiceURL = "https://ingest.k6.io/builder/api/v1"
 

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -39,6 +39,11 @@ const (
 	// registry catalog is considered fresh before `k6 x` refetches it.
 	ProvisionCatalogCacheAge = "K6_PROVISION_CATALOG_CACHE_AGE"
 
+	// ProvisionCatalogURL overrides the k6 extension registry catalog endpoint
+	// fetched by `k6 x`. Tests point this at httptest or an unreachable address
+	// to keep the command tree construction off the real network.
+	ProvisionCatalogURL = "K6_PROVISION_CATALOG_URL"
+
 	// defaultBuildServiceURL defines the URL to the default (grafana hosted) build service
 	defaultBuildServiceURL = "https://ingest.k6.io/builder/api/v1"
 

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -102,7 +102,10 @@ func registryStubs(gs *state.GlobalState, baked []*cobra.Command) []*cobra.Comma
 	}
 
 	cachePath := catalogCachePath(gs)
-	subs, _ := readCachedCatalog(gs, cachePath)
+	subs, err := readCachedCatalog(gs, cachePath)
+	if err != nil {
+		gs.Logger.WithError(err).Debug("k6 extension catalog")
+	}
 	if subs == nil && first == 0 { // first == 0: not TAB completion, network allowed
 		url := cmp.Or(gs.Env[state.ProvisionCatalogURL], defaultCatalogURL())
 		_, _ = fmt.Fprint(gs.Stderr, "Loading the subcommand list...")
@@ -115,7 +118,10 @@ func registryStubs(gs *state.GlobalState, baked []*cobra.Command) []*cobra.Comma
 		_, _ = fmt.Fprint(gs.Stderr, tail)
 		if err == nil {
 			subs = fetched
-			_ = writeCachedCatalog(gs, cachePath, raw)
+			err = writeCachedCatalog(gs, cachePath, raw)
+		}
+		if err != nil {
+			gs.Logger.WithError(err).Debug("k6 extension catalog")
 		}
 	}
 

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -105,7 +105,15 @@ func registryStubs(gs *state.GlobalState, baked []*cobra.Command) []*cobra.Comma
 	subs, _ := readCachedCatalog(gs, cachePath)
 	if subs == nil && first == 0 { // first == 0: not TAB completion, network allowed
 		url := cmp.Or(gs.Env[state.ProvisionCatalogURL], defaultCatalogURL())
-		if fetched, raw, err := fetchCatalog(gs.Ctx, url); err == nil {
+		_, _ = fmt.Fprint(gs.Stderr, "Loading the subcommand list...")
+		tail := "\n\n"
+		if gs.Stderr.IsTTY {
+			// Best-effort VT100 erase so help renders without a leftover trail.
+			tail = "\r\x1b[2K"
+		}
+		fetched, raw, err := fetchCatalog(gs.Ctx, url)
+		_, _ = fmt.Fprint(gs.Stderr, tail)
+		if err == nil {
 			subs = fetched
 			_ = writeCachedCatalog(gs, cachePath, raw)
 		}

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -176,11 +176,16 @@ func detectExtensionCompletion(root *cobra.Command, gs *state.GlobalState) (stri
 	}
 
 	cmd, remaining, err := root.Find(args[1:])
-	if err != nil || cmd.Name() != "x" || len(remaining) < 2 {
+	if err != nil {
 		return "", false
 	}
-
-	return remaining[0], true
+	switch {
+	case cmd.Annotations[xStubAnnotation] == "true" && len(remaining) >= 1:
+		return cmd.Name(), true
+	case cmd.Name() == "x" && len(remaining) >= 2:
+		return remaining[0], true
+	}
+	return "", false
 }
 
 // dependenciesFromSubcommand constructs a dependencies object for the given subcommand,

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -9,6 +10,11 @@ import (
 	"go.k6.io/k6/v2/ext"
 	"go.k6.io/k6/v2/subcommand"
 )
+
+// xStubAnnotation marks a cobra subcommand under `x` as a registry-sourced
+// stub: it exists only to advertise an extension subcommand in `k6 x` help.
+// Running it falls into the same provisioning path as an unregistered name.
+const xStubAnnotation = "k6-x-stub"
 
 // getX creates the "x" command that serves as a namespace for extension-provided subcommands.
 //
@@ -47,6 +53,8 @@ func getX(gs *state.GlobalState) *cobra.Command {
 
 This command serves as a parent for subcommands registered by k6 extensions,
 allowing them to extend k6's functionality with custom commands.
+
+Run "k6 x explore" to see the full list of official and community-provided subcommands.
 `,
 		// Disable flag parsing to pass all arguments unchanged to the provisioned binary.
 		// This ensures flags like --help reach the extension subcommand after provisioning.
@@ -67,9 +75,49 @@ allowing them to extend k6's functionality with custom commands.
 		},
 	}
 
-	cmd.AddCommand(extensionSubcommands(gs)...)
+	baked := extensionSubcommands(gs)
+	cmd.AddCommand(baked...)
+	cmd.AddCommand(registryStubs(gs, baked)...)
 
 	return cmd
+}
+
+// registryStubs returns cobra stubs for registry-advertised subcommands not
+// already provided by baked-in extensions. The stubs only exist so `k6 x`
+// help can advertise the wider catalog; invoking one drops into the regular
+// provisioning path. The function is a no-op outside `k6 x` invocations so
+// other commands don't pay for the registry I/O.
+func registryStubs(gs *state.GlobalState, baked []*cobra.Command) []*cobra.Command {
+	if !gs.Flags.AutoExtensionResolution {
+		return nil
+	}
+
+	args := gs.CmdArgs[1:]
+	first := slices.IndexFunc(args, func(a string) bool {
+		return a != cobra.ShellCompRequestCmd && a != cobra.ShellCompNoDescRequestCmd
+	})
+	if first < 0 || args[first] != "x" {
+		return nil
+	}
+
+	subs, _ := readCachedCatalog(gs, catalogCachePath(gs))
+
+	var stubs []*cobra.Command
+	for _, r := range subs {
+		if slices.ContainsFunc(baked, func(b *cobra.Command) bool { return b.Name() == r.Name }) {
+			continue
+		}
+		stubs = append(stubs, &cobra.Command{
+			Use:                r.Name,
+			Short:              r.Short,
+			DisableFlagParsing: true,
+			Annotations:        map[string]string{xStubAnnotation: "true"},
+			RunE: func(c *cobra.Command, _ []string) error {
+				return buildExtensionDeps(gs, c.Name())
+			},
+		})
+	}
+	return stubs
 }
 
 // buildExtensionDeps returns a [binaryIsNotSatisfyingDependenciesError] for

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"cmp"
 	"fmt"
 	"slices"
 	"strings"
@@ -100,7 +101,15 @@ func registryStubs(gs *state.GlobalState, baked []*cobra.Command) []*cobra.Comma
 		return nil
 	}
 
-	subs, _ := readCachedCatalog(gs, catalogCachePath(gs))
+	cachePath := catalogCachePath(gs)
+	subs, _ := readCachedCatalog(gs, cachePath)
+	if subs == nil && first == 0 { // first == 0: not TAB completion, network allowed
+		url := cmp.Or(gs.Env[state.ProvisionCatalogURL], defaultCatalogURL())
+		if fetched, raw, err := fetchCatalog(gs.Ctx, url); err == nil {
+			subs = fetched
+			_ = writeCachedCatalog(gs, cachePath, raw)
+		}
+	}
 
 	var stubs []*cobra.Command
 	for _, r := range subs {

--- a/internal/cmd/subcommand_test.go
+++ b/internal/cmd/subcommand_test.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"regexp"
 	"sync"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/internal/cmd/tests"
+	"go.k6.io/k6/v2/lib/fsext"
 	"go.k6.io/k6/v2/subcommand"
 )
 
@@ -157,6 +159,48 @@ func TestXCommandRegistryStubs(t *testing.T) {
 				} else {
 					require.NotRegexp(t, pattern, out, "unexpected stub row %q", name)
 				}
+			}
+		})
+	}
+}
+
+func TestXCompletionUsesCacheOnly(t *testing.T) {
+	t.Parallel()
+
+	registerTestSubcommandExtensions(t)
+
+	tt := []struct {
+		name      string
+		withCache bool
+		want      []string
+		notWant   []string
+	}{
+		{name: "no stubs without cache", notWant: []string{"alpha", "bravo", "charlie"}},
+		{name: "stubs from cache", withCache: true, want: []string{"alpha", "bravo", "charlie"}},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := tests.NewGlobalTestState(t)
+			// Any catalog URL is fine: completion must stay offline regardless.
+			ts.Env[state.ProvisionCatalogURL] = "http://127.0.0.1:1/unreachable"
+
+			if tc.withCache {
+				path := catalogCachePath(ts.GlobalState)
+				require.NoError(t, ts.FS.MkdirAll(filepath.Dir(path), 0o750))
+				require.NoError(t, fsext.WriteFile(ts.FS, path, []byte(testCatalogJSON), 0o600))
+			}
+
+			ts.CmdArgs = []string{"k6", "__complete", "x", ""}
+			newRootCommand(ts.GlobalState).execute()
+
+			out := ts.Stdout.String()
+			for _, w := range tc.want {
+				require.Contains(t, out, w)
+			}
+			for _, nw := range tc.notWant {
+				require.NotContains(t, out, nw)
 			}
 		})
 	}

--- a/internal/cmd/subcommand_test.go
+++ b/internal/cmd/subcommand_test.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"maps"
+	"net/http"
+	"net/http/httptest"
+	"regexp"
 	"sync"
 	"testing"
 
@@ -11,6 +14,26 @@ import (
 	"go.k6.io/k6/v2/internal/cmd/tests"
 	"go.k6.io/k6/v2/subcommand"
 )
+
+const testCatalogJSON = `{
+"example.com/x-alpha": {"subcommands":["alpha"],"description":"alpha sub","tier":"official"},
+"example.com/x-bravo": {"subcommands":["bravo"],"description":"bravo sub","tier":"official"},
+"example.com/x-charlie": {"subcommands":["charlie"],"description":"charlie sub","tier":"community"}
+}`
+
+func newCatalogServer(t *testing.T, body ...string) *httptest.Server {
+	t.Helper()
+	catalog := testCatalogJSON
+	if len(body) > 0 {
+		catalog = body[0]
+	}
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(catalog))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
 
 func TestExtensionSubcommands(t *testing.T) {
 	t.Parallel()
@@ -90,6 +113,51 @@ func TestXCommandHelpDisplayCommands(t *testing.T) {
 			newRootCommand(ts.GlobalState).execute()
 
 			require.Contains(t, ts.Stdout.String(), tc.wantStdoutContains)
+		})
+	}
+}
+
+func TestXCommandRegistryStubs(t *testing.T) {
+	t.Parallel()
+
+	registerTestSubcommandExtensions(t)
+	server := newCatalogServer(t)
+
+	tt := []struct {
+		name      string
+		catalog   string
+		autoOff   bool
+		wantStubs bool
+	}{
+		{name: "reachable catalog shows stubs", catalog: server.URL, wantStubs: true},
+		{name: "unreachable catalog hides stubs", catalog: "http://127.0.0.1:1/unreachable"},
+		{name: "auto-extension-resolution off hides stubs", catalog: server.URL, autoOff: true},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := tests.NewGlobalTestState(t)
+			ts.Env[state.ProvisionCatalogURL] = tc.catalog
+			if tc.autoOff {
+				ts.Env[state.AutoExtensionResolution] = "false"
+			}
+			ts.CmdArgs = []string{"k6", "x"}
+			ts.ReparseFlags()
+			newRootCommand(ts.GlobalState).execute()
+
+			out := ts.Stdout.String()
+			require.Contains(t, out, "Available Commands:")
+			require.Regexp(t, `(?m)^  test-cmd-1\s+Test command 1$`, out)
+
+			for _, name := range []string{"alpha", "bravo", "charlie"} {
+				pattern := `(?m)^  ` + regexp.QuoteMeta(name) + `\s`
+				if tc.wantStubs {
+					require.Regexp(t, pattern+`+\S`, out, "missing stub row %q", name)
+				} else {
+					require.NotRegexp(t, pattern, out, "unexpected stub row %q", name)
+				}
+			}
 		})
 	}
 }

--- a/internal/cmd/subcommand_test.go
+++ b/internal/cmd/subcommand_test.go
@@ -206,6 +206,37 @@ func TestXCompletionUsesCacheOnly(t *testing.T) {
 	}
 }
 
+func TestXCompletionRoutesStubsToProvisioning(t *testing.T) {
+	t.Parallel()
+
+	registerTestSubcommandExtensions(t)
+
+	tt := []struct {
+		name string
+		args []string
+	}{
+		{"committed stub name", []string{"k6", "__complete", "x", "alpha", ""}},
+		{"deeper args under stub", []string{"k6", "__complete", "x", "alpha", "deep", ""}},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := tests.NewGlobalTestState(t)
+			// Pre-write cache so alpha registers as a stub under `k6 x`.
+			path := catalogCachePath(ts.GlobalState)
+			require.NoError(t, ts.FS.MkdirAll(filepath.Dir(path), 0o750))
+			require.NoError(t, fsext.WriteFile(ts.FS, path, []byte(testCatalogJSON), 0o600))
+
+			ts.CmdArgs = tc.args
+			root := newRootCommand(ts.GlobalState)
+			ext, ok := detectExtensionCompletion(root.cmd, ts.GlobalState)
+			require.True(t, ok)
+			require.Equal(t, "alpha", ext)
+		})
+	}
+}
+
 func Test_dependenciesFromSubcommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/tests/test_state.go
+++ b/internal/cmd/tests/test_state.go
@@ -90,12 +90,17 @@ func NewGlobalTestState(tb testing.TB) *GlobalTestState {
 	defaultFlags := state.GetDefaultFlags(".config", ".cache")
 
 	ts.GlobalState = &state.GlobalState{
-		Ctx:          ctx,
-		FS:           fs,
-		Getwd:        func() (string, error) { return ts.Cwd, nil },
-		BinaryName:   "k6",
-		CmdArgs:      []string{},
-		Env:          map[string]string{"K6_NO_USAGE_REPORT": "true"},
+		Ctx:        ctx,
+		FS:         fs,
+		Getwd:      func() (string, error) { return ts.Cwd, nil },
+		BinaryName: "k6",
+		CmdArgs:    []string{},
+		Env: map[string]string{
+			"K6_NO_USAGE_REPORT": "true",
+			// Keep `k6 x` command-tree construction off the real registry.k6.io
+			// when tests don't explicitly point it at an httptest server.
+			state.ProvisionCatalogURL: "http://127.0.0.1:1/unreachable",
+		},
 		Events:       event.NewEventSystem(100, logger),
 		DefaultFlags: defaultFlags,
 		Flags:        defaultFlags,

--- a/internal/cmd/x_registry.go
+++ b/internal/cmd/x_registry.go
@@ -80,7 +80,7 @@ func catalogCachePath(gs *state.GlobalState) string {
 // failures return an error so the caller can surface them at debug.
 func readCachedCatalog(gs *state.GlobalState, cachePath string) (registrySubcommands, error) {
 	maxAge := 24 * time.Hour
-	if d, err := time.ParseDuration(gs.Env[state.ProvisionCatalogCacheAge]); err == nil {
+	if d, err := time.ParseDuration(gs.Env[state.ProvisionCatalogTTL]); err == nil {
 		maxAge = d
 	}
 	info, err := gs.FS.Stat(cachePath)

--- a/internal/cmd/x_registry.go
+++ b/internal/cmd/x_registry.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
+	"net/http"
 	"path/filepath"
 	"strings"
 	"time"
@@ -47,6 +50,12 @@ func (r *registrySubcommands) UnmarshalJSON(data []byte) error {
 		}
 	}
 	return nil
+}
+
+// defaultCatalogURL returns the canonical k6 extension registry catalog URL
+// for the running k6 binary's major version.
+func defaultCatalogURL() string {
+	return fmt.Sprintf("https://registry.k6.io/%s/catalog.json", catalogMajorVersion())
 }
 
 // catalogMajorVersion returns the registry path segment (e.g. "v2") matching
@@ -93,4 +102,48 @@ func readCachedCatalog(gs *state.GlobalState, cachePath string) (registrySubcomm
 		return nil, fmt.Errorf("parsing extensions cache: %w", err)
 	}
 	return subs, nil
+}
+
+// fetchCatalog downloads and parses the k6 extension registry catalog from
+// url. Returns the parsed subcommands plus the raw bytes so the caller can
+// persist them to the cache without re-marshaling.
+func fetchCatalog(ctx context.Context, url string) (registrySubcommands, []byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("requesting extensions catalog: %w", err)
+	}
+	// The URL can be overridden via env for tests and development; that is the
+	// intended behaviour of the catalog override, not an SSRF vector.
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching extensions catalog: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("fetching extensions catalog: status %s", resp.Status)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("reading extensions catalog response: %w", err)
+	}
+	var subs registrySubcommands
+	if err := json.Unmarshal(raw, &subs); err != nil {
+		return nil, nil, fmt.Errorf("parsing extensions catalog: %w", err)
+	}
+	return subs, raw, nil
+}
+
+// writeCachedCatalog persists raw catalog bytes under cachePath, creating any
+// missing parent directories.
+func writeCachedCatalog(gs *state.GlobalState, cachePath string, raw []byte) error {
+	if err := gs.FS.MkdirAll(filepath.Dir(cachePath), 0o750); err != nil {
+		return fmt.Errorf("creating extensions cache dir: %w", err)
+	}
+	if err := fsext.WriteFile(gs.FS, cachePath, raw, 0o600); err != nil {
+		return fmt.Errorf("writing extensions cache: %w", err)
+	}
+	return nil
 }

--- a/internal/cmd/x_registry.go
+++ b/internal/cmd/x_registry.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/lib/fsext"
+)
+
+// registrySubcommand is the projection of one entry in the k6 extension
+// registry catalog that `k6 x` advertises to users: a subcommand name and a
+// one-line description.
+type registrySubcommand struct {
+	Name  string
+	Short string
+}
+
+type registrySubcommands []registrySubcommand
+
+type catalogEntry struct {
+	Subcommands []string `json:"subcommands"`
+	Description string   `json:"description"`
+	Short       string   `json:"short"`
+}
+
+// UnmarshalJSON flattens the registry's name→entry map into one
+// registrySubcommand per advertised subcommand, falling back to Description
+// when the forward-compatible Short field is missing.
+func (r *registrySubcommands) UnmarshalJSON(data []byte) error {
+	var catalog map[string]catalogEntry
+	if err := json.Unmarshal(data, &catalog); err != nil {
+		return err
+	}
+	for _, e := range catalog {
+		short := e.Short
+		if short == "" {
+			short = e.Description
+		}
+		for _, name := range e.Subcommands {
+			*r = append(*r, registrySubcommand{Name: name, Short: short})
+		}
+	}
+	return nil
+}
+
+// catalogMajorVersion returns the registry path segment (e.g. "v2") matching
+// the running k6 binary, so the catalog endpoint and on-disk cache track the
+// k6 vN release line without manual coordination.
+func catalogMajorVersion() string {
+	v := runtimeK6Version()
+	if dot := strings.Index(v[1:], "."); dot >= 0 {
+		return v[:dot+1]
+	}
+	return v
+}
+
+// catalogCachePath returns the on-disk location of the k6 extension registry
+// catalog cache, alongside the build cache so both share the user cache dir.
+func catalogCachePath(gs *state.GlobalState) string {
+	return filepath.Join(filepath.Dir(gs.Flags.BinaryCache), catalogMajorVersion(), "catalog.json")
+}
+
+// readCachedCatalog returns subcommands parsed from the on-disk extensions
+// cache. A missing or stale cache returns (nil, nil); real I/O or parse
+// failures return an error so the caller can surface them at debug.
+func readCachedCatalog(gs *state.GlobalState, cachePath string) (registrySubcommands, error) {
+	maxAge := 24 * time.Hour
+	if d, err := time.ParseDuration(gs.Env[state.ProvisionCatalogCacheAge]); err == nil {
+		maxAge = d
+	}
+	info, err := gs.FS.Stat(cachePath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("checking extensions cache: %w", err)
+	}
+	if time.Since(info.ModTime()) > maxAge {
+		return nil, nil
+	}
+	raw, err := fsext.ReadFile(gs.FS, cachePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading extensions cache: %w", err)
+	}
+	var subs registrySubcommands
+	if err := json.Unmarshal(raw, &subs); err != nil {
+		return nil, fmt.Errorf("parsing extensions cache: %w", err)
+	}
+	return subs, nil
+}


### PR DESCRIPTION
## What?

`k6 x` lists subcommands (baked + advertised by the registry (official and community)).

```text
$ k6 x
...
Available Commands:
  agent       Bootstrap an AI-assisted k6 testing workflow in any editor
  docs        CLI k6 docs for AI agents and users
  explore     Explore k6 extensions for Automatic Resolution
  mcp         An MCP server for k6 for AI agents
```

> [!NOTE]
We retrieve the catalog from the network (10s timeout) and cache it.

#### TAB completions

```bash
$ k6 x <TAB>                # after a previous `k6 x` cached the catalog
agent  docs  explore  mcp
```

Tab completion lists the same set, but only when the catalog is already cached locally. Hitting `<TAB>` must never block on the network, so until a prior `k6 x` run populates the cache, completion returns only what's baked into the binary.

## Why?

AI agents driving a k6 binary can't directly introspect subcommands; they're blind to extensions. As agentic workflows grow, the binary needs to answer the question "what can you do?" on its own.

## Notes

All subcommands render in a single `Available Commands:` block. Cobra v1.4 lacks a command-group API, and tagging them by tier would require a Cobra bump or a custom help template for a marginal UX gain.

`k6 x explore` covers more than subcommands (all extensions), requires provisioning before it can run, and folding it into k6 would mean a stable internal API across versions, help address output mismatches with every other built-in command, and changes (+exports) inside `xk6-subcommand-explore` itself. A static, generated built-in extensions list was also considered a fallback and rejected: it would go stale until the next k6 release and would be out of sync.

## Follow-up

- When the k6 extension registry exposes a `short` field per entry, `k6 x` will surface it without a code change here: the catalog parser already prefers `short` and falls back to `description`.
- `--json` output on the catalog endpoint for richer agent consumption.

## Related

- Closes #5907
