### PR TITLE
Move Docker Hub publishing to GAR mirror

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ permissions:
 
 env:
   APP_NAME: "k6"
-  DOCKER_IMAGE_ID: "grafana/k6"
+  DOCKER_IMAGE_ID: "us-docker.pkg.dev/grafanalabs-global/dockerhub-k6-prod-mirror/k6"
   GHCR_IMAGE_ID: ${{ github.repository }}
   DEFAULT_GO_VERSION: "1.26.x"
 
@@ -240,9 +240,11 @@ jobs:
           docker run $DOCKER_IMAGE_ID help
           docker run $DOCKER_IMAGE_ID run --help
           docker run $DOCKER_IMAGE_ID inspect --help
-      - name: Login to DockerHub
+      - name: Login to GAR (Docker Hub mirror)
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
-        uses: grafana/shared-workflows/actions/dockerhub-login@ef3a62a3ca4c1a15505b4235a5a51493194da3c7 # dockerhub-login/v1.0.4
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
       - name: Login to GitHub Container Registry
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         env:


### PR DESCRIPTION
## What?

Move the Docker Hub publishing path in `.github/workflows/build.yml` off the shared `dockerhub-login` action and onto `login-to-gar`. Images are now pushed to `us-docker.pkg.dev/grafanalabs-global/dockerhub-k6-prod-mirror/k6`; the `gar-image-mirror` service mirrors them asynchronously to `docker.io/grafana/k6`. The end-user pull path (`docker pull grafana/k6:…`) is unchanged.

## Why?

The shared org-wide Docker Hub credentials previously fetched from Vault by `dockerhub-login` have been disabled. The replacement is a short-lived, repo-scoped OIDC token minted via Workload Identity Federation, which can only push to a GAR staging repo provisioned per GitHub repository. This removes the long-lived shared Docker Hub password from the supply chain.

The matching `deployment_tools` change provisioned the GAR repo, the WIF binding for `grafana/k6`, and the mirror mapping (`dockerhub-k6-prod-mirror` → `docker.io/grafana`, images: `['k6']`). It was applied via Atlantis and verified (GAR repo + IAM bindings present, `ops-eu-south-0` Flux reconciled the mapping).

GHCR publishing is unchanged and continues to use `GITHUB_TOKEN`.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Matching deployment_tools PR: grafana/deployment_tools#599817
- Migration precedents (same `login-to-gar` pattern):
  - grafana/tempo#7243
  - grafana/alloy#6322
  - grafana/loki#22137
