### PR TITLE
chore(deps): bump Azure/go-ntlmssp to v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.25.9
 
 require (
 	buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.36.11-20251118093737-4105057cc7d4.1
-	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
+	github.com/Azure/go-ntlmssp v0.1.1
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/PuerkitoBio/goquery v1.11.0
 	github.com/Soontao/goHttpDigestClient v0.0.0-20170320082612-6d28bb1415c5

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ buf.build/gen/go/gogo/protobuf/protocolbuffers/go v1.36.11-20240617172848-e1dbca
 buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.36.11-20251118093737-4105057cc7d4.1 h1:tk/yD1MiQW1n5U/07iphh2Pksv0HDiQ1VOYC6alZJR0=
 buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.36.11-20251118093737-4105057cc7d4.1/go.mod h1:6rM4oiNLtvSABJBFC+GReCtGUaWLYwhsadnb9FgJ/2k=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
-github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/Azure/go-ntlmssp v0.1.1 h1:l+FM/EEMb0U9QZE7mKNEDw5Mu3mFiaa2GKOoTSsNDPw=
+github.com/Azure/go-ntlmssp v0.1.1/go.mod h1:NYqdhxd/8aAct/s4qSYZEerdPuH1liG2/X9DiVTbhpk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=

--- a/vendor/github.com/Azure/go-ntlmssp/E2E_README.md
+++ b/vendor/github.com/Azure/go-ntlmssp/E2E_README.md
@@ -1,0 +1,107 @@
+# E2E NTLM Tests
+
+This directory contains end-to-end tests for the go-ntlmssp library that test against real NTLM servers.
+
+## Running E2E Tests Locally
+
+### Prerequisites
+
+- Windows machine with IIS capabilities
+- Go 1.20 or later
+- Administrator privileges (for IIS setup)
+
+### Setup
+
+1. **Enable IIS with Windows Authentication:**
+   ```powershell
+   # Run as Administrator
+   Enable-WindowsOptionalFeature -Online -FeatureName IIS-WebServerRole -All
+   Enable-WindowsOptionalFeature -Online -FeatureName IIS-WindowsAuthentication -All
+   ```
+
+2. **Create test site:**
+   ```powershell
+   Import-Module WebAdministration
+   New-Website -Name "ntlmtest" -Port 8080 -PhysicalPath "C:\inetpub\wwwroot"
+   Set-WebConfigurationProperty -Filter "/system.webServer/security/authentication/anonymousAuthentication" -Name enabled -Value false -PSPath "IIS:\Sites\ntlmtest"
+   Set-WebConfigurationProperty -Filter "/system.webServer/security/authentication/windowsAuthentication" -Name enabled -Value true -PSPath "IIS:\Sites\ntlmtest"
+   ```
+
+3. **Set environment variables:**
+   ```powershell
+   $env:NTLM_TEST_URL = "http://localhost:8080/"
+   $env:NTLM_TEST_USER = "your_username"
+   $env:NTLM_TEST_PASSWORD = "your_password" 
+   $env:NTLM_TEST_DOMAIN = "your_domain"  # Optional
+   ```
+   
+   > **Note**: The setup script automatically generates a random secure password if none is provided. For security, avoid hardcoded passwords in scripts or CI environments.
+
+4. **Run tests:**
+   ```bash
+   go test -v -tags=e2e ./e2e -run TestNTLM_E2E
+   ```
+
+## GitHub Actions
+
+The E2E tests run automatically in GitHub Actions on Windows runners. The workflow:
+
+1. Sets up a clean Windows Server environment
+2. Generates a random secure password for the test user
+3. Creates a test user account with the random password
+4. Configures IIS with Windows Authentication
+5. Runs the E2E tests against the real NTLM server
+5. Cleans up resources
+
+## Test Coverage
+
+The E2E tests cover:
+
+- ✅ Basic NTLM authentication flow
+- ✅ UPN format usernames (`user@domain.com`)
+- ✅ SAM format usernames (`DOMAIN\user`) 
+- ✅ Authentication failure scenarios
+- ✅ Server accessibility checks
+- ✅ Context cancellation handling
+- ✅ Direct ProcessChallenge function testing
+
+## Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `NTLM_TEST_URL` | URL of NTLM-enabled server | `http://localhost:8080/` |
+| `NTLM_TEST_USER` | Username for authentication | `$USERNAME` (Windows) |
+| `NTLM_TEST_PASSWORD` | Password for authentication | Required |
+| `NTLM_TEST_DOMAIN` | Domain for authentication | `$USERDOMAIN` (Windows) |
+
+## Troubleshooting
+
+### Common Issues
+
+1. **"No username available"** - Set `NTLM_TEST_USER` environment variable
+2. **"No password available"** - Set `NTLM_TEST_PASSWORD` environment variable  
+3. **Connection refused** - Ensure IIS is running and accessible on the specified port
+4. **401 Unauthorized** - Check that Windows Authentication is enabled and working
+
+### IIS Debugging
+
+Check IIS status:
+```powershell
+Get-Website
+Get-WebApplication
+Get-WebConfigurationProperty -Filter "/system.webServer/security/authentication/windowsAuthentication" -Name enabled -PSPath "IIS:\Sites\Default Web Site"
+```
+
+View IIS logs:
+```powershell
+Get-Content "C:\inetpub\logs\LogFiles\W3SVC1\*.log" | Select-Object -Last 50
+```
+
+## Security Note
+
+These tests use real authentication credentials. In CI/CD:
+- Test credentials are generated dynamically per job
+- Credentials are cleaned up after each test run
+- No persistent credentials are stored
+
+For local development, use test accounts or ensure credentials are not committed to version control.

--- a/vendor/github.com/Azure/go-ntlmssp/authheader.go
+++ b/vendor/github.com/Azure/go-ntlmssp/authheader.go
@@ -1,66 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package ntlmssp
 
 import (
 	"encoding/base64"
+	"net/http"
 	"strings"
 )
 
-type authheader []string
+var schemaPreference = [...]string{"NTLM", "Negotiate", "Basic"}
 
-func (h authheader) IsBasic() bool {
-	for _, s := range h {
-		if strings.HasPrefix(string(s), "Basic ") {
-			return true
-		}
-	}
-	return false
+type authheader struct {
+	schema string
+	data   string
 }
 
-func (h authheader) Basic() string {
-	for _, s := range h {
-		if strings.HasPrefix(string(s), "Basic ") {
-			return s
-		}
-	}
-	return ""
-}
-
-func (h authheader) IsNegotiate() bool {
-	for _, s := range h {
-		if strings.HasPrefix(string(s), "Negotiate") {
-			return true
-		}
-	}
-	return false
-}
-
-func (h authheader) IsNTLM() bool {
-	for _, s := range h {
-		if strings.HasPrefix(string(s), "NTLM") {
-			return true
-		}
-	}
-	return false
-}
-
-func (h authheader) GetData() ([]byte, error) {
-	for _, s := range h {
-		if strings.HasPrefix(string(s), "NTLM") || strings.HasPrefix(string(s), "Negotiate") || strings.HasPrefix(string(s), "Basic ") {
-			p := strings.Split(string(s), " ")
-			if len(p) < 2 {
-				return nil, nil
+// newAuthHeader extracts the authheader from the provided HTTP headers.
+// It selects the most preferred authentication scheme.
+// If no supported scheme is found, it returns an empty authheader.
+func newAuthHeader(req http.Header) authheader {
+	auth := req.Values("Www-Authenticate")
+	preferred, idx := -1, -1
+	for i, s := range auth {
+		for j, schema := range schemaPreference {
+			if s == schema || strings.HasPrefix(s, schema+" ") {
+				if preferred == -1 || j < preferred {
+					preferred = j
+					idx = i
+					break
+				}
 			}
-			return base64.StdEncoding.DecodeString(string(p[1]))
 		}
 	}
-	return nil, nil
+	if idx == -1 {
+		return authheader{}
+	}
+	schema, data, _ := strings.Cut(auth[idx], " ")
+	return authheader{
+		schema: schema,
+		data:   data,
+	}
 }
 
-func (h authheader) GetBasicCreds() (username, password string, err error) {
-	d, err := h.GetData()
-	if err != nil {
-		return "", "", err
+// isNTLM returns true if the authheader schema is NTLM or Negotiate.
+func (h authheader) isNTLM() bool {
+	return h.schema == "NTLM" || h.schema == "Negotiate"
+}
+
+// isBasic returns true if the authheader schema is Basic.
+func (h authheader) isBasic() bool {
+	return h.schema == "Basic"
+}
+
+// token extracts and decodes the base64 token from the authheader.
+// It returns nil if the schema is not NTLM or Negotiate.
+func (h authheader) token() ([]byte, error) {
+	if !h.isNTLM() {
+		// Schema not supported for token extraction
+		return nil, nil
 	}
-	parts := strings.SplitN(string(d), ":", 2)
-	return parts[0], parts[1], nil
+	// RFC4559 4.2 - The token is a base64-encoded value
+	return base64.StdEncoding.DecodeString(h.data)
 }

--- a/vendor/github.com/Azure/go-ntlmssp/avids.go
+++ b/vendor/github.com/Azure/go-ntlmssp/avids.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package ntlmssp
 
 type avID uint16

--- a/vendor/github.com/Azure/go-ntlmssp/challenge_message.go
+++ b/vendor/github.com/Azure/go-ntlmssp/challenge_message.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package ntlmssp
 
 import (
@@ -32,8 +35,8 @@ func (m *challengeMessage) UnmarshalBinary(data []byte) error {
 	if err != nil {
 		return err
 	}
-	if !m.challengeMessageFields.IsValid() {
-		return fmt.Errorf("Message is not a valid challenge message: %+v", m.challengeMessageFields.messageHeader)
+	if !m.IsValid() {
+		return fmt.Errorf("message is not a valid challenge message: %+v", m.messageHeader)
 	}
 
 	if m.challengeMessageFields.TargetName.Len > 0 {
@@ -72,7 +75,7 @@ func (m *challengeMessage) UnmarshalBinary(data []byte) error {
 				return err
 			}
 			if n != int(l) {
-				return fmt.Errorf("Expected to read %d bytes, got only %d", l, n)
+				return fmt.Errorf("expected to read %d bytes, got only %d", l, n)
 			}
 			m.TargetInfo[id] = value
 		}

--- a/vendor/github.com/Azure/go-ntlmssp/internal/md4/md4.go
+++ b/vendor/github.com/Azure/go-ntlmssp/internal/md4/md4.go
@@ -1,0 +1,113 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package md4 implements the MD4 hash algorithm as defined in RFC 1320.
+package md4
+
+import (
+	"hash"
+)
+
+// The size of an MD4 checksum in bytes.
+const Size = 16
+
+// The blocksize of MD4 in bytes.
+const BlockSize = 64
+
+const (
+	_Chunk = 64
+	_Init0 = 0x67452301
+	_Init1 = 0xEFCDAB89
+	_Init2 = 0x98BADCFE
+	_Init3 = 0x10325476
+)
+
+// digest represents the partial evaluation of a checksum.
+type digest struct {
+	s   [4]uint32
+	x   [_Chunk]byte
+	nx  int
+	len uint64
+}
+
+func (d *digest) Reset() {
+	d.s[0] = _Init0
+	d.s[1] = _Init1
+	d.s[2] = _Init2
+	d.s[3] = _Init3
+	d.nx = 0
+	d.len = 0
+}
+
+// New returns a new hash.Hash computing the MD4 checksum.
+func New() hash.Hash {
+	d := new(digest)
+	d.Reset()
+	return d
+}
+
+func (d *digest) Size() int { return Size }
+
+func (d *digest) BlockSize() int { return BlockSize }
+
+func (d *digest) Write(p []byte) (nn int, err error) {
+	nn = len(p)
+	d.len += uint64(nn)
+	if d.nx > 0 {
+		n := len(p)
+		if n > _Chunk-d.nx {
+			n = _Chunk - d.nx
+		}
+		for i := 0; i < n; i++ {
+			d.x[d.nx+i] = p[i]
+		}
+		d.nx += n
+		if d.nx == _Chunk {
+			_Block(d, d.x[0:])
+			d.nx = 0
+		}
+		p = p[n:]
+	}
+	n := _Block(d, p)
+	p = p[n:]
+	if len(p) > 0 {
+		d.nx = copy(d.x[:], p)
+	}
+	return
+}
+
+func (d0 *digest) Sum(in []byte) []byte {
+	// Make a copy of d0, so that caller can keep writing and summing.
+	d := new(digest)
+	*d = *d0
+
+	// Padding.  Add a 1 bit and 0 bits until 56 bytes mod 64.
+	len := d.len
+	var tmp [64]byte
+	tmp[0] = 0x80
+	if len%64 < 56 {
+		d.Write(tmp[0 : 56-len%64])
+	} else {
+		d.Write(tmp[0 : 64+56-len%64])
+	}
+
+	// Length in bits.
+	len <<= 3
+	for i := uint(0); i < 8; i++ {
+		tmp[i] = byte(len >> (8 * i))
+	}
+	d.Write(tmp[0:8])
+
+	if d.nx != 0 {
+		panic("d.nx != 0")
+	}
+
+	for _, s := range d.s {
+		in = append(in, byte(s>>0))
+		in = append(in, byte(s>>8))
+		in = append(in, byte(s>>16))
+		in = append(in, byte(s>>24))
+	}
+	return in
+}

--- a/vendor/github.com/Azure/go-ntlmssp/internal/md4/md4block.go
+++ b/vendor/github.com/Azure/go-ntlmssp/internal/md4/md4block.go
@@ -1,0 +1,91 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// MD4 block step.
+// In its own file so that a faster assembly or C version
+// can be substituted easily.
+
+package md4
+
+import "math/bits"
+
+var shift1 = []int{3, 7, 11, 19}
+var shift2 = []int{3, 5, 9, 13}
+var shift3 = []int{3, 9, 11, 15}
+
+var xIndex2 = []uint{0, 4, 8, 12, 1, 5, 9, 13, 2, 6, 10, 14, 3, 7, 11, 15}
+var xIndex3 = []uint{0, 8, 4, 12, 2, 10, 6, 14, 1, 9, 5, 13, 3, 11, 7, 15}
+
+func _Block(dig *digest, p []byte) int {
+	a := dig.s[0]
+	b := dig.s[1]
+	c := dig.s[2]
+	d := dig.s[3]
+	n := 0
+	var X [16]uint32
+	for len(p) >= _Chunk {
+		aa, bb, cc, dd := a, b, c, d
+
+		j := 0
+		for i := 0; i < 16; i++ {
+			X[i] = uint32(p[j]) | uint32(p[j+1])<<8 | uint32(p[j+2])<<16 | uint32(p[j+3])<<24
+			j += 4
+		}
+
+		// If this needs to be made faster in the future,
+		// the usual trick is to unroll each of these
+		// loops by a factor of 4; that lets you replace
+		// the shift[] lookups with constants and,
+		// with suitable variable renaming in each
+		// unrolled body, delete the a, b, c, d = d, a, b, c
+		// (or you can let the optimizer do the renaming).
+		//
+		// The index variables are uint so that % by a power
+		// of two can be optimized easily by a compiler.
+
+		// Round 1.
+		for i := uint(0); i < 16; i++ {
+			x := i
+			s := shift1[i%4]
+			f := ((c ^ d) & b) ^ d
+			a += f + X[x]
+			a = bits.RotateLeft32(a, s)
+			a, b, c, d = d, a, b, c
+		}
+
+		// Round 2.
+		for i := uint(0); i < 16; i++ {
+			x := xIndex2[i]
+			s := shift2[i%4]
+			g := (b & c) | (b & d) | (c & d)
+			a += g + X[x] + 0x5a827999
+			a = bits.RotateLeft32(a, s)
+			a, b, c, d = d, a, b, c
+		}
+
+		// Round 3.
+		for i := uint(0); i < 16; i++ {
+			x := xIndex3[i]
+			s := shift3[i%4]
+			h := b ^ c ^ d
+			a += h + X[x] + 0x6ed9eba1
+			a = bits.RotateLeft32(a, s)
+			a, b, c, d = d, a, b, c
+		}
+
+		a += aa
+		b += bb
+		c += cc
+		d += dd
+
+		p = p[_Chunk:]
+		n += _Chunk
+	}
+
+	dig.s[0] = a
+	dig.s[1] = b
+	dig.s[2] = c
+	dig.s[3] = d
+	return n
+}

--- a/vendor/github.com/Azure/go-ntlmssp/messageheader.go
+++ b/vendor/github.com/Azure/go-ntlmssp/messageheader.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package ntlmssp
 
 import (

--- a/vendor/github.com/Azure/go-ntlmssp/negotiate_flags.go
+++ b/vendor/github.com/Azure/go-ntlmssp/negotiate_flags.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package ntlmssp
 
 type negotiateFlags uint32
@@ -48,5 +51,5 @@ func (field negotiateFlags) Has(flags negotiateFlags) bool {
 }
 
 func (field *negotiateFlags) Unset(flags negotiateFlags) {
-	*field = *field ^ (*field & flags)
+	*field ^= *field & flags
 }

--- a/vendor/github.com/Azure/go-ntlmssp/negotiator.go
+++ b/vendor/github.com/Azure/go-ntlmssp/negotiator.go
@@ -1,151 +1,331 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package ntlmssp
 
 import (
 	"bytes"
 	"encoding/base64"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
 
-// GetDomain : parse domain name from based on slashes in the input
-// Need to check for upn as well
-func GetDomain(user string) (string, string, bool) {
-	domain := ""
-	domainNeeded := false
+// negotiatorBody wraps an io.ReadSeeker to allow waiting for its closure
+// before rewinding and reusing it.
+type negotiatorBody struct {
+	body     io.ReadSeeker
+	closed   chan struct{}
+	startPos int64
+}
 
-	if strings.Contains(user, "\\") {
-		ucomponents := strings.SplitN(user, "\\", 2)
+// newNegotiatorBody creates a negotiatorBody from the provided io.Reader.
+// If the body is nil, it returns nil.
+// If the body is already an io.ReadSeeker, it uses it directly.
+// Otherwise, it reads the entire body into memory to allow rewinding.
+func newNegotiatorBody(body io.Reader) (*negotiatorBody, error) {
+	if body == nil {
+		return nil, nil
+	}
+	// Check if body is already seekable to avoid buffering large bodies
+	if seeker, ok := body.(io.ReadSeeker); ok {
+		// Remember the current position
+		startPos, err := seeker.Seek(0, io.SeekCurrent)
+		if err == nil {
+			// Seeking succeeded, use the seekable body directly
+			return &negotiatorBody{
+				body:     seeker,
+				closed:   make(chan struct{}, 1),
+				startPos: startPos,
+			}, nil
+		}
+		// Seeking failed (e.g., pipes), fallback to buffering
+	}
+	// For non-seekable bodies, buffer in memory as required
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, err
+	}
+	return &negotiatorBody{
+		body:   bytes.NewReader(data),
+		closed: make(chan struct{}, 1),
+	}, nil
+}
+
+func (b *negotiatorBody) Read(p []byte) (n int, err error) {
+	if b == nil {
+		return 0, io.EOF
+	}
+	return b.body.Read(p)
+}
+
+// Close signals that the body is no longer needed for the current request.
+// It allows the negotiator to rewind the body for potential reuse.
+// The underlying body is not closed here; use close() for that.
+func (b *negotiatorBody) Close() error {
+	if b == nil {
+		return nil
+	}
+	select {
+	case b.closed <- struct{}{}:
+	default:
+		// Already signaled
+	}
+	return nil
+}
+
+// close closes the underlying body if it implements io.Closer.
+func (b *negotiatorBody) close() {
+	if b == nil {
+		return
+	}
+	if closer, ok := b.body.(io.Closer); ok {
+		_ = closer.Close()
+	}
+}
+
+// rewind rewinds the body to the start position for reuse.
+func (b *negotiatorBody) rewind() error {
+	if b == nil {
+		return nil
+	}
+	// Wait for the body to be closed before rewinding
+	<-b.closed
+	_, err := b.body.Seek(b.startPos, io.SeekStart)
+	return err
+}
+
+// GetDomain extracts the user domain from the username if present.
+//
+// Deprecated: Pass the username directly to [ProcessChallenge], it will handle domain extraction.
+// Don't pass the resulting domain to [NewNegotiateMessage], that function expects the client
+// machine domain, not the user domain.
+func GetDomain(username string) (user string, domain string, domainNeeded bool) {
+	if strings.Contains(username, "\\") {
+		ucomponents := strings.SplitN(username, "\\", 2)
 		domain = ucomponents[0]
 		user = ucomponents[1]
 		domainNeeded = true
-	} else if strings.Contains(user, "@") {
+	} else if strings.Contains(username, "@") {
+		user = username
 		domainNeeded = false
 	} else {
+		user = username
 		domainNeeded = true
 	}
 	return user, domain, domainNeeded
 }
 
-//Negotiator is a http.Roundtripper decorator that automatically
-//converts basic authentication to NTLM/Negotiate authentication when appropriate.
-type Negotiator struct{ http.RoundTripper }
+// Negotiator is a [net/http.RoundTripper] decorator that automatically
+// converts basic authentication to NTLM/Negotiate authentication when appropriate.
+//
+// The credentials must be set using [net/http.Request.SetBasicAuth] on a per-request basis.
+//
+// By default, no credentials will be sent to the server unless it requests
+// Basic authentication and [Negotiator.AllowBasicAuth] is set to true.
+type Negotiator struct {
+	// RoundTripper is the underlying round tripper to use.
+	// If nil, http.DefaultTransport is used.
+	http.RoundTripper
 
-//RoundTrip sends the request to the server, handling any authentication
-//re-sends as needed.
-func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error) {
+	// AllowBasicAuth controls whether to send Basic authentication credentials
+	// if the server requests it.
+	//
+	// If false (default), Basic authentication requests are ignored
+	// and only NTLM/Negotiate authentication is performed.
+	// If true, Basic authentication requests are honored.
+	//
+	// Only set this to true if you trust the server you are connecting to.
+	// Basic authentication sends the credentials in clear text and may be
+	// vulnerable to man-in-the-middle attacks and compromised servers.
+	AllowBasicAuth bool
+
+	// WorkstationDomain is the domain of the client machine.
+	// It is normally not needed to set this field.
+	// It is passed to the negotiate message.
+	WorkstationDomain string
+
+	// WorkstationName is the workstation name of the client machine.
+	// It is passed to the negotiate and authenticate messages.
+	// Useful for auditing purposes on the server side.
+	WorkstationName string
+}
+
+// RoundTrip sends the request to the server, handling any authentication
+// re-sends as needed.
+func (l Negotiator) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Use default round tripper if not provided
 	rt := l.RoundTripper
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
+
 	// If it is not basic auth, just round trip the request as usual
-	reqauth := authheader(req.Header.Values("Authorization"))
-	if !reqauth.IsBasic() {
+	username, password, ok := req.BasicAuth()
+	if !ok {
 		return rt.RoundTrip(req)
 	}
-	reqauthBasic := reqauth.Basic()
-	// Save request body
-	body := bytes.Buffer{}
-	if req.Body != nil {
-		_, err = body.ReadFrom(req.Body)
-		if err != nil {
-			return nil, err
-		}
-
-		req.Body.Close()
-		req.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
+	id := identity{
+		username: username,
+		password: password,
 	}
-	// first try anonymous, in case the server still finds us
-	// authenticated from previous traffic
+
+	req = req.Clone(req.Context()) // Clone the request to avoid modifying the original
+
+	// We need to buffer or seek the request body to handle authentication challenges
+	// that require resending the body multiple times during the NTLM handshake.
+	body, err := newNegotiatorBody(req.Body)
+	if err != nil {
+		if req.Body != nil {
+			_ = req.Body.Close()
+		}
+		return nil, err
+	}
+	defer body.close()
+
+	// First try anonymous, in case the server still finds us authenticated from previous traffic
+	req.Body = body
 	req.Header.Del("Authorization")
-	res, err = rt.RoundTrip(req)
+	resp, err := rt.RoundTrip(req)
 	if err != nil {
 		return nil, err
 	}
-	if res.StatusCode != http.StatusUnauthorized {
-		return res, err
-	}
-	resauth := authheader(res.Header.Values("Www-Authenticate"))
-	if !resauth.IsNegotiate() && !resauth.IsNTLM() {
-		// Unauthorized, Negotiate not requested, let's try with basic auth
-		req.Header.Set("Authorization", string(reqauthBasic))
-		io.Copy(ioutil.Discard, res.Body)
-		res.Body.Close()
-		req.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
-
-		res, err = rt.RoundTrip(req)
-		if err != nil {
-			return nil, err
-		}
-		if res.StatusCode != http.StatusUnauthorized {
-			return res, err
-		}
-		resauth = authheader(res.Header.Values("Www-Authenticate"))
+	if resp.StatusCode != http.StatusUnauthorized {
+		// No authentication required, return the response as is
+		return resp, nil
 	}
 
-	if resauth.IsNegotiate() || resauth.IsNTLM() {
-		// 401 with request:Basic and response:Negotiate
-		io.Copy(ioutil.Discard, res.Body)
-		res.Body.Close()
+	// Note that from here on, the response returned in case of error or unsuccessful
+	// negotiation is the one we just got from the server. This is to allow the caller
+	// to do its own handling in case we can't do it in this roundtrip.
+	originalResp := resp
 
-		// recycle credentials
-		u, p, err := reqauth.GetBasicCreds()
+	resauth := newAuthHeader(resp.Header)
+	if l.AllowBasicAuth && resauth.isBasic() {
+		// Basic auth requested instead of NTLM/Negotiate.
+		//
+		// Rewind the body, we will resend it.
+		if body.rewind() != nil {
+			return originalResp, nil
+		}
+		req.SetBasicAuth(id.username, id.password)
+		resp, err := rt.RoundTrip(req)
 		if err != nil {
-			return nil, err
+			return originalResp, nil
 		}
-
-		// get domain from username
-		domain := ""
-		u, domain, domainNeeded := GetDomain(u)
-
-		// send negotiate
-		negotiateMessage, err := NewNegotiateMessage(domain, "")
-		if err != nil {
-			return nil, err
+		if resp.StatusCode != http.StatusUnauthorized {
+			// Basic auth succeeded, return the new response
+			drainResponse(originalResp)
+			return resp, nil
 		}
-		if resauth.IsNTLM() {
-			req.Header.Set("Authorization", "NTLM "+base64.StdEncoding.EncodeToString(negotiateMessage))
-		} else {
-			req.Header.Set("Authorization", "Negotiate "+base64.StdEncoding.EncodeToString(negotiateMessage))
+		resauth = newAuthHeader(resp.Header)
+		if !resauth.isNTLM() {
+			// No NTLM/Negotiate requested, return the response as is
+			return resp, nil
 		}
-
-		req.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
-
-		res, err = rt.RoundTrip(req)
-		if err != nil {
-			return nil, err
-		}
-
-		// receive challenge?
-		resauth = authheader(res.Header.Values("Www-Authenticate"))
-		challengeMessage, err := resauth.GetData()
-		if err != nil {
-			return nil, err
-		}
-		if !(resauth.IsNegotiate() || resauth.IsNTLM()) || len(challengeMessage) == 0 {
-			// Negotiation failed, let client deal with response
-			return res, nil
-		}
-		io.Copy(ioutil.Discard, res.Body)
-		res.Body.Close()
-
-		// send authenticate
-		authenticateMessage, err := ProcessChallenge(challengeMessage, u, p, domainNeeded)
-		if err != nil {
-			return nil, err
-		}
-		if resauth.IsNTLM() {
-			req.Header.Set("Authorization", "NTLM "+base64.StdEncoding.EncodeToString(authenticateMessage))
-		} else {
-			req.Header.Set("Authorization", "Negotiate "+base64.StdEncoding.EncodeToString(authenticateMessage))
-		}
-
-		req.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
-
-		return rt.RoundTrip(req)
+		// Server upgraded from Basic to NTLM/Negotiate (rare but possible)
+		drainResponse(resp)
+		// After Basic-to-NTLM upgrade, update originalResp to the NTLM-triggering response
+		originalResp = resp
+	} else if !resauth.isNTLM() {
+		// No NTLM/Negotiate requested, return the response as is
+		return originalResp, nil
 	}
 
-	return res, err
+	// Server requested Negotiate/NTLM, start handshake
+
+	// First step: send negotiate message
+	resp = clientHandshake(rt, req, resauth.schema, l.WorkstationDomain, l.WorkstationName)
+	if resp == nil {
+		return originalResp, nil
+	}
+	if resp.StatusCode != http.StatusUnauthorized {
+		// We are expecting a 401 with challenge, but the server responded differently,
+		// maybe it even accepted our negotiate message without further challenge, which is
+		// valid per the spec (RFC 4559 Section 5).
+		// Return the response as is, negotiation is over.
+		drainResponse(originalResp)
+		return resp, nil
+	}
+	resauth = newAuthHeader(resp.Header)
+	drainResponse(resp)
+
+	// Second step: process challenge and resend the original body with the authenticate message
+	resp = completeHandshake(rt, resauth, req, id, l.WorkstationName)
+	if resp == nil {
+		return originalResp, nil
+	}
+	// We could return the original response in case of 401 again, but at this point
+	// it's better to return the latest response from the server, as it might be the case
+	// that we are really not authorized.
+	drainResponse(originalResp) // Done with the original response
+	return resp, nil
+}
+
+type identity struct {
+	username string
+	password string
+}
+
+func drainResponse(res *http.Response) {
+	// Drain body and close it to allow reusing the connection
+	_, _ = io.Copy(io.Discard, res.Body)
+	_ = res.Body.Close()
+}
+
+func rewindBody(req *http.Request) error {
+	if req.Body == nil {
+		return nil
+	}
+	if nb, ok := req.Body.(*negotiatorBody); ok {
+		return nb.rewind()
+	}
+	return nil
+}
+
+func clientHandshake(rt http.RoundTripper, req *http.Request, schema string, domain, workstation string) *http.Response {
+	if rewindBody(req) != nil {
+		return nil
+	}
+	auth, err := NewNegotiateMessage(domain, workstation)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Authorization", schema+" "+base64.StdEncoding.EncodeToString(auth))
+	res, err := rt.RoundTrip(req)
+	if err != nil {
+		return nil
+	}
+	return res
+}
+
+func completeHandshake(rt http.RoundTripper, resauth authheader, req *http.Request, id identity, workstation string) *http.Response {
+	if rewindBody(req) != nil {
+		return nil
+	}
+	challenge, err := resauth.token()
+	if err != nil {
+		return nil
+	}
+	if !resauth.isNTLM() || len(challenge) == 0 {
+		// The only expected schema here is NTLM/Negotiate with a challenge token,
+		// otherwise the negotiation is over.
+		return nil
+	}
+	var opts *AuthenticateMessageOptions
+	if workstation != "" {
+		opts = &AuthenticateMessageOptions{
+			WorkstationName: workstation,
+		}
+	}
+	auth, err := NewAuthenticateMessage(challenge, id.username, id.password, opts)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Authorization", resauth.schema+" "+base64.StdEncoding.EncodeToString(auth))
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		return nil
+	}
+	return resp
 }

--- a/vendor/github.com/Azure/go-ntlmssp/nlmp.go
+++ b/vendor/github.com/Azure/go-ntlmssp/nlmp.go
@@ -1,5 +1,6 @@
-// Package ntlmssp provides NTLM/Negotiate authentication over HTTP
-//
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 // Protocol details from https://msdn.microsoft.com/en-us/library/cc236621.aspx,
 // implementation hints from http://davenport.sourceforge.net/ntlm.html .
 // This package only implements authentication, no key exchange or encryption. It
@@ -10,12 +11,17 @@ package ntlmssp
 import (
 	"crypto/hmac"
 	"crypto/md5"
-	"golang.org/x/crypto/md4"
 	"strings"
+
+	"github.com/Azure/go-ntlmssp/internal/md4"
 )
 
-func getNtlmV2Hash(password, username, target string) []byte {
-	return hmacMd5(getNtlmHash(password), toUnicode(strings.ToUpper(username)+target))
+func getNtlmV2Hash(password, username, domain string) []byte {
+	return getNtlmV2Hashed(getNtlmHash(password), username, domain)
+}
+
+func getNtlmV2Hashed(ntlmHash []byte, username, domain string) []byte {
+	return hmacMd5(ntlmHash, toUnicode(strings.ToUpper(username)+domain))
 }
 
 func getNtlmHash(password string) []byte {
@@ -25,8 +31,8 @@ func getNtlmHash(password string) []byte {
 }
 
 func computeNtlmV2Response(ntlmV2Hash, serverChallenge, clientChallenge,
-	timestamp, targetInfo []byte) []byte {
-
+	timestamp, targetInfo []byte,
+) []byte {
 	temp := []byte{1, 1, 0, 0, 0, 0, 0, 0}
 	temp = append(temp, timestamp...)
 	temp = append(temp, clientChallenge...)

--- a/vendor/github.com/Azure/go-ntlmssp/unicode.go
+++ b/vendor/github.com/Azure/go-ntlmssp/unicode.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package ntlmssp
 
 import (
@@ -11,7 +14,7 @@ import (
 
 func fromUnicode(d []byte) (string, error) {
 	if len(d)%2 > 0 {
-		return "", errors.New("Unicode (UTF 16 LE) specified, but uneven data length")
+		return "", errors.New("unicode (UTF 16 LE) specified, but uneven data length")
 	}
 	s := make([]uint16, len(d)/2)
 	err := binary.Read(bytes.NewReader(d), binary.LittleEndian, &s)
@@ -24,6 +27,6 @@ func fromUnicode(d []byte) (string, error) {
 func toUnicode(s string) []byte {
 	uints := utf16.Encode([]rune(s))
 	b := bytes.Buffer{}
-	binary.Write(&b, binary.LittleEndian, &uints)
+	_ = binary.Write(&b, binary.LittleEndian, &uints)
 	return b.Bytes()
 }

--- a/vendor/github.com/Azure/go-ntlmssp/varfield.go
+++ b/vendor/github.com/Azure/go-ntlmssp/varfield.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package ntlmssp
 
 import (
@@ -11,10 +14,14 @@ type varField struct {
 }
 
 func (f varField) ReadFrom(buffer []byte) ([]byte, error) {
-	if len(buffer) < int(f.BufferOffset+uint32(f.Len)) {
-		return nil, errors.New("Error reading data, varField extends beyond buffer")
+	// f.Len is controlled by the sender, so we need to check that
+	// it doesn't cause an overflow when added to f.BufferOffset.
+	start := uint64(f.BufferOffset)
+	end := start + uint64(f.Len)
+	if end < start || end > uint64(len(buffer)) {
+		return nil, errors.New("error reading data, varField extends beyond buffer")
 	}
-	return buffer[f.BufferOffset : f.BufferOffset+uint32(f.Len)], nil
+	return buffer[int(start):int(end)], nil
 }
 
 func (f varField) ReadStringFrom(buffer []byte, unicode bool) (string, error) {

--- a/vendor/github.com/Azure/go-ntlmssp/version.go
+++ b/vendor/github.com/Azure/go-ntlmssp/version.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package ntlmssp
 
 // Version is a struct representing https://msdn.microsoft.com/en-us/library/cc236654.aspx

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,9 +4,10 @@ buf.build/gen/go/gogo/protobuf/protocolbuffers/go/gogoproto
 # buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.36.11-20251118093737-4105057cc7d4.1
 ## explicit; go 1.23
 buf.build/gen/go/prometheus/prometheus/protocolbuffers/go
-# github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
-## explicit
+# github.com/Azure/go-ntlmssp v0.1.1
+## explicit; go 1.24
 github.com/Azure/go-ntlmssp
+github.com/Azure/go-ntlmssp/internal/md4
 # github.com/Masterminds/semver/v3 v3.4.0
 ## explicit; go 1.21
 github.com/Masterminds/semver/v3


### PR DESCRIPTION
## What?

Bumps `github.com/Azure/go-ntlmssp` from `v0.0.0-20221128193559-754e69321358` to `v0.1.1` on the `v1.x` branch, including the corresponding `go.mod`, `go.sum`, and `vendor/` updates.

## Why?

Aligns the `v1.x` branch with what `v2.0.0`/`master` already ships, so the NTLM auth path in `lib/netext/httpext` uses the same upstream release across branches. This is a v1.8.0 backport-style dependency bump — no behavior or API changes required in k6 itself; the only call site (`lib/netext/httpext/request.go`, `ntlmssp.Negotiator{RoundTripper: transport}`) continues to compile unchanged.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

Notes:
- No tests added — this is a vendored dependency bump with no source changes.
- Verified locally: `go build ./...` is clean, and `go test -race ./lib/netext/httpext/...` (the only package importing go-ntlmssp) passes.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Master/v2.0.0 already ships go-ntlmssp v0.1.1; this brings v1.x in line.