### PR TITLE
Add single() to k6/html selections

### DIFF
--- a/js/modules/k6/html/html.go
+++ b/js/modules/k6/html/html.go
@@ -172,6 +172,10 @@ func (s Selection) Find(arg any) Selection {
 	return s.varargFnCall(arg, s.sel.Find, s.sel.FindSelection, s.sel.FindNodes)
 }
 
+func (s Selection) Single(selector string) Selection {
+	return Selection{s.rt, s.sel.FindMatcher(goquery.Single(selector)), s.URL}
+}
+
 func (s Selection) Closest(arg any) Selection {
 	return s.varargFnCall(arg, s.sel.Closest, s.sel.ClosestSelection, s.sel.ClosestNodes)
 }

--- a/js/modules/k6/html/html.go
+++ b/js/modules/k6/html/html.go
@@ -173,7 +173,11 @@ func (s Selection) Find(arg any) Selection {
 }
 
 func (s Selection) Single(selector string) Selection {
-	return Selection{s.rt, s.sel.FindMatcher(goquery.Single(selector)), s.URL}
+	sel := s.sel.FindMatcher(goquery.Single(selector))
+	if len(sel.Nodes) > 1 {
+		sel.Nodes = sel.Nodes[:1]
+	}
+	return Selection{s.rt, sel, s.URL}
 }
 
 func (s Selection) Closest(arg any) Selection {

--- a/js/modules/k6/html/html_test.go
+++ b/js/modules/k6/html/html_test.go
@@ -128,6 +128,31 @@ func TestParseHTML(t *testing.T) {
 			assert.Equal(t, "Lorem ipsum", sel.Text())
 		}
 	})
+	t.Run("Single", func(t *testing.T) {
+		t.Parallel()
+		rt := getTestRuntimeWithDoc(t, testHTML)
+
+		t.Run("returns first matching descendant", func(t *testing.T) {
+			v, err := rt.RunString(`doc.single("p")`)
+			if assert.NoError(t, err) && assert.IsType(t, Selection{}, v.Export()) {
+				sel := v.Export().(Selection).sel
+				assert.Equal(t, 1, sel.Length())
+				assert.Equal(t, "Lorem ipsum dolor", sel.Text()[0:17])
+			}
+		})
+		t.Run("supports chaining from a selection", func(t *testing.T) {
+			v, err := rt.RunString(`doc.find("body").single("option").text()`)
+			if assert.NoError(t, err) {
+				assert.Equal(t, "no", v.Export())
+			}
+		})
+		t.Run("returns empty selection when no nodes match", func(t *testing.T) {
+			v, err := rt.RunString(`doc.single(".missing").size()`)
+			if assert.NoError(t, err) {
+				assert.Equal(t, int64(0), v.Export())
+			}
+		})
+	})
 	t.Run("Add", func(t *testing.T) {
 		t.Parallel()
 		rt := getTestRuntimeWithDoc(t, testHTML)

--- a/js/modules/k6/html/html_test.go
+++ b/js/modules/k6/html/html_test.go
@@ -137,13 +137,29 @@ func TestParseHTML(t *testing.T) {
 			if assert.NoError(t, err) && assert.IsType(t, Selection{}, v.Export()) {
 				sel := v.Export().(Selection).sel
 				assert.Equal(t, 1, sel.Length())
-				assert.Equal(t, "Lorem ipsum dolor", sel.Text()[0:17])
+				text := sel.Text()
+				require.GreaterOrEqual(t, len(text), 17)
+				assert.Equal(t, "Lorem ipsum dolor", text[:17])
 			}
 		})
 		t.Run("supports chaining from a selection", func(t *testing.T) {
 			v, err := rt.RunString(`doc.find("body").single("option").text()`)
 			if assert.NoError(t, err) {
 				assert.Equal(t, "no", v.Export())
+			}
+		})
+		t.Run("returns one overall match for multiple receiver nodes", func(t *testing.T) {
+			v, err := rt.RunString(`doc.find("select").single("option")`)
+			if assert.NoError(t, err) && assert.IsType(t, Selection{}, v.Export()) {
+				sel := v.Export().(Selection).sel
+				assert.Equal(t, 1, sel.Length())
+				assert.Equal(t, "no", sel.Text())
+			}
+		})
+		t.Run("preserves end semantics", func(t *testing.T) {
+			v, err := rt.RunString(`doc.find("select").single("option").end().first().attr("id")`)
+			if assert.NoError(t, err) {
+				assert.Equal(t, "select_one", v.Export())
 			}
 		})
 		t.Run("returns empty selection when no nodes match", func(t *testing.T) {


### PR DESCRIPTION
Adds `selection.single(selector)` to `k6/html`, backed by `goquery.Single(selector)`.

This gives scripts a direct way to select only the first matching descendant instead of collecting all matches with `find(selector).first()`.

Closes #2161.

Testing:
- `make lint`
- `go test ./js/modules/k6/html`
- `go test -race ./js/modules/k6/html`
- `go test ./js/modules/k6/http`
- `GOMAXPROCS=1 go test -p 1 -timeout 1600s ./internal/js/modules/k6/browser/tests/...`
- Retried full `make check`; lint passes, but the repo-wide race suite still fails locally when browser tests run with the default `go test ./...` parallelism.

Checklist:
- [x] Self-reviewed
- [x] Added tests
- [ ] Ran full `make check`
