### PR TITLE
fix: trim trailing slashes from cloud login stack URL

### DIFF
--- a/internal/cmd/cloud_login.go
+++ b/internal/cmd/cloud_login.go
@@ -312,6 +312,10 @@ func validateTokenV6(
 // normalizeStackURL converts a stack slug to a full URL if needed.
 // The stackInput can be either a full URL (e.g., https://my-team.grafana.net) or just a slug (e.g., my-team).
 func normalizeStackURL(stackInput string) string {
+	// Trim trailing slashes so "https://my-team.grafana.net/" is treated the
+	// same as "https://my-team.grafana.net". The cloud API lookup uses an
+	// exact match and otherwise rejects the trailing-slash form (#5894).
+	stackInput = strings.TrimRight(stackInput, "/")
 	// If it's already a full URL, return it as is
 	if strings.HasPrefix(stackInput, "http://") || strings.HasPrefix(stackInput, "https://") {
 		return stackInput

--- a/internal/cmd/cloud_login_test.go
+++ b/internal/cmd/cloud_login_test.go
@@ -96,3 +96,29 @@ func TestPrintConfigTokenOutput(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeStackURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"slug", "my-team", "https://my-team.grafana.net"},
+		{"slug with .grafana.net suffix", "my-team.grafana.net", "https://my-team.grafana.net"},
+		{"full https url", "https://my-team.grafana.net", "https://my-team.grafana.net"},
+		{"full http url", "http://my-team.grafana.net", "http://my-team.grafana.net"},
+		// https://github.com/grafana/k6/issues/5894
+		{"https url with trailing slash", "https://my-team.grafana.net/", "https://my-team.grafana.net"},
+		{"https url with several trailing slashes", "https://my-team.grafana.net///", "https://my-team.grafana.net"},
+		{"slug with trailing slash", "my-team/", "https://my-team.grafana.net"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, normalizeStackURL(tc.in))
+		})
+	}
+}


### PR DESCRIPTION
Closes #5894.

\`normalizeStackURL\` handed the raw stack input straight through when it already looked like a URL, so \`https://my-team.grafana.net/\` went to the cloud API with the trailing slash and got rejected with "Stack not found", while the slash-free form worked fine.

Trim trailing slashes off the input first. Table test covers the slug, slug-with-suffix, and full-URL shapes plus the trailing-slash variants from the issue.