### PR TITLE
Browser: handleExitEvent race fix (v1.8.0 backport of #5785)

### DIFF
--- a/internal/js/modules/k6/browser/browser/registry.go
+++ b/internal/js/modules/k6/browser/browser/registry.go
@@ -325,13 +325,25 @@ func (r *browserRegistry) handleIterEvents(
 }
 
 func (r *browserRegistry) handleExitEvent(exitCh <-chan *k6event.Event, unsubscribeFn func()) {
+	var e *k6event.Event
+	// Defers run LIFO: unsubscribeFn (registered second) runs before e.Done
+	// (registered first). unsubscribeFn must complete before Done is signalled
+	// so that by the time the caller's waitDone returns, the subscription is
+	// already removed. Otherwise a concurrent Exit emission (e.g. from
+	// t.Cleanup in tests) can be delivered to a closed goroutine, causing
+	// e.Done to never be called and waitDone to block forever.
+	defer func() {
+		if e != nil {
+			e.Done()
+		}
+	}()
 	defer unsubscribeFn()
 
-	e, ok := <-exitCh
+	var ok bool
+	e, ok = <-exitCh
 	if !ok {
 		return
 	}
-	defer e.Done()
 	r.clear()
 
 	// Stop traces registry before calling e.Done()


### PR DESCRIPTION
## What?

Backport of #5785 to the v1.x branch for the v1.8.0 release.

Fix a race in `handleExitEvent` where the deferred calls ran in the wrong
order: `e.Done()` fired first (LIFO), releasing the caller's `waitDone`
before `unsubscribeFn()` had removed the subscription. A concurrent
`Exit` emission (e.g. from `t.Cleanup` in `k6test.NewVU`) could then
land on `exitCh` after the goroutine had already exited, so `e.Done()`
was never called and `waitDone` blocked forever — causing
`TestBrowserRegistry/dont_close_browser_on_vu_context_close` to hang
until the 26-minute test timeout.

The fix registers the defers in the opposite order so `unsubscribeFn()`
runs before `e.Done()`, guaranteeing the subscription is gone by the
time `waitDone` returns.

## Why?

To pick up the race fix on the v1.x branch in time for the v1.8.0
release, so the browser registry tests stop intermittently hanging on
this branch.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- https://github.com/grafana/k6/pull/5785 (original PR on master)