### PR TITLE
openspec: clarify struct shape, removal action, fix outputs

### DIFF
--- a/openspec/changes/add-feature-flags/design.md
+++ b/openspec/changes/add-feature-flags/design.md
@@ -43,6 +43,30 @@ Team consensus (Design Doc): flags declared as exported fields on a singleton st
 
 A build-time code generator emitting the struct from YAML was considered and rejected: it satisfies the same invariants but adds a `go generate` step and a separate source-of-truth file. Hand-written struct keeps definitions co-located with Go code. SDK-based and string-keyed strategies are excluded by D1.
 
+#### Struct shape
+
+Each flag is an exported `bool` field. Lifecycle stage, description, and optional name override are declared as struct tags on the same field:
+
+```go
+type Flags struct {
+    NativeHistograms bool `lifecycle:"experimental" help:"Use HDR histograms for built-in metrics"`
+    NewSummary       bool `lifecycle:"ga"           help:"Enable the new end-of-test summary format"`
+    OldCsvOutput     bool `lifecycle:"deprecated"   help:"Keep the legacy CSV output format" name:"old-csv"`
+}
+```
+
+Engine code gates on fields directly:
+
+```go
+if flags.NativeHistograms {
+    // experimental code path
+}
+```
+
+#### Canonical name derivation
+
+The bootstrapper derives the canonical kebab-case name from the Go field name by inserting a hyphen before each uppercase letter and lowercasing everything (e.g., `NativeHistograms` → `native-histograms`, `NewSummary` → `new-summary`). If a `name` struct tag is present, it overrides the derived name (e.g., `OldCsvOutput` with `name:"old-csv"` uses `old-csv` instead of `old-csv-output`). The resulting canonical name is validated against `^[a-z][a-z0-9]*(-[a-z0-9]+)*$`; a non-conforming name is a hard error at definition time.
+
 ### D3 — Winner-takes-all governs the activation set, not engine behavior
 A higher-priority *supplied* surface fully overrides lower ones (enables "disable by omission"). But `GA` features are forced on at startup regardless of the activation set; omitting a `GA` flag from the winning surface does not turn its behavior off.
 

--- a/openspec/changes/add-feature-flags/design.md
+++ b/openspec/changes/add-feature-flags/design.md
@@ -30,6 +30,7 @@ The chosen design is recorded in the stakeholder-approved Product DNA & Design D
 - **Lifecycle stages**: `Experimental` (gated path runs only if activated), `GA` (gated path runs unconditionally; activation only nudges removal via `INFO`), `Deprecated` (gated path runs only if activated; activation triggers `WARN`). `Unknown` is a runtime resolution outcome, not a definable stage.
 - **Lifecycle journey**: `Experimental` → `GA` → (grace) → removed, or `Experimental` → `Deprecated` → (grace) → removed. Registry removal is the forcing function.
 - **Grace periods**: flexible, default guidance 1–2 minor releases, delegated to the retiring maintainer, informed by telemetry.
+- **Removal action at gated sites**: when the struct field is deleted and the compiler flags each `if flags.X { ... }` site, the maintainer's action depends on how the feature ended. Adopted (was GA): keep the code inside the block, remove the `if` wrapper — the behavior is now unconditionally on. Abandoned (was Deprecated): delete the entire block — the behavior is being killed.
 - **Activation set**: canonical names honored for one run = winner-takes-all surface choice → within-env union → legacy-alias canonical substitution. Drives metric tags and telemetry.
 - **Resolution outcome**: each activation-set name is `Recognized` (matches registry → lifecycle log/behavior) or `Unknown` (`ERROR`, run continues, no contribution).
 

--- a/openspec/changes/add-feature-flags/specs/feature-flags/spec.md
+++ b/openspec/changes/add-feature-flags/specs/feature-flags/spec.md
@@ -205,6 +205,16 @@ The alias phase is independent of the canonical feature's lifecycle stage. The t
 - **GIVEN** a Phase-1 honored alias set to a truthy value
 - **THEN** the canonical feature activates, a `WARN` is emitted, and the run continues
 
+#### Scenario: Phase-1 alias with removed canonical errors and warns
+- **GIVEN** a Phase-1 honored alias `K6_FOO_ENABLED` maps to canonical `foo`
+- **AND** `foo` has been removed from the registry (maintainer has not yet moved alias to Phase 2)
+- **WHEN** `K6_FOO_ENABLED=true` is set
+- **THEN** the alias-side `WARN` is emitted (Phase-1 alias deprecation)
+- **AND** `foo` resolves as Unknown, an `ERROR` is emitted with `{ "feature": "foo", "outcome": "unknown", "source": "env_legacy_alias" }`
+- **AND** `foo` does not enter the activation set and the run continues
+
+Note: when removing a canonical from the registry, maintainers SHOULD move its Phase-1 aliases to Phase 2 (tombstoned) to avoid this transitional state.
+
 #### Scenario: Phase 2 tombstoned alias errors and continues
 - **GIVEN** a tombstoned alias env var is set
 - **THEN** an `ERROR` is emitted with a migration hint naming `--features` / `K6_FEATURES`, no feature is activated, and the run continues

--- a/openspec/changes/add-feature-flags/tasks.md
+++ b/openspec/changes/add-feature-flags/tasks.md
@@ -33,7 +33,7 @@
 ## 5. Observability — metrics tags & telemetry
 
 - [ ] 5.1 Emit sparse per-sample boolean tags `k6_feature_<name_snake>="true"` for activated features via existing tag machinery (kebab→snake for tag key only)
-- [ ] 5.2 Verify propagation across output formats (JSON, CSV, Prometheus RW, Cloud, StatsD, Datadog, Loki)
+- [ ] 5.2 Verify propagation across output formats (JSON, CSV, Prometheus RW, Cloud, StatsD, Datadog, InfluxDB, OpenTelemetry)
 - [ ] 5.3 Add resolved activation set (sorted canonical kebab-case names) to usage telemetry
 - [ ] 5.4 Unit/integration-test: GA-not-activated emits no tag/telemetry; legacy-alias activation reported once under canonical name
 


### PR DESCRIPTION
## What?

Fills gaps found during spec review that would slow down or confuse implementation.

- Adds the concrete struct definition, struct tag schema, and canonical name derivation rules to the design doc. Covers the CamelCase-to-kebab algorithm and the `name` tag override.
- Documents what a maintainer does at each compiler-flagged site when removing a feature: keep the code for adopted (GA) features, delete the block for abandoned (Deprecated) ones.
- Adds a scenario for a Phase-1 honored alias whose canonical was already removed from the registry, plus guidance to move aliases to Phase 2 on canonical removal.
- Replaces Loki with InfluxDB and OpenTelemetry in the output verification task. Loki is an xk6 extension, not a builtin output.

## Why?

The design doc described the struct strategy and the forcing function in prose but never showed what the struct looks like, how field names become kebab-case names, or what "remove the flag" means at each gated site. Someone implementing from the branch alone would have to guess the tag schema, the derivation algorithm, and whether to keep or delete the gated code.

## Related PR(s)/Issue(s)

Depends on #5964
Closes #5944
