### PR TITLE
browser: add ElementHandle.isInViewport

### DIFF
--- a/internal/js/modules/k6/browser/browser/element_handle_mapping.go
+++ b/internal/js/modules/k6/browser/browser/element_handle_mapping.go
@@ -147,6 +147,11 @@ func mapElementHandle(vu moduleVU, eh *common.ElementHandle) mapping { //nolint:
 				return eh.IsHidden() //nolint:wrapcheck
 			})
 		},
+		"isInViewport": func() *sobek.Promise {
+			return promise(vu, func() (any, error) {
+				return eh.IsInViewport() //nolint:wrapcheck
+			})
+		},
 		"isVisible": func() *sobek.Promise {
 			return promise(vu, func() (any, error) {
 				return eh.IsVisible() //nolint:wrapcheck

--- a/internal/js/modules/k6/browser/browser/mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/mapping_test.go
@@ -488,6 +488,7 @@ type elementHandleAPI interface { //nolint:interfacebloat
 	IsEditable() (bool, error)
 	IsEnabled() (bool, error)
 	IsHidden() (bool, error)
+	IsInViewport() (bool, error)
 	IsVisible() (bool, error)
 	OwnerFrame() (*common.Frame, error)
 	Press(key string, opts sobek.Value) error

--- a/internal/js/modules/k6/browser/common/element_handle.go
+++ b/internal/js/modules/k6/browser/common/element_handle.go
@@ -1080,6 +1080,41 @@ func (h *ElementHandle) IsHidden() (bool, error) {
 	return ok, nil
 }
 
+// IsInViewport checks if the element is fully visible within the viewport.
+func (h *ElementHandle) IsInViewport() (bool, error) {
+	fn := `
+		(node) => {
+			if (!node.isConnected) {
+				return false;
+			}
+			const rect = node.getBoundingClientRect();
+			const viewportHeight = window.innerHeight || document.documentElement.clientHeight;
+			const viewportWidth = window.innerWidth || document.documentElement.clientWidth;
+
+			return rect.width > 0 && rect.height > 0 &&
+				rect.top >= 0 &&
+				rect.left >= 0 &&
+				rect.bottom <= viewportHeight &&
+				rect.right <= viewportWidth;
+		}
+	`
+	opts := evalOptions{
+		forceCallable: true,
+		returnByValue: true,
+	}
+	result, err := h.eval(h.ctx, opts, fn)
+	if err != nil {
+		return false, fmt.Errorf("checking element is in viewport: %w", err)
+	}
+
+	inViewport, ok := result.(bool)
+	if !ok {
+		return false, fmt.Errorf("checking element is in viewport: unexpected type %T", result)
+	}
+
+	return inViewport, nil
+}
+
 // IsVisible checks if the element is visible.
 func (h *ElementHandle) IsVisible() (bool, error) {
 	ok, err := h.isVisible(h.ctx)

--- a/internal/js/modules/k6/browser/tests/element_handle_test.go
+++ b/internal/js/modules/k6/browser/tests/element_handle_test.go
@@ -123,6 +123,90 @@ func TestElementHandleBoundingBoxSVG(t *testing.T) {
 	require.EqualValues(t, bbox, rect)
 }
 
+func TestElementHandleIsInViewport(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t)
+	p := tb.NewPage(nil)
+
+	err := p.SetViewportSize(&common.Size{Width: 300, Height: 200})
+	require.NoError(t, err)
+
+	err = p.SetContent(`
+		<style>
+			body { margin: 0; }
+			div { width: 20px; height: 20px; }
+			#below { position: absolute; top: 260px; }
+			#partial { position: absolute; top: 190px; }
+			#hidden { display: none; }
+		</style>
+		<div id="visible"></div>
+		<div id="below"></div>
+		<div id="partial"></div>
+		<div id="hidden"></div>
+	`, nil)
+	require.NoError(t, err)
+
+	visible, err := p.Query("#visible")
+	require.NoError(t, err)
+	got, err := visible.IsInViewport()
+	require.NoError(t, err)
+	require.True(t, got)
+
+	below, err := p.Query("#below")
+	require.NoError(t, err)
+	got, err = below.IsInViewport()
+	require.NoError(t, err)
+	require.False(t, got)
+
+	partial, err := p.Query("#partial")
+	require.NoError(t, err)
+	got, err = partial.IsInViewport()
+	require.NoError(t, err)
+	require.False(t, got)
+
+	hidden, err := p.Query("#hidden")
+	require.NoError(t, err)
+	got, err = hidden.IsInViewport()
+	require.NoError(t, err)
+	require.False(t, got)
+
+	_, err = p.Evaluate(`() => document.querySelector("#below").scrollIntoView()`)
+	require.NoError(t, err)
+	got, err = below.IsInViewport()
+	require.NoError(t, err)
+	require.True(t, got)
+}
+
+func TestElementHandleIsInViewportWithMapper(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t)
+	tb.vu.ActivateVU()
+	tb.vu.StartIteration(t)
+	defer tb.vu.EndIteration(t)
+
+	got := tb.vu.RunPromise(t, `
+		const p = await browser.newPage();
+		await p.setViewportSize({ width: 300, height: 200 });
+		await p.setContent('<style>body{margin:0}div{width:20px;height:20px}#below{position:absolute;top:260px}</style><div id="visible"></div><div id="below"></div>');
+
+		const visible = await p.$('#visible');
+		const below = await p.$('#below');
+		const visibleInViewport = await visible.isInViewport();
+		const belowInViewport = await below.isInViewport();
+		await p.evaluate(() => document.querySelector("#below").scrollIntoView());
+		const belowAfterScroll = await below.isInViewport();
+		await p.close();
+
+		if (!visibleInViewport || belowInViewport || !belowAfterScroll) {
+			throw new Error("unexpected isInViewport result");
+		}
+		return true;
+	`)
+	assert.Equal(t, tb.vu.ToSobekValue(true), got.Result())
+}
+
 func TestElementHandleClick(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What\n\nAdds an ElementHandle.isInViewport() browser API that evaluates whether the element is fully inside the current viewport. The change also exposes the method through the JS mapping and keeps the mapping consistency test in sync.\n\nCloses #4423\n\n## Testing\n\n- go test ./internal/js/modules/k6/browser/tests -run 'TestElementHandleIsInViewport' -count=1 -v -timeout 60s\n- go test ./internal/js/modules/k6/browser/common ./internal/js/modules/k6/browser/browser -count=1\n- git diff --check