### PR TITLE
[feat] Add browser video recording

### DIFF
--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"go.k6.io/k6/v2/internal/js/modules/k6/browser/env"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/k6ext"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/log"
 
@@ -87,6 +88,10 @@ type FrameSession struct {
 	// onFrameNavigated, but subsequent calls to onFrameNavigated in the same
 	// mainframe never again create a navigation span.
 	initialNavDone bool
+
+	// recorder captures screencast frames into a webm video. Non-nil only on
+	// the main frame session when K6_BROWSER_RECORDING_DIR is set.
+	recorder *Recorder
 }
 
 // NewFrameSession initializes and returns a new FrameSession.
@@ -190,7 +195,81 @@ func NewFrameSession(
 		return nil, err
 	}
 
+	fs.maybeStartRecording()
+
 	return &fs, nil
+}
+
+// maybeStartRecording starts a CDP screencast on the main frame when the
+// K6_BROWSER_RECORDING_DIR env var is set. Failures are logged and never
+// abort the page setup — recording is best-effort.
+func (fs *FrameSession) maybeStartRecording() {
+	if !fs.isMainFrame() {
+		return
+	}
+	dir, ok := env.Lookup(env.RecordingDir)
+	if !ok || dir == "" {
+		return
+	}
+
+	name := fs.targetID.String()
+	if state := fs.vu.State(); state != nil {
+		name = fmt.Sprintf("vu-%d-iter-%d-%s", state.VUID, state.Iteration, fs.targetID)
+	}
+
+	rec, err := NewRecorder(dir, name, 10, fs.logger)
+	if err != nil {
+		fs.logger.Warnf("FrameSession:maybeStartRecording",
+			"could not start recorder: %v", err)
+		return
+	}
+	fs.recorder = rec
+
+	action := cdppage.StartScreencast().
+		WithFormat(cdppage.ScreencastFormatJpeg).
+		WithQuality(80).
+		WithEveryNthFrame(1)
+	if err := action.Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {
+		fs.logger.Warnf("FrameSession:maybeStartRecording",
+			"Page.startScreencast failed: %v", err)
+		_ = rec.Close()
+		fs.recorder = nil
+	}
+}
+
+// onScreencastFrame writes the received JPEG frame to the recorder and
+// acknowledges receipt so chromium continues to deliver frames.
+func (fs *FrameSession) onScreencastFrame(ev *cdppage.EventScreencastFrame) {
+	if fs.recorder == nil {
+		return
+	}
+	if err := fs.recorder.WriteFrame(ev.Data); err != nil {
+		fs.logger.Warnf("FrameSession:onScreencastFrame",
+			"failed to write frame: %v", err)
+	}
+	ack := cdppage.ScreencastFrameAck(ev.SessionID)
+	if err := ack.Do(cdp.WithExecutor(fs.ctx, fs.session)); err != nil {
+		fs.logger.Debugf("FrameSession:onScreencastFrame",
+			"screencastFrameAck failed: %v", err)
+	}
+}
+
+// stopRecording halts the screencast and finalizes the webm. Safe to call
+// when recording was never started.
+func (fs *FrameSession) stopRecording() {
+	if fs.recorder == nil {
+		return
+	}
+	// Use teardownCtx because fs.ctx may already be Done at this point.
+	if err := cdppage.StopScreencast().Do(cdp.WithExecutor(fs.teardownCtx, fs.session)); err != nil {
+		fs.logger.Debugf("FrameSession:stopRecording",
+			"Page.stopScreencast failed: %v", err)
+	}
+	if err := fs.recorder.Close(); err != nil {
+		fs.logger.Warnf("FrameSession:stopRecording",
+			"finalizing recording failed: %v", err)
+	}
+	fs.recorder = nil
 }
 
 func (fs *FrameSession) emulateLocale() error {
@@ -263,6 +342,7 @@ func (fs *FrameSession) initEvents() {
 				fs.mainFrameSpan.End()
 				fs.mainFrameSpan = nil
 			}
+			fs.stopRecording()
 			fs.logger.Debugf("NewFrameSession:initEvents:go:return",
 				"sid:%v tid:%v", fs.session.ID(), fs.targetID)
 		}()
@@ -319,6 +399,8 @@ func (fs *FrameSession) initEvents() {
 					fs.onEventJavascriptDialogOpening(ev)
 				case *cdpruntime.EventBindingCalled:
 					fs.onEventBindingCalled(ev)
+				case *cdppage.EventScreencastFrame:
+					fs.onScreencastFrame(ev)
 				}
 			}
 		}
@@ -601,6 +683,7 @@ func (fs *FrameSession) initRendererEvents() {
 		cdproto.EventTargetAttachedToTarget,
 		cdproto.EventTargetDetachedFromTarget,
 		cdproto.EventRuntimeBindingCalled,
+		cdproto.EventPageScreencastFrame,
 	}
 	fs.session.on(fs.ctx, events, fs.eventCh)
 }

--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -217,7 +217,7 @@ func (fs *FrameSession) maybeStartRecording() {
 		name = fmt.Sprintf("vu-%d-iter-%d-%s", state.VUID, state.Iteration, fs.targetID)
 	}
 
-	rec, err := NewRecorder(dir, name, 10, fs.logger)
+	rec, err := NewRecorder(fs.teardownCtx, dir, name, 10, fs.logger)
 	if err != nil {
 		fs.logger.Warnf("FrameSession:maybeStartRecording",
 			"could not start recorder: %v", err)
@@ -314,7 +314,52 @@ func (fs *FrameSession) initDomains() error {
 	return nil
 }
 
-//nolint:cyclop
+func (fs *FrameSession) dispatchEvent(event Event) {
+	switch ev := event.data.(type) {
+	case *inspector.EventTargetCrashed:
+		fs.onTargetCrashed()
+	case *cdplog.EventEntryAdded:
+		fs.onLogEntryAdded(ev)
+	case *cdppage.EventFrameAttached:
+		fs.onFrameAttached(ev.FrameID, ev.ParentFrameID)
+	case *cdppage.EventFrameDetached:
+		fs.onFrameDetached(ev.FrameID, ev.Reason)
+	case *cdppage.EventFrameNavigated:
+		const initial = false
+		fs.onFrameNavigated(ev.Frame, initial)
+	case *cdppage.EventFrameRequestedNavigation:
+		fs.onFrameRequestedNavigation(ev)
+	case *cdppage.EventFrameStartedLoading:
+		fs.onFrameStartedLoading(ev.FrameID)
+	case *cdppage.EventFrameStoppedLoading:
+		fs.onFrameStoppedLoading(ev.FrameID)
+	case *cdppage.EventLifecycleEvent:
+		fs.onPageLifecycle(ev)
+	case *cdppage.EventNavigatedWithinDocument:
+		fs.onPageNavigatedWithinDocument(ev)
+	case *cdpruntime.EventConsoleAPICalled:
+		fs.onConsoleAPICalled(ev)
+	case *cdpruntime.EventExceptionThrown:
+		fs.onExceptionThrown(ev)
+	case *cdpruntime.EventExecutionContextCreated:
+		fs.onExecutionContextCreated(ev)
+	case *cdpruntime.EventExecutionContextDestroyed:
+		fs.onExecutionContextDestroyed(ev.ExecutionContextID)
+	case *cdpruntime.EventExecutionContextsCleared:
+		fs.onExecutionContextsCleared()
+	case *target.EventAttachedToTarget:
+		fs.onAttachedToTarget(ev)
+	case *target.EventDetachedFromTarget:
+		fs.onDetachedFromTarget(ev)
+	case *cdppage.EventJavascriptDialogOpening:
+		fs.onEventJavascriptDialogOpening(ev)
+	case *cdpruntime.EventBindingCalled:
+		fs.onEventBindingCalled(ev)
+	case *cdppage.EventScreencastFrame:
+		fs.onScreencastFrame(ev)
+	}
+}
+
 func (fs *FrameSession) initEvents() {
 	fs.logger.Debugf("NewFrameSession:initEvents",
 		"sid:%v tid:%v", fs.session.ID(), fs.targetID)
@@ -359,49 +404,7 @@ func (fs *FrameSession) initEvents() {
 
 				return
 			case event := <-fs.eventCh:
-				switch ev := event.data.(type) {
-				case *inspector.EventTargetCrashed:
-					fs.onTargetCrashed()
-				case *cdplog.EventEntryAdded:
-					fs.onLogEntryAdded(ev)
-				case *cdppage.EventFrameAttached:
-					fs.onFrameAttached(ev.FrameID, ev.ParentFrameID)
-				case *cdppage.EventFrameDetached:
-					fs.onFrameDetached(ev.FrameID, ev.Reason)
-				case *cdppage.EventFrameNavigated:
-					const initial = false
-					fs.onFrameNavigated(ev.Frame, initial)
-				case *cdppage.EventFrameRequestedNavigation:
-					fs.onFrameRequestedNavigation(ev)
-				case *cdppage.EventFrameStartedLoading:
-					fs.onFrameStartedLoading(ev.FrameID)
-				case *cdppage.EventFrameStoppedLoading:
-					fs.onFrameStoppedLoading(ev.FrameID)
-				case *cdppage.EventLifecycleEvent:
-					fs.onPageLifecycle(ev)
-				case *cdppage.EventNavigatedWithinDocument:
-					fs.onPageNavigatedWithinDocument(ev)
-				case *cdpruntime.EventConsoleAPICalled:
-					fs.onConsoleAPICalled(ev)
-				case *cdpruntime.EventExceptionThrown:
-					fs.onExceptionThrown(ev)
-				case *cdpruntime.EventExecutionContextCreated:
-					fs.onExecutionContextCreated(ev)
-				case *cdpruntime.EventExecutionContextDestroyed:
-					fs.onExecutionContextDestroyed(ev.ExecutionContextID)
-				case *cdpruntime.EventExecutionContextsCleared:
-					fs.onExecutionContextsCleared()
-				case *target.EventAttachedToTarget:
-					fs.onAttachedToTarget(ev)
-				case *target.EventDetachedFromTarget:
-					fs.onDetachedFromTarget(ev)
-				case *cdppage.EventJavascriptDialogOpening:
-					fs.onEventJavascriptDialogOpening(ev)
-				case *cdpruntime.EventBindingCalled:
-					fs.onEventBindingCalled(ev)
-				case *cdppage.EventScreencastFrame:
-					fs.onScreencastFrame(ev)
-				}
+				fs.dispatchEvent(event)
 			}
 		}
 	})

--- a/internal/js/modules/k6/browser/common/recorder.go
+++ b/internal/js/modules/k6/browser/common/recorder.go
@@ -1,0 +1,152 @@
+package common
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"go.k6.io/k6/v2/internal/js/modules/k6/browser/log"
+)
+
+// Recorder captures CDP screencast frames for a single page and pipes them
+// into ffmpeg to produce a webm video. Methods are safe for concurrent use.
+type Recorder struct {
+	logger  *log.Logger
+	outPath string
+
+	mu      sync.Mutex
+	cmd     *exec.Cmd
+	stdin   io.WriteCloser
+	stderr  *bytes.Buffer
+	closed  bool
+	broken  bool
+	frames  int
+}
+
+// NewRecorder creates the output directory and spawns an ffmpeg process that
+// reads JPEG frames from stdin and writes a webm to <dir>/<name>.webm.
+//
+// Pre-condition: ffmpeg must be on PATH. Callers should fall back gracefully
+// when this returns an error.
+func NewRecorder(dir, name string, framerate int, logger *log.Logger) (*Recorder, error) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		return nil, fmt.Errorf("ffmpeg not found on PATH: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating recording dir %q: %w", dir, err)
+	}
+	if framerate <= 0 {
+		framerate = 10
+	}
+
+	outPath := filepath.Join(dir, name+".webm")
+	// libvpx (VP8) is broadly supported by ffmpeg builds. The pad filter ensures
+	// even dimensions, which the encoder requires.
+	cmd := exec.Command("ffmpeg", //nolint:gosec
+		"-y",
+		"-loglevel", "error",
+		"-f", "image2pipe",
+		"-framerate", strconv.Itoa(framerate),
+		"-i", "-",
+		"-vf", "pad=ceil(iw/2)*2:ceil(ih/2)*2",
+		"-c:v", "libvpx",
+		"-b:v", "1M",
+		outPath,
+	)
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("getting ffmpeg stdin: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("starting ffmpeg: %w", err)
+	}
+
+	return &Recorder{
+		logger:  logger,
+		outPath: outPath,
+		cmd:     cmd,
+		stdin:   stdin,
+		stderr:  stderr,
+	}, nil
+}
+
+// WriteFrame decodes a base64 JPEG screencast frame and forwards it to ffmpeg.
+// Frames received after Close, or after the ffmpeg pipe has broken once, are
+// silently dropped — the first pipe failure is reported, then we latch off to
+// avoid log spam at the screencast frame rate.
+func (r *Recorder) WriteFrame(b64 string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed || r.broken {
+		return nil
+	}
+	data, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return fmt.Errorf("decoding screencast frame: %w", err)
+	}
+	if _, err := r.stdin.Write(data); err != nil {
+		r.broken = true
+		return fmt.Errorf("writing frame to ffmpeg: %w", err)
+	}
+	r.frames++
+	return nil
+}
+
+// Close finalizes the recording: it closes ffmpeg's stdin and waits for the
+// process to exit. Safe to call multiple times.
+func (r *Recorder) Close() error {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return nil
+	}
+	r.closed = true
+	stdin := r.stdin
+	cmd := r.cmd
+	frames := r.frames
+	out := r.outPath
+	stderr := r.stderr
+	r.mu.Unlock()
+
+	if stdin != nil {
+		_ = stdin.Close()
+	}
+	if cmd == nil {
+		return nil
+	}
+
+	if frames == 0 {
+		// No frames captured; kill ffmpeg to avoid it waiting forever and
+		// remove the empty output file it may have created.
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+		_ = os.Remove(out)
+		r.logger.Warnf("Recorder", "no frames captured; recording skipped")
+		return nil
+	}
+
+	if err := cmd.Wait(); err != nil {
+		// ExitError still produces a (possibly partial) file. Surface as warning
+		// rather than failing the test.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			r.logger.Warnf("Recorder", "ffmpeg exited with %v; output may be partial: %s; stderr: %s",
+				err, out, strings.TrimSpace(stderr.String()))
+			return nil
+		}
+		return fmt.Errorf("waiting for ffmpeg: %w", err)
+	}
+
+	return nil
+}

--- a/internal/js/modules/k6/browser/common/recorder.go
+++ b/internal/js/modules/k6/browser/common/recorder.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -22,13 +23,13 @@ type Recorder struct {
 	logger  *log.Logger
 	outPath string
 
-	mu      sync.Mutex
-	cmd     *exec.Cmd
-	stdin   io.WriteCloser
-	stderr  *bytes.Buffer
-	closed  bool
-	broken  bool
-	frames  int
+	mu     sync.Mutex
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stderr *bytes.Buffer
+	closed bool
+	broken bool
+	frames int
 }
 
 // NewRecorder creates the output directory and spawns an ffmpeg process that
@@ -36,11 +37,11 @@ type Recorder struct {
 //
 // Pre-condition: ffmpeg must be on PATH. Callers should fall back gracefully
 // when this returns an error.
-func NewRecorder(dir, name string, framerate int, logger *log.Logger) (*Recorder, error) {
+func NewRecorder(ctx context.Context, dir, name string, framerate int, logger *log.Logger) (*Recorder, error) {
 	if _, err := exec.LookPath("ffmpeg"); err != nil {
 		return nil, fmt.Errorf("ffmpeg not found on PATH: %w", err)
 	}
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o750); err != nil { //nolint:forbidigo
 		return nil, fmt.Errorf("creating recording dir %q: %w", dir, err)
 	}
 	if framerate <= 0 {
@@ -50,7 +51,7 @@ func NewRecorder(dir, name string, framerate int, logger *log.Logger) (*Recorder
 	outPath := filepath.Join(dir, name+".webm")
 	// libvpx (VP8) is broadly supported by ffmpeg builds. The pad filter ensures
 	// even dimensions, which the encoder requires.
-	cmd := exec.Command("ffmpeg", //nolint:gosec
+	cmd := exec.CommandContext(ctx, "ffmpeg", //nolint:gosec
 		"-y",
 		"-loglevel", "error",
 		"-f", "image2pipe",
@@ -131,7 +132,7 @@ func (r *Recorder) Close() error {
 		// remove the empty output file it may have created.
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
-		_ = os.Remove(out)
+		_ = os.Remove(out) //nolint:forbidigo
 		r.logger.Warnf("Recorder", "no frames captured; recording skipped")
 		return nil
 	}

--- a/internal/js/modules/k6/browser/env/env.go
+++ b/internal/js/modules/k6/browser/env/env.go
@@ -73,6 +73,15 @@ const (
 	ScreenshotsOutput = "K6_BROWSER_SCREENSHOTS_OUTPUT"
 )
 
+// Recording.
+const (
+	// RecordingDir, when set to a directory path, enables CDP screencast
+	// based recording of every main-frame page. Frames are streamed into
+	// ffmpeg and a <pageTargetID>.webm file is written per page. Requires
+	// ffmpeg to be installed and available on PATH.
+	RecordingDir = "K6_BROWSER_RECORDING_DIR"
+)
+
 // Infrastructural.
 const (
 	// K6TestRunID represents the test run id. Note: this was taken from

--- a/internal/js/modules/k6/browser/env/env.go
+++ b/internal/js/modules/k6/browser/env/env.go
@@ -77,8 +77,11 @@ const (
 const (
 	// RecordingDir, when set to a directory path, enables CDP screencast
 	// based recording of every main-frame page. Frames are streamed into
-	// ffmpeg and a <pageTargetID>.webm file is written per page. Requires
-	// ffmpeg to be installed and available on PATH.
+	// ffmpeg and a vu-<N>-iter-<N>-<pageTargetID>.webm file is written
+	// per page. Requires ffmpeg to be installed and available on PATH.
+	//
+	// EXPERIMENTAL: this env var is experimental and may change name,
+	// semantics, or be removed in a future release without notice.
 	RecordingDir = "K6_BROWSER_RECORDING_DIR"
 )
 


### PR DESCRIPTION
## What?

Set `K6_BROWSER_RECORDING_DIR=<dir> ` and you get a WebM recording per page. One file per VU+iteration.

This feature is off by default. 

Requires ffmpeg on PATH; if it's not there, recording just doesn't happen, and the test runs normally.

## Why?

When a browser test fails, logs only get you so far. Being able to actually watch what the page did saves a ton of time. 

The implementation is the same as some other tools follow: CDP screencast frames piped into ffmpeg.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [X] I have performed a self-review of my code.
- [X] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

#4487 

<!-- Thanks for your contribution! 🙏🏼 -->
