### PR TITLE
Fix position parser for base pointer options (v1.8.0 backport of #5574)

### DIFF
--- a/internal/js/modules/k6/browser/common/element_handle_options.go
+++ b/internal/js/modules/k6/browser/common/element_handle_options.go
@@ -187,11 +187,12 @@ func (o *ElementHandleBasePointerOptions) Parse(ctx context.Context, opts sobek.
 			switch k {
 			case "position":
 				var p map[string]float64
-				o.Position = &Position{}
-				if rt.ExportTo(opts.Get(k), &p) != nil {
-					o.Position.X = p["x"]
-					o.Position.Y = p["y"]
+				if err := rt.ExportTo(opts.Get(k), &p); err != nil {
+					return err
 				}
+				o.Position = &Position{}
+				o.Position.X = p["x"]
+				o.Position.Y = p["y"]
 			case "trial":
 				o.Trial = opts.Get(k).ToBoolean()
 			}

--- a/internal/js/modules/k6/browser/common/element_handle_options_test.go
+++ b/internal/js/modules/k6/browser/common/element_handle_options_test.go
@@ -1,0 +1,83 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/internal/js/modules/k6/browser/k6ext/k6test"
+)
+
+func TestElementHandleBasePointerOptionsParse(t *testing.T) {
+	t.Parallel()
+
+	for name, test := range map[string]struct {
+		opts      map[string]any
+		expectErr bool
+		verify    func(t *testing.T, opts *ElementHandleBasePointerOptions)
+	}{
+		"valid_full": {
+			opts: map[string]any{
+				"timeout": 1234,
+				"force":   true,
+				"trial":   true,
+				"position": map[string]any{
+					"x": 10,
+					"y": 20,
+				},
+			},
+			verify: func(t *testing.T, opts *ElementHandleBasePointerOptions) {
+				assert.Equal(t, 1234*time.Millisecond, opts.Timeout)
+				assert.True(t, opts.Force)
+				assert.True(t, opts.Trial)
+				require.NotNil(t, opts.Position)
+				assert.Equal(t, 10.0, opts.Position.X)
+				assert.Equal(t, 20.0, opts.Position.Y)
+			},
+		},
+		"valid_minimal": {
+			opts: map[string]any{},
+			verify: func(t *testing.T, opts *ElementHandleBasePointerOptions) {
+				assert.False(t, opts.Trial)
+				assert.Nil(t, opts.Position)
+				// Default timeout passed to NewElementHandleBasePointerOptions is 500ms in the test
+				assert.Equal(t, 500*time.Millisecond, opts.Timeout)
+			},
+		},
+		"null_options": {
+			opts: nil,
+			verify: func(t *testing.T, opts *ElementHandleBasePointerOptions) {
+				assert.Nil(t, opts.Position)
+				assert.Equal(t, 500*time.Millisecond, opts.Timeout)
+			},
+		},
+		"invalid_position_type": {
+			opts: map[string]any{
+				"position": "invalid",
+			},
+			expectErr: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			vu := k6test.NewVU(t)
+			ctx := vu.Context()
+			rt := vu.Runtime()
+
+			val := rt.ToValue(test.opts)
+
+			opts := NewElementHandleBasePointerOptions(500 * time.Millisecond)
+			err := opts.Parse(ctx, val)
+
+			if test.expectErr {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				if test.verify != nil {
+					test.verify(t, opts)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What?

Backport of #5574 to the `v1.x` release branch for v1.8.0.

Fixes an incorrect error check in the position parsing logic for base pointer options in the browser module's `element_handle_options.go`, and adds unit tests covering the parser.

Credit to external contributor @chrismooreproductions for the original fix.

## Why?

The original parser had an incorrect error check when parsing the `position` field of base pointer options, which could lead to wrong behavior when handling pointer-based interactions in the browser module. We want this fix included in the v1.8.0 release.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5574
- Original fix by @chrismooreproductions
- Closes #4429 (original upstream)