### PR TITLE
chore: let Renovate track Go minor version in setup-go workflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,8 +18,8 @@
         "go-version:\\s+\\[(?<currentValue>\\d+\\.\\d+)\\.x\\]"
       ],
       "depNameTemplate": "golang/go",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^go(?<version>\\d+\\.\\d+)",
+      "datasourceTemplate": "golang-version",
+      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)",
       "versioningTemplate": "loose"
     }
   ],

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,21 @@
     "**/vendor/**",
     ".github/workflows/xk6-tests/**"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track Go minor version in setup-go go-version: 1.X.x lines",
+      "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
+      "matchStrings": [
+        "go-version:\\s+(?<currentValue>\\d+\\.\\d+)\\.x",
+        "go-version:\\s+\\[(?<currentValue>\\d+\\.\\d+)\\.x\\]"
+      ],
+      "depNameTemplate": "golang/go",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^go(?<version>\\d+\\.\\d+)",
+      "versioningTemplate": "loose"
+    }
+  ],
   "baseBranchPatterns": [
     "master",
     "v1.x"


### PR DESCRIPTION
## Summary

Adds a Renovate `customManager` so the Go version pinned in our GitHub Actions workflows gets bumped automatically when a new Go minor release ships, instead of needing manual PRs.

The regex matches two forms used across the workflows:
- Plain: `go-version: 1.26.x`
- Matrix: `go-version: [1.26.x]`

Only the `major.minor` portion is replaced — the `.x` suffix stays, so workflows still pick up the latest patch automatically.

### Files covered
- `lint.yml`, `tc39.yml`, `wpt.yml`, `xk6.yml`
- `test.yml`, `test-browser.yml` (both `[1.25.x]` and `[1.26.x]` matrix entries)

### Intentionally excluded
- `browser_e2e.yml` — uses `1.x` (floating major, doesn't need bumping)
- `build.yml` — Go version comes from a workflow input, not a literal

### Notes
- The two `[1.25.x]` matrix entries in `test.yml` / `test-browser.yml` look like deliberate N-1 lagging. With this manager, Renovate will propose bumping them too — if we want them pegged behind, a follow-up `packageRule` with `matchFileNames` + `allowedVersions` can constrain them.
- Renovate needs a GitHub token at runtime to resolve `github-releases` lookups (already the case in CI).

## Test plan
- [x] `renovate-config-validator` passes on the new config
- [x] Regex matches exactly the 8 expected lines (verified via grep)
- [x] Local `renovate --dry-run=lookup` extracts `depName: golang/go` for each matched file; with one file temporarily downgraded to `1.20.x`, Renovate flags it as a separate update candidate from the others on `1.26.x`
- [ ] After merge: confirm Renovate opens the expected PR(s) on the next scheduled run