### PR TITLE
refactor(browser): move PageScreenshotOptions to mapping layer

### DIFF
--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/chromedp/cdproto/page"
 	"github.com/grafana/sobek"
 
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/common"
@@ -417,12 +418,12 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 		},
 		"route": mapPageRoute(vu, p),
 		"screenshot": func(opts sobek.Value) (*sobek.Promise, error) {
-			popts := common.NewPageScreenshotOptions()
-			if err := popts.Parse(vu.Context(), opts); err != nil {
+			popts, err := parsePageScreenshotOptions(rt, opts, common.NewPageScreenshotOptions())
+			if err != nil {
 				return nil, fmt.Errorf("parsing page screenshot options: %w", err)
 			}
 
-			rt := vu.Runtime()
+			rt := vu.Runtime() // I believe we can remove this
 			promise, res, rej := rt.NewPromise()
 			callback := vu.RegisterCallback()
 			go func() {
@@ -1147,6 +1148,53 @@ func parsePageEmulateMediaOptions(
 			defaults.Media = common.MediaType(obj.Get(k).String())
 		case "reducedMotion":
 			defaults.ReducedMotion = common.ReducedMotion(obj.Get(k).String())
+		}
+	}
+
+	return defaults, nil
+}
+
+// parsePageScreenshotOptions parses the page screenshot options.
+func parsePageScreenshotOptions(rt *sobek.Runtime, opts sobek.Value, defaults *common.PageScreenshotOptions) (*common.PageScreenshotOptions, error) {
+	if k6common.IsNullish(opts) {
+		return defaults, nil
+	}
+
+	formatSpecified := false
+	obj := opts.ToObject(rt)
+	for _, k := range obj.Keys() {
+		switch k {
+		case "clip":
+			var c map[string]float64
+			if rt.ExportTo(obj.Get(k), &c) != nil {
+				defaults.Clip = &page.Viewport{
+					X: c["x"],
+					Y: c["y"],
+					Width: c["width"],
+					Height: c["height"],
+					Scale: 1,
+				}
+			}
+		case "fullPage":
+			defaults.FullPage = obj.Get(k).ToBoolean()
+		case "omitBackground":
+			defaults.OmitBackground = obj.Get(k).ToBoolean()
+		case "path":
+			defaults.Path = obj.Get(k).String()
+		case "quality":
+			defaults.Quality = obj.Get(k).ToInteger()
+		case "type":
+			if f, ok := common.ImageIDFromString(obj.Get(k).String()) ; ok {
+				defaults.Format = f
+				formatSpecified = true
+			}
+		}
+	}
+
+	// Infer file format by path if format not explicitly specified (default is PNG)
+	if defaults.Path != "" && !formatSpecified {
+		if strings.HasSuffix(defaults.Path, ".jpg") || strings.HasSuffix(defaults.Path, ".jpeg") {
+			defaults.Format = common.ImageFormatJPEG
 		}
 	}
 

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -418,7 +418,7 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 		},
 		"route": mapPageRoute(vu, p),
 		"screenshot": func(opts sobek.Value) (*sobek.Promise, error) {
-			popts, err := parsePageScreenshotOptions(rt, opts, common.NewPageScreenshotOptions())
+			popts, err := parsePageScreenshotOptions(rt, opts)
 			if err != nil {
 				return nil, fmt.Errorf("parsing page screenshot options: %w", err)
 			}
@@ -1155,9 +1155,10 @@ func parsePageEmulateMediaOptions(
 }
 
 // parsePageScreenshotOptions parses the page screenshot options.
-func parsePageScreenshotOptions(rt *sobek.Runtime, opts sobek.Value, defaults *common.PageScreenshotOptions) (*common.PageScreenshotOptions, error) {
+func parsePageScreenshotOptions(rt *sobek.Runtime, opts sobek.Value) (*common.PageScreenshotOptions, error) {
+	popts := common.NewPageScreenshotOptions()
 	if k6common.IsNullish(opts) {
-		return defaults, nil
+		return popts, nil
 	}
 
 	formatSpecified := false
@@ -1166,37 +1167,38 @@ func parsePageScreenshotOptions(rt *sobek.Runtime, opts sobek.Value, defaults *c
 		switch k {
 		case "clip":
 			var c map[string]float64
-			if rt.ExportTo(obj.Get(k), &c) != nil {
-				defaults.Clip = &page.Viewport{
-					X: c["x"],
-					Y: c["y"],
-					Width: c["width"],
-					Height: c["height"],
-					Scale: 1,
-				}
+			if err := rt.ExportTo(obj.Get(k), &c) ; err != nil {
+				return popts, err
+			}
+			popts.Clip = &page.Viewport{
+				X:      c["x"],
+				Y:      c["y"],
+				Width:  c["width"],
+				Height: c["height"],
+				Scale:  1,
 			}
 		case "fullPage":
-			defaults.FullPage = obj.Get(k).ToBoolean()
+			popts.FullPage = obj.Get(k).ToBoolean()
 		case "omitBackground":
-			defaults.OmitBackground = obj.Get(k).ToBoolean()
+			popts.OmitBackground = obj.Get(k).ToBoolean()
 		case "path":
-			defaults.Path = obj.Get(k).String()
+			popts.Path = obj.Get(k).String()
 		case "quality":
-			defaults.Quality = obj.Get(k).ToInteger()
+			popts.Quality = obj.Get(k).ToInteger()
 		case "type":
-			if f, ok := common.ImageIDFromString(obj.Get(k).String()) ; ok {
-				defaults.Format = f
+			if f, ok := common.ImageIDFromString(obj.Get(k).String()); ok {
+				popts.Format = f
 				formatSpecified = true
 			}
 		}
 	}
 
 	// Infer file format by path if format not explicitly specified (default is PNG)
-	if defaults.Path != "" && !formatSpecified {
-		if strings.HasSuffix(defaults.Path, ".jpg") || strings.HasSuffix(defaults.Path, ".jpeg") {
-			defaults.Format = common.ImageFormatJPEG
+	if popts.Path != "" && !formatSpecified {
+		if strings.HasSuffix(popts.Path, ".jpg") || strings.HasSuffix(popts.Path, ".jpeg") {
+			popts.Format = common.ImageFormatJPEG
 		}
 	}
 
-	return defaults, nil
+	return popts, nil
 }

--- a/internal/js/modules/k6/browser/browser/page_mapping.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping.go
@@ -423,7 +423,6 @@ func mapPage(vu moduleVU, p *common.Page) mapping { //nolint:gocognit,cyclop
 				return nil, fmt.Errorf("parsing page screenshot options: %w", err)
 			}
 
-			rt := vu.Runtime() // I believe we can remove this
 			promise, res, rej := rt.NewPromise()
 			callback := vu.RegisterCallback()
 			go func() {
@@ -1167,7 +1166,7 @@ func parsePageScreenshotOptions(rt *sobek.Runtime, opts sobek.Value) (*common.Pa
 		switch k {
 		case "clip":
 			var c map[string]float64
-			if err := rt.ExportTo(obj.Get(k), &c) ; err != nil {
+			if err := rt.ExportTo(obj.Get(k), &c); err != nil {
 				return popts, err
 			}
 			popts.Clip = &page.Viewport{

--- a/internal/js/modules/k6/browser/browser/page_mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping_test.go
@@ -3,6 +3,7 @@ package browser
 import (
 	"testing"
 
+	"github.com/chromedp/cdproto/page"
 	"github.com/grafana/sobek"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -180,6 +181,63 @@ func TestParsePageEmulateMediaOptions(t *testing.T) {
 			require.NoError(t, err)
 
 			opts, err := parsePageEmulateMediaOptions(vu.Runtime(), v, newDefaults())
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, opts)
+		})
+	}
+}
+
+func TestParsePageScreenshotOptions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct{
+		name string
+		input string
+		want *common.PageScreenshotOptions
+	}{
+		{
+			name: "defaults_on_null",
+			input: `null`,
+			want: common.NewPageScreenshotOptions(),
+		},
+		{
+			name: "partial_options",
+			input: `({fullPage: true, quality: 100, type: "png"})`,
+			want: &common.PageScreenshotOptions{
+				FullPage: true,
+				Quality: 100,
+				Format: common.ImageFormatPNG,
+			},
+		},
+		{
+			name: "all_options",
+			input: `({clip: {x: 32.5, y: 16, width: 200, height: 100}, fullPage: false, omitBackground: true, quality: 100, type: "jpg", path: "image.jpg"})`,
+			want: &common.PageScreenshotOptions{
+				Clip: &page.Viewport{
+					X: 32.5,
+					Y: 16,
+					Width: 200,
+					Height: 100,
+					Scale: 1,
+				},
+				FullPage: false,
+				OmitBackground: true,
+				Quality: 100,
+				Format: common.ImageFormatJPEG,
+				Path: "image.jpg",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func (t *testing.T) {
+			t.Parallel()
+
+			vu := k6test.NewVU(t)
+			v, err := vu.Runtime().RunString(tt.input)
+			require.NoError(t, err)
+
+			opts, err := parsePageScreenshotOptions(vu.Runtime(), v)
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, opts)
 		})

--- a/internal/js/modules/k6/browser/browser/page_mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/page_mapping_test.go
@@ -190,47 +190,47 @@ func TestParsePageEmulateMediaOptions(t *testing.T) {
 func TestParsePageScreenshotOptions(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct{
-		name string
+	tests := []struct {
+		name  string
 		input string
-		want *common.PageScreenshotOptions
+		want  *common.PageScreenshotOptions
 	}{
 		{
-			name: "defaults_on_null",
+			name:  "defaults_on_null",
 			input: `null`,
-			want: common.NewPageScreenshotOptions(),
+			want:  common.NewPageScreenshotOptions(),
 		},
 		{
-			name: "partial_options",
+			name:  "partial_options",
 			input: `({fullPage: true, quality: 100, type: "png"})`,
 			want: &common.PageScreenshotOptions{
 				FullPage: true,
-				Quality: 100,
-				Format: common.ImageFormatPNG,
+				Quality:  100,
+				Format:   common.ImageFormatPNG,
 			},
 		},
 		{
-			name: "all_options",
+			name:  "all_options",
 			input: `({clip: {x: 32.5, y: 16, width: 200, height: 100}, fullPage: false, omitBackground: true, quality: 100, type: "jpg", path: "image.jpg"})`,
 			want: &common.PageScreenshotOptions{
 				Clip: &page.Viewport{
-					X: 32.5,
-					Y: 16,
-					Width: 200,
+					X:      32.5,
+					Y:      16,
+					Width:  200,
 					Height: 100,
-					Scale: 1,
+					Scale:  1,
 				},
-				FullPage: false,
+				FullPage:       false,
 				OmitBackground: true,
-				Quality: 100,
-				Format: common.ImageFormatJPEG,
-				Path: "image.jpg",
+				Quality:        100,
+				Format:         common.ImageFormatJPEG,
+				Path:           "image.jpg",
 			},
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func (t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			vu := k6test.NewVU(t)

--- a/internal/js/modules/k6/browser/common/page_options.go
+++ b/internal/js/modules/k6/browser/common/page_options.go
@@ -3,7 +3,6 @@ package common
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/chromedp/cdproto/page"
@@ -120,54 +119,6 @@ func NewPageScreenshotOptions() *PageScreenshotOptions {
 		OmitBackground: false,
 		Quality:        100,
 	}
-}
-
-// Parse parses the page screenshot options.
-func (o *PageScreenshotOptions) Parse(ctx context.Context, opts sobek.Value) error {
-	if common.IsNullish(opts) {
-		return nil
-	}
-
-	rt := k6ext.Runtime(ctx)
-	formatSpecified := false
-	obj := opts.ToObject(rt)
-	for _, k := range obj.Keys() {
-		switch k {
-		case "clip":
-			var c map[string]float64
-			if rt.ExportTo(obj.Get(k), &c) != nil {
-				o.Clip = &page.Viewport{
-					X:      c["x"],
-					Y:      c["y"],
-					Width:  c["width"],
-					Height: c["height"],
-					Scale:  1,
-				}
-			}
-		case "fullPage":
-			o.FullPage = obj.Get(k).ToBoolean()
-		case "omitBackground":
-			o.OmitBackground = obj.Get(k).ToBoolean()
-		case "path":
-			o.Path = obj.Get(k).String()
-		case "quality":
-			o.Quality = obj.Get(k).ToInteger()
-		case "type":
-			if f, ok := imageFormatToID[obj.Get(k).String()]; ok {
-				o.Format = f
-				formatSpecified = true
-			}
-		}
-	}
-
-	// Infer file format by path if format not explicitly specified (default is PNG)
-	if o.Path != "" && !formatSpecified {
-		if strings.HasSuffix(o.Path, ".jpg") || strings.HasSuffix(o.Path, ".jpeg") {
-			o.Format = ImageFormatJPEG
-		}
-	}
-
-	return nil
 }
 
 // PageWaitForResponseOptions are options for Page.waitForResponse.

--- a/internal/js/modules/k6/browser/common/screenshotter.go
+++ b/internal/js/modules/k6/browser/common/screenshotter.go
@@ -45,6 +45,11 @@ var imageFormatToID = map[string]ImageFormat{ //nolint:gochecknoglobals
 	"png":  ImageFormatPNG,
 }
 
+func ImageIDFromString(format string) (ImageFormat, bool) {
+	id, exists := imageFormatToID[format]
+	return id, exists
+}
+
 // MarshalJSON marshals the enum as a quoted JSON string.
 func (f ImageFormat) MarshalJSON() ([]byte, error) {
 	buffer := bytes.NewBufferString(`"`)


### PR DESCRIPTION
## What?

Moving `PageScreenshotOptions` parsing from `common` to browser mapping layer

## Why?

As mentioned in #5305, since options parsing is required only in the mapping layer. This PR refactors for the same

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

#5305
