### PR TITLE
[v1.x] ci: avoid promoting pre-releases and old majors to latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
       major: ${{ steps.classify_release.outputs.major }}
       is_prerelease: ${{ steps.classify_release.outputs.is_prerelease }}
       is_latest_stable: ${{ steps.classify_release.outputs.is_latest_stable }}
+      is_latest_in_major: ${{ steps.classify_release.outputs.is_latest_in_major }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -114,6 +115,7 @@ jobs:
           MAJOR=""
           IS_PRERELEASE=false
           IS_LATEST_STABLE=false
+          IS_LATEST_IN_MAJOR=false
           if [[ "${GITHUB_REF}" =~ ^refs/tags/v.+$ ]]; then
             MAJOR=$(echo "${VERSION}" | sed -E 's/^v([0-9]+).*/\1/')
             if [[ "${VERSION}" == *-* ]]; then
@@ -125,10 +127,22 @@ jobs:
             if [[ "${IS_PRERELEASE}" == "false" && "${VERSION}" == "${MAX_STABLE}" ]]; then
               IS_LATEST_STABLE=true
             fi
+            # Highest stable tag within this tag's major. Needed because
+            # we can ship multiple bugfix releases on an older major
+            # (e.g. v1.4.2 after v1.5.0 is already out on the v1 line):
+            # only the newest one on that major should move :vN.
+            MAX_STABLE_IN_MAJOR=$(git tag --sort=-v:refname \
+              | grep -vE '-' \
+              | grep -E "^v${MAJOR}\." \
+              | head -n1 || true)
+            if [[ "${IS_PRERELEASE}" == "false" && "${VERSION}" == "${MAX_STABLE_IN_MAJOR}" ]]; then
+              IS_LATEST_IN_MAJOR=true
+            fi
           fi
           echo "major=${MAJOR}" >> ${GITHUB_OUTPUT}
           echo "is_prerelease=${IS_PRERELEASE}" >> ${GITHUB_OUTPUT}
           echo "is_latest_stable=${IS_LATEST_STABLE}" >> ${GITHUB_OUTPUT}
+          echo "is_latest_in_major=${IS_LATEST_IN_MAJOR}" >> ${GITHUB_OUTPUT}
 
   build:
     runs-on: ubuntu-latest
@@ -273,10 +287,12 @@ jobs:
             --platform linux/amd64,linux/arm64 \
             -t $DOCKER_IMAGE_ID:$VERSION-with-browser \
             -t ghcr.io/$GHCR_IMAGE_ID:$VERSION-with-browser .
-      # Move the floating major tag (e.g. :v1, :v2) for any stable release on
-      # that major. Pre-releases (-rc, -beta, ...) do not move it.
+      # Move the floating major tag (e.g. :v1, :v2) only when this tag is
+      # the highest stable tag on its major. Pre-releases never move it,
+      # and a bugfix released on an older line within the same major
+      # (e.g. v1.4.2 after v1.5.0) does not regress :vN.
       - name: Publish floating major tag
-        if: ${{ startsWith(github.ref, 'refs/tags/v') && needs.configure.outputs.is_prerelease == 'false' }}
+        if: ${{ needs.configure.outputs.is_latest_in_major == 'true' }}
         env:
           MAJOR: ${{ needs.configure.outputs.major }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,9 @@ jobs:
       k6_version: ${{ steps.get_k6_version.outputs.k6_version }}
       go_version: ${{ steps.get_go_version.outputs.go_version }}
       sign_windows_artifacts: ${{ steps.determine_windows_signing.outputs.sign_windows_artifacts }}
+      major: ${{ steps.classify_release.outputs.major }}
+      is_prerelease: ${{ steps.classify_release.outputs.is_prerelease }}
+      is_latest_stable: ${{ steps.classify_release.outputs.is_latest_stable }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -95,6 +98,37 @@ jobs:
             sign_windows_artifacts="false"
           fi
           echo "sign_windows_artifacts=${sign_windows_artifacts}" >> ${GITHUB_OUTPUT}
+
+      # Classify the release so we can decide whether this build should:
+      #  - move the Docker :latest tag (only the highest stable tag overall)
+      #  - move the Docker :vN floating major tag (any stable tag, per major)
+      #  - be marked as the GitHub "Latest release" or as a pre-release
+      # This prevents pre-releases (e.g. -rc) and maintenance releases on
+      # older majors (e.g. v1.x after v2.0.0 ships) from claiming "latest".
+      - name: Classify release
+        id: classify_release
+        env:
+          VERSION: ${{ steps.get_k6_version.outputs.k6_version }}
+        run: |
+          set -x
+          MAJOR=""
+          IS_PRERELEASE=false
+          IS_LATEST_STABLE=false
+          if [[ "${GITHUB_REF}" =~ ^refs/tags/v.+$ ]]; then
+            MAJOR=$(echo "${VERSION}" | sed -E 's/^v([0-9]+).*/\1/')
+            if [[ "${VERSION}" == *-* ]]; then
+              IS_PRERELEASE=true
+            fi
+            # Highest stable tag in the repo (excludes anything with a
+            # pre-release identifier like -rc, -beta, -dev).
+            MAX_STABLE=$(git tag --sort=-v:refname | grep -vE '-' | head -n1 || true)
+            if [[ "${IS_PRERELEASE}" == "false" && "${VERSION}" == "${MAX_STABLE}" ]]; then
+              IS_LATEST_STABLE=true
+            fi
+          fi
+          echo "major=${MAJOR}" >> ${GITHUB_OUTPUT}
+          echo "is_prerelease=${IS_PRERELEASE}" >> ${GITHUB_OUTPUT}
+          echo "is_latest_stable=${IS_LATEST_STABLE}" >> ${GITHUB_OUTPUT}
 
   build:
     runs-on: ubuntu-latest
@@ -239,7 +273,30 @@ jobs:
             --platform linux/amd64,linux/arm64 \
             -t $DOCKER_IMAGE_ID:$VERSION-with-browser \
             -t ghcr.io/$GHCR_IMAGE_ID:$VERSION-with-browser .
-          # We also want to tag the latest stable version as latest
+      # Move the floating major tag (e.g. :v1, :v2) for any stable release on
+      # that major. Pre-releases (-rc, -beta, ...) do not move it.
+      - name: Publish floating major tag
+        if: ${{ startsWith(github.ref, 'refs/tags/v') && needs.configure.outputs.is_prerelease == 'false' }}
+        env:
+          MAJOR: ${{ needs.configure.outputs.major }}
+        run: |
+          echo "Publish $GHCR_IMAGE_ID:v$MAJOR images"
+          docker buildx build --push \
+            --target release \
+            --platform linux/amd64,linux/arm64 \
+            -t $DOCKER_IMAGE_ID:v$MAJOR \
+            -t ghcr.io/$GHCR_IMAGE_ID:v$MAJOR .
+          docker buildx build --push \
+            --target with-browser \
+            --platform linux/amd64,linux/arm64 \
+            -t $DOCKER_IMAGE_ID:v$MAJOR-with-browser \
+            -t ghcr.io/$GHCR_IMAGE_ID:v$MAJOR-with-browser .
+      # Only the highest stable tag in the repo gets :latest. Maintenance
+      # releases on older majors (e.g. v1.x after v2.0.0 ships) and any
+      # pre-release must not move :latest.
+      - name: Publish :latest
+        if: ${{ needs.configure.outputs.is_latest_stable == 'true' }}
+        run: |
           echo "Publish $GHCR_IMAGE_ID:latest"
           docker buildx build --push \
             --target release \
@@ -493,13 +550,24 @@ jobs:
       - name: Create release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IS_LATEST_STABLE: ${{ needs.configure.outputs.is_latest_stable }}
+          IS_PRERELEASE: ${{ needs.configure.outputs.is_prerelease }}
         run: |
           set -x
           assets=()
           for asset in ./dist/*; do
             assets+=("$asset")
           done
-          gh release create "$VERSION" "${assets[@]}" --target "$GITHUB_SHA" -F "./release notes/${VERSION}.md"
+          # --latest=false prevents pre-releases and maintenance releases on
+          # older majors from being shown as the "Latest release" on GitHub.
+          extra_args=( "--latest=${IS_LATEST_STABLE}" )
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            extra_args+=( "--prerelease" )
+          fi
+          gh release create "$VERSION" "${assets[@]}" \
+            --target "$GITHUB_SHA" \
+            -F "./release notes/${VERSION}.md" \
+            "${extra_args[@]}"
 
   submit-winget-manifest:
     needs: [configure, publish-github]


### PR DESCRIPTION
## What?

Backports the release-classification logic from #5947 and its follow-up
(`2766254d1`) to the `v1.x` branch. Two commits cherry-picked:

1. `ci: avoid promoting pre-releases and old majors to latest` (#5947)
2. `ci: only move :vN when releasing the latest tag on that major`

Together they rework the release section of
`.github/workflows/build.yml` so that publishing a tag no longer
unconditionally claims `:latest` and the GitHub "Latest release"
marker. A new "Classify release" step derives four outputs from the
tag and the repo's tag history:

- `major`
- `is_prerelease`
- `is_latest_stable` — true only for the highest stable tag overall
- `is_latest_in_major` — true only for the highest stable tag within
  its major

These gate:

- `:latest` (Docker) — only when `is_latest_stable`
- `:vN` floating major tag (Docker) — only when `is_latest_in_major`,
  so a v1.4.2 bugfix released after v1.5.0 does not regress `:v1`
- GitHub "Latest release" — `--latest=$IS_LATEST_STABLE` plus
  `--prerelease` when applicable

Both commits cherry-picked cleanly onto v1.x — `Auto-merging` only,
no conflicts despite v1.x's `build.yml` being significantly behind
master.

## Why?

This is a **release prerequisite** for v1.8.0. GitHub Actions runs
the workflow that lives on the branch being tagged, so v1.x must
carry this logic before we tag v1.8.0 — otherwise tagging v1.8.0
after v2.0.0 shipped would:

- overwrite Docker `:latest` to point at v1.8.0, demoting v2.0.0
- mark v1.8.0 as the GitHub "Latest release", hiding v2.0.0

Behaviour matrix once this lands on v1.x (mirroring the matrix in #5947,
extended with the current v1/v2 reality):

| Release | GH "Latest" | Docker `:latest` | Docker `:vN` | Docker `:X.Y.Z` |
|---|---|---|---|---|
| `v2.3.0` (current major, stable) | ✅ | ✅ | ✅ `:v2` | ✅ |
| `v2.3.0-rc1` (pre-release) | ❌ | ❌ | ❌ | ✅ |
| `v1.8.0` (older-major maintenance, top of v1) | ❌ | ❌ | ✅ `:v1` | ✅ |
| `v1.8.0-rc1` | ❌ | ❌ | ❌ | ✅ |
| `v1.7.3` (older-major bugfix, behind v1.8.0) | ❌ | ❌ | ❌ | ✅ |

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

CI workflow change only — exercised on tag pushes, not unit-testable.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5947