### PR TITLE
browser: fix flaky TestPageScreenshotFullpage

### DIFF
--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -685,6 +685,12 @@ func TestPageScreenshotFullpage(t *testing.T) {
 	}`)
 	require.NoError(t, err)
 
+	// Wait for the browser to commit a frame so the gradient div is painted
+	// before the screenshot is captured. Without this, on slow CI runners the
+	// screenshot can race the first paint and capture the still-white background.
+	_, err = p.Evaluate(`() => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)))`)
+	require.NoError(t, err)
+
 	opts := common.NewPageScreenshotOptions()
 	opts.FullPage = true
 	buf, err := p.Screenshot(opts, &mockPersister{})


### PR DESCRIPTION
## What?

After injecting the gradient `<div>` in `TestPageScreenshotFullpage`, wait for two `requestAnimationFrame`s before taking the full-page screenshot, so Chromium is guaranteed to have laid out and painted the new content.

## Why?

The test intermittently fails on CI with the bottom pixel coming back white (e.g. `R: 65535, B: 65535`) instead of the expected dominant blue. The `Evaluate` call resolves as soon as the JS returns, but the appended gradient node is not guaranteed to have been painted before the subsequent `Page.captureScreenshot` CDP call. On a slow/contended runner the screenshot can race the first paint and capture the still-white background. Awaiting two rAFs ensures a frame has been committed before the screenshot is requested.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

<!-- Closes # -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)