### PR TITLE
[v1.x] Fix swapped Min and Max values for Gauge metrics in Cloud output v2

### DIFF
--- a/output/cloud/expv2/mapping.go
+++ b/output/cloud/expv2/mapping.go
@@ -89,8 +89,8 @@ func addBucketToTimeSeriesProto(
 		samples.Values = append(samples.Values, &pbcloud.GaugeValue{
 			Time:  timestampAsProto(time),
 			Last:  typedMetricValue.Last,
-			Min:   typedMetricValue.Max,
-			Max:   typedMetricValue.Min,
+			Min:   typedMetricValue.Min,
+			Max:   typedMetricValue.Max,
 			Avg:   typedMetricValue.Avg,
 			Count: typedMetricValue.Count,
 		})


### PR DESCRIPTION
## What?

Backports #5786 to the `v1.x` branch for inclusion in v1.8.0. Swaps the
`Min` and `Max` fields back to their correct positions when constructing
the Gauge protobuf payload in Cloud output v2.

## Why?

The fields were transposed, so cloud test result queries reported the
period maximum where the minimum should be and vice versa. The fix is
a two-line correction and carries no other behaviour change.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5786
- Original author: @esquonk