### PR TITLE
websockets: track bufferedAmount for typed arrays in ArrayBuffer (v1.8.0 backport of #5716)

### DIFF
--- a/internal/js/modules/k6/websockets/websockets.go
+++ b/internal/js/modules/k6/websockets/websockets.go
@@ -665,6 +665,7 @@ func (w *webSocket) send(msg sobek.Value) {
 			common.Throw(rt,
 				fmt.Errorf("got error while trying to export ArrayBufferView to bytes: %w", err))
 		}
+		w.bufferedAmount += len(b)
 		w.writeQueueCh <- message{
 			mtype: websocket.BinaryMessage,
 			data:  b,

--- a/internal/js/modules/k6/websockets/websockets_test.go
+++ b/internal/js/modules/k6/websockets/websockets_test.go
@@ -1524,6 +1524,7 @@ func TestArrayBufferViewSupport(t *testing.T) {
 			t.Parallel()
 
 			testArrayBufferViewSupport(t, name)
+			testArrayBufferViewBufferedAmount(t, name)
 		})
 	}
 }
@@ -1544,6 +1545,32 @@ func testArrayBufferViewSupport(t *testing.T, viewName string) {
 					if (sent.at(i) != received.at(i)) {
 						throw "Values at " + i + " were different " + sent.at(i) + " vs " + received.at(i);
 					}
+				}
+				ws.close()
+			}
+		})
+	`, viewName)))
+	require.NoError(t, err)
+	logs := hook.Drain()
+	require.Len(t, logs, 0)
+}
+
+func testArrayBufferViewBufferedAmount(t *testing.T, viewName string) {
+	t.Helper()
+	ts := newTestState(t)
+	logger, hook := testutils.NewLoggerWithHook(t, logrus.WarnLevel)
+	ts.runtime.VU.StateField.Logger = logger
+	_, err := ts.runtime.RunOnEventLoop(ts.tb.Replacer.Replace(fmt.Sprintf(`
+		var ws = new WebSocket("WSBIN_URL/ws-echo")
+		ws.addEventListener("open", () => {
+			const sent = new %[1]s([164, 41])
+			ws.send(sent)
+			if (ws.bufferedAmount != sent.byteLength) {
+				throw new Error("Expected " + sent.byteLength + " bufferedAmount got " + ws.bufferedAmount);
+			}
+			ws.onmessage = async (e) => {
+				if (ws.bufferedAmount != 0) {
+					throw new Error("Expected 0 bufferedAmount got " + ws.bufferedAmount);
 				}
 				ws.close()
 			}


### PR DESCRIPTION
## What?

Backport of #5716 to the v1.x release branch for v1.8.0.

Fixes a bug in the WebSocket implementation where `bufferedAmount` was not
being tracked when sending typed arrays backed by an `ArrayBuffer`. The
fix correctly accounts for the byte length of these payloads, and a test
is added to cover the case.

Credit to external contributor @prakharbirla-ng for the original change.

## Why?

The `bufferedAmount` property is part of the WebSocket API contract;
users relying on it to backpressure-manage large binary sends would have
observed an incorrect (zero) value when sending typed arrays. Backporting
this small, well-scoped fix into v1.8.0 keeps the v1.x line consistent
with master without pulling in unrelated changes.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5716
- Original issue: https://github.com/grafana/k6/issues/5715