### PR TITLE
browser: add chromium.connectOverCDP for external browsers

### DIFF
--- a/examples/browser/remote.js
+++ b/examples/browser/remote.js
@@ -1,0 +1,20 @@
+import { chromium } from 'k6/browser';
+
+// Connect to an external browser via K6_BROWSER_WS_URL.
+// No options.browser — k6 won't launch or manage a browser.
+//
+// Usage:
+//   K6_BROWSER_WS_URL=ws://localhost:9222 k6 run examples/browser/remote.js
+
+export default async function () {
+  const browser = await chromium.connectOverCDP(__ENV.K6_BROWSER_WS_URL);
+  const page = await browser.newPage();
+
+  try {
+    await page.goto('https://quickpizza.grafana.com/', { waitUntil: 'networkidle' });
+    console.log(`title: ${await page.title()}`);
+  } finally {
+    await page.close();
+    await browser.close();
+  }
+}

--- a/internal/js/modules/k6/browser/browser/browser_context_mapping.go
+++ b/internal/js/modules/k6/browser/browser/browser_context_mapping.go
@@ -57,7 +57,7 @@ func mapBrowserContext(vu moduleVU, bc *common.BrowserContext) mapping { //nolin
 		},
 		"browser": func() mapping {
 			// the browser is grabbed from VU.
-			return mapBrowser(vu)
+			return mapBrowser(vu, vu.browser)
 		},
 		"clearCookies": func() *sobek.Promise {
 			return promise(vu, func() (any, error) {

--- a/internal/js/modules/k6/browser/browser/browser_mapping.go
+++ b/internal/js/modules/k6/browser/browser/browser_mapping.go
@@ -8,13 +8,18 @@ import (
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/common"
 )
 
-// mapBrowser to the JS module.
+// browserProvider is a function that provides a browser instance.
+type browserProvider func() (*common.Browser, error)
+
+// mapBrowser to the JS module API using the provider to get the browser instance.
+// This allows us to reuse the same mapping for both the regular browser module
+// and the one that connects to an existing Chromium, as they share the same API.
 //
 //nolint:gocognit
-func mapBrowser(vu moduleVU) mapping {
+func mapBrowser(vu moduleVU, browser browserProvider) mapping {
 	return mapping{
 		"context": func() (mapping, error) {
-			b, err := vu.browser()
+			b, err := browser()
 			if err != nil {
 				return nil, err
 			}
@@ -22,7 +27,7 @@ func mapBrowser(vu moduleVU) mapping {
 		},
 		"closeContext": func() *sobek.Promise {
 			return promise(vu, func() (any, error) {
-				b, err := vu.browser()
+				b, err := browser()
 				if err != nil {
 					return nil, err
 				}
@@ -30,7 +35,7 @@ func mapBrowser(vu moduleVU) mapping {
 			})
 		},
 		"isConnected": func() (bool, error) {
-			b, err := vu.browser()
+			b, err := browser()
 			if err != nil {
 				return false, err
 			}
@@ -42,7 +47,7 @@ func mapBrowser(vu moduleVU) mapping {
 				return nil, fmt.Errorf("parsing browser.newContext options: %w", err)
 			}
 			return promise(vu, func() (any, error) {
-				b, err := vu.browser()
+				b, err := browser()
 				if err != nil {
 					return nil, err
 				}
@@ -58,14 +63,14 @@ func mapBrowser(vu moduleVU) mapping {
 			}), nil
 		},
 		"userAgent": func() (string, error) {
-			b, err := vu.browser()
+			b, err := browser()
 			if err != nil {
 				return "", err
 			}
 			return b.UserAgent(), nil
 		},
 		"version": func() (string, error) {
-			b, err := vu.browser()
+			b, err := browser()
 			if err != nil {
 				return "", err
 			}
@@ -77,7 +82,7 @@ func mapBrowser(vu moduleVU) mapping {
 				return nil, fmt.Errorf("parsing browser.newPage options: %w", err)
 			}
 			return promise(vu, func() (any, error) {
-				b, err := vu.browser()
+				b, err := browser()
 				if err != nil {
 					return nil, err
 				}

--- a/internal/js/modules/k6/browser/browser/chromium_mapping.go
+++ b/internal/js/modules/k6/browser/browser/chromium_mapping.go
@@ -1,0 +1,34 @@
+package browser
+
+import (
+	"fmt"
+
+	"github.com/grafana/sobek"
+
+	"go.k6.io/k6/v2/internal/js/modules/k6/browser/chromium"
+	"go.k6.io/k6/v2/internal/js/modules/k6/browser/common"
+)
+
+// mapChromium maps the chromium browser type API.
+func mapChromium(vu moduleVU, bt *chromium.BrowserType) mapping {
+	return mapping{
+		"connectOverCDP": func(wsEndpoint string) *sobek.Promise {
+			return promise(vu, func() (any, error) {
+				b, err := bt.ConnectOverCDP(vu.Context(), wsEndpoint)
+				if err != nil {
+					return nil, fmt.Errorf("connecting to Chromium over CDP: %w", err)
+				}
+				m := mapBrowser(vu, func() (*common.Browser, error) {
+					return b, nil
+				})
+				m["close"] = func() *sobek.Promise {
+					return promise(vu, func() (any, error) {
+						b.Close()
+						return nil, nil
+					})
+				}
+				return m, nil
+			})
+		},
+	}
+}

--- a/internal/js/modules/k6/browser/browser/mapping.go
+++ b/internal/js/modules/k6/browser/browser/mapping.go
@@ -9,7 +9,6 @@ import (
 	"github.com/grafana/sobek"
 
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/common"
-	"go.k6.io/k6/v2/internal/js/modules/k6/browser/k6ext"
 
 	k6common "go.k6.io/k6/v2/js/common"
 )
@@ -19,19 +18,15 @@ import (
 // and customization over our API.
 type mapping = map[string]any
 
-// mapBrowserToSobek maps the browser API to the JS module.
-// The motivation of this mapping was to support $ and $$ wildcard
-// methods.
-// See issue #661 for more details.
-func mapBrowserToSobek(vu moduleVU) *sobek.Object {
+// mapToSobek converts a mapping to a sobek object.
+func mapToSobek(vu moduleVU, m mapping) *sobek.Object {
 	var (
 		rt  = vu.Runtime()
 		obj = rt.NewObject()
 	)
-	for k, v := range mapBrowser(vu) {
-		err := obj.Set(k, rt.ToValue(v))
-		if err != nil {
-			k6common.Throw(rt, k6ext.BrowserError(fmt.Errorf("mapping: %w", err)))
+	for k, v := range m {
+		if err := obj.Set(k, rt.ToValue(v)); err != nil {
+			k6common.Throw(rt, fmt.Errorf("mapping: %w", err))
 		}
 	}
 

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -126,7 +126,8 @@ func TestMappings(t *testing.T) {
 		"browser": {
 			apiInterface: (*browserAPI)(nil),
 			mapp: func() mapping {
-				return mapBrowser(moduleVU{VU: vu})
+				mvu := moduleVU{VU: vu}
+				return mapBrowser(mvu, mvu.browser)
 			},
 		},
 		"browserContext": {

--- a/internal/js/modules/k6/browser/browser/module.go
+++ b/internal/js/modules/k6/browser/browser/module.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/sobek"
 
+	"go.k6.io/k6/v2/internal/js/modules/k6/browser/chromium"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/common"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/env"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/k6ext"
@@ -41,6 +42,7 @@ type (
 	// JSModule exposes the properties available to the JS script.
 	JSModule struct {
 		Browser         *sobek.Object
+		Chromium        *sobek.Object
 		Devices         map[string]common.Device
 		NetworkProfiles map[string]common.NetworkProfile `js:"networkProfiles"`
 	}
@@ -76,22 +78,25 @@ func (m *RootModule) NewModuleInstance(vu k6modules.VU) k6modules.Instance {
 		m.initialize(vu)
 	})
 
+	mvu := moduleVU{
+		VU:          vu,
+		pidRegistry: m.PidRegistry,
+		browserRegistry: newBrowserRegistry(
+			context.Background(),
+			vu,
+			m.remoteRegistry,
+			m.PidRegistry,
+			m.tracesMetadata,
+		),
+		taskQueueRegistry: newTaskQueueRegistry(vu),
+		filePersister:     m.filePersister,
+		testRunID:         m.testRunID,
+	}
+
 	return &ModuleInstance{
 		mod: &JSModule{
-			Browser: mapBrowserToSobek(moduleVU{
-				VU:          vu,
-				pidRegistry: m.PidRegistry,
-				browserRegistry: newBrowserRegistry(
-					context.Background(),
-					vu,
-					m.remoteRegistry,
-					m.PidRegistry,
-					m.tracesMetadata,
-				),
-				taskQueueRegistry: newTaskQueueRegistry(vu),
-				filePersister:     m.filePersister,
-				testRunID:         m.testRunID,
-			}),
+			Browser:         mapToSobek(mvu, mapBrowser(mvu, mvu.browser)),
+			Chromium:        mapToSobek(mvu, mapChromium(mvu, chromium.NewBrowserType(vu))),
 			Devices:         common.GetDevices(),
 			NetworkProfiles: common.GetNetworkProfiles(),
 		},

--- a/internal/js/modules/k6/browser/browser/module_test.go
+++ b/internal/js/modules/k6/browser/browser/module_test.go
@@ -21,4 +21,5 @@ func TestModuleNew(t *testing.T) {
 	require.NotNil(t, m.mod.Browser, "Browser should be set")
 	require.NotNil(t, m.mod.Devices, "Devices should be set")
 	require.NotNil(t, m.mod.NetworkProfiles, "Profiles should be set")
+	require.NotNil(t, m.mod.Chromium, "Chromium should be set")
 }

--- a/internal/js/modules/k6/browser/chromium/browser_type.go
+++ b/internal/js/modules/k6/browser/chromium/browser_type.go
@@ -92,6 +92,39 @@ func (b *BrowserType) initContext(ctx context.Context) context.Context {
 	return ctx
 }
 
+// ConnectOverCDP attaches k6 browser to an existing browser instance
+// using CDP directly, without requiring scenario browser options.
+// This is for user-managed browsers where the script controls the
+// connection lifecycle (e.g. connecting to external browser farms).
+//
+// The user is responsible for calling Close() before the iteration
+// ends. Unlike the registry-managed Connect path (which uses a
+// background context so the event system can close the connection
+// after iteration cancel), here nobody calls Close() post-cancel,
+// so ctx controls both the connection and the browser lifetime.
+func (b *BrowserType) ConnectOverCDP(ctx context.Context, wsEndpoint string) (*common.Browser, error) {
+	ctx = b.initContext(ctx)
+
+	logger, err := makeLogger(ctx, b.envLookupper)
+	if err != nil {
+		return nil, fmt.Errorf("setting up logger: %w", err)
+	}
+
+	opts := common.NewRemoteBrowserOptions()
+	ctx = common.WithBrowserOptions(ctx, opts)
+
+	bp, err := b.connect(ctx, ctx, wsEndpoint, opts, logger)
+	if err != nil {
+		err = &k6ext.UserFriendlyError{
+			Err:     err,
+			Timeout: opts.Timeout,
+		}
+		return nil, fmt.Errorf("%w", err)
+	}
+
+	return bp, nil
+}
+
 // Connect attaches k6 browser to an existing browser instance.
 //
 // vuCtx is the context coming from the VU itself. The k6 vu/iteration controls

--- a/internal/js/modules/k6/browser/tests/browser_type_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_type_test.go
@@ -29,6 +29,31 @@ func TestBrowserTypeConnect(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestChromiumConnect(t *testing.T) {
+	t.Parallel()
+
+	// Launch a browser to get a WS URL, then connect
+	// through the JS chromium.connect() API.
+	tb := newTestBrowser(t)
+
+	vu := k6test.NewVU(t)
+	mod := browser.New().NewModuleInstance(vu)
+	jsMod, ok := mod.Exports().Default.(*browser.JSModule)
+	require.Truef(t, ok, "unexpected default mod export type %T", mod.Exports().Default)
+
+	vu.ActivateVU()
+	vu.StartIteration(t)
+
+	vu.SetVar(t, "chromium", jsMod.Chromium)
+	_, err := vu.RunAsync(t, `
+		const b = await chromium.connectOverCDP("%s");
+		const p = await b.newPage();
+		await p.close();
+		await b.close();
+	`, tb.wsURL)
+	require.NoError(t, err)
+}
+
 func TestBrowserTypeLaunchToConnect(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What?

Scripts can connect to external CDP-compatible browsers at runtime without declaring `options.browser`.

```js
import { chromium } from 'k6/browser';

export default async function () {
  const browser = await chromium.connectOverCDP('ws://...');
  const page = await browser.newPage();
  // ...
  await page.close();
  await browser.close();
}
```

The naming follows Playwright's `chromium.connectOverCDP()`.

## Why?

Users with their own browser infrastructure want to run k6 browser tests against their own browsers. Their flow requires a fresh WebSocket URL per session, obtained at runtime via an API call.

## Note

CI failures are not related to this PR.