### PR TITLE
[v1.8.0 backport] Add retry to newAction-based locator APIs (browser)

### DIFF
--- a/internal/js/modules/k6/browser/browser/element_handle_mapping.go
+++ b/internal/js/modules/k6/browser/browser/element_handle_mapping.go
@@ -17,9 +17,9 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 		"boundingBox": func() *sobek.Promise {
 			return promise(vu, func() (any, error) {
 				box, err := eh.BoundingBox()
-				// We want to avoid errors when an element is not visible and instead
+				// We want to avoid errors when an element is not visible or detached and instead
 				// opt to return a nil rectangle -- this matches Playwright's behaviour.
-				if errors.Is(err, common.ErrElementNotVisible) {
+				if errors.Is(err, common.ErrElementNotVisible) || errors.Is(err, common.ErrElementNotAttachedToDOM) {
 					return nil, nil
 				}
 				return box, err

--- a/internal/js/modules/k6/browser/browser/locator_mapping.go
+++ b/internal/js/modules/k6/browser/browser/locator_mapping.go
@@ -37,9 +37,9 @@ func mapLocator(vu moduleVU, lo *common.Locator) mapping {
 			}
 			return promise(vu, func() (any, error) {
 				box, err := lo.BoundingBox(popts)
-				// We want to avoid errors when an element is not visible and instead
+				// We want to avoid errors when an element is not visible or detached and instead
 				// opt to return a nil rectangle -- this matches Playwright's behaviour.
-				if errors.Is(err, common.ErrElementNotVisible) {
+				if errors.Is(err, common.ErrElementNotVisible) || errors.Is(err, common.ErrElementNotAttachedToDOM) {
 					return nil, nil
 				}
 				return box, err

--- a/internal/js/modules/k6/browser/common/consts.go
+++ b/internal/js/modules/k6/browser/common/consts.go
@@ -17,4 +17,7 @@ const (
 	// API default consts.
 
 	StrictModeOff = false
+
+	withRetry = true
+	noRetry   = false
 )

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -50,7 +50,7 @@ type ElementHandle struct {
 	frame *Frame
 }
 
-// String returns a string repesentation of ElementHandle.
+// String returns a string representation of ElementHandle.
 // It exists mostly for debugging where we don't want fmt.Sprintf to just
 // go through a complex object and try to stringify it.
 func (h *ElementHandle) String() string {
@@ -559,7 +559,7 @@ func (h *ElementHandle) waitAndScrollIntoViewIfNeeded(
 
 		return h.eval(apiCtx, opts, fn)
 	}
-	actFn := h.newAction([]string{"visible", "stable"}, fn, force, noWaitAfter, timeout)
+	actFn := h.newAction([]string{"visible", "stable"}, fn, force, withRetry, noWaitAfter, timeout)
 	_, err := call(h.ctx, actFn, timeout)
 
 	return err
@@ -861,7 +861,7 @@ func (h *ElementHandle) DispatchEvent(typ string, eventInit any) error {
 	}
 	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	dispatchEventAction := h.newAction(
-		[]string{}, dispatchEvent, opts.Force, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, dispatchEvent, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(h.ctx, dispatchEventAction, opts.Timeout); err != nil {
 		return fmt.Errorf("dispatching element event %q: %w", typ, err)
@@ -879,7 +879,7 @@ func (h *ElementHandle) Fill(value string, opts *ElementHandleBaseOptions) error
 	}
 	fillAction := h.newAction(
 		[]string{"visible", "enabled", "editable"},
-		fill, opts.Force, opts.NoWaitAfter, opts.Timeout,
+		fill, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(h.ctx, fillAction, opts.Timeout); err != nil {
 		return fmt.Errorf("filling element: %w", err)
@@ -897,7 +897,7 @@ func (h *ElementHandle) Focus() error {
 	}
 	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	focusAction := h.newAction(
-		[]string{}, focus, opts.Force, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, focus, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(h.ctx, focusAction, opts.Timeout); err != nil {
 		return fmt.Errorf("focusing on element: %w", err)
@@ -916,7 +916,7 @@ func (h *ElementHandle) GetAttribute(name string) (string, bool, error) {
 	}
 	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	getAttributeAction := h.newAction(
-		[]string{}, getAttribute, opts.Force, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, getAttribute, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 
 	v, err := call(h.ctx, getAttributeAction, opts.Timeout)
@@ -959,7 +959,7 @@ func (h *ElementHandle) InnerHTML() (string, error) {
 	}
 	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	innerHTMLAction := h.newAction(
-		[]string{}, innerHTML, opts.Force, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, innerHTML, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	v, err := call(h.ctx, innerHTMLAction, opts.Timeout)
 	if err != nil {
@@ -983,7 +983,7 @@ func (h *ElementHandle) InnerText() (string, error) {
 	}
 	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	innerTextAction := h.newAction(
-		[]string{}, innerText, opts.Force, opts.NoWaitAfter, opts.Timeout.Abs(),
+		[]string{}, innerText, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout.Abs(),
 	)
 	v, err := call(h.ctx, innerTextAction, opts.Timeout)
 	if err != nil {
@@ -1005,7 +1005,7 @@ func (h *ElementHandle) InputValue(opts *ElementHandleBaseOptions) (string, erro
 	inputValue := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return handle.inputValue(apiCtx)
 	}
-	inputValueAction := h.newAction([]string{}, inputValue, opts.Force, opts.NoWaitAfter, opts.Timeout)
+	inputValueAction := h.newAction([]string{}, inputValue, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout)
 	v, err := call(h.ctx, inputValueAction, opts.Timeout)
 	if err != nil {
 		return "", fmt.Errorf("getting element's input value: %w", err)
@@ -1142,7 +1142,7 @@ func (h *ElementHandle) Press(key string, opts *ElementHandlePressOptions) error
 		return nil, handle.press(apiCtx, key, KeyboardOptions{})
 	}
 	pressAction := h.newAction(
-		[]string{}, press, false, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, press, false, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(h.ctx, pressAction, opts.Timeout); err != nil {
 		return fmt.Errorf("pressing %q on element: %w", key, err)
@@ -1387,7 +1387,7 @@ func (h *ElementHandle) SelectOption(values []any, opts *ElementHandleBaseOption
 		return handle.selectOption(apiCtx, values)
 	}
 	selectOptionAction := h.newAction(
-		[]string{}, selectOption, opts.Force, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, selectOption, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	selectedOptions, err := call(h.ctx, selectOptionAction, opts.Timeout)
 	if err != nil {
@@ -1409,7 +1409,7 @@ func (h *ElementHandle) SelectText(opts *ElementHandleBaseOptions) error {
 		return nil, handle.selectText(apiCtx)
 	}
 	selectTextAction := h.newAction(
-		[]string{}, selectText, opts.Force, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, selectText, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(h.ctx, selectTextAction, opts.Timeout); err != nil {
 		return fmt.Errorf("selecting text: %w", err)
@@ -1425,7 +1425,7 @@ func (h *ElementHandle) SetInputFiles(files *Files, opts *ElementHandleSetInputF
 	setInputFiles := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
 		return nil, handle.setInputFiles(apiCtx, files)
 	}
-	setInputFilesAction := h.newAction([]string{}, setInputFiles, opts.Force, opts.NoWaitAfter, opts.Timeout)
+	setInputFilesAction := h.newAction([]string{}, setInputFiles, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout)
 	if _, err := call(h.ctx, setInputFilesAction, opts.Timeout); err != nil {
 		return fmt.Errorf("setting input files: %w", err)
 	}
@@ -1491,7 +1491,7 @@ func (h *ElementHandle) TextContent() (string, bool, error) {
 	}
 	opts := NewElementHandleBaseOptions(h.DefaultTimeout())
 	textContentAction := h.newAction(
-		[]string{}, textContent, opts.Force, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, textContent, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	v, err := call(h.ctx, textContentAction, opts.Timeout)
 	if err != nil {
@@ -1523,7 +1523,7 @@ func (h *ElementHandle) Type(text string, opts *ElementHandleTypeOptions) error 
 		return nil, handle.typ(apiCtx, text, KeyboardOptions{})
 	}
 	typeAction := h.newAction(
-		[]string{}, typ, false, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, typ, false, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(h.ctx, typeAction, opts.Timeout); err != nil {
 		return fmt.Errorf("typing text %q: %w", text, err)
@@ -1577,7 +1577,7 @@ func (h *ElementHandle) eval(
 }
 
 func (h *ElementHandle) newAction(
-	states []string, fn elementHandleActionFunc, force, noWaitAfter bool, timeout time.Duration,
+	states []string, fn elementHandleActionFunc, force bool, retry bool, noWaitAfter bool, timeout time.Duration,
 ) func(apiCtx context.Context, resultCh chan any, errCh chan error) {
 	// All or a subset of the following actionability checks are made before performing the actual action:
 	// 1. Attached to DOM
@@ -1611,7 +1611,16 @@ func (h *ElementHandle) newAction(
 	}
 
 	return func(apiCtx context.Context, resultCh chan any, errCh chan error) {
-		if res, err := actionFn(apiCtx); err != nil {
+		var res any
+		var err error
+
+		if retry && !force {
+			res, err = retryAction(apiCtx, actionFn)
+		} else {
+			res, err = actionFn(apiCtx)
+		}
+
+		if err != nil {
 			select {
 			case <-apiCtx.Done():
 			case errCh <- err:
@@ -1621,6 +1630,24 @@ func (h *ElementHandle) newAction(
 			case <-apiCtx.Done():
 			case resultCh <- res:
 			}
+		}
+	}
+}
+
+func retryAction(apiCtx context.Context, fn func(apiCtx context.Context) (any, error)) (res any, err error) {
+	for {
+		res, err := fn(apiCtx)
+
+		if err == nil {
+			return res, nil
+		}
+
+		shouldRetry, retryErr := shouldRetry(apiCtx, err)
+		if !shouldRetry {
+			if retryErr != nil {
+				return res, retryErr
+			}
+			return res, err
 		}
 	}
 }
@@ -1768,19 +1795,29 @@ func retryPointerAction(
 			return res, err
 		}
 
-		if !errors.Is(err, ErrElementNotVisible) &&
-			!errors.Is(err, ErrElementNotAttachedToDOM) &&
-			!strings.Contains(err.Error(), "frame has been detached") {
+		shouldRetry, retryErr := shouldRetry(apiCtx, err)
+		if !shouldRetry {
+			if retryErr != nil {
+				return res, retryErr
+			}
 			return res, err
 		}
+	}
+}
 
-		// Wait with timeout or context cancellation
-		select {
-		case <-apiCtx.Done():
-			return nil, ContextErr(apiCtx)
-		case <-time.After(20 * time.Millisecond):
-			// Continue retrying after delay
-		}
+func shouldRetry(apiCtx context.Context, err error) (bool, error) {
+	if !errors.Is(err, ErrElementNotVisible) &&
+		!errors.Is(err, ErrElementNotAttachedToDOM) &&
+		!strings.Contains(err.Error(), "frame has been detached") {
+		return false, nil
+	}
+
+	// Wait with timeout or context cancellation
+	select {
+	case <-apiCtx.Done():
+		return false, apiCtx.Err()
+	case <-time.After(20 * time.Millisecond):
+		return true, nil // Continue retrying after delay
 	}
 }
 
@@ -1814,6 +1851,14 @@ func errorFromDOMError(v any) error {
 	}
 
 	if serr == "error:notconnected" {
+		return ErrElementNotAttachedToDOM
+	}
+
+	if errors.Is(err, ErrElementNotVisible) {
+		return ErrElementNotVisible
+	}
+
+	if errors.Is(err, ErrElementNotAttachedToDOM) {
 		return ErrElementNotAttachedToDOM
 	}
 

--- a/internal/js/modules/k6/browser/common/frame.go
+++ b/internal/js/modules/k6/browser/common/frame.go
@@ -571,10 +571,10 @@ func (f *Frame) waitFor(
 
 func (f *Frame) boundingBox(selector string, opts *FrameBaseOptions) (*Rect, error) {
 	getBoundingBox := func(apiCtx context.Context, handle *ElementHandle) (any, error) {
-		return handle.boundingBox()
+		return handle.BoundingBox()
 	}
 	act := f.newAction(
-		selector, DOMElementStateAttached, opts.Strict, getBoundingBox, []string{}, false, true, opts.Timeout,
+		selector, DOMElementStateAttached, opts.Strict, getBoundingBox, []string{}, false, noRetry, true, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -747,7 +747,7 @@ func (f *Frame) isChecked(selector string, opts *FrameIsCheckedOptions) (bool, e
 		return v, err
 	}
 	act := f.newAction(
-		selector, DOMElementStateAttached, opts.Strict, isChecked, []string{}, false, true, opts.Timeout,
+		selector, DOMElementStateAttached, opts.Strict, isChecked, []string{}, false, withRetry, true, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -842,7 +842,7 @@ func (f *Frame) dispatchEvent(selector, typ string, eventInit any, opts *FrameDi
 	)
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, dispatchEvent, []string{},
-		force, noWaitAfter, opts.Timeout,
+		force, withRetry, noWaitAfter, opts.Timeout,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err)
@@ -944,7 +944,7 @@ func (f *Frame) fill(selector, value string, opts *FrameFillOptions) error {
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict,
 		fill, []string{"visible", "enabled", "editable"},
-		opts.Force, opts.NoWaitAfter, opts.Timeout,
+		opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err)
@@ -972,7 +972,7 @@ func (f *Frame) focus(selector string, opts *FrameBaseOptions) error {
 	}
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, focus,
-		[]string{}, false, true, opts.Timeout,
+		[]string{}, false, withRetry, true, opts.Timeout,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err)
@@ -1011,7 +1011,7 @@ func (f *Frame) getAttribute(selector, name string, opts *FrameBaseOptions) (str
 	}
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, getAttribute,
-		[]string{}, false, true, opts.Timeout,
+		[]string{}, false, withRetry, true, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -1303,7 +1303,7 @@ func (f *Frame) innerHTML(selector string, opts *FrameInnerHTMLOptions) (string,
 	}
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, innerHTML,
-		[]string{}, false, true, opts.Timeout,
+		[]string{}, false, withRetry, true, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -1339,7 +1339,7 @@ func (f *Frame) innerText(selector string, opts *FrameInnerTextOptions) (string,
 	}
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, innerText,
-		[]string{}, false, true, opts.Timeout,
+		[]string{}, false, withRetry, true, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -1374,7 +1374,7 @@ func (f *Frame) inputValue(selector string, opts *FrameInputValueOptions) (strin
 	}
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, inputValue,
-		[]string{}, false, true, opts.Timeout,
+		[]string{}, false, withRetry, true, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -1426,7 +1426,7 @@ func (f *Frame) isEditable(selector string, opts *FrameIsEditableOptions) (bool,
 		return v, err
 	}
 	act := f.newAction(
-		selector, DOMElementStateAttached, opts.Strict, isEditable, []string{}, false, true, opts.Timeout,
+		selector, DOMElementStateAttached, opts.Strict, isEditable, []string{}, false, withRetry, true, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -1463,7 +1463,7 @@ func (f *Frame) isEnabled(selector string, opts *FrameIsEnabledOptions) (bool, e
 		return v, err
 	}
 	act := f.newAction(
-		selector, DOMElementStateAttached, opts.Strict, isEnabled, []string{}, false, true, opts.Timeout,
+		selector, DOMElementStateAttached, opts.Strict, isEnabled, []string{}, false, withRetry, true, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -1500,7 +1500,7 @@ func (f *Frame) isDisabled(selector string, opts *FrameIsDisabledOptions) (bool,
 		return v, err
 	}
 	act := f.newAction(
-		selector, DOMElementStateAttached, opts.Strict, isDisabled, []string{}, false, true, opts.Timeout,
+		selector, DOMElementStateAttached, opts.Strict, isDisabled, []string{}, false, withRetry, true, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -1663,7 +1663,7 @@ func (f *Frame) press(selector, key string, opts *FramePressOptions) error {
 	}
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, press,
-		[]string{}, false, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, false, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err)
@@ -1693,7 +1693,7 @@ func (f *Frame) selectOption(selector string, values []any, opts *FrameSelectOpt
 	}
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, selectOption,
-		[]string{}, opts.Force, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -1803,7 +1803,7 @@ func (f *Frame) setInputFiles(selector string, files *Files, opts *FrameSetInput
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict,
 		setInputFiles, []string{},
-		opts.Force, opts.NoWaitAfter, opts.Timeout,
+		opts.Force, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
@@ -1833,7 +1833,7 @@ func (f *Frame) textContent(selector string, opts *FrameTextContentOptions) (str
 	}
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, TextContent,
-		[]string{}, false, true, opts.Timeout,
+		[]string{}, false, withRetry, true, opts.Timeout,
 	)
 	v, err := call(f.ctx, act, opts.Timeout)
 	if err != nil {
@@ -1892,7 +1892,7 @@ func (f *Frame) typ(selector, text string, opts *FrameTypeOptions) error {
 	}
 	act := f.newAction(
 		selector, DOMElementStateAttached, opts.Strict, typeText,
-		[]string{}, false, opts.NoWaitAfter, opts.Timeout,
+		[]string{}, false, withRetry, opts.NoWaitAfter, opts.Timeout,
 	)
 	if _, err := call(f.ctx, act, opts.Timeout); err != nil {
 		return errorFromDOMError(err)
@@ -2261,7 +2261,7 @@ func (f *Frame) evaluateWithSelector(selector string, pageFunc string, args ...a
 	}
 
 	act := f.newAction(
-		selector, DOMElementStateAttached, true, evaluate, []string{}, false, true, f.defaultTimeout(),
+		selector, DOMElementStateAttached, true, evaluate, []string{}, false, withRetry, true, f.defaultTimeout(),
 	)
 	v, err := call(f.ctx, act, f.defaultTimeout())
 	if err != nil {
@@ -2278,7 +2278,7 @@ func (f *Frame) evaluateHandleWithSelector(selector string, pageFunc string, arg
 	}
 
 	act := f.newAction(
-		selector, DOMElementStateAttached, true, evaluateHandle, []string{}, false, true, f.defaultTimeout(),
+		selector, DOMElementStateAttached, true, evaluateHandle, []string{}, false, withRetry, true, f.defaultTimeout(),
 	)
 	v, err := call(f.ctx, act, f.defaultTimeout())
 	if err != nil {
@@ -2356,7 +2356,7 @@ func (f *Frame) runActionOnSelector(
 //nolint:unparam
 func (f *Frame) newAction(
 	selector string, state DOMElementState, strict bool, fn elementHandleActionFunc, states []string,
-	force, noWaitAfter bool, timeout time.Duration,
+	force bool, retry bool, noWaitAfter bool, timeout time.Duration,
 ) func(apiCtx context.Context, resultCh chan any, errCh chan error) {
 	// We execute a frame action in the following steps:
 	// 1. Find element matching specified selector
@@ -2381,7 +2381,7 @@ func (f *Frame) newAction(
 			}
 			return
 		}
-		f := handle.newAction(states, fn, force, noWaitAfter, timeout)
+		f := handle.newAction(states, fn, force, retry, noWaitAfter, timeout)
 		f(apiCtx, resultCh, errCh)
 	}
 }

--- a/internal/js/modules/k6/browser/tests/locator_test.go
+++ b/internal/js/modules/k6/browser/tests/locator_test.go
@@ -1034,6 +1034,47 @@ func TestActionabilityRetry(t *testing.T) {
 	require.Equal(t, "0", text)
 }
 
+// BoundingBox() should return nil and an error indicating that the target element is not visible.
+// It should not retry and hence not time out
+func TestBoundingBoxOnInvisibleElement(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t)
+	p := tb.NewPage(nil)
+	err := p.SetContent("<html> <h1 id=\"elem\" style=\"display:none\">Test</h1> </html>", nil)
+
+	require.NoError(t, err)
+
+	loc := p.Locator("#elem", &common.LocatorOptions{})
+
+	rect, err := loc.BoundingBox(&common.FrameBaseOptions{Strict: true, Timeout: time.Second})
+
+	require.ErrorIs(t, err, common.ErrElementNotVisible)
+	require.Nil(t, rect)
+}
+
+// Ensure that focus() will retry and succeed even when the target element is detached after actionability checks but gets re-attached later.
+// This is done by focus() on an element that is detached/re-attached as fast as possible.
+// Note that this test will only fail 1/10 times if a bug is introduced because it is testing a race condition.
+func TestDetachedRetry(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withFileServer())
+	p := tb.NewPage(nil)
+
+	_, err := p.Goto(
+		tb.staticURL("detach_attach.html"),
+		&common.FrameGotoOptions{Timeout: common.DefaultTimeout},
+	)
+	require.NoError(t, err)
+
+	loc := p.Locator("#elem", &common.LocatorOptions{})
+
+	err = loc.Focus(&common.FrameBaseOptions{Strict: true, Timeout: time.Second})
+
+	require.NoError(t, err)
+}
+
 func TestLocatorFilter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/static/detach_attach.html
+++ b/internal/js/modules/k6/browser/tests/static/detach_attach.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<body>
+  <input id="elem"></input>
+
+  <script>
+    var attached = true;
+    const elem = document.getElementById('elem');
+
+    function loop() {
+      if (attached) {
+        elem.remove();
+      } else {
+        document.body.appendChild(elem);
+      }
+      attached = !attached;
+      setTimeout(loop, 0);
+    }
+
+    setTimeout(loop, 0);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## What?

Backport of #5657 to the `v1.x` release branch for inclusion in v1.8.0.

Adds retry behavior to the `newAction`-based locator APIs in the browser
module. The retry logic is extracted into a shared helper and reused
across the affected locator/element-handle entry points. `BoundingBox()`
is explicitly excluded from retrying. `ErrFromDOMError` now also surfaces
`errElementNotVisible` and the not-attached-to-DOM error so callers see
the correct error class, and the retry switch is driven by new named
constants.

Changes:
- `internal/js/modules/k6/browser/browser/element_handle_mapping.go`
- `internal/js/modules/k6/browser/browser/locator_mapping.go`
- `internal/js/modules/k6/browser/common/consts.go`
- `internal/js/modules/k6/browser/common/element_handle.go`
- `internal/js/modules/k6/browser/common/frame.go`
- `internal/js/modules/k6/browser/tests/locator_test.go`
- `internal/js/modules/k6/browser/tests/static/detach_attach.html` (new)

## Why?

These locator APIs could fail with transient DOM errors (e.g. element
detached/reattached during navigation) where Playwright-style retries
would normally succeed. Bringing this behavior to v1.x makes browser
tests more robust on the v1.8.0 release without waiting for the next
major.

Original author: @janHildebrandt98 — credit for the work goes to them;
this PR is purely a backport.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of https://github.com/grafana/k6/pull/5657 (original author: @janHildebrandt98)