### PR TITLE
chore(deps): bump grafana/sobek to match v2.0.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/grafana/k6provider v0.2.0
-	github.com/grafana/sobek v0.0.0-20260219184149-bdae4a158e94
+	github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
 	github.com/grafana/xk6-dashboard v0.8.1
 	github.com/grafana/xk6-redis v0.3.6
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
@@ -83,7 +83,7 @@ require (
 	github.com/chromedp/sysutil v1.1.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
-	github.com/dlclark/regexp2 v1.11.5 // indirect
+	github.com/dlclark/regexp2 v1.12.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/pprof v0.0.0-20230728192033-2ba5b33183c6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
 github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
-github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
-github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
+github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -92,8 +92,8 @@ github.com/grafana/k6foundry v0.4.7 h1:1YXkTBwO/2dSx0pqJrraJATsFlsIX0vEpaEjV7E35
 github.com/grafana/k6foundry v0.4.7/go.mod h1:eLsr0whhH+5Y1y7YpDxJi3Jv5wHMuf+80vdRyMH10pg=
 github.com/grafana/k6provider v0.2.0 h1:Zu8FBnk6cJyTTkpCA+y+Ravc2YFeAQjsIfPpcbZtfB0=
 github.com/grafana/k6provider v0.2.0/go.mod h1:TJ6vzPm4yDQ2ji/Fet0dFOpdjktrKZp4hsnLZhRoZVA=
-github.com/grafana/sobek v0.0.0-20260219184149-bdae4a158e94 h1:yB8ad5rnZcJ6Aun/tobcYMMLtb3+tZp46M5Cs5v4j9w=
-github.com/grafana/sobek v0.0.0-20260219184149-bdae4a158e94/go.mod h1:YtuqiJX1W3XvRSilL/kUZzduJG3phPJWyzM9DiIEfBo=
+github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b h1:mM/qn1luOrRZHT3G+405JMdCx4mGxeLKpOkVBa5+lFw=
+github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b/go.mod h1:8pB+ag4SAbqtDxh1LNTeUI62/5f8mmEACImwbDHoUC0=
 github.com/grafana/xk6-dashboard v0.8.1 h1:QTEXPhkSYxiSN1lnl/cIlrnA97dUvOW+0yxQQCa9AAU=
 github.com/grafana/xk6-dashboard v0.8.1/go.mod h1:H1d7bUniuCFWWACgBdJBvpM5dC9vXehycQyMKzCC8CE=
 github.com/grafana/xk6-dashboard-assets v0.1.2 h1:n2wqytPICn2ZYsKa9HE6GlvFXk+WjByMfT4eM+ms3gE=

--- a/internal/js/tc39/breaking_test_errors-stripTypes=false.json
+++ b/internal/js/tc39/breaking_test_errors-stripTypes=false.json
@@ -36,7 +36,6 @@
   "test/built-ins/Error/isError/prop-desc.js-strict:true": "test/built-ins/Error/isError/prop-desc.js: Test262Error: obj should have an own property isError <at omitted>",
   "test/built-ins/Error/isError/symbols.js-strict:true": "test/built-ins/Error/isError/symbols.js: TypeError: Object has no member 'isError' <at omitted>",
   "test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy.js-strict:true": "test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy.js: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all <at omitted>",
-  "test/built-ins/GeneratorPrototype/return/try-finally-set-property-within-try.js-strict:true": "panic while running test/built-ins/GeneratorPrototype/return/try-finally-set-property-within-try.js: runtime error: slice bounds out of range [:-1]",
   "test/built-ins/Iterator/concat/arguments-checked-in-order.js-strict:true": "test/built-ins/Iterator/concat/arguments-checked-in-order.js: Test262Error: Expected a TypeError but got a ReferenceError <at omitted>",
   "test/built-ins/Iterator/concat/fresh-iterator-result.js-strict:true": "test/built-ins/Iterator/concat/fresh-iterator-result.js: ReferenceError: Iterator is not defined <at omitted>",
   "test/built-ins/Iterator/concat/get-iterator-method-only-once.js-strict:true": "test/built-ins/Iterator/concat/get-iterator-method-only-once.js: ReferenceError: Iterator is not defined <at omitted>",

--- a/internal/js/tc39/breaking_test_errors-stripTypes=true.json
+++ b/internal/js/tc39/breaking_test_errors-stripTypes=true.json
@@ -36,7 +36,6 @@
   "test/built-ins/Error/isError/prop-desc.js-strict:true": "test/built-ins/Error/isError/prop-desc.js: Test262Error: obj should have an own property isError <at omitted>",
   "test/built-ins/Error/isError/symbols.js-strict:true": "test/built-ins/Error/isError/symbols.js: TypeError: Object has no member 'isError' <at omitted>",
   "test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy.js-strict:true": "test/built-ins/Function/internals/Construct/base-ctor-revoked-proxy.js: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all <at omitted>",
-  "test/built-ins/GeneratorPrototype/return/try-finally-set-property-within-try.js-strict:true": "panic while running test/built-ins/GeneratorPrototype/return/try-finally-set-property-within-try.js: runtime error: slice bounds out of range [:-1]",
   "test/built-ins/Iterator/concat/arguments-checked-in-order.js-strict:true": "test/built-ins/Iterator/concat/arguments-checked-in-order.js: Test262Error: Expected a TypeError but got a ReferenceError <at omitted>",
   "test/built-ins/Iterator/concat/fresh-iterator-result.js-strict:true": "test/built-ins/Iterator/concat/fresh-iterator-result.js: ReferenceError: Iterator is not defined <at omitted>",
   "test/built-ins/Iterator/concat/get-iterator-method-only-once.js-strict:true": "test/built-ins/Iterator/concat/get-iterator-method-only-once.js: ReferenceError: Iterator is not defined <at omitted>",

--- a/vendor/github.com/dlclark/regexp2/runner.go
+++ b/vendor/github.com/dlclark/regexp2/runner.go
@@ -313,12 +313,9 @@ func (r *runner) execute() error {
 					}
 				} else {
 					// The inner expression found an empty match, so we'll go directly to 'back2' if we
-					// backtrack.  In this case, we need to push something on the stack, since back2 pops.
-					// However, in the case of ()+? or similar, this empty match may be legitimate, so push the text
-					// position associated with that empty match.
-					r.stackPush(oldMarkPos)
-
-					r.trackPushNeg1(r.stackPeek()) // Save old mark
+					// backtrack. Don't touch the grouping stack here; instead, record the old mark and
+					// a flag indicating that backtracking doesn't need to pop a grouping stack frame.
+					r.trackPushNeg2(oldMarkPos, 0)
 				}
 				r.advance(1)
 				continue
@@ -334,18 +331,22 @@ func (r *runner) execute() error {
 
 			r.trackPopN(2)
 			pos := r.trackPeekN(1)
-			r.trackPushNeg1(r.trackPeek()) // Save old mark
-			r.stackPush(pos)               // Make new mark
-			r.textto(pos)                  // Recall position
-			r.goTo(r.operand(0))           // Loop
+			r.trackPushNeg2(r.trackPeek(), 1) // Save old mark, note that we pushed a new mark
+			r.stackPush(pos)                  // Make new mark
+			r.textto(pos)                     // Recall position
+			r.goTo(r.operand(0))              // Loop
 			continue
 
 		case syntax.Lazybranchmark | syntax.Back2:
 			// The lazy loop has failed.  We'll do a true backtrack and
 			// start over before the lazy loop.
-			r.stackPop()
-			r.trackPop()
-			r.stackPush(r.trackPeek()) // Recall old mark
+			r.trackPopN(2)
+			oldMark := r.trackPeek()
+			needsPop := r.trackPeekN(1)
+			if needsPop != 0 {
+				r.stackPop()
+			}
+			r.stackPush(oldMark) // Recall old mark
 			break
 
 		case syntax.Setcount:

--- a/vendor/github.com/grafana/sobek/AGENTS.md
+++ b/vendor/github.com/grafana/sobek/AGENTS.md
@@ -1,0 +1,33 @@
+# Sobek
+
+ECMAScript engine in pure Go, used as k6's JavaScript runtime. Fork of goja.
+
+## Architecture
+
+Three-stage pipeline: **parse -> compile -> execute**. Source text becomes an AST, the compiler transforms the AST into bytecode stored in a compiled program, and a register-based VM executes the bytecode within a runtime instance.
+
+The runtime is the central type. It owns the global object, all JS built-ins, the VM, and a job queue for promise microtasks. **One runtime per goroutine.** It is not goroutine-safe. Objects cannot be passed between runtimes; doing so panics with a type error.
+
+Go values cross the boundary in two directions. Go-to-JS conversion auto-wraps structs, slices, maps, and function signatures into proxy objects. A field name mapper interface controls how Go struct fields and methods appear as JS property names. JS-to-Go export reverses this, returning plain Go types. Primitive values are goroutine-safe and transferable; objects are not.
+
+ESM module support exists but is experimental. It requires the embedder to provide an event loop -- sobek has none. k6 builds its own event loop on top.
+
+Strings use a custom internal representation to handle UTF-16 semantics on top of Go's UTF-8 strings. Conversion between the two is lossy for lone surrogates.
+
+Regex patterns fall back to a third-party engine when Go's stdlib regex cannot handle the pattern (lookbehind, backreferences, etc.).
+
+The promise job queue drains synchronously when the top-level script function returns. On interrupt, the queue is discarded without running pending jobs.
+
+## Gotchas
+
+- **Merging upstream goja**: Sobek periodically merges from the upstream fork. Always use merge commits, never rebase or squash. The upstream remote is conventionally named `goja`.
+
+- **WeakMap values leak**: Values stay reachable as long as the key is reachable, even after the WeakMap is collected. This is a Go GC limitation. WeakRef and FinalizationRegistry cannot be implemented.
+
+- **Broken surrogate pairs in JSON**: Go's stdlib JSON operates on UTF-8, so lone surrogates in JSON strings get replaced with the Unicode replacement character instead of being preserved.
+
+- **No event loop**: There is no setTimeout, setInterval, or any async scheduling. The embedder must provide all concurrency primitives.
+
+- **Interrupt vs. cancel**: Runaway scripts are stopped with the runtime's interrupt method, not context cancellation. After interrupting, the interrupt flag must be explicitly cleared before reuse, or the next execution immediately aborts.
+
+- **Object cross-runtime panic**: Passing an Object created in one runtime to another runtime's method silently compiles but panics at runtime. The check is in the Go-to-JS value conversion path.

--- a/vendor/github.com/grafana/sobek/compiler_expr.go
+++ b/vendor/github.com/grafana/sobek/compiler_expr.go
@@ -14,7 +14,7 @@ type compiledExpr interface {
 	emitSetter(valueExpr compiledExpr, putOnStack bool)
 	emitRef()
 	emitUnary(prepare, body func(), postfix, putOnStack bool)
-	deleteExpr() compiledExpr
+	emitDelete(putOnStack bool)
 	constant() bool
 	addSrcMap()
 }
@@ -77,32 +77,6 @@ type compiledObjectAssignmentPattern struct {
 type compiledArrayAssignmentPattern struct {
 	baseCompiledExpr
 	expr *ast.ArrayPattern
-}
-
-type deleteGlobalExpr struct {
-	baseCompiledExpr
-	name unistring.String
-}
-
-type deleteVarExpr struct {
-	baseCompiledExpr
-	name unistring.String
-}
-
-type deletePropExpr struct {
-	baseCompiledExpr
-	left compiledExpr
-	name unistring.String
-}
-
-type deleteElemExpr struct {
-	baseCompiledExpr
-	left, member compiledExpr
-}
-
-type constantExpr struct {
-	baseCompiledExpr
-	val Value
 }
 
 type baseCompiledExpr struct {
@@ -217,11 +191,6 @@ type compiledEnumGetExpr struct {
 	baseCompiledExpr
 }
 
-type defaultDeleteExpr struct {
-	baseCompiledExpr
-	expr compiledExpr
-}
-
 type compiledSpreadCallArgument struct {
 	baseCompiledExpr
 	expr compiledExpr
@@ -238,13 +207,6 @@ type compiledOptional struct {
 }
 type compiledDynamicImport struct {
 	baseCompiledExpr
-}
-
-func (e *defaultDeleteExpr) emitGetter(putOnStack bool) {
-	e.expr.emitGetter(false)
-	if putOnStack {
-		e.c.emitLiteralValue(valueTrue)
-	}
 }
 
 func (c *compiler) compileExpression(v ast.Expression) compiledExpr {
@@ -361,12 +323,11 @@ func (e *baseCompiledExpr) emitRef() {
 	e.c.assert(false, e.offset, "Cannot emit reference for this type of expression")
 }
 
-func (e *baseCompiledExpr) deleteExpr() compiledExpr {
-	r := &constantExpr{
-		val: valueTrue,
+func (e *baseCompiledExpr) emitDelete(putOnStack bool) {
+	if putOnStack {
+		e.addSrcMap()
+		e.c.emitLiteralValue(valueTrue)
 	}
-	r.init(e.c, file.Idx(e.offset+1))
-	return r
 }
 
 func (e *baseCompiledExpr) emitUnary(func(), func(), bool, bool) {
@@ -376,13 +337,6 @@ func (e *baseCompiledExpr) emitUnary(func(), func(), bool, bool) {
 func (e *baseCompiledExpr) addSrcMap() {
 	if e.offset >= 0 {
 		e.c.p.addSrcMap(e.offset)
-	}
-}
-
-func (e *constantExpr) emitGetter(putOnStack bool) {
-	if putOnStack {
-		e.addSrcMap()
-		e.c.emitLiteralValue(e.val)
 	}
 }
 
@@ -536,33 +490,34 @@ func (e *compiledIdentifierExpr) emitUnary(prepare, body func(), postfix, putOnS
 	}
 }
 
-func (e *compiledIdentifierExpr) deleteExpr() compiledExpr {
+func (e *compiledIdentifierExpr) emitDelete(putOnStack bool) {
 	if e.c.scope.strict {
 		e.c.throwSyntaxError(e.offset, "Delete of an unqualified identifier in strict mode")
 		panic("Unreachable")
 	}
 	if b, noDynamics := e.c.scope.lookupName(e.name); noDynamics {
 		if b == nil {
-			r := &deleteGlobalExpr{
-				name: e.name,
+			e.addSrcMap()
+			e.c.emit(deleteGlobal(e.name))
+			if !putOnStack {
+				e.c.emit(pop)
 			}
-			r.init(e.c, file.Idx(0))
-			return r
+			return
 		}
 	} else {
 		if b == nil {
-			r := &deleteVarExpr{
-				name: e.name,
+			e.addSrcMap()
+			e.c.emit(deleteVar(e.name))
+			if !putOnStack {
+				e.c.emit(pop)
 			}
-			r.init(e.c, file.Idx(e.offset+1))
-			return r
+			return
 		}
 	}
-	r := &compiledLiteral{
-		val: valueFalse,
+	if putOnStack {
+		e.addSrcMap()
+		e.c.emitLiteralValue(valueFalse)
 	}
-	r.init(e.c, file.Idx(e.offset+1))
-	return r
 }
 
 type compiledSuperDotExpr struct {
@@ -654,8 +609,13 @@ func (e *compiledSuperDotExpr) emitRef() {
 	}
 }
 
-func (e *compiledSuperDotExpr) deleteExpr() compiledExpr {
-	return e.c.superDeleteError(e.offset)
+func (c *compiler) emitSuperReferenceError() {
+	c.emit(throwConst{referenceError("Unsupported reference to 'super'")})
+}
+
+func (e *compiledSuperDotExpr) emitDelete(_ bool) {
+	e.addSrcMap()
+	e.c.emitSuperReferenceError()
 }
 
 type compiledDotExpr struct {
@@ -790,9 +750,8 @@ func (e *compiledPrivateDotExpr) emitUnary(prepare, body func(), postfix, putOnS
 	}
 }
 
-func (e *compiledPrivateDotExpr) deleteExpr() compiledExpr {
+func (e *compiledPrivateDotExpr) emitDelete(_ bool) {
 	e.c.throwSyntaxError(e.offset, "Private fields can not be deleted")
-	panic("unreachable")
 }
 
 func (e *compiledPrivateDotExpr) emitRef() {
@@ -900,14 +859,9 @@ func (e *compiledSuperBracketExpr) emitRef() {
 	}
 }
 
-func (c *compiler) superDeleteError(offset int) compiledExpr {
-	return c.compileEmitterExpr(func() {
-		c.emit(throwConst{referenceError("Unsupported reference to 'super'")})
-	}, file.Idx(offset+1))
-}
-
-func (e *compiledSuperBracketExpr) deleteExpr() compiledExpr {
-	return e.c.superDeleteError(e.offset)
+func (e *compiledSuperBracketExpr) emitDelete(_ bool) {
+	e.addSrcMap()
+	e.c.emitSuperReferenceError()
 }
 
 func (c *compiler) checkConstantString(expr compiledExpr) (unistring.String, bool) {
@@ -1043,13 +997,17 @@ func (e *compiledDotExpr) emitUnary(prepare, body func(), postfix, putOnStack bo
 	}
 }
 
-func (e *compiledDotExpr) deleteExpr() compiledExpr {
-	r := &deletePropExpr{
-		left: e.left,
-		name: e.name,
+func (e *compiledDotExpr) emitDelete(putOnStack bool) {
+	e.left.emitGetter(true)
+	e.addSrcMap()
+	if e.c.scope.strict {
+		e.c.emit(deletePropStrict(e.name))
+	} else {
+		e.c.emit(deleteProp(e.name))
 	}
-	r.init(e.c, file.Idx(e.offset)+1)
-	return r
+	if !putOnStack {
+		e.c.emit(pop)
+	}
 }
 
 func (e *compiledBracketExpr) emitGetter(putOnStack bool) {
@@ -1139,16 +1097,7 @@ func (e *compiledBracketExpr) emitUnary(prepare, body func(), postfix, putOnStac
 	}
 }
 
-func (e *compiledBracketExpr) deleteExpr() compiledExpr {
-	r := &deleteElemExpr{
-		left:   e.left,
-		member: e.member,
-	}
-	r.init(e.c, file.Idx(e.offset)+1)
-	return r
-}
-
-func (e *deleteElemExpr) emitGetter(putOnStack bool) {
+func (e *compiledBracketExpr) emitDelete(putOnStack bool) {
 	e.left.emitGetter(true)
 	e.member.emitGetter(true)
 	e.addSrcMap()
@@ -1157,42 +1106,6 @@ func (e *deleteElemExpr) emitGetter(putOnStack bool) {
 	} else {
 		e.c.emit(deleteElem)
 	}
-	if !putOnStack {
-		e.c.emit(pop)
-	}
-}
-
-func (e *deletePropExpr) emitGetter(putOnStack bool) {
-	e.left.emitGetter(true)
-	e.addSrcMap()
-	if e.c.scope.strict {
-		e.c.emit(deletePropStrict(e.name))
-	} else {
-		e.c.emit(deleteProp(e.name))
-	}
-	if !putOnStack {
-		e.c.emit(pop)
-	}
-}
-
-func (e *deleteVarExpr) emitGetter(putOnStack bool) {
-	/*if e.c.scope.strict {
-		e.c.throwSyntaxError(e.offset, "Delete of an unqualified identifier in strict mode")
-		return
-	}*/
-	e.c.emit(deleteVar(e.name))
-	if !putOnStack {
-		e.c.emit(pop)
-	}
-}
-
-func (e *deleteGlobalExpr) emitGetter(putOnStack bool) {
-	/*if e.c.scope.strict {
-		e.c.throwSyntaxError(e.offset, "Delete of an unqualified identifier in strict mode")
-		return
-	}*/
-
-	e.c.emit(deleteGlobal(e.name))
 	if !putOnStack {
 		e.c.emit(pop)
 	}
@@ -2608,7 +2521,7 @@ func (e *compiledUnaryExpr) emitGetter(putOnStack bool) {
 		e.c.emit(typeof)
 		goto end
 	case token.DELETE:
-		e.operand.deleteExpr().emitGetter(putOnStack)
+		e.operand.emitDelete(putOnStack)
 		return
 	case token.MINUS:
 		e.c.emitExpr(e.operand, true)
@@ -3221,12 +3134,12 @@ func (e *compiledCallExpr) emitGetter(putOnStack bool) {
 	}
 }
 
-func (e *compiledCallExpr) deleteExpr() compiledExpr {
-	r := &defaultDeleteExpr{
-		expr: e,
+func (e *compiledCallExpr) emitDelete(putOnStack bool) {
+	e.emitGetter(false)
+	if putOnStack {
+		e.addSrcMap()
+		e.c.emitLiteralValue(valueTrue)
 	}
-	r.init(e.c, file.Idx(e.offset+1))
-	return r
 }
 
 func (c *compiler) compileSpreadCallArgument(spread *ast.SpreadElement) compiledExpr {
@@ -3634,12 +3547,44 @@ func (c *compiler) endOptChain() {
 	c.block = c.block.outer
 }
 
+func (c *compiler) endOptChainDelete() {
+	lbl := len(c.p.code)
+	for _, item := range c.block.breaks {
+		c.p.code[item] = joptdel(lbl - item)
+	}
+	for _, item := range c.block.conts {
+		c.p.code[item] = joptdelc(lbl - item)
+	}
+	c.block = c.block.outer
+}
+
+func (c *compiler) endOptChainDeleteP() {
+	lbl := len(c.p.code)
+	for _, item := range c.block.breaks {
+		c.p.code[item] = joptdelP(lbl - item)
+	}
+	for _, item := range c.block.conts {
+		c.p.code[item] = joptdelcP(lbl - item)
+	}
+	c.block = c.block.outer
+}
+
 func (e *compiledOptionalChain) emitGetter(putOnStack bool) {
 	e.c.startOptChain()
 	e.expr.emitGetter(true)
 	e.c.endOptChain()
 	if !putOnStack {
 		e.c.emit(pop)
+	}
+}
+
+func (e *compiledOptionalChain) emitDelete(putOnStack bool) {
+	e.c.startOptChain()
+	e.expr.emitDelete(putOnStack)
+	if putOnStack {
+		e.c.endOptChainDelete()
+	} else {
+		e.c.endOptChainDeleteP()
 	}
 }
 

--- a/vendor/github.com/grafana/sobek/func.go
+++ b/vendor/github.com/grafana/sobek/func.go
@@ -748,8 +748,9 @@ func (ar *asyncRunner) start(nArgs int) {
 }
 
 type generator struct {
-	ctx execCtx
-	vm  *vm
+	ctx       execCtx
+	vm        *vm
+	returning Value
 
 	tryStackLen, iterStackLen, refStackLen uint32
 }
@@ -765,29 +766,96 @@ func (g *generator) enter() {
 	g.storeLengths()
 }
 
-func (g *generator) step() (res Value, resultType resultType, ex *Exception) {
-	for {
-		ex = g.vm.runTryInner()
-		if ex != nil {
-			return
+func (g *generator) enterNextFinallyFrame() (canContinue bool) {
+	vm := g.vm
+	callStackLen := len(vm.callStack)
+
+	for len(vm.tryStack) > 0 {
+		tf := &vm.tryStack[len(vm.tryStack)-1]
+		if int(tf.callStackLen) != callStackLen { // have we breached the function boundary?
+			break
 		}
-		if g.vm.halted() {
+		ex := vm.restoreStacks(tf.iterLen, tf.refLen)
+		if ex != nil {
+			vm.throw(ex)
+			return true
+		}
+		if tf.finallyPos >= 0 {
+			vm.sp = int(tf.sp)
+			vm.stash = tf.stash
+			vm.privEnv = tf.privEnv
+			vm.pc = int(tf.finallyPos)
+			tf.catchPos = tryPanicMarker
+			tf.finallyPos = -1
+			tf.finallyRet = -2 // -1 would cause it to continue after leaveFinally
+			return true
+		}
+		vm.popTryFrame()
+	}
+	return
+}
+
+func (g *generator) step() (res Value, resultType resultType, ex *Exception) {
+	vm := g.vm
+	if g.returning == nil {
+		for {
+			ex = vm.runTryInner()
+			if ex != nil {
+				return
+			}
+			if vm.halted() {
+				break
+			}
+		}
+		res = vm.pop()
+	} else {
+		for {
+			ex = vm.runTryInner()
+			if ex != nil {
+				if vm.prg != nil || vm.pc != -2 {
+					// The exception was thrown in the outermost finally block, it never got to leaveFinally
+					// which does popTryFrame()
+					vm.popTryFrame()
+				}
+				return
+			}
+
+			if vm.prg != nil && vm.pc == -2 { // normal exit from finally
+				if g.enterNextFinallyFrame() {
+					continue
+				}
+
+				// All finally blocks have exited without result
+				res, g.returning = g.returning, nil
+				ex = vm.restoreStacks(g.iterStackLen, g.refStackLen)
+				if ex != nil {
+					return
+				}
+				vm.sp = vm.sb - 1
+				vm.callStack = vm.callStack[:len(vm.callStack)-1]
+
+				return
+			}
+			res = vm.pop()
+			if vm.prg == nil { // It was a return, not a yield
+				return
+			}
 			break
 		}
 	}
-	res = g.vm.pop()
+
 	if ym, ok := res.(*yieldMarker); ok {
 		resultType = ym.resultType
 		g.ctx = execCtx{}
-		g.vm.pc = -g.vm.pc + 1
+		vm.pc = -vm.pc + 1
 		if res != yieldEmpty {
-			res = g.vm.pop()
+			res = vm.pop()
 		} else {
 			res = nil
 		}
-		g.vm.suspend(&g.ctx, g.tryStackLen, g.iterStackLen, g.refStackLen)
-		g.vm.sp = g.vm.sb - 1
-		g.vm.callStack = g.vm.callStack[:len(g.vm.callStack)-1] // remove the frame with pc == -2, as ret would do
+		vm.suspend(&g.ctx, g.tryStackLen, g.iterStackLen, g.refStackLen)
+		vm.sp = vm.sb - 1
+		vm.callStack = vm.callStack[:len(vm.callStack)-1] // remove the frame with pc == -2, as ret would do
 	}
 	return
 }
@@ -990,66 +1058,34 @@ func (g *generatorObject) _return(v Value) Value {
 		}
 	}
 
+	g.gen.returning = v
 	g.state = genStateExecuting
-
 	g.gen.enterNext()
+	canContinue := g.gen.enterNextFinallyFrame()
+	if !canContinue {
+		vm := g.gen.vm
+		g.state = genStateCompleted
 
+		vm.popTryFrame()
+
+		ex := vm.restoreStacks(g.gen.iterStackLen, g.gen.refStackLen)
+
+		if ex != nil {
+			panic(ex)
+		}
+
+		vm.callStack = vm.callStack[:len(vm.callStack)-1]
+		vm.sp = vm.sb - 1
+		vm.popCtx()
+
+		return g.val.runtime.createIterResultObject(v, true)
+	}
+	res, done, ex := g.gen.step()
 	vm := g.gen.vm
-	var ex *Exception
-	for len(vm.tryStack) > 0 {
-		tf := &vm.tryStack[len(vm.tryStack)-1]
-		if int(tf.callStackLen) != len(vm.callStack) {
-			break
-		}
-
-		if tf.finallyPos >= 0 {
-			vm.sp = int(tf.sp)
-			vm.stash = tf.stash
-			vm.privEnv = tf.privEnv
-			ex1 := vm.restoreStacks(tf.iterLen, tf.refLen)
-			if ex1 != nil {
-				ex = ex1
-				vm.popTryFrame()
-				continue
-			}
-
-			vm.pc = int(tf.finallyPos)
-			tf.catchPos = tryPanicMarker
-			tf.finallyPos = -1
-			tf.finallyRet = -2 // -1 would cause it to continue after leaveFinally
-			for {
-				ex1 := vm.runTryInner()
-				if ex1 != nil {
-					ex = ex1
-					vm.popTryFrame()
-					break
-				}
-				if vm.halted() {
-					break
-				}
-			}
-		} else {
-			vm.popTryFrame()
-		}
-	}
-
-	g.state = genStateCompleted
-
 	vm.popTryFrame()
-
-	if ex == nil {
-		ex = vm.restoreStacks(g.gen.iterStackLen, g.gen.refStackLen)
-	}
-
-	if ex != nil {
-		panic(ex)
-	}
-
-	vm.callStack = vm.callStack[:len(vm.callStack)-1]
-	vm.sp = vm.sb - 1
 	vm.popCtx()
 
-	return g.val.runtime.createIterResultObject(v, true)
+	return g.step(res, done, ex)
 }
 
 func (f *baseJsFuncObject) generatorCall(vmCall func(*vm, int), nArgs int) Value {

--- a/vendor/github.com/grafana/sobek/vm.go
+++ b/vendor/github.com/grafana/sobek/vm.go
@@ -4522,6 +4522,55 @@ func (j joptc) exec(vm *vm) {
 	}
 }
 
+type joptdel int32
+
+func (j joptdel) exec(vm *vm) {
+	switch vm.stack[vm.sp-1].(type) {
+	case valueNull, valueUndefined:
+		vm.stack[vm.sp-1] = valueTrue
+		vm.pc += int(j)
+	default:
+		vm.pc++
+	}
+}
+
+type joptdelc int32
+
+func (j joptdelc) exec(vm *vm) {
+	switch vm.stack[vm.sp-1].(type) {
+	case valueNull, valueUndefined, memberUnresolved:
+		vm.sp--
+		vm.stack[vm.sp-1] = valueTrue
+		vm.pc += int(j)
+	default:
+		vm.pc++
+	}
+}
+
+type joptdelP int32
+
+func (j joptdelP) exec(vm *vm) {
+	switch vm.stack[vm.sp-1].(type) {
+	case valueNull, valueUndefined:
+		vm.sp--
+		vm.pc += int(j)
+	default:
+		vm.pc++
+	}
+}
+
+type joptdelcP int32
+
+func (j joptdelcP) exec(vm *vm) {
+	switch vm.stack[vm.sp-1].(type) {
+	case valueNull, valueUndefined, memberUnresolved:
+		vm.sp -= 2
+		vm.pc += int(j)
+	default:
+		vm.pc++
+	}
+}
+
 type jcoalesc int32
 
 func (j jcoalesc) exec(vm *vm) {
@@ -4866,6 +4915,7 @@ func (leaveTry) exec(vm *vm) {
 		vm.pc = int(tf.finallyPos)
 		tf.finallyPos = -1
 		tf.catchPos = -1
+		vm.sp, vm.stash = int(tf.sp), tf.stash
 	} else {
 		vm.popTryFrame()
 		vm.pc++

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -111,7 +111,7 @@ github.com/davecgh/go-spew/spew
 # github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f
 ## explicit
 github.com/dgryski/go-rendezvous
-# github.com/dlclark/regexp2 v1.11.5
+# github.com/dlclark/regexp2 v1.12.0
 ## explicit; go 1.13
 github.com/dlclark/regexp2
 github.com/dlclark/regexp2/syntax
@@ -190,7 +190,7 @@ github.com/grafana/k6build/pkg/client
 # github.com/grafana/k6provider v0.2.0
 ## explicit; go 1.24.0
 github.com/grafana/k6provider
-# github.com/grafana/sobek v0.0.0-20260219184149-bdae4a158e94
+# github.com/grafana/sobek v0.0.0-20260429085637-a66d4790012b
 ## explicit; go 1.20
 github.com/grafana/sobek
 github.com/grafana/sobek/ast


### PR DESCRIPTION
## What?

Bumps `github.com/grafana/sobek` from `v0.0.0-20260219184149-bdae4a158e94`
to `v0.0.0-20260429085637-a66d4790012b` on the `v1.x` branch, matching
the sobek revision that ships in k6 v2.0.0. Transitively, `github.com/dlclark/regexp2`
moves from `v1.11.5` to `v1.12.0` (it's sobek's regex dep).

`go.mod`, `go.sum`, and the vendored copies are updated; no k6 source
changes were required (`go build ./...` is clean).

### sobek fixes picked up

- **`delete obj?.prop` now actually deletes** (sobek `913bd86`). Previously, `delete` with an optional-chain operand returned `true` but didn't remove the property.
- **Generator `return()` correctly handles yields from `finally` blocks** (sobek `6a7976c`). Generators that were `.return()`-ed while a `yield` was running inside a `try/finally` could mishandle yields from the finally block.
- **`finally` environment is properly restored on the abnormal-exit path** (sobek `065cd97`, fixes upstream issue #703). Variable scope inside `finally` could be wrong when entering it via abnormal control flow.

### regexp2 fix picked up

- **Stack corruption in the regex runner fixed** (regexp2 `3d5df45`, upstream issues #34 / #37). Pathological backtracking patterns could corrupt the runner's state stack; the fix mirrors the .NET regex engine's behavior.

## Why?

Aligns the v1.x line with v2.0.0 on the JS engine for v1.8.0, picking up
the user-visible runtime correctness fixes above without diverging
runtime behavior between v1.8.0 and v2.0.0.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

`./internal/js/...` was run with `-race -timeout 300s`; all JS-runtime
packages (including `internal/js`, `internal/js/compiler`,
`internal/js/eventloop`, `internal/js/tc39`, and every
`internal/js/modules/k6/*` package outside `browser/tests`) pass. The
`browser/tests` package showed flaky CDP/websocket failures locally
unrelated to sobek; CI is the right confirmation.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

Aligns v1.x with the sobek revision shipped in v2.0.0.