### PR TITLE
[v1.x] fix: respect K6_CLOUD_PUSH_REF_ID in cloud local execution

### DIFF
--- a/internal/cmd/outputs_cloud.go
+++ b/internal/cmd/outputs_cloud.go
@@ -24,13 +24,12 @@ const (
 	testRunIDKey    = "K6_CLOUDRUN_TEST_RUN_ID"
 )
 
-// createCloudTest performs some test and Cloud configuration validations and if everything
-// looks good, then it creates a test run in the k6 Cloud, using the Cloud API, meant to be used
-// for streaming test results.
+// createCloudTest performs test and Cloud configuration validations and prepares the test run.
+// It creates a new test run in the k6 Cloud backend unless a PushRefID is provided,
+// in which case it reuses an existing test run.
 //
-// This method is also responsible for filling the test run id on the test environment, so it can be used later,
-// and to populate the Cloud configuration back in case the Cloud API returned some overrides,
-// as expected by the Cloud output.
+// This method also sets the test run ID in the environment so it can be used later,
+// and applies any Cloud configuration overrides returned by the API.
 //
 //nolint:funlen,gocognit,cyclop
 func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error {
@@ -111,6 +110,12 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 	if conf.MaxTimeSeriesInBatch.Int64 < 1 {
 		return fmt.Errorf("max allowed number of time series in a single batch must be a positive number but is %d",
 			conf.MaxTimeSeriesInBatch.Int64)
+	}
+
+	if conf.PushRefID.Valid && conf.PushRefID.String != "" {
+		test.preInitState.RuntimeOptions.Env[testRunIDKey] = conf.PushRefID.String
+		gs.Logger.Debug("using PushRefID, skipping CreateTestRun")
+		return nil
 	}
 
 	var testArchive *lib.Archive

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -83,7 +83,7 @@ export const options = {
 
 export default function() {};`
 
-		ts := makeTestState(t, script, []string{"--local-execution"}, 0)
+		ts := makeTestState(t, script, []string{"--local-execution"})
 
 		testServerHandlerFunc := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			// When using the local execution mode, the test archive should be uploaded to the cloud
@@ -131,7 +131,7 @@ export const options = {
 
 export default function() {};`
 
-		ts := makeTestState(t, script, []string{"--local-execution", "--no-archive-upload"}, 0)
+		ts := makeTestState(t, script, []string{"--local-execution", "--no-archive-upload"})
 
 		testServerHandlerFunc := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			body, err := io.ReadAll(req.Body)
@@ -183,7 +183,7 @@ export default function() {
 	` + "console.log(`The test run id is ${__ENV.K6_CLOUDRUN_TEST_RUN_ID}`);" + `
 };`
 
-		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"}, 0)
+		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"})
 
 		const testRunID = 1337
 		srv := getCloudTestEndChecker(t, testRunID, nil, cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed)
@@ -197,9 +197,47 @@ export default function() {
 		assert.Contains(t, stdout, "output: cloud (https://app.k6.io/runs/1337)")
 		assert.Contains(t, stdout, "The test run id is "+strconv.Itoa(testRunID))
 	})
+
+	t.Run("reuses existing test run when K6_CLOUD_PUSH_REF_ID is set", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+export const options = {
+  cloud: {
+	  name: 'Hello k6 Cloud!',
+	  projectID: 123456,
+  },
+};
+
+export default function() {
+    ` + "console.log(`The test run id is ${__ENV.K6_CLOUDRUN_TEST_RUN_ID}`);" + `
+};`
+
+		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"})
+
+		const pushRefID = "99999"
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = pushRefID
+
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^/v1/tests$": http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				require.Fail(t, "CreateTestRun must not be called when K6_CLOUD_PUSH_REF_ID is set")
+			}),
+		})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+
+		assert.Contains(t, stdout, "execution: local")
+		assert.Contains(t, stdout, "output: cloud (https://app.k6.io/runs/"+pushRefID+")")
+		assert.Contains(t, stdout, "The test run id is "+pushRefID)
+	})
 }
 
-func makeTestState(tb testing.TB, script string, cliFlags []string, expExitCode exitcodes.ExitCode) *GlobalTestState {
+func makeTestState(tb testing.TB, script string, cliFlags []string) *GlobalTestState {
 	if cliFlags == nil {
 		cliFlags = []string{"-v", "--log-output=stdout"}
 	}
@@ -207,7 +245,6 @@ func makeTestState(tb testing.TB, script string, cliFlags []string, expExitCode 
 	ts := NewGlobalTestState(tb)
 	require.NoError(tb, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), []byte(script), 0o644))
 	ts.CmdArgs = append(append([]string{"k6", "cloud", "run"}, cliFlags...), "test.js")
-	ts.ExpectedExitCode = int(expExitCode)
 	ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud
 
 	return ts


### PR DESCRIPTION
## What?

Backports #5814 to the `v1.x` branch for inclusion in v1.8.0. Makes
`k6 cloud run --local-execution` honour the `K6_CLOUD_PUSH_REF_ID`
environment variable: if it is set, k6 reuses the referenced test run
instead of unconditionally calling `CreateTestRun`.

Also drops the unused `expExitCode` parameter from the `makeTestState`
test helper. All callers on v1.x passed `0`, and
`GlobalTestState.ExpectedExitCode` defaults to `0` when the field is
not set — so removing the parameter is a no-op behaviourally and
matches the upstream signature that #5814 was originally written
against.

## Why?

Without this fix, the local-execution path always creates a new test
run, which breaks CI integrations that pre-allocate a run via the API
and pass its ID through `K6_CLOUD_PUSH_REF_ID`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5814
- Original author: @Reranko05