### PR TITLE
[v1.8.0 backport] fix: preserve context cancellation causes (#5620)

### DIFF
--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -455,7 +455,7 @@ func (b *Browser) isPageAttachmentErrorIgnorable(ev *target.EventAttachedToTarge
 	case <-b.vuCtx.Done():
 		b.logger.Debugf("Browser:isPageAttachmentErrorIgnorable:return:<-ctx.Done",
 			"sid:%v tid:%v pageType:%s err:%v",
-			ev.SessionID, targetPage.TargetID, targetPage.Type, b.vuCtx.Err())
+			ev.SessionID, targetPage.TargetID, targetPage.Type, ContextErr(b.vuCtx))
 		return true
 	default:
 	}
@@ -549,7 +549,7 @@ func (b *Browser) newPageInContext(id cdp.BrowserContextID) (*Page, error) {
 		page = b.pages[tid]
 		b.pagesMu.RUnlock()
 	case <-ctx.Done():
-		b.logger.Debugf("Browser:newPageInContext:<-ctx.Done", "tid:%v bctxid:%v err:%v", tid, id, ctx.Err())
+		b.logger.Debugf("Browser:newPageInContext:<-ctx.Done", "tid:%v bctxid:%v err:%v", tid, id, ContextErr(ctx))
 	}
 
 	if err = ContextErr(ctx); err != nil {

--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -483,7 +483,7 @@ func (c *Connection) send(
 		_ = c.close(code)
 		return fmt.Errorf("closing communication with browser: %w", &websocket.CloseError{Code: code})
 	case <-ctx.Done():
-		c.logger.Debugf("Connection:send:<-ctx.Done", "wsURL:%q sid:%v err:%v", c.wsURL, msg.SessionID, c.ctx.Err())
+		c.logger.Debugf("Connection:send:<-ctx.Done", "wsURL:%q sid:%v err:%v", c.wsURL, msg.SessionID, ContextErr(ctx))
 		return nil
 	case <-c.done:
 		c.logger.Debugf("Connection:send:<-c.done", "wsURL:%q sid:%v", c.wsURL, msg.SessionID)
@@ -526,7 +526,7 @@ func (c *Connection) send(
 		c.logger.Debugf("Connection:send:<-c.done #2", "sid:%v tid:%v wsURL:%q", msg.SessionID, tid, c.wsURL)
 	case <-ctx.Done():
 		c.logger.Debugf("Connection:send:<-ctx.Done()", "sid:%v tid:%v wsURL:%q err:%v",
-			msg.SessionID, tid, c.wsURL, ContextErr(c.ctx))
+			msg.SessionID, tid, c.wsURL, ContextErr(ctx))
 		return ContextErr(ctx)
 	case <-c.ctx.Done():
 		c.logger.Debugf("Connection:send:<-c.ctx.Done()", "sid:%v tid:%v wsURL:%q err:%v",
@@ -563,7 +563,7 @@ func (c *Connection) sendLoop() {
 			c.logger.Debugf("Connection:sendLoop:<-c.done#2", "wsURL:%q", c.wsURL)
 			return
 		case <-c.ctx.Done():
-			c.logger.Debugf("connection:sendLoop", "returning, ctx.Err: %q", c.ctx.Err())
+			c.logger.Debugf("connection:sendLoop", "returning, ctx.Err: %q", ContextErr(c.ctx))
 			return
 		}
 	}
@@ -594,14 +594,15 @@ func (c *Connection) Execute(
 		for {
 			select {
 			case <-evCancelCtx.Done():
-				c.logger.Debugf("connection:Execute:<-evCancelCtx.Done()", "wsURL:%q err:%v", c.wsURL, evCancelCtx.Err())
+				c.logger.Debugf("connection:Execute:<-evCancelCtx.Done()", "wsURL:%q err:%v", c.wsURL, ContextErr(evCancelCtx))
 				return
 			case ev := <-chEvHandler:
 				msg, ok := ev.data.(*cdproto.Message)
 				if ok && msg.ID == id {
 					select {
 					case <-evCancelCtx.Done():
-						c.logger.Debugf("connection:Execute:<-evCancelCtx.Done()#2", "wsURL:%q err:%v", c.wsURL, evCancelCtx.Err())
+						c.logger.Debugf("connection:Execute:<-evCancelCtx.Done()#2",
+							"wsURL:%q err:%v", c.wsURL, ContextErr(evCancelCtx))
 					case ch <- msg:
 						// Stopping goroutine as we expect only one response with the matching message ID
 						return

--- a/internal/js/modules/k6/browser/common/context.go
+++ b/internal/js/modules/k6/browser/common/context.go
@@ -94,7 +94,7 @@ func ContextErr(ctx context.Context) error {
 	}
 
 	cause := context.Cause(ctx)
-	if cause == nil || errors.Is(cause, err) {
+	if cause == nil || errors.Is(err, cause) {
 		return err
 	}
 

--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1650,9 +1650,9 @@ func (p *Page) GoBackForward(delta int, opts *PageGoBackForwardOptions) (_ *Resp
 	for {
 		select {
 		case <-p.ctx.Done():
-			return nil, p.ctx.Err()
+			return nil, ContextErr(p.ctx)
 		case <-timeoutCtx.Done():
-			return nil, wrapTimeoutError(timeoutCtx.Err())
+			return nil, wrapTimeoutError(ContextErr(timeoutCtx))
 		case <-ticker.C:
 			mainFrame := p.frameManager.MainFrame()
 			if mainFrame == nil {

--- a/internal/js/runner.go
+++ b/internal/js/runner.go
@@ -822,7 +822,7 @@ func (u *VU) Activate(params *lib.VUActivationParams) lib.ActiveVU {
 func (u *ActiveVU) RunOnce() error {
 	select {
 	case <-u.RunContext.Done():
-		return u.RunContext.Err() // we are done, return
+		return lib.ContextErr(u.RunContext) // we are done, return
 	case u.busy <- struct{}{}:
 		// nothing else can run now, and the VU cannot be deactivated
 	}

--- a/internal/lib/testutils/minirunner/minirunner.go
+++ b/internal/lib/testutils/minirunner/minirunner.go
@@ -211,7 +211,7 @@ func (vu *ActiveVU) RunOnce() error {
 
 	select {
 	case <-vu.RunContext.Done():
-		return vu.RunContext.Err() // we are done, return
+		return lib.ContextErr(vu.RunContext) // we are done, return
 	case vu.busy <- struct{}{}:
 		// nothing else can run now, and the VU cannot be deactivated
 	}

--- a/internal/secretsource/url/url.go
+++ b/internal/secretsource/url/url.go
@@ -19,6 +19,7 @@ import (
 	"github.com/tidwall/gjson"
 	"gopkg.in/guregu/null.v3"
 
+	"go.k6.io/k6/lib"
 	"go.k6.io/k6/lib/fsext"
 	"go.k6.io/k6/lib/types"
 	"go.k6.io/k6/secretsource"
@@ -293,7 +294,7 @@ func retry(
 			// Wait with context cancellation support
 			select {
 			case <-ctx.Done():
-				return ctx.Err()
+				return lib.ContextErr(ctx)
 			case <-time.After(wait):
 			}
 		}

--- a/lib/context.go
+++ b/lib/context.go
@@ -2,6 +2,8 @@ package lib
 
 import (
 	"context"
+	"errors"
+	"fmt"
 )
 
 type ctxKey int
@@ -38,4 +40,19 @@ func GetScenarioState(ctx context.Context) *ScenarioState {
 		return nil
 	}
 	return v.(*ScenarioState) //nolint:forcetypeassert
+}
+
+// ContextErr returns ctx.Err() and, if present, appends the cancel cause.
+func ContextErr(ctx context.Context) error {
+	err := ctx.Err()
+	if err == nil {
+		return nil
+	}
+
+	cause := context.Cause(ctx)
+	if cause == nil || errors.Is(err, cause) {
+		return err
+	}
+
+	return fmt.Errorf("%w: %w", err, cause)
 }


### PR DESCRIPTION
## What?

Backport of #5620 ("fix: preserve context cancellation causes") onto the
`v1.x` release branch for the v1.8.0 release.

The change updates k6 to preserve the underlying cause of context
cancellation throughout scheduler, runner, browser (common), secretsource
URL, and minirunner code paths by adopting `context.WithCancelCause` /
`context.Cause` patterns. A new `lib.ContextErr(ctx)` helper is added in
`lib/context.go` which returns the cancellation cause when available
(falling back to `ctx.Err()`), and call sites now propagate that cause
instead of swallowing it.

Affected files (9 files, +37/-18):
- `internal/execution/scheduler.go`
- `internal/js/modules/k6/browser/common/browser.go`
- `internal/js/modules/k6/browser/common/connection.go`
- `internal/js/modules/k6/browser/common/context.go`
- `internal/js/modules/k6/browser/common/page.go`
- `internal/js/runner.go`
- `internal/lib/testutils/minirunner/minirunner.go`
- `internal/secretsource/url/url.go`
- `lib/context.go`

## Why?

To ship the cancellation-cause preservation fix in the v1.8.0 release so
users get clearer, more actionable error messages whenever a context is
cancelled (e.g. by a test timeout, a teardown, or a parent cancellation)
instead of a generic `context canceled` error.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5620 (commit `daea83767`).