### PR TITLE
testutils: route per-test logger output to the instance, not global logrus

### DIFF
--- a/internal/lib/testutils/test_output.go
+++ b/internal/lib/testutils/test_output.go
@@ -32,7 +32,7 @@ func newLogger(t testing.TB, level logrus.Level) *logrus.Logger { //nolint:forbi
 	} else {
 		w = NewTestOutput(t)
 	}
-	logrus.SetOutput(w)
+	l.SetOutput(w)
 	return l
 }
 


### PR DESCRIPTION
## What?

Fix a one-line bug in `testutils.newLogger`: it created a fresh `*logrus.Logger` and then called `logrus.SetOutput(w)` on the package-level standard logger instead of `l.SetOutput(w)` on the returned instance.

## Why?

Because the returned instance kept its default output (`os.Stderr`), every per-test logger built through `testutils.NewLogger` — including `GlobalTestState.FallbackLogger` — bypassed `t.Logf` and wrote straight to the process's stderr. Under `go test`, those lines were not attributed to any test and showed up interleaved with unrelated parallel tests in the same package.

Concrete symptom: `TestBadLogOutput/LokiBadConfig` (which intentionally feeds k6 a malformed `--log-output` value to exercise the fallback path) leaked `level=error msg="unknown loki config key levels" fallback=true` next to entirely unrelated failures such as `TestRunCSVParseConcurrentFromMultipleModules`, making the latter look broken in ways it wasn't.

After the fix, lines flow through `testOutput.Write` -> `t.Logf` and `go test` scopes them to the right (sub)test.

There are no remaining users of `logrus.SetOutput` / `logrus.StandardLogger` outside `vendor/`, and the only direct global-logrus call in the tree is a `logrus.Fatal` in dashboard asset init (unreachable from tests), so removing the global side-effect changes nothing user-visible beyond fixing the attribution.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

None.