### PR TITLE
Add v1.8.0 release notes

### DIFF
--- a/release notes/v1.8.0.md
+++ b/release notes/v1.8.0.md
@@ -1,0 +1,60 @@
+k6 `v1.8.0` is here! This maintenance release on v1.x includes:
+
+- Cloud secrets are now automatically available in `k6 cloud run --local-execution` — use `--no-cloud-secrets` to opt out.
+- Pre-manifest extension dependencies are captured in archive metadata for cloud consumers.
+- Structured logging from k6provider for better visibility into automatic extension provisioning.
+- Multiple bug fixes for Browser, WebSocket, and Cloud modules.
+- Dependency updates and reliability improvements.
+
+## Breaking changes
+
+There are no breaking changes in this release.
+
+## New features
+
+### Cloud secrets now automatically available in local execution [#5738](https://github.com/grafana/k6/pull/5738) & [#5875](https://github.com/grafana/k6/pull/5875)
+
+When running `k6 cloud run --local-execution`, secrets stored in Grafana Cloud are now automatically available to your script via `secrets.get()` without any additional configuration. 
+
+To opt out, pass `--no-cloud-secrets`:
+
+```shell
+k6 cloud run --local-execution --no-cloud-secrets script.js
+```
+
+Thanks, @vortegatorres!
+
+### Pre-manifest extension dependencies captured in archive metadata [#5819](https://github.com/grafana/k6/pull/5819) & [#5977](https://github.com/grafana/k6/pull/5977)
+
+When creating a k6 archive (`k6 archive`), extension dependency information is now captured in `metadata.json` under a `"dependencies"` field, using the constraints declared by the script before any external manifest overrides are applied. This ensures that `k6/x/` imports are preserved correctly during auto-extension-resolution re-execution.
+
+## UX improvements and enhancements
+
+- [#5815](https://github.com/grafana/k6/pull/5815) & [#5993](https://github.com/grafana/k6/pull/5993) Warns when `http.get()` or `http.head()` receive extra arguments that are silently ignored, helping catch common scripting mistakes. Thanks, @moko-poi!
+- [#5657](https://github.com/grafana/k6/pull/5657) Adds automatic retries to `newAction`-based Locator APIs in the browser module, improving reliability of browser tests. Thanks, @janHildebrandt98!
+- [#5845](https://github.com/grafana/k6/pull/5845) Wires k6provider's structured logging into k6's logger. Provisioning operations (artifact resolution, cache hits, downloads, retries, and cache pruning) now appear in k6's log output at the correct level.
+
+## Bug fixes
+
+- [#5855](https://github.com/grafana/k6/pull/5855) Fixes auto-extension-resolution incorrectly triggering binary provisioning when a script manifest specifies a dependency as a Go module pseudo-version (`v0.0.0+sha` or `v0.0.0-timestamp-sha`), even when the running binary already satisfied the constraint.
+- [#5574](https://github.com/grafana/k6/pull/5574) Fixes position parser for base pointer options. Thanks, @chrismooreproductions!
+- [#5630](https://github.com/grafana/k6/pull/5630) & [#5987](https://github.com/grafana/k6/pull/5987) Fixes duplicate redirect request metric emissions in the browser module, where each redirect was incorrectly emitting metrics for all prior redirects in the chain.
+- [#5620](https://github.com/grafana/k6/pull/5620) & [#5991](https://github.com/grafana/k6/pull/5991) Preserves context cancellation causes across the scheduler, browser, and secret-source layers, improving the accuracy of error messages surfaced when a test is interrupted. Thanks, @LBaronceli!
+- [#5716](https://github.com/grafana/k6/pull/5716) & [#5990](https://github.com/grafana/k6/pull/5990) Fixes WebSocket `bufferedAmount` not being incremented when sending TypedArrays, causing it to go negative. Thanks, @prakharbirla-ng!
+- [#5814](https://github.com/grafana/k6/pull/5814) & [#5975](https://github.com/grafana/k6/pull/5975) Fixes `k6 cloud run --local-execution` ignoring `K6_CLOUD_PUSH_REF_ID` and unconditionally creating a new test run instead of reusing the provided run ID. Thanks, @Reranko05!
+- [#5786](https://github.com/grafana/k6/pull/5786) Fixes swapped Min and Max values for Gauge metrics in Cloud output v2, which caused incorrect peak and floor values in cloud test result queries. Thanks, @esquonk!
+- [#5785](https://github.com/grafana/k6/pull/5785) Fixes a race condition in the browser module's `handleExitEvent` where `Done()` was signalled before the subscription was removed, causing tests to hang until the timeout.
+- [#5905](https://github.com/grafana/k6/pull/5905) Fixes a deadlock where WebSocket connections hang forever during teardown when the server sends pings. A server ping arriving during shutdown could permanently stall the k6 process.
+- [#5923](https://github.com/grafana/k6/pull/5923) & [#5989](https://github.com/grafana/k6/pull/5989) Fixes a nil pointer panic in `ElementHandle.DefaultTimeout` (and any method that calls it, such as `GetAttribute`) when invoked on a nil or partially-initialized handle. Thanks, @SAY-5!
+
+## Maintenance and internal improvements
+
+- [#5896](https://github.com/grafana/k6/pull/5896) & [#5897](https://github.com/grafana/k6/pull/5897) Updates `go.opentelemetry.io/otel/exporters/otlp/otlptracehttp` and `otlpmetrichttp` to `v1.43.0` [security], adding a 4 MiB response body cap to mitigate memory exhaustion from misconfigured or malicious servers.
+- [#5857](https://github.com/grafana/k6/pull/5857), [#5950](https://github.com/grafana/k6/pull/5950) Updates Go to `v1.25.10`.
+- [#5863](https://github.com/grafana/k6/pull/5863), [#5880](https://github.com/grafana/k6/pull/5880), [#5908](https://github.com/grafana/k6/pull/5908) Updates `github.com/grafana/k6provider` to `v0.5.0`.
+- [#5740](https://github.com/grafana/k6/pull/5740), [#5796](https://github.com/grafana/k6/pull/5796), [#5910](https://github.com/grafana/k6/pull/5910) Updates `github.com/grafana/sobek` digest.
+- [#6035](https://github.com/grafana/k6/pull/6035) Move Docker Hub publishing to GAR mirror.
+
+## External contributors
+
+A huge thank you to the external contributors who helped during this release: @moko-poi, @janHildebrandt98, @Reranko05, @prakharbirla-ng, @esquonk, @chrismooreproductions, @vortegatorres, @SAY-5, and @LBaronceli! 🙏

--- a/release notes/v1.8.0.md
+++ b/release notes/v1.8.0.md
@@ -51,9 +51,13 @@ When creating a k6 archive (`k6 archive`), extension dependency information is n
 
 - [#5896](https://github.com/grafana/k6/pull/5896) & [#5897](https://github.com/grafana/k6/pull/5897) Updates `go.opentelemetry.io/otel/exporters/otlp/otlptracehttp` and `otlpmetrichttp` to `v1.43.0` [security], adding a 4 MiB response body cap to mitigate memory exhaustion from misconfigured or malicious servers.
 - [#5857](https://github.com/grafana/k6/pull/5857), [#5950](https://github.com/grafana/k6/pull/5950) Updates Go to `v1.25.10`.
+- [#5946](https://github.com/grafana/k6/pull/5946) Updates `golang.org/x/net` to `v0.55.0` [security].
+- [#6042](https://github.com/grafana/k6/pull/6042) Updates Go toolchain to `v1.25.11` [security].
+- [#6047](https://github.com/grafana/k6/pull/6047) Updates `golang.org/x/crypto` to `v0.52.0` [security].
 - [#5863](https://github.com/grafana/k6/pull/5863), [#5880](https://github.com/grafana/k6/pull/5880), [#5908](https://github.com/grafana/k6/pull/5908) Updates `github.com/grafana/k6provider` to `v0.5.0`.
 - [#5740](https://github.com/grafana/k6/pull/5740), [#5796](https://github.com/grafana/k6/pull/5796), [#5910](https://github.com/grafana/k6/pull/5910) Updates `github.com/grafana/sobek` digest.
 - [#6035](https://github.com/grafana/k6/pull/6035) Move Docker Hub publishing to GAR mirror.
+- [#6064](https://github.com/grafana/k6/pull/6064) Bumps Dockerfile images for security updates.
 
 ## External contributors
 


### PR DESCRIPTION
## Summary

This PR adds release notes for k6 `v1.8.0`, a maintenance release on the v1.x line.

v1.8.0 includes several improvements:

- Cloud secrets are now automatically available in `k6 cloud run --local-execution` — use `--no-cloud-secrets` to opt out.
- Pre-manifest extension dependencies are captured in archive metadata for cloud consumers.
- Structured logging from k6provider for better visibility into automatic extension provisioning.
- Multiple bug fixes for Browser, WebSocket, and Cloud modules.
- Dependency updates and reliability improvements.

## Changes

The release notes document:

- **New features**: Cloud secret source automatic availability (#5738, #5875), and pre-manifest extension dependencies in archive metadata (#5819, #5977)
- **UX improvements**: HTTP argument validation warnings, Browser locator API retries, structured logging integration
- **Bug fixes**: 9 bug fixes across Browser, WebSocket, Cloud, and auto-extension-resolution modules
- **Maintenance**: Updates to OTel exporters, Go, k6provider, and Sobek

## Contributors

This release was improved by contributions from:
@moko-poi, @janHildebrandt98, @Reranko05, @prakharbirla-ng, @esquonk, @chrismooreproductions, @vortegatorres, @SAY-5, and @LBaronceli. 🙏

## Test plan

- [x] Release notes file created at `release notes/v1.8.0.md`
- [x] All PR links verified and formatted correctly
- [x] External contributors credited
- [x] Markdown formatting validated

🤖 Generated with [Claude Code](https://claude.com/claude-code)