### PR TITLE
[v1.x] Add cloud secret-source for local execution (#5738 + #5875)

### DIFF
--- a/cloudapi/api.go
+++ b/cloudapi/api.go
@@ -48,6 +48,25 @@ type CreateTestRunResponse struct {
 	ReferenceID    string     `json:"reference_id"`
 	ConfigOverride *Config    `json:"config"`
 	Logs           []LogEntry `json:"logs"`
+
+	// TestRunToken is an ephemeral token for authenticating secrets requests for this run.
+	// It has limited scope (read-only secrets for this project) and expires after the test
+	// duration plus a grace period.
+	TestRunToken string `json:"test_run_token,omitempty"`
+
+	// SecretsConfig contains the endpoint and response format for fetching secrets.
+	SecretsConfig *SecretsConfig `json:"secrets_config,omitempty"`
+}
+
+// SecretsConfig holds the endpoint configuration needed to access secrets from the cloud.
+type SecretsConfig struct {
+	// Endpoint is the URL template for fetching secrets.
+	// It should contain {key} placeholder, e.g., "https://api.k6.io/v1/secrets/12345/{key}"
+	Endpoint string `json:"endpoint,omitempty"`
+
+	// ResponsePath is the JSON path to extract the secret value from the response.
+	// Default is "plaintext" for cloud secrets.
+	ResponsePath string `json:"response_path,omitempty"`
 }
 
 // TestProgressResponse represents the progress of a cloud test.

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -18,6 +18,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"go.k6.io/k6/internal/event"
+	cloudsecrets "go.k6.io/k6/internal/secretsource/cloud"
 	"go.k6.io/k6/internal/ui/console"
 	"go.k6.io/k6/internal/usage"
 	"go.k6.io/k6/lib/fsext"
@@ -78,9 +79,10 @@ type GlobalState struct {
 	Logger         *logrus.Logger //nolint:forbidigo //TODO:change to FieldLogger
 	FallbackLogger logrus.FieldLogger
 
-	SecretsManager *secretsource.Manager
-	Usage          *usage.Usage
-	TestStatus     *lib.TestStatus
+	SecretsManager    *secretsource.Manager
+	CloudSecretSource *cloudsecrets.SecretSource
+	Usage             *usage.Usage
+	TestStatus        *lib.TestStatus
 }
 
 // NewGlobalState returns a new GlobalState with the given ctx.

--- a/internal/cmd/cloud_run.go
+++ b/internal/cmd/cloud_run.go
@@ -4,12 +4,11 @@ import (
 	"errors"
 	"fmt"
 
-	"go.k6.io/k6/errext/exitcodes"
-
-	"go.k6.io/k6/errext"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"go.k6.io/k6/errext"
+	"go.k6.io/k6/errext/exitcodes"
 	"go.k6.io/k6/internal/execution"
 	"go.k6.io/k6/internal/execution/local"
 )
@@ -31,6 +30,9 @@ type cmdCloudRun struct {
 	// This flag indicates to the local execution mode to not send the test
 	// archive to the cloud service.
 	noArchiveUpload bool
+
+	// noCloudSecrets stores the state of the --no-cloud-secrets flag.
+	noCloudSecrets bool
 
 	// runCmd holds an instance of the k6 run command that we store
 	// in order to be able to call its run method to support
@@ -123,6 +125,13 @@ func (c *cmdCloudRun) preRun(cmd *cobra.Command, args []string) error {
 		)
 	}
 
+	if c.noCloudSecrets {
+		return errext.WithExitCodeIfNone(
+			fmt.Errorf("the --no-cloud-secrets flag can only be used in conjunction with the --local-execution flag"),
+			exitcodes.InvalidConfig,
+		)
+	}
+
 	return c.deprecatedCloudCmd.preRun(cmd, args)
 }
 
@@ -176,6 +185,12 @@ func (c *cmdCloudRun) flagSet() *pflag.FlagSet {
 		"no-archive-upload",
 		c.noArchiveUpload,
 		"only when using the local-execution mode, don't upload the test archive to the cloud service",
+	)
+	flags.BoolVar(
+		&c.noCloudSecrets,
+		"no-cloud-secrets",
+		c.noCloudSecrets,
+		"only when using the local-execution mode, don't automatically configure the cloud secret source",
 	)
 
 	return flags

--- a/internal/cmd/outputs_cloud.go
+++ b/internal/cmd/outputs_cloud.go
@@ -15,6 +15,7 @@ import (
 	"go.k6.io/k6/cloudapi"
 	"go.k6.io/k6/cmd/state"
 	"go.k6.io/k6/internal/build"
+	cloudsecrets "go.k6.io/k6/internal/secretsource/cloud"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/metrics"
 )
@@ -152,6 +153,14 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 
 	// We store the test run id in the environment, so it can be used later.
 	test.preInitState.RuntimeOptions.Env[testRunIDKey] = response.ReferenceID
+
+	if response.SecretsConfig != nil && gs.CloudSecretSource != nil {
+		gs.CloudSecretSource.SetConfig(&cloudsecrets.Config{
+			Token:        response.TestRunToken,
+			Endpoint:     response.SecretsConfig.Endpoint,
+			ResponsePath: response.SecretsConfig.ResponsePath,
+		})
+	}
 
 	// If the Cloud API returned configuration overrides, we apply them to the current configuration.
 	// Then, we serialize the overridden configuration back, so it can be used by the Cloud output.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"go.k6.io/k6/secretsource"
 
 	_ "go.k6.io/k6/internal/secretsource" // import it to register internal secret sources
+	cloudsecrets "go.k6.io/k6/internal/secretsource/cloud"
 )
 
 const waitLoggerCloseTimeout = time.Second * 5
@@ -142,7 +143,27 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 	return c
 }
 
-func (c *rootCommand) persistentPreRunE(_ *cobra.Command, _ []string) error {
+func (c *rootCommand) persistentPreRunE(cmd *cobra.Command, _ []string) error {
+	// The 'cloud' secret source is managed automatically and is not a valid value for
+	// --secret-source. Reject it here, before auto-injection, so the check only sees
+	// user-provided values. The logger is not yet configured at this point, so write
+	// the error directly to gs.Stderr and return errAlreadyReported to suppress the
+	// duplicate log entry that execute() would otherwise emit.
+	if err := validateNoCloudSecretSource(c.globalState.Flags.SecretSource); err != nil {
+		_, _ = fmt.Fprintln(c.globalState.Stderr, err.Error())
+		return errext.WithExitCodeIfNone(errAlreadyReported, exitcodes.InvalidConfig)
+	}
+
+	// For 'k6 cloud run --local-execution', automatically register the cloud secret source
+	// so scripts can call secrets.get() without any extra flags.
+	// This must happen before setupLoggers, which calls createSecretSources internally.
+	if isCloudRunWithLocalExecution(cmd) {
+		f := cmd.Flag("no-cloud-secrets")
+		if f == nil || f.Value.String() != "true" {
+			c.globalState.Flags.SecretSource = append(c.globalState.Flags.SecretSource, "cloud")
+		}
+	}
+
 	err := c.setupLoggers(c.stopLoggersCh)
 	if err != nil {
 		return err
@@ -408,6 +429,7 @@ func (c *rootCommand) setLoggerHook(ctx context.Context, h log.AsyncHook) {
 	c.globalState.Logger.SetOutput(io.Discard) // don't output to anywhere else
 }
 
+//nolint:gocognit
 func createSecretSources(gs *state.GlobalState) (map[string]secretsource.Source, error) {
 	baseParams := secretsource.Params{
 		Logger:      gs.Logger,
@@ -420,14 +442,13 @@ func createSecretSources(gs *state.GlobalState) (map[string]secretsource.Source,
 	for _, line := range gs.Flags.SecretSource {
 		t, config, ok := strings.Cut(line, "=")
 		if !ok {
-			// Special case: allow --secret-source=url without explicit config
-			// (it will use environment variables + defaults)
-			if line == "url" {
-				t = line
-				config = ""
-			} else {
+			if strings.TrimSpace(line) == "" {
 				return nil, fmt.Errorf("couldn't parse secret source configuration %q", line)
 			}
+			// Allow any non-empty source type without explicit config — it will use
+			// environment variables and built-in defaults.
+			t = line
+			config = ""
 		}
 		secretSources := ext.Get(ext.SecretSourceExtension)
 		found, ok := secretSources[t]
@@ -437,6 +458,10 @@ func createSecretSources(gs *state.GlobalState) (map[string]secretsource.Source,
 		c := found.Module.(secretsource.Constructor) //nolint:forcetypeassert
 		params := baseParams
 		name, isDefault, config := extractNameAndDefault(config)
+		if name == "" {
+			// Default the name to the source type to avoid an empty-string key.
+			name = t
+		}
 		params.ConfigArgument = config
 
 		secretSource, err := c(params)
@@ -462,7 +487,76 @@ func createSecretSources(gs *state.GlobalState) (map[string]secretsource.Source,
 		}
 	}
 
+	// Capture the cloud source instance if it was registered (via local-execution auto-injection
+	// or the env-var path below), so createCloudTest can call SetConfig on it later.
+	if cs, ok := result["cloud"].(*cloudsecrets.SecretSource); ok {
+		gs.CloudSecretSource = cs
+	}
+
+	// When  K6_CLOUD_SECRETS_TOKEN + K6_CLOUD_SECRETS_ENDPOINT are injected, create and configure the cloud source
+	// directly from env vars without a /v1/tests round-trip. Set it as the default source if none was chosen.
+	if token := gs.Env["K6_CLOUD_SECRETS_TOKEN"]; token != "" {
+		if gs.CloudSecretSource == nil {
+			cloudSource, err := cloudsecrets.New(baseParams)
+			if err != nil {
+				return nil, fmt.Errorf("failed to initialize cloud secret source: %w", err)
+			}
+			result["cloud"] = cloudSource
+			gs.CloudSecretSource = cloudSource
+		}
+		gs.CloudSecretSource.SetConfig(&cloudsecrets.Config{
+			Token:        token,
+			Endpoint:     gs.Env["K6_CLOUD_SECRETS_ENDPOINT"],
+			ResponsePath: gs.Env["K6_CLOUD_SECRETS_RESPONSE_PATH"],
+		})
+		if _, ok := result["default"]; !ok {
+			result["default"] = gs.CloudSecretSource
+		}
+	}
+
 	return result, nil
+}
+
+// isCloudRunWithLocalExecution returns true when the command being executed is
+// 'k6 cloud run' with the --local-execution flag set.
+func isCloudRunWithLocalExecution(cmd *cobra.Command) bool {
+	if cmd == nil || cmd.Name() != cloudRunCommandName {
+		return false
+	}
+	parent := cmd.Parent()
+	if parent == nil || parent.Name() != "cloud" {
+		return false
+	}
+	localExecution, err := cmd.Flags().GetBool("local-execution")
+	if err != nil {
+		return false
+	}
+	return localExecution
+}
+
+// hasCloudSecretSource returns true if the 'cloud' secret source type appears in sources.
+func hasCloudSecretSource(sources []string) bool {
+	for _, s := range sources {
+		t, _, _ := strings.Cut(s, "=")
+		if strings.TrimSpace(t) == "cloud" {
+			return true
+		}
+	}
+	return false
+}
+
+// validateNoCloudSecretSource returns an error if sources contains 'cloud', which is not
+// a valid value for --secret-source. Cloud secrets are automatically available for
+// 'k6 cloud run --local-execution' and do not require explicit configuration.
+func validateNoCloudSecretSource(sources []string) error {
+	if hasCloudSecretSource(sources) {
+		return errext.WithExitCodeIfNone(
+			fmt.Errorf("'cloud' is not a valid value for --secret-source; "+
+				"cloud secrets are automatically available for 'k6 cloud run --local-execution'"),
+			exitcodes.InvalidConfig,
+		)
+	}
+	return nil
 }
 
 func extractNameAndDefault(config string) (name string, isDefault bool, remaining string) {

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -589,8 +589,9 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
 		Long: `Start a test. This also exposes a REST API to interact with it. Various k6 subcommands offer
 a commandline interface for interacting with it.`,
 		Example: exampleText,
-		Args:    exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
-		RunE:    c.run,
+		Args: exactArgsWithMsg(1,
+			"arg should either be \"-\", if reading script from stdin, or a path to a script file"),
+		RunE: c.run,
 	}
 
 	runCmd.Flags().SortFlags = false

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -51,6 +51,21 @@ func TestCloudRunCommandIncompatibleFlags(t *testing.T) {
 			cliArgs:            []string{"--local-execution", "--show-logs"},
 			wantStderrContains: "the --local-execution flag is not compatible with the --show-logs flag",
 		},
+		{
+			name:               "--secret-source=cloud is not a valid value",
+			cliArgs:            []string{"--secret-source=cloud"},
+			wantStderrContains: "'cloud' is not a valid value for --secret-source",
+		},
+		{
+			name:               "--secret-source=cloud is not a valid value even with --local-execution",
+			cliArgs:            []string{"--local-execution", "--secret-source=cloud"},
+			wantStderrContains: "'cloud' is not a valid value for --secret-source",
+		},
+		{
+			name:               "using --no-cloud-secrets without --local-execution should fail",
+			cliArgs:            []string{"--no-cloud-secrets"},
+			wantStderrContains: "the --no-cloud-secrets flag can only be used in conjunction with the --local-execution flag",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -83,7 +98,7 @@ export const options = {
 
 export default function() {};`
 
-		ts := makeTestState(t, script, []string{"--local-execution"}, 0)
+		ts := makeTestState(t, script, []string{"--local-execution"})
 
 		testServerHandlerFunc := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			// When using the local execution mode, the test archive should be uploaded to the cloud
@@ -100,6 +115,11 @@ export default function() {};`
 			resp.WriteHeader(http.StatusOK)
 			_, err = fmt.Fprint(resp, `{
 			"reference_id": "1337",
+			"test_run_token": "mock-test-run-token",
+			"secrets_config": {
+				"endpoint": "https://mock-secrets.example.com/{key}",
+				"response_path": "plaintext"
+			},
 			"config": {
 				"testRunDetails": "https://some.other.url/foo/tests/org/1337?bar=baz"
 			}
@@ -131,7 +151,7 @@ export const options = {
 
 export default function() {};`
 
-		ts := makeTestState(t, script, []string{"--local-execution", "--no-archive-upload"}, 0)
+		ts := makeTestState(t, script, []string{"--local-execution", "--no-archive-upload"})
 
 		testServerHandlerFunc := http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 			body, err := io.ReadAll(req.Body)
@@ -150,6 +170,11 @@ export default function() {};`
 			resp.WriteHeader(http.StatusOK)
 			_, err = fmt.Fprint(resp, `{
 			"reference_id": "1337",
+			"test_run_token": "mock-test-run-token",
+			"secrets_config": {
+				"endpoint": "https://mock-secrets.example.com/{key}",
+				"response_path": "plaintext"
+			},
 			"config": {
 				"testRunDetails": "https://some.other.url/foo/tests/org/1337?bar=baz"
 			}
@@ -183,7 +208,7 @@ export default function() {
 	` + "console.log(`The test run id is ${__ENV.K6_CLOUDRUN_TEST_RUN_ID}`);" + `
 };`
 
-		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"}, 0)
+		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"})
 
 		const testRunID = 1337
 		srv := getCloudTestEndChecker(t, testRunID, nil, cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed)
@@ -199,7 +224,46 @@ export default function() {
 	})
 }
 
-func makeTestState(tb testing.TB, script string, cliFlags []string, expExitCode exitcodes.ExitCode) *GlobalTestState {
+func TestCloudRunLocalExecutionNoCloudSecrets(t *testing.T) {
+	t.Parallel()
+
+	script := `
+export const options = {
+  cloud: {
+      name: 'Test no-cloud-secrets',
+      projectID: 123456,
+  },
+};
+export default function() {};`
+
+	ts := makeTestState(t, script, []string{"--local-execution", "--no-cloud-secrets"})
+
+	testServerHandlerFunc := http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
+		resp.WriteHeader(http.StatusOK)
+		_, err := fmt.Fprint(resp, `{
+			"reference_id": "1337",
+			"test_run_token": "mock-test-run-token",
+			"secrets_config": {
+				"endpoint": "https://mock-secrets.example.com/{key}",
+				"response_path": "plaintext"
+			},
+			"config": {
+				"testRunDetails": "https://some.other.url/foo/tests/org/1337?bar=baz"
+			}
+		}`)
+		assert.NoError(t, err)
+	})
+
+	srv := getCloudTestEndChecker(t, 1337, testServerHandlerFunc, cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed)
+	ts.Env["K6_CLOUD_HOST"] = srv.URL
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	// --no-cloud-secrets must prevent the cloud source from being registered.
+	assert.Nil(t, ts.CloudSecretSource, "cloud secret source should not be registered when --no-cloud-secrets is set")
+}
+
+func makeTestState(tb testing.TB, script string, cliFlags []string) *GlobalTestState {
 	if cliFlags == nil {
 		cliFlags = []string{"-v", "--log-output=stdout"}
 	}
@@ -207,7 +271,6 @@ func makeTestState(tb testing.TB, script string, cliFlags []string, expExitCode 
 	ts := NewGlobalTestState(tb)
 	require.NoError(tb, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), []byte(script), 0o644))
 	ts.CmdArgs = append(append([]string{"k6", "cloud", "run"}, cliFlags...), "test.js")
-	ts.ExpectedExitCode = int(expExitCode)
 	ts.Env["K6_CLOUD_TOKEN"] = "foo" // doesn't matter, we mock the cloud
 
 	return ts

--- a/internal/cmd/tests/cmd_cloud_test.go
+++ b/internal/cmd/tests/cmd_cloud_test.go
@@ -283,7 +283,14 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 func cloudTestStartSimple(tb testing.TB, testRunID int) http.Handler {
 	return http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 		resp.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprintf(resp, `{"reference_id": "%d"}`, testRunID)
+		_, err := fmt.Fprintf(resp, `{
+			"reference_id": "%d",
+			"test_run_token": "mock-test-run-token",
+			"secrets_config": {
+				"endpoint": "https://mock-secrets.example.com/{key}",
+				"response_path": "plaintext"
+			}
+		}`, testRunID)
 		assert.NoError(tb, err)
 	})
 }

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -3459,3 +3459,84 @@ func TestSpaceInPath(t *testing.T) {
 	t.Log(stderr)
 	assert.Contains(t, stderr, `something 42`)
 }
+
+// TestCloudSourceNotRegisteredForPlainRun verifies that the "cloud" secret source is NOT
+// registered for plain 'k6 run'. Scripts referencing it should get "no such source", not
+// a silent "not configured" that implies cloud was attempted.
+func TestCloudSourceNotRegisteredForPlainRun(t *testing.T) {
+	t.Parallel()
+
+	script := `
+		import secrets from "k6/secrets";
+		export default async () => {
+			try {
+				await secrets.source("cloud").get("key");
+			} catch (e) {
+				console.log("cloud error: " + e.toString());
+			}
+		}
+	`
+	ts := NewGlobalTestState(t)
+	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "script.js"), []byte(script), 0o644))
+	ts.CmdArgs = []string{"k6", "run", "script.js"}
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stderr := ts.Stderr.String()
+	t.Log(stderr)
+	// Cloud source is not registered for plain k6 run — the catch block must report the
+	// "no sources configured" error, not a "cloud secrets not configured" error that would
+	// imply cloud was silently registered and attempted.
+	assert.Contains(t, stderr, "cloud error: no secret sources are configured")
+	assert.NotContains(t, stderr, "cloud secrets not configured")
+}
+
+// TestCloudSecretSourceInvalidForK6Run verifies that 'cloud' is not a valid value for
+// --secret-source; cloud secrets are automatic and not user-configurable via that flag.
+func TestCloudSecretSourceInvalidForK6Run(t *testing.T) {
+	t.Parallel()
+
+	ts := getSingleFileTestState(t, `export default function() {}`, []string{"--secret-source=cloud"}, exitcodes.InvalidConfig)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	assert.Contains(t, ts.Stderr.String(), "'cloud' is not a valid value for --secret-source")
+}
+
+// TestPLZCloudSecretsEnvVars verifies that setting K6_CLOUD_SECRETS_TOKEN and
+// K6_CLOUD_SECRETS_ENDPOINT configures the cloud secret source without a /v1/tests
+// API round-trip (the PLZ operator path).
+func TestPLZCloudSecretsEnvVars(t *testing.T) {
+	t.Parallel()
+
+	// Spin up a mock server that returns the secret as a JSON {"plaintext": "..."} response.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Verify the Authorization header carries the token.
+		assert.Equal(t, "Bearer plz-token", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{"plaintext":"plz-secret-value"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	script := `
+		import secrets from "k6/secrets";
+		export default async () => {
+			const v = await secrets.source("cloud").get("mykey");
+			console.log(v);
+		}
+	`
+	ts := NewGlobalTestState(t)
+	require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "script.js"), []byte(script), 0o644))
+
+	ts.Env["K6_CLOUD_SECRETS_TOKEN"] = "plz-token"
+	ts.Env["K6_CLOUD_SECRETS_ENDPOINT"] = srv.URL + "/secrets/{key}"
+	// Cloud source is auto-registered when PLZ env vars are set; no extra flags needed.
+	ts.CmdArgs = []string{"k6", "run", "script.js"}
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stderr := ts.Stderr.String()
+	t.Log(stderr)
+	assert.NotContains(t, stderr, "level=error")
+	assert.Contains(t, stderr, `level=info msg="***SECRET_REDACTED***" source=console`)
+	assert.NotContains(t, stderr, "plz-secret-value")
+}

--- a/internal/secretsource/cloud/cloud.go
+++ b/internal/secretsource/cloud/cloud.go
@@ -1,0 +1,138 @@
+// Package cloud implements a secret source that fetches secrets from Grafana Cloud k6.
+// This is a thin wrapper around the URL secret source that automatically configures
+// itself from the cloud API response.
+package cloud
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"sync"
+	"sync/atomic"
+
+	"go.k6.io/k6/internal/secretsource/url"
+	"go.k6.io/k6/secretsource"
+)
+
+// Config holds the configuration for accessing cloud secrets.
+type Config struct {
+	// Token is the ephemeral token for accessing secrets during test execution.
+	Token string
+
+	// Endpoint is the URL template with {key} placeholder.
+	Endpoint string
+
+	// ResponsePath is the JSON path to extract the secret value from the response.
+	ResponsePath string
+}
+
+// New creates a SecretSource with its own per-instance config pointer.
+// Exported so createSecretSources can pre-register it and later call SetConfig
+// once the cloud API response is available (before any VU goroutine calls Get).
+func New(params secretsource.Params) (*SecretSource, error) {
+	return &SecretSource{
+		params:    params,
+		configPtr: &atomic.Pointer[Config]{},
+	}, nil
+}
+
+//nolint:gochecknoinits // This is how k6 secret source registration works.
+func init() {
+	secretsource.RegisterExtension("cloud", func(params secretsource.Params) (secretsource.Source, error) {
+		return New(params)
+	})
+}
+
+// SecretSource wraps the URL secret source for cloud-based secrets.
+// It is automatically registered for 'k6 cloud run --local-execution' (unless
+// --no-cloud-secrets is passed). Configuration arrives via SetConfig from the
+// CreateTestRun API response (createCloudTest) before the first Get() call.
+//
+// The URL source is rebuilt whenever configPtr changes (i.e. a new test run starts with
+// different credentials). This supports sequential test runs in the same process — each run
+// calls SetConfig with its own token/endpoint, and the URL source is re-initialized.
+// A mutex serialises concurrent Get() calls during initialisation.
+type SecretSource struct {
+	params    secretsource.Params
+	configPtr *atomic.Pointer[Config]
+	mu        sync.Mutex
+	activeCfg *Config // the Config pointer that urlSource was built from
+	urlSource secretsource.Source
+	initErr   error
+}
+
+// SetConfig stores the cloud secrets configuration. Called from createCloudTest once the
+// CreateTestRun API response is available, before any VU goroutine can call Get().
+func (cs *SecretSource) SetConfig(c *Config) {
+	cs.configPtr.Store(c)
+}
+
+// Description returns a description of this secret source.
+func (cs *SecretSource) Description() string {
+	return "Grafana Cloud k6 secret source"
+}
+
+// ensureInitialized builds (or rebuilds) the URL source from configPtr.
+func (cs *SecretSource) ensureInitialized() (secretsource.Source, error) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	current := cs.configPtr.Load()
+
+	// Re-use the cached source if the config pointer is unchanged.
+	if cs.activeCfg == current && (cs.urlSource != nil || cs.initErr != nil) {
+		return cs.urlSource, cs.initErr
+	}
+
+	// (Re-)initialize for the new config.
+	cs.activeCfg = current
+	cs.urlSource = nil
+	cs.initErr = nil
+
+	if current == nil {
+		cs.initErr = errors.New("cloud secrets not configured: no secrets configuration available. " +
+			"Make sure you're using 'k6 cloud run --local-execution' and the cloud API " +
+			"returned secrets configuration")
+		return nil, cs.initErr
+	}
+
+	if current.Token == "" {
+		cs.initErr = errors.New("cloud secrets not configured: token not set")
+		return nil, cs.initErr
+	}
+
+	if current.Endpoint == "" {
+		cs.initErr = errors.New("cloud secrets not configured: endpoint not set")
+		return nil, cs.initErr
+	}
+
+	extra := 2 // always: URL template + Authorization header
+	if current.ResponsePath != "" {
+		extra = 3
+	}
+	envCopy := make(map[string]string, len(cs.params.Environment)+extra)
+	maps.Copy(envCopy, cs.params.Environment)
+	envCopy["K6_SECRET_SOURCE_URL_URL_TEMPLATE"] = current.Endpoint
+	envCopy["K6_SECRET_SOURCE_URL_HEADER_AUTHORIZATION"] = "Bearer " + current.Token
+	if current.ResponsePath != "" {
+		envCopy["K6_SECRET_SOURCE_URL_RESPONSE_PATH"] = current.ResponsePath
+	}
+
+	p := cs.params
+	p.Environment = envCopy
+	cs.urlSource, cs.initErr = url.New(p)
+	if cs.initErr != nil {
+		cs.initErr = fmt.Errorf("failed to initialize cloud secret source: %w", cs.initErr)
+		return nil, cs.initErr
+	}
+	return cs.urlSource, nil
+}
+
+// Get retrieves a secret from the cloud by delegating to the URL secret source.
+func (cs *SecretSource) Get(key string) (string, error) {
+	src, err := cs.ensureInitialized()
+	if err != nil {
+		return "", err
+	}
+	return src.Get(key)
+}

--- a/internal/secretsource/cloud/cloud_test.go
+++ b/internal/secretsource/cloud/cloud_test.go
@@ -1,0 +1,265 @@
+package cloud
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/ext"
+	"go.k6.io/k6/lib/fsext"
+	"go.k6.io/k6/secretsource"
+
+	_ "go.k6.io/k6/internal/secretsource/url"
+)
+
+func getCloudConstructor(t *testing.T) secretsource.Constructor {
+	t.Helper()
+	extensions := ext.Get(ext.SecretSourceExtension)
+	cloudExt, ok := extensions["cloud"]
+	require.True(t, ok, "cloud secret source not registered")
+	constructor, ok := cloudExt.Module.(secretsource.Constructor)
+	require.True(t, ok, "cloud secret source has invalid type")
+	return constructor
+}
+
+func makeParams() secretsource.Params {
+	return secretsource.Params{
+		Logger:      logrus.New(),
+		Environment: map[string]string{},
+		FS:          fsext.NewMemMapFs(),
+	}
+}
+
+// TestCloudSecretsRequiresConfig verifies construction succeeds but Get fails with no config.
+func TestCloudSecretsRequiresConfig(t *testing.T) {
+	t.Parallel()
+
+	source, err := New(makeParams())
+	require.NoError(t, err, "construction should succeed")
+
+	// Error should occur on Get() when no config is set
+	_, err = source.Get("test-key")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cloud secrets not configured")
+}
+
+// TestCloudSecretsDescription verifies the extension is registered with the expected description.
+func TestCloudSecretsDescription(t *testing.T) {
+	t.Parallel()
+
+	constructor := getCloudConstructor(t)
+	source, err := constructor(makeParams())
+	require.NoError(t, err)
+	require.NotNil(t, source)
+
+	require.Equal(t, "Grafana Cloud k6 secret source", source.Description())
+}
+
+// TestCloudSecretsGet verifies a successful secret fetch via an httptest server.
+func TestCloudSecretsGet(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"plaintext": "my-secret-value"})
+	}))
+	defer server.Close()
+
+	source, err := New(makeParams())
+	require.NoError(t, err)
+	source.SetConfig(&Config{
+		Token:        "test-token-123",
+		Endpoint:     server.URL + "/{key}",
+		ResponsePath: "plaintext",
+	})
+
+	value, err := source.Get("MY_KEY")
+	require.NoError(t, err)
+	require.Equal(t, "my-secret-value", value)
+}
+
+// TestCloudSecretsGetAuthHeader verifies that the Authorization header is set correctly.
+func TestCloudSecretsGetAuthHeader(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"plaintext": "secret"})
+	}))
+	defer server.Close()
+
+	source, err := New(makeParams())
+	require.NoError(t, err)
+	source.SetConfig(&Config{
+		Token:        "test-token-123",
+		Endpoint:     server.URL + "/{key}",
+		ResponsePath: "plaintext",
+	})
+
+	_, err = source.Get("MY_KEY")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer test-token-123", gotAuth)
+}
+
+// TestCloudSecretsGetConcurrent verifies that 50 goroutines calling Get() concurrently is safe.
+func TestCloudSecretsGetConcurrent(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"plaintext": "concurrent-secret"})
+	}))
+	defer server.Close()
+
+	source, err := New(makeParams())
+	require.NoError(t, err)
+	source.SetConfig(&Config{
+		Token:        "concurrent-token",
+		Endpoint:     server.URL + "/{key}",
+		ResponsePath: "plaintext",
+	})
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			value, getErr := source.Get("concurrent-key")
+			assert.NoError(t, getErr)
+			assert.Equal(t, "concurrent-secret", value)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestCloudSecretsGetResponsePath verifies nested JSON path extraction.
+func TestCloudSecretsGetResponsePath(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]string{"value": "nested-secret"},
+		})
+	}))
+	defer server.Close()
+
+	source, err := New(makeParams())
+	require.NoError(t, err)
+	source.SetConfig(&Config{
+		Token:        "path-token",
+		Endpoint:     server.URL + "/{key}",
+		ResponsePath: "data.value",
+	})
+
+	value, err := source.Get("nested-key")
+	require.NoError(t, err)
+	require.Equal(t, "nested-secret", value)
+}
+
+// TestCloudSecretsGetMissingToken verifies that an empty token produces a clear error.
+func TestCloudSecretsGetMissingToken(t *testing.T) {
+	t.Parallel()
+
+	source, err := New(makeParams())
+	require.NoError(t, err)
+	source.SetConfig(&Config{Token: "", Endpoint: "https://example.com/{key}"})
+
+	_, err = source.Get("key")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token not set")
+}
+
+// TestCloudSecretsGetMissingEndpoint verifies that an empty endpoint produces a clear error.
+func TestCloudSecretsGetMissingEndpoint(t *testing.T) {
+	t.Parallel()
+
+	source, err := New(makeParams())
+	require.NoError(t, err)
+	source.SetConfig(&Config{Token: "some-token", Endpoint: ""})
+
+	_, err = source.Get("key")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "endpoint not set")
+}
+
+// TestCloudSecretsMultipleRuns verifies that a single pre-registered source correctly
+// re-initializes when SetConfig is called for a second sequential test run.
+// With sync.Once this would silently use the first run's credentials forever.
+func TestCloudSecretsMultipleRuns(t *testing.T) {
+	t.Parallel()
+
+	makeServer := func(secret string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]string{"plaintext": secret})
+		}))
+	}
+
+	server1 := makeServer("secret-run-1")
+	defer server1.Close()
+	server2 := makeServer("secret-run-2")
+	defer server2.Close()
+
+	// Pre-registered once at startup (createSecretSources)
+	source, err := New(makeParams())
+	require.NoError(t, err)
+
+	// First test run
+	source.SetConfig(&Config{Token: "token-run-1", Endpoint: server1.URL + "/{key}", ResponsePath: "plaintext"})
+	val, err := source.Get("mykey")
+	require.NoError(t, err)
+	require.Equal(t, "secret-run-1", val)
+
+	// Second test run — SetConfig with different credentials
+	source.SetConfig(&Config{Token: "token-run-2", Endpoint: server2.URL + "/{key}", ResponsePath: "plaintext"})
+	val, err = source.Get("mykey")
+	require.NoError(t, err)
+	require.Equal(t, "secret-run-2", val, "second run must use new credentials, not cached ones from first run")
+}
+
+// TestSetConfigAndGet verifies the normal flow: SetConfig then Get via a pre-registered source.
+// This mirrors how createSecretSources (root.go) pre-registers the source and createCloudTest
+// (outputs_cloud.go) calls SetConfig before VUs start.
+func TestSetConfigAndGet(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{"plaintext": "preconfigured-secret"})
+	}))
+	defer server.Close()
+
+	// Simulate createSecretSources: pre-register source
+	cloudSource, err := New(makeParams())
+	require.NoError(t, err)
+	manager, _, err := secretsource.NewManager(map[string]secretsource.Source{
+		"cloud":   cloudSource,
+		"default": cloudSource,
+	})
+	require.NoError(t, err)
+
+	// Simulate createCloudTest: SetConfig called after manager creation, before VUs start
+	cloudSource.SetConfig(&Config{
+		Token:        "pre-config-token",
+		Endpoint:     server.URL + "/{key}",
+		ResponsePath: "plaintext",
+	})
+
+	val, err := manager.Get("cloud", "mykey")
+	require.NoError(t, err)
+	require.Equal(t, "preconfigured-secret", val)
+
+	val, err = manager.Get("default", "mykey")
+	require.NoError(t, err)
+	require.Equal(t, "preconfigured-secret", val)
+}

--- a/internal/secretsource/init.go
+++ b/internal/secretsource/init.go
@@ -2,7 +2,8 @@
 package secretsource
 
 import (
-	_ "go.k6.io/k6/internal/secretsource/file" // import them for init
-	_ "go.k6.io/k6/internal/secretsource/mock" // import them for init
-	_ "go.k6.io/k6/internal/secretsource/url"  // import them for init
+	_ "go.k6.io/k6/internal/secretsource/cloud" // import them for init
+	_ "go.k6.io/k6/internal/secretsource/file"  // import them for init
+	_ "go.k6.io/k6/internal/secretsource/mock"  // import them for init
+	_ "go.k6.io/k6/internal/secretsource/url"   // import them for init
 )

--- a/internal/secretsource/url/url.go
+++ b/internal/secretsource/url/url.go
@@ -125,21 +125,24 @@ func (c extConfig) Apply(cfg extConfig) extConfig {
 
 //nolint:gochecknoinits // This is how k6 secret source registration works.
 func init() {
-	secretsource.RegisterExtension("url", func(params secretsource.Params) (secretsource.Source, error) {
-		config, err := getConfig(params.ConfigArgument, params.FS, params.Environment)
-		if err != nil {
-			return nil, fmt.Errorf("missing or invalid config: %w", err)
-		}
+	secretsource.RegisterExtension("url", New)
+}
 
-		return &urlSecrets{
-			config: config,
-			httpClient: &http.Client{
-				Timeout: time.Duration(config.Timeout.Duration),
-			},
-			limiter: newLimiter(int(config.RequestsPerMinuteLimit.Int64), int(config.RequestsBurst.Int64)),
-			logger:  params.Logger,
-		}, nil
-	})
+// New creates a URL secret source. Exported for direct use by the cloud source.
+func New(params secretsource.Params) (secretsource.Source, error) {
+	config, err := getConfig(params.ConfigArgument, params.FS, params.Environment)
+	if err != nil {
+		return nil, fmt.Errorf("missing or invalid config: %w", err)
+	}
+
+	return &urlSecrets{
+		config: config,
+		httpClient: &http.Client{
+			Timeout: time.Duration(config.Timeout.Duration),
+		},
+		limiter: newLimiter(int(config.RequestsPerMinuteLimit.Int64), int(config.RequestsBurst.Int64)),
+		logger:  params.Logger,
+	}, nil
 }
 
 type urlSecrets struct {


### PR DESCRIPTION
## What?

Backports the cloud secret-source feature to `v1.x` for inclusion in
v1.8.0. Combines:

- #5738 — the original "add cloud secret source for local execution"
  feature
- #5875 — "Add cloud secret-source by default" follow-up
- the `--no-cloud-secrets` opt-out flag follow-up

into a single squashed commit on the backport branch. Upstream the
work was merged as a 15-commit rebased series of small `[refactor]` /
`[fix]` iterations plus the two follow-up PRs; the original SHAs are
listed in the commit message for attribution.

### What this adds

When running `k6 cloud run --local-execution`:

- A new built-in `cloud` secret source is registered automatically.
  It is populated from the `secrets_config` returned by the API for
  the test run, so `secrets.get()` calls in the script Just Work.
- Pass `--no-cloud-secrets` to opt out.

### Conflict resolution

`internal/cmd/tests/cmd_cloud_run_test.go` had a conflict against
v1.x's 4-arg `makeTestState(tb, script, cliFlags, expExitCode)`
signature. Resolved by dropping the unused `expExitCode` parameter,
matching the upstream 3-arg form that the new tests were originally
written against:

- All v1.x callers passed `0`.
- `GlobalTestState.ExpectedExitCode` zero-initialises, so the
  removal is a behavioural no-op.
- This matches the same cleanup applied in
  https://github.com/grafana/k6/pull/5975 (backport of #5814) — one of
  these two PRs will need a trivial rebase once the other lands.

## Why?

This is not a breaking change for v1.x: `secrets.get()` in a script is
itself opt-in, so users not already using cloud secrets see no
behavioural difference. Users who *do* use cloud secrets get the
"just works" UX without having to wait for v2.0.0.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backports https://github.com/grafana/k6/pull/5738
- Backports https://github.com/grafana/k6/pull/5875