### PR TITLE
Move Docker Hub publishing to GAR mirror (v1.x backport)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ permissions:
 
 env:
   APP_NAME: "k6"
-  DOCKER_IMAGE_ID: "grafana/k6"
+  DOCKER_IMAGE_ID: "us-docker.pkg.dev/grafanalabs-global/dockerhub-k6-prod-mirror/k6"
   GHCR_IMAGE_ID: ${{ github.repository }}
   DEFAULT_GO_VERSION: "1.26.x"
 
@@ -245,9 +245,11 @@ jobs:
           docker run $DOCKER_IMAGE_ID scale --help
           docker run $DOCKER_IMAGE_ID pause --help
           docker run $DOCKER_IMAGE_ID resume --help
-      - name: Login to DockerHub
+      - name: Login to GAR (Docker Hub mirror)
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
-        uses: grafana/shared-workflows/actions/dockerhub-login@081a366728379fd0426b9cfef190e9a21c2d5418 # dockerhub-login/v1.0.3
+        uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1
+        with:
+          registry: us-docker.pkg.dev
       - name: Login to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         env:


### PR DESCRIPTION
## What?

Backport of #6033 to the `v1.x` long-living maintenance branch. Same 5-line change: switch `.github/workflows/build.yml` from `dockerhub-login` to `login-to-gar`, and point `DOCKER_IMAGE_ID` at `us-docker.pkg.dev/grafanalabs-global/dockerhub-k6-prod-mirror/k6`. Images mirror asynchronously to `docker.io/grafana/k6` via the `gar-image-mirror` service. End-user pull path is unchanged.

## Why?

The shared org-wide Docker Hub credentials previously fetched from Vault by `dockerhub-login` have been disabled. Without this backport, any future v1 patch release (e.g. `v1.7.2`, `v1.8.0`) tagged off this branch or a `v1.X.x` sibling would fail at the "Login to DockerHub" step and never publish a `docker.io/grafana/k6:v1.x.x` image.

The matching GAR repo + WIF binding + mirror mapping in `deployment_tools` (PR grafana/deployment_tools#599817) was applied last week. The WIF principal is scoped per-repo, not per-branch, so the same binding that authorises master pushes also authorises tag pushes from `v1.x` or any `v1.X.x` branch — verified empirically by master push 1908adf8c2 publishing `:master` and `:master-with-browser` to GAR and onwards to Docker Hub.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- master PR being backported: #6033
- deployment_tools side (GAR repo + mirror mapping): grafana/deployment_tools#599817
