### PR TITLE
Support configuration of basic auth for OTLP HTTP exporter.

### DIFF
--- a/internal/output/opentelemetry/config.go
+++ b/internal/output/opentelemetry/config.go
@@ -62,6 +62,12 @@ type Config struct {
 	// HTTPExporterURLPath sets the target URL path the OpenTelemetry Exporter
 	HTTPExporterURLPath null.String `json:"httpExporterURLPath" envconfig:"K6_OTEL_HTTP_EXPORTER_URL_PATH"`
 
+	// Username is the User for Basic Auth.
+	HTTPUsername null.String `json:"username" envconfig:"K6_OTEL_HTTP_EXPORTER_USERNAME"`
+
+	// Password is the Password for the Basic Auth.
+	HTTPPassword null.String `json:"password" envconfig:"K6_OTEL_HTTP_EXPORTER_PASSWORD"`
+
 	// GRPCExporterEndpoint sets the target endpoint the OpenTelemetry Exporter
 	// will connect to.
 	GRPCExporterEndpoint null.String `json:"grpcExporterEndpoint" envconfig:"K6_OTEL_GRPC_EXPORTER_ENDPOINT"`
@@ -185,6 +191,14 @@ func (cfg Config) Apply(v Config) Config {
 
 	if v.Headers.Valid {
 		cfg.Headers = v.Headers
+	}
+
+	if v.HTTPUsername.Valid {
+		cfg.HTTPUsername = v.HTTPUsername
+	}
+
+	if v.HTTPPassword.Valid {
+		cfg.HTTPPassword = v.HTTPPassword
 	}
 
 	return cfg

--- a/internal/output/opentelemetry/config_test.go
+++ b/internal/output/opentelemetry/config_test.go
@@ -69,6 +69,8 @@ func TestConfig(t *testing.T) {
 				"K6_OTEL_TLS_CLIENT_CERTIFICATE":   "client_cert_path",
 				"K6_OTEL_TLS_CLIENT_KEY":           "client_key_path",
 				"K6_OTEL_HEADERS":                  "key1=value1,key2=value2",
+				"K6_OTEL_HTTP_EXPORTER_USERNAME":   "foo",
+				"K6_OTEL_HTTP_EXPORTER_PASSWORD":   "bar",
 			},
 			expectedConfig: Config{
 				ServiceName:           null.NewString("foo", true),
@@ -86,6 +88,8 @@ func TestConfig(t *testing.T) {
 				TLSClientCertificate:  null.NewString("client_cert_path", true),
 				TLSClientKey:          null.NewString("client_key_path", true),
 				Headers:               null.NewString("key1=value1,key2=value2", true),
+				HTTPUsername:          null.NewString("foo", true),
+				HTTPPassword:          null.NewString("bar", true),
 			},
 		},
 
@@ -124,7 +128,9 @@ func TestConfig(t *testing.T) {
 					`"tlsCertificate":"cert_path",` +
 					`"tlsClientCertificate":"client_cert_path",` +
 					`"tlsClientKey":"client_key_path",` +
-					`"headers":"key1=value1,key2=value2"` +
+					`"headers":"key1=value1,key2=value2",` +
+					`"username":"foo",` +
+					`"password":"bar"` +
 					`}`,
 			),
 			expectedConfig: Config{
@@ -143,6 +149,8 @@ func TestConfig(t *testing.T) {
 				TLSClientCertificate:  null.NewString("client_cert_path", true),
 				TLSClientKey:          null.NewString("client_key_path", true),
 				Headers:               null.NewString("key1=value1,key2=value2", true),
+				HTTPUsername:          null.NewString("foo", true),
+				HTTPPassword:          null.NewString("bar", true),
 			},
 		},
 

--- a/internal/output/opentelemetry/exporter.go
+++ b/internal/output/opentelemetry/exporter.go
@@ -3,6 +3,7 @@ package opentelemetry
 import (
 	"context"
 	"crypto/tls"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"net/url"
@@ -36,6 +37,12 @@ func getExporter(cfg Config) (metric.Exporter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse headers: %w", err)
 		}
+	}
+
+	// if at least valid user was configured, use basic auth
+	if cfg.HTTPUsername.Valid {
+		auth := []byte(cfg.HTTPUsername.String + ":" + cfg.HTTPPassword.String)
+		headers["Authorization"] = fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString(auth))
 	}
 
 	switch cfg.ExporterProtocol.String {


### PR DESCRIPTION
## What?

This change adds the option to define `K6_OTEL_HTTP_EXPORTER_USERNAME` and `K6_OTEL_HTTP_EXPORTER_PASSWORD` to set baisc auth credentials directly.

## Why?

While it is possible to define an `Authorization` header via `K6_OTEL_HEADERS` it is a bit inconvenient when used through Kubernetes secrets. Eg a secret would have to include the value `Authorization= Basic <base64(user+":"password)>`. It is simpler to pass username and password.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable