### PR TITLE
Backport to v1.8.0: Remove extra redirect request metric emits (#5630)

### DIFF
--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -528,10 +528,6 @@ func (m *NetworkManager) onRequest(event *network.EventRequestWillBeSent,
 		redirectChain = make([]*Request, 0)
 	}
 
-	for _, r := range redirectChain {
-		m.emitRequestMetrics(r)
-	}
-
 	var frame *Frame = nil
 	var ok bool
 	if event.FrameID != "" {


### PR DESCRIPTION
## What?

Backport of #5630 to the `v1.x` branch for the v1.8.0 release.

Removes duplicate redirect request metric emissions in the browser network manager. The previous code looped over all elements in `redirectChain` on every redirect and emitted a metric for each one — including elements that had already had metrics emitted in prior iterations — which compounded as the chain grew.

## Why?

This is incorrect behaviour. The `redirectChain` grows by one after each redirect, so re-emitting metrics for the whole chain on every redirect produced duplicate/compounding metric emissions for the same redirect requests. Fixing it on `v1.x` ensures the v1.8.0 release contains the corrected behaviour.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5630