### PR TITLE
chore: align go directive and toolchain to 1.25.0 / 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module go.k6.io/k6/v2
 
-go 1.25.11
+go 1.25.0
+
+toolchain go1.25.11
 
 require (
 	buf.build/gen/go/prometheus/prometheus/protocolbuffers/go v1.36.11-20260331160422-eae785f0a21d.1


### PR DESCRIPTION
## Summary
Align `go.mod` to `go 1.25.0` and `toolchain go1.25.11` to match the k6-core baseline.

## Test plan
- [ ] `go mod tidy` is clean
- [ ] CI passes