### PR TITLE
Backport #5815 to v1.8.0: Warn when http.get or http.head receive extra arguments

### DIFF
--- a/js/modules/k6/http/http.go
+++ b/js/modules/k6/http/http.go
@@ -69,12 +69,30 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	// wrappers (facades) that convert the old k6 idiosyncratic APIs to the new
 	// proper Client ones that accept Request objects and don't suck
 	mustExport("get", func(url sobek.Value, args ...sobek.Value) (*Response, error) {
+		// http.get should not have more than one additional argument
+		if len(args) > 1 {
+			if state := mi.vu.State(); state != nil {
+				state.Logger.Warnf(
+					"http.get only accepts a url and a params argument (2 arguments), but %d were given",
+					len(args)+1,
+				)
+			}
+		}
 		// http.get(url, params) doesn't have a body argument, so we add undefined
 		// as the third argument to http.request(method, url, body, params)
 		args = append([]sobek.Value{sobek.Undefined()}, args...)
 		return mi.defaultClient.Request(http.MethodGet, url, args...)
 	})
 	mustExport("head", func(url sobek.Value, args ...sobek.Value) (*Response, error) {
+		// http.head should not have more than one additional argument
+		if len(args) > 1 {
+			if state := mi.vu.State(); state != nil {
+				state.Logger.Warnf(
+					"http.head only accepts a url and a params argument (2 arguments), but %d were given",
+					len(args)+1,
+				)
+			}
+		}
 		// http.head(url, params) doesn't have a body argument, so we add undefined
 		// as the third argument to http.request(method, url, body, params)
 		args = append([]sobek.Value{sobek.Undefined()}, args...)

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1175,6 +1175,38 @@ func TestRequest(t *testing.T) {
 		assertRequestMetricsEmitted(t, metrics.GetBufferedSamples(samples), "HEAD", sr("HTTPBIN_URL/get?a=1&b=2"), 200, "")
 	})
 
+	t.Run("GETExtraArgs", func(t *testing.T) {
+		ts := newTestCase(t)
+		rt := ts.runtime.VU.Runtime()
+
+		ts.hook.Reset()
+		_, err := rt.RunString(ts.tb.Replacer.Replace(`
+		var res = http.get("HTTPBIN_URL/get", null, {headers: {"X-We-Want-This": "value"}});
+		`))
+		require.NoError(t, err)
+
+		logEntry := ts.hook.LastEntry()
+		require.NotNil(t, logEntry)
+		assert.Equal(t, logrus.WarnLevel, logEntry.Level)
+		assert.Contains(t, logEntry.Message, "http.get only accepts a url and a params argument")
+	})
+
+	t.Run("HEADExtraArgs", func(t *testing.T) {
+		ts := newTestCase(t)
+		rt := ts.runtime.VU.Runtime()
+
+		ts.hook.Reset()
+		_, err := rt.RunString(ts.tb.Replacer.Replace(`
+		var res = http.head("HTTPBIN_URL/get", null, {headers: {"X-We-Want-This": "value"}});
+		`))
+		require.NoError(t, err)
+
+		logEntry := ts.hook.LastEntry()
+		require.NotNil(t, logEntry)
+		assert.Equal(t, logrus.WarnLevel, logEntry.Level)
+		assert.Contains(t, logEntry.Message, "http.head only accepts a url and a params argument")
+	})
+
 	t.Run("OPTIONS", func(t *testing.T) {
 		_, err := rt.RunString(sr(`
 		var res = http.options("HTTPBIN_URL/?a=1&b=2", null, {headers: {"X-We-Want-This": "value"}});


### PR DESCRIPTION
## What?

Backport of #5815 to the v1.x branch for the v1.8.0 release.

Warns when `http.get` or `http.head` are invoked with extra unexpected arguments. These methods only accept `(url, params)`, so any additional positional arguments are silently ignored — this change logs a warning to help users catch mistakes (e.g. passing a body argument by analogy with `http.post`).

Credit to external contributor @moko-poi for the original change.

## Why?

`http.get` and `http.head` previously accepted and silently discarded any extra arguments, which made it easy to write subtly broken scripts (for instance, attempting to pass a body to `http.get` as if it were `http.post`). Emitting a warning surfaces the mistake to the user without breaking existing scripts.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5815