### PR TITLE
[v1.x] websockets: fix shutdown deadlock on server pings

### DIFF
--- a/internal/js/modules/k6/websockets/websockets.go
+++ b/internal/js/modules/k6/websockets/websockets.go
@@ -369,11 +369,28 @@ func (w *webSocket) emitConnectionMetrics(ctx context.Context, start time.Time, 
 const writeWait = 10 * time.Second
 
 func (w *webSocket) loop() {
-	// Pass ping/pong events through the main control loop
+	// Pass ping/pong events through the main control loop.
+	// The handlers below run synchronously inside ReadMessage (via advanceFrame),
+	// so a blocking send here stalls the entire readPump goroutine.
+	// The select on w.done lets them bail out when the loop has already exited,
+	// preventing a deadlock where readPump blocks forever on an unbuffered send
+	// that nobody will receive.
 	pingChan := make(chan string)
 	pongChan := make(chan string)
-	w.conn.SetPingHandler(func(msg string) error { pingChan <- msg; return nil })
-	w.conn.SetPongHandler(func(pingID string) error { pongChan <- pingID; return nil })
+	w.conn.SetPingHandler(func(msg string) error {
+		select {
+		case pingChan <- msg:
+		case <-w.done:
+		}
+		return nil
+	})
+	w.conn.SetPongHandler(func(pingID string) error {
+		select {
+		case pongChan <- pingID:
+		case <-w.done:
+		}
+		return nil
+	})
 
 	ctx := w.vu.Context()
 	wg := new(sync.WaitGroup)

--- a/internal/js/modules/k6/websockets/websockets_test.go
+++ b/internal/js/modules/k6/websockets/websockets_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gorilla/websocket"
 	"github.com/sirupsen/logrus"
@@ -1680,4 +1681,53 @@ func TestRemoteCloseWithCodeAndReason(t *testing.T) {
 	samples := metrics.GetBufferedSamples(ts.samples)
 	assertSessionMetricsEmitted(t, samples, "", sr("WSBIN_URL/ws-remote-close"), http.StatusSwitchingProtocols, "")
 	assert.Equal(t, []string{"remote closed"}, ts.callRecorder.Recorded())
+}
+
+// TestPingHandlerDeadlock verifies that server pings arriving during connection
+// teardown don't deadlock the readPump goroutine. The server sends aggressive
+// pings then abruptly kills the TCP connection. Without the fix, the ping
+// handler blocks forever on an unbuffered channel send after the loop exits.
+// The goleak check in TestMain catches the leaked goroutine.
+func TestPingHandlerDeadlock(t *testing.T) {
+	t.Parallel()
+	ts := newTestState(t)
+
+	ts.tb.Mux.HandleFunc("/ws-ping-deadlock", func(w http.ResponseWriter, req *http.Request) {
+		conn, upgErr := (&websocket.Upgrader{}).Upgrade(w, req, w.Header())
+		if !assert.NoError(t, upgErr) {
+			return
+		}
+
+		// Drain reads so the server doesn't block on unread messages.
+		// ReadMessage errors are expected here because we kill TCP below.
+		go func() {
+			for {
+				if _, _, err := conn.ReadMessage(); err != nil {
+					return
+				}
+			}
+		}()
+
+		// Send a burst of pings to fill the receive buffer.
+		for range 20 {
+			assert.NoError(t, conn.WriteControl(
+				websocket.PingMessage, []byte("p"), time.Now().Add(time.Second),
+			))
+		}
+
+		// Abruptly kill TCP so the client's writePump fails,
+		// triggering connectionClosedWithError -> close(w.done)
+		// while the readPump may still be in the ping handler.
+		assert.NoError(t, conn.UnderlyingConn().Close())
+	})
+
+	sr := ts.tb.Replacer.Replace
+	_, err := ts.runtime.RunOnEventLoop(sr(`
+		var ws = new WebSocket("WSBIN_URL/ws-ping-deadlock")
+		ws.onerror = (e) => { call("error: " + e.error) }
+		ws.onopen = () => {
+			ws.send("keepalive")
+		}
+	`))
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## What?

Backports #5905 to the `v1.x` branch for inclusion in v1.8.0. Fixes a
deadlock where a WebSocket connection could hang forever during
teardown when the server sent pings. The ping/pong handlers run
synchronously inside `ReadMessage` (via `advanceFrame`), and they were
doing an unbuffered send into `pingChan` / `pongChan`. Once the main
loop exited (e.g. because the writer side failed and `w.done` was
closed) nothing was draining those channels, so the readPump goroutine
blocked forever and the iteration never finished.

The fix wraps each send in a `select` with `<-w.done`, so the handlers
exit cleanly when the loop has already gone away.

A regression test sends a burst of server pings then abruptly closes
the TCP connection; without the fix the package's `goleak` check
catches the leaked readPump goroutine.

## Why?

A server ping arriving during shutdown could permanently stall the k6
process — the iteration never completes and the test hangs until
timeout. This is a clear correctness fix that's worth carrying to v1.x.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5905
- Original author: @inancgumus