### PR TITLE
browser: prevent nil pointer panic in ElementHandle.DefaultTimeout (v1.8.0 backport of #5923)

### DIFF
--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -226,7 +226,13 @@ func (h *ElementHandle) dblclick(p *Position, opts *MouseClickOptions) error {
 }
 
 // DefaultTimeout returns the default timeout for this element handle.
+// If the receiver or any of the chained fields are nil (which can happen
+// when the element handle is no longer attached to a live frame), the
+// package-level DefaultTimeout constant is returned instead of panicking.
 func (h *ElementHandle) DefaultTimeout() time.Duration {
+	if h == nil || h.frame == nil || h.frame.manager == nil || h.frame.manager.timeoutSettings == nil {
+		return DefaultTimeout
+	}
 	return h.frame.manager.timeoutSettings.timeout()
 }
 

--- a/internal/js/modules/k6/browser/common/element_handle_test.go
+++ b/internal/js/modules/k6/browser/common/element_handle_test.go
@@ -12,6 +12,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestElementHandleDefaultTimeoutNilSafe(t *testing.T) {
+	t.Parallel()
+
+	// A nil receiver must return the package-level DefaultTimeout instead of
+	// panicking. See https://github.com/grafana/k6/issues/4957.
+	var h *ElementHandle
+	assert.Equal(t, DefaultTimeout, h.DefaultTimeout())
+
+	// Partially-initialized handles with nil intermediate fields must also
+	// fall back to DefaultTimeout rather than dereferencing a nil pointer.
+	assert.Equal(t, DefaultTimeout, (&ElementHandle{}).DefaultTimeout())
+}
+
 func TestErrorFromDOMError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What?

Backport of #5923 to the `v1.x` release branch for v1.8.0.

When `ElementHandle.GetAttribute` (and other methods) is called on a nil
or partially-initialized element handle, `DefaultTimeout` previously
panicked with a SIGSEGV while dereferencing `h.frame.manager.timeoutSettings`.
This change guards the receiver and chained fields and falls back to the
package-level `DefaultTimeout` constant.

## Why?

To prevent crashes in user scripts that interact with element handles
that may be nil or only partially initialized, and to ship the fix as
part of the v1.8.0 release.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5923
- Original commit: 40935d43d
- Closes #4957 (on master)