### PR TITLE
Feature flags (1/2): definition and resolution library

### DIFF
--- a/internal/features/aliases.go
+++ b/internal/features/aliases.go
@@ -1,0 +1,78 @@
+package features
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/sirupsen/logrus"
+)
+
+type aliasPhase int
+
+const (
+	honored aliasPhase = iota
+	tombstoned
+	removed
+)
+
+type alias struct {
+	EnvVar    string
+	Canonical string
+	Phase     aliasPhase
+}
+
+func defaultAliases() []alias {
+	return nil
+}
+
+func registerAlias(defs *definitions, a alias) error {
+	if !kebabRe.MatchString(a.Canonical) {
+		return fmt.Errorf("alias %s: canonical name %q is not valid kebab-case", a.EnvVar, a.Canonical)
+	}
+	for _, existing := range defs.aliases {
+		if existing.EnvVar == a.EnvVar {
+			return fmt.Errorf("alias %s: already registered", a.EnvVar)
+		}
+	}
+	defs.aliases = append(defs.aliases, a)
+	return nil
+}
+
+func resolveEnvAliases(defs *definitions,
+	env map[string]string, logger logrus.FieldLogger,
+) (names []string, supplied bool, aliasOf map[string]string) {
+	aliasOf = make(map[string]string)
+	for _, a := range defs.aliases {
+		val, set := env[a.EnvVar]
+		if !set {
+			continue
+		}
+
+		switch a.Phase {
+		case honored:
+			if b, err := strconv.ParseBool(val); err != nil || !b {
+				continue
+			}
+			names = append(names, a.Canonical)
+			aliasOf[a.Canonical] = a.EnvVar
+			supplied = true
+		}
+	}
+
+	return names, supplied, aliasOf
+}
+
+func resolveEnvSurface(defs *definitions, osEnv map[string]string, logger logrus.FieldLogger) Source {
+	names, aliasSupplied, aliasOf := resolveEnvAliases(defs, osEnv, logger)
+
+	k6Features, k6FeaturesSet := osEnv["K6_FEATURES"]
+	if k6FeaturesSet {
+		names = append(names, k6Features)
+	}
+
+	return Source{
+		Values:   names,
+		Supplied: k6FeaturesSet || aliasSupplied,
+		aliasOf:  aliasOf,
+	}
+}

--- a/internal/features/aliases.go
+++ b/internal/features/aliases.go
@@ -56,6 +56,15 @@ func resolveEnvAliases(defs *definitions,
 			names = append(names, a.Canonical)
 			aliasOf[a.Canonical] = a.EnvVar
 			supplied = true
+
+		case tombstoned:
+			logger.WithFields(logrus.Fields{
+				"env":     a.EnvVar,
+				"source":  "env_tombstoned_alias",
+				"outcome": "unknown",
+			}).Error("Legacy env var is no longer supported, use --features or K6_FEATURES instead")
+
+		case removed:
 		}
 	}
 

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strings"
 	"unicode"
+
+	"github.com/sirupsen/logrus"
 )
 
 // Lifecycle represents the maturity stage of a feature flag.
@@ -72,12 +74,44 @@ func All() ([]Flag, error) {
 	return allOf(reflect.TypeFor[Flags]())
 }
 
+// Init resolves the surfaces and returns the typed flags.
+func Init(
+	logger logrus.FieldLogger, cli, json Source, runtimeEnv map[string]string,
+) (*Flags, error) {
+	flags := &Flags{}
+	active, err := initInto(reflect.ValueOf(flags).Elem(), logger, cli, json, runtimeEnv, defaultAliases())
+	if err != nil {
+		return nil, err
+	}
+
+	flags.activated = active
+	return flags, nil
+}
+
 func allOf(t reflect.Type) ([]Flag, error) {
 	defs, err := parseDefinitions(t)
 	if err != nil {
 		return nil, err
 	}
 	return allDefinitions(defs), nil
+}
+
+func initInto(
+	target reflect.Value, logger logrus.FieldLogger, cli, json Source,
+	runtimeEnv map[string]string, aliases []alias,
+) ([]string, error) {
+	defs, err := parseDefinitions(target.Type())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, a := range aliases {
+		if err := registerAlias(defs, a); err != nil {
+			return nil, err
+		}
+	}
+
+	return resolveInto(defs, target, cli, resolveEnvSurface(defs, runtimeEnv, logger), json, logger)
 }
 
 // definition holds the parsed metadata and field index for one flag field.
@@ -91,6 +125,7 @@ type definitions struct {
 	typ         reflect.Type
 	definitions []definition
 	byName      map[string]int
+	aliases     []alias
 }
 
 var kebabRe = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`)

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -41,6 +41,23 @@ type Flags struct {
 	activated []string
 }
 
+// Activated returns a copy of the sorted canonical names of active features.
+func (f *Flags) Activated() []string {
+	out := make([]string, len(f.activated))
+	copy(out, f.activated)
+	return out
+}
+
+// Tags returns per-flag metric tags (k6_feature_<snake>="true") for active features.
+func (f *Flags) Tags() map[string]string {
+	tags := make(map[string]string, len(f.activated))
+	for _, name := range f.activated {
+		snake := strings.ReplaceAll(name, "-", "_")
+		tags["k6_feature_"+snake] = "true"
+	}
+	return tags
+}
+
 // Flag is a single feature flag's metadata.
 type Flag struct {
 	Name        string

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -2,9 +2,11 @@
 package features
 
 import (
+	"cmp"
 	"fmt"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 	"unicode"
 )
@@ -63,6 +65,19 @@ type Flag struct {
 	Name        string
 	Lifecycle   Lifecycle
 	Description string
+}
+
+// All returns flags sorted for display: Experimental, Deprecated, GA, then by name.
+func All() ([]Flag, error) {
+	return allOf(reflect.TypeFor[Flags]())
+}
+
+func allOf(t reflect.Type) ([]Flag, error) {
+	defs, err := parseDefinitions(t)
+	if err != nil {
+		return nil, err
+	}
+	return allDefinitions(defs), nil
 }
 
 // definition holds the parsed metadata and field index for one flag field.
@@ -163,6 +178,33 @@ func parseDefinitions(t reflect.Type) (*definitions, error) {
 	}
 
 	return ds, nil
+}
+
+func lifecycleOrder(l Lifecycle) int {
+	switch l {
+	case Experimental:
+		return 0
+	case Deprecated:
+		return 1
+	case GA:
+		return 2
+	default:
+		return 3
+	}
+}
+
+func allDefinitions(defs *definitions) []Flag {
+	out := make([]Flag, len(defs.definitions))
+	for i, def := range defs.definitions {
+		out[i] = def.flag
+	}
+	slices.SortFunc(out, func(a, b Flag) int {
+		if c := cmp.Compare(lifecycleOrder(a.Lifecycle), lifecycleOrder(b.Lifecycle)); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Name, b.Name)
+	})
+	return out
 }
 
 // noCopy prevents Flags from being copied by value.

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -1,0 +1,155 @@
+// Package features implements a feature flag system for k6.
+package features
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// Lifecycle represents the maturity stage of a feature flag.
+type Lifecycle int
+
+const (
+	// Experimental flags are opt-in and may change without notice.
+	Experimental Lifecycle = iota
+	// GA flags are generally available and enabled by default.
+	GA
+	// Deprecated flags are scheduled for removal.
+	Deprecated
+)
+
+// String returns the title-case lifecycle name.
+func (l Lifecycle) String() string {
+	switch l {
+	case Experimental:
+		return "Experimental"
+	case GA:
+		return "GA"
+	case Deprecated:
+		return "Deprecated"
+	default:
+		return "Unknown"
+	}
+}
+
+// Flags declares every feature flag as a tagged bool field.
+type Flags struct {
+	_         noCopy
+	activated []string
+}
+
+// Flag is a single feature flag's metadata.
+type Flag struct {
+	Name        string
+	Lifecycle   Lifecycle
+	Description string
+}
+
+// definition holds the parsed metadata and field index for one flag field.
+type definition struct {
+	flag  Flag
+	index []int
+}
+
+// definitions holds parsed flag metadata for a specific struct type.
+type definitions struct {
+	typ         reflect.Type
+	definitions []definition
+	byName      map[string]int
+}
+
+var kebabRe = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z0-9]+)*$`)
+
+func deriveKebabName(fieldName string) string {
+	var b strings.Builder
+	for i, r := range fieldName {
+		if unicode.IsUpper(r) && i > 0 {
+			b.WriteByte('-')
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}
+
+func parseLifecycle(s string) (Lifecycle, bool) {
+	switch s {
+	case "experimental":
+		return Experimental, true
+	case "ga":
+		return GA, true
+	case "deprecated":
+		return Deprecated, true
+	default:
+		return 0, false
+	}
+}
+
+// parseDefinitions reflects over a struct type to build a definitions.
+func parseDefinitions(t reflect.Type) (*definitions, error) {
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("features: parseDefinitions requires a struct type, got %s", t.Kind())
+	}
+
+	ds := &definitions{
+		typ:    t,
+		byName: make(map[string]int),
+	}
+
+	for i := range t.NumField() {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+		if f.Type.Kind() != reflect.Bool {
+			return nil, fmt.Errorf("field %s: feature flags must be bool, got %s", f.Name, f.Type.Kind())
+		}
+
+		lcTag, ok := f.Tag.Lookup("lifecycle")
+		if !ok {
+			return nil, fmt.Errorf("field %s: missing lifecycle tag", f.Name)
+		}
+		lc, valid := parseLifecycle(lcTag)
+		if !valid {
+			return nil, fmt.Errorf("field %s: invalid lifecycle %q", f.Name, lcTag)
+		}
+
+		help := f.Tag.Get("help")
+		if help == "" {
+			return nil, fmt.Errorf("field %s: missing or empty help tag", f.Name)
+		}
+
+		name := f.Tag.Get("name")
+		if name == "" {
+			name = deriveKebabName(f.Name)
+		}
+		if !kebabRe.MatchString(name) {
+			return nil, fmt.Errorf("field %s: name %q is not valid kebab-case", f.Name, name)
+		}
+
+		if _, exists := ds.byName[name]; exists {
+			return nil, fmt.Errorf("field %s: duplicate canonical name %q", f.Name, name)
+		}
+
+		idx := len(ds.definitions)
+		ds.definitions = append(ds.definitions, definition{
+			flag: Flag{
+				Name:        name,
+				Lifecycle:   lc,
+				Description: help,
+			},
+			index: f.Index,
+		})
+		ds.byName[name] = idx
+	}
+
+	return ds, nil
+}
+
+// noCopy prevents Flags from being copied by value.
+type noCopy struct{}
+
+func (*noCopy) Lock()   {}
+func (*noCopy) Unlock() {}

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -148,6 +149,11 @@ func TestResolveFeatures(t *testing.T) {
 			wantActive: []string{},
 			wantFlags:  testFlags{Gamma: true},
 		},
+		{
+			name:       "no surface activates only ga fields",
+			wantActive: []string{},
+			wantFlags:  testFlags{Gamma: true},
+		},
 	}
 
 	for _, tt := range tests {
@@ -158,6 +164,33 @@ func TestResolveFeatures(t *testing.T) {
 
 			assert.Equal(t, tt.wantActive, active)
 			assert.Equal(t, tt.wantFlags, *flags)
+		})
+	}
+}
+
+func TestResolveLogs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		feature   string
+		wantLevel logrus.Level
+		lifecycle string
+	}{
+		{name: "experimental", feature: "alpha", wantLevel: logrus.InfoLevel, lifecycle: "experimental"},
+		{name: "ga", feature: "gamma", wantLevel: logrus.InfoLevel, lifecycle: "ga"},
+		{name: "deprecated", feature: "delta", wantLevel: logrus.WarnLevel, lifecycle: "deprecated"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			hook := resolveTestLogs(t, supplied(tt.feature), Source{}, Source{})
+
+			entry := assertSingleLog(t, hook, tt.wantLevel)
+			assert.Equal(t, tt.feature, entry.Data["feature"])
+			assert.Equal(t, tt.lifecycle, entry.Data["lifecycle"])
 		})
 	}
 }
@@ -178,4 +211,30 @@ func resolveTestFlags(t *testing.T, cli, env, json Source) (*testFlags, []string
 	require.NoError(t, err)
 
 	return flags, activated
+}
+
+func resolveTestLogs(t *testing.T, cli, env, json Source) *logtest.Hook {
+	t.Helper()
+
+	defs, err := parseDefinitions(reflect.TypeFor[testFlags]())
+	require.NoError(t, err)
+
+	flags := &testFlags{}
+	logger, hook := logtest.NewNullLogger()
+	_, err = resolveInto(defs, reflect.ValueOf(flags).Elem(), cli, env, json, logger)
+	require.NoError(t, err)
+
+	return hook
+}
+
+func assertSingleLog(t *testing.T, hook *logtest.Hook, level logrus.Level) *logrus.Entry {
+	t.Helper()
+
+	entries := hook.AllEntries()
+	require.Len(t, entries, 1)
+
+	entry := entries[0]
+	assert.Equal(t, level, entry.Level)
+
+	return entry
 }

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -1,0 +1,114 @@
+package features
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testFlags struct {
+	Alpha bool `lifecycle:"experimental" help:"a"`
+	Beta  bool `lifecycle:"experimental" help:"b"`
+	Gamma bool `lifecycle:"ga" help:"g"`
+	Delta bool `lifecycle:"deprecated" help:"d"`
+}
+
+func TestFeatureDefinitionNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+		want string
+	}{
+		{
+			name: "camel case",
+			typ: reflect.TypeOf(struct {
+				MultiWordFeature bool `lifecycle:"experimental" help:"x"`
+			}{}),
+			want: "multi-word-feature",
+		},
+		{
+			name: "name override",
+			typ: reflect.TypeOf(struct {
+				HTTPCache bool `lifecycle:"experimental" help:"x" name:"http-cache"`
+			}{}),
+			want: "http-cache",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			defs, err := parseDefinitions(tt.typ)
+			require.NoError(t, err)
+
+			require.Len(t, defs.definitions, 1)
+			assert.Equal(t, tt.want, defs.definitions[0].flag.Name)
+		})
+	}
+}
+
+func TestFeatureDefinitionsRejectInvalidStructs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+	}{
+		{
+			name: "non struct",
+			typ:  reflect.TypeFor[int](),
+		},
+		{
+			name: "non bool field",
+			typ: reflect.TypeOf(struct {
+				Foo string `lifecycle:"experimental" help:"x"`
+			}{}),
+		},
+		{
+			name: "missing lifecycle",
+			typ: reflect.TypeOf(struct {
+				Foo bool `help:"x"`
+			}{}),
+		},
+		{
+			name: "invalid lifecycle",
+			typ: reflect.TypeOf(struct {
+				Foo bool `lifecycle:"beta" help:"x"`
+			}{}),
+		},
+		{
+			name: "missing help",
+			typ: reflect.TypeOf(struct {
+				Foo bool `lifecycle:"experimental"`
+			}{}),
+		},
+		{
+			name: "invalid name",
+			typ: reflect.TypeOf(struct {
+				Foo bool `lifecycle:"experimental" help:"x" name:"Bad-Name"`
+			}{}),
+		},
+		{
+			name: "duplicate name",
+			typ: reflect.TypeOf(struct {
+				Foo bool `lifecycle:"experimental" help:"x" name:"dup"`
+				Bar bool `lifecycle:"experimental" help:"y" name:"dup"`
+			}{}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseDefinitions(tt.typ)
+
+			assert.Error(t, err)
+		})
+	}
+}

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -131,14 +131,14 @@ func TestResolveFeatures(t *testing.T) {
 			env:        supplied("beta"),
 			json:       supplied("delta"),
 			wantActive: []string{"alpha"},
-			wantFlags:  testFlags{Alpha: true},
+			wantFlags:  testFlags{Alpha: true, Gamma: true},
 		},
 		{
 			name:       "env wins over json and splits values",
 			env:        supplied(" alpha, beta,, "),
 			json:       supplied("delta"),
 			wantActive: []string{"alpha", "beta"},
-			wantFlags:  testFlags{Alpha: true, Beta: true},
+			wantFlags:  testFlags{Alpha: true, Beta: true, Gamma: true},
 		},
 		{
 			name:       "empty supplied cli clears lower surfaces",
@@ -146,7 +146,7 @@ func TestResolveFeatures(t *testing.T) {
 			env:        supplied("alpha"),
 			json:       supplied("beta"),
 			wantActive: []string{},
-			wantFlags:  testFlags{},
+			wantFlags:  testFlags{Gamma: true},
 		},
 	}
 

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -154,6 +154,12 @@ func TestResolveFeatures(t *testing.T) {
 			wantActive: []string{},
 			wantFlags:  testFlags{Gamma: true},
 		},
+		{
+			name:       "unknown names stay inactive",
+			cli:        supplied("not-a-flag"),
+			wantActive: []string{},
+			wantFlags:  testFlags{Gamma: true},
+		},
 	}
 
 	for _, tt := range tests {
@@ -193,6 +199,17 @@ func TestResolveLogs(t *testing.T) {
 			assert.Equal(t, tt.lifecycle, entry.Data["lifecycle"])
 		})
 	}
+}
+
+func TestResolveLogsUnknownNames(t *testing.T) {
+	t.Parallel()
+
+	hook := resolveTestLogs(t, supplied("not-a-flag"), Source{}, Source{})
+
+	entry := assertSingleLog(t, hook, logrus.ErrorLevel)
+	assert.Equal(t, "not-a-flag", entry.Data["feature"])
+	assert.Equal(t, "unknown", entry.Data["outcome"])
+	assert.Equal(t, "cli", entry.Data["source"])
 }
 
 func supplied(v ...string) Source {

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -261,6 +261,20 @@ func TestInitIntoResolvesAliases(t *testing.T) {
 			wantActive: []string{},
 			wantFlags:  testFlags{Gamma: true},
 		},
+		{
+			name:       "tombstoned alias does not activate",
+			env:        map[string]string{aliasEnv: "true"},
+			aliases:    []alias{{EnvVar: aliasEnv, Canonical: "alpha", Phase: tombstoned}},
+			wantActive: []string{},
+			wantFlags:  testFlags{Gamma: true},
+		},
+		{
+			name:       "removed alias is ignored",
+			env:        map[string]string{aliasEnv: "true"},
+			aliases:    []alias{{EnvVar: aliasEnv, Canonical: "alpha", Phase: removed}},
+			wantActive: []string{},
+			wantFlags:  testFlags{Gamma: true},
+		},
 	}
 
 	for _, tt := range tests {
@@ -290,6 +304,41 @@ func TestInitIntoLogsAliases(t *testing.T) {
 	info := entryByLevel(t, hook, logrus.InfoLevel)
 	assert.Equal(t, "alpha", info.Data["feature"])
 	assert.Equal(t, "experimental", info.Data["lifecycle"])
+}
+
+func TestInitIntoLogsRetiredAliases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tombstoned", func(t *testing.T) {
+		t.Parallel()
+
+		hook := runTestInitForLogs(t, Source{}, map[string]string{aliasEnv: "true"},
+			[]alias{{EnvVar: aliasEnv, Canonical: "alpha", Phase: tombstoned}})
+
+		entry := assertSingleLog(t, hook, logrus.ErrorLevel)
+		assert.Equal(t, aliasEnv, entry.Data["env"])
+		assert.Equal(t, "env_tombstoned_alias", entry.Data["source"])
+		assert.Equal(t, "unknown", entry.Data["outcome"])
+	})
+
+	t.Run("dangling", func(t *testing.T) {
+		t.Parallel()
+
+		hook := runTestInitForLogs(t, Source{}, map[string]string{aliasEnv: "true"},
+			[]alias{{EnvVar: aliasEnv, Canonical: "gone-feature", Phase: honored}})
+
+		warn := entryByLevel(t, hook, logrus.WarnLevel)
+		assert.Equal(t, "gone-feature", warn.Data["feature"])
+		assert.Equal(t, "env_legacy_alias", warn.Data["source"])
+		assert.Equal(t, "deprecated_alias", warn.Data["lifecycle"])
+		assert.Equal(t, aliasEnv, warn.Data["env"])
+
+		errEntry := entryByLevel(t, hook, logrus.ErrorLevel)
+		assert.Equal(t, "gone-feature", errEntry.Data["feature"])
+		assert.Equal(t, "unknown", errEntry.Data["outcome"])
+		assert.Equal(t, "env_legacy_alias", errEntry.Data["source"])
+		assert.Equal(t, aliasEnv, errEntry.Data["env"])
+	})
 }
 
 func supplied(v ...string) Source {

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -17,6 +17,8 @@ type testFlags struct {
 	Delta bool `lifecycle:"deprecated" help:"d"`
 }
 
+const aliasEnv = "K6_TEST_ALIAS"
+
 func TestFeatureDefinitionNames(t *testing.T) {
 	t.Parallel()
 
@@ -226,6 +228,70 @@ func TestResolveLogsUnknownNames(t *testing.T) {
 	assert.Equal(t, "cli", entry.Data["source"])
 }
 
+func TestInitIntoResolvesAliases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cli        Source
+		env        map[string]string
+		aliases    []alias
+		wantActive []string
+		wantFlags  testFlags
+	}{
+		{
+			name:       "honored alias activates when env wins",
+			env:        map[string]string{aliasEnv: "true"},
+			aliases:    []alias{{EnvVar: aliasEnv, Canonical: "alpha", Phase: honored}},
+			wantActive: []string{"alpha"},
+			wantFlags:  testFlags{Alpha: true, Gamma: true},
+		},
+		{
+			name:       "cli wins over alias env",
+			cli:        supplied("beta"),
+			env:        map[string]string{aliasEnv: "true"},
+			aliases:    []alias{{EnvVar: aliasEnv, Canonical: "alpha", Phase: honored}},
+			wantActive: []string{"beta"},
+			wantFlags:  testFlags{Beta: true, Gamma: true},
+		},
+		{
+			name:       "dangling alias canonical stays inactive",
+			env:        map[string]string{aliasEnv: "true"},
+			aliases:    []alias{{EnvVar: aliasEnv, Canonical: "gone-feature", Phase: honored}},
+			wantActive: []string{},
+			wantFlags:  testFlags{Gamma: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			flags, active := runTestInit(t, tt.cli, Source{}, tt.env, tt.aliases)
+
+			assert.Equal(t, tt.wantActive, active)
+			assert.Equal(t, tt.wantFlags, *flags)
+		})
+	}
+}
+
+func TestInitIntoLogsAliases(t *testing.T) {
+	t.Parallel()
+
+	hook := runTestInitForLogs(t, Source{}, map[string]string{aliasEnv: "true"},
+		[]alias{{EnvVar: aliasEnv, Canonical: "alpha", Phase: honored}})
+
+	warn := entryByLevel(t, hook, logrus.WarnLevel)
+	assert.Equal(t, "alpha", warn.Data["feature"])
+	assert.Equal(t, "env_legacy_alias", warn.Data["source"])
+	assert.Equal(t, "deprecated_alias", warn.Data["lifecycle"])
+	assert.Equal(t, aliasEnv, warn.Data["env"])
+
+	info := entryByLevel(t, hook, logrus.InfoLevel)
+	assert.Equal(t, "alpha", info.Data["feature"])
+	assert.Equal(t, "experimental", info.Data["lifecycle"])
+}
+
 func supplied(v ...string) Source {
 	return Source{Values: v, Supplied: true}
 }
@@ -242,6 +308,30 @@ func resolveTestFlags(t *testing.T, cli, env, json Source) (*testFlags, []string
 	require.NoError(t, err)
 
 	return flags, activated
+}
+
+func runTestInit(
+	t *testing.T, cli, json Source, env map[string]string, aliases []alias,
+) (*testFlags, []string) {
+	t.Helper()
+
+	flags := &testFlags{}
+	logger, _ := logtest.NewNullLogger()
+	active, err := initInto(reflect.ValueOf(flags).Elem(), logger, cli, json, env, aliases)
+	require.NoError(t, err)
+
+	return flags, active
+}
+
+func runTestInitForLogs(t *testing.T, cli Source, env map[string]string, aliases []alias) *logtest.Hook {
+	t.Helper()
+
+	flags := &testFlags{}
+	logger, hook := logtest.NewNullLogger()
+	_, err := initInto(reflect.ValueOf(flags).Elem(), logger, cli, Source{}, env, aliases)
+	require.NoError(t, err)
+
+	return hook
 }
 
 func resolveTestLogs(t *testing.T, cli, env, json Source) *logtest.Hook {
@@ -268,4 +358,18 @@ func assertSingleLog(t *testing.T, hook *logtest.Hook, level logrus.Level) *logr
 	assert.Equal(t, level, entry.Level)
 
 	return entry
+}
+
+func entryByLevel(t *testing.T, hook *logtest.Hook, level logrus.Level) *logrus.Entry {
+	t.Helper()
+
+	var found *logrus.Entry
+	for _, e := range hook.AllEntries() {
+		if e.Level == level {
+			require.Nil(t, found, "more than one %s entry", level)
+			found = e
+		}
+	}
+	require.NotNil(t, found, "no %s entry found", level)
+	return found
 }

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -115,6 +115,20 @@ func TestFeatureDefinitionsRejectInvalidStructs(t *testing.T) {
 	}
 }
 
+func TestFeatureDefinitions(t *testing.T) {
+	t.Parallel()
+
+	flags, err := allOf(reflect.TypeFor[testFlags]())
+	require.NoError(t, err)
+
+	assert.Equal(t, []Flag{
+		{Name: "alpha", Lifecycle: Experimental, Description: "a"},
+		{Name: "beta", Lifecycle: Experimental, Description: "b"},
+		{Name: "delta", Lifecycle: Deprecated, Description: "d"},
+		{Name: "gamma", Lifecycle: GA, Description: "g"},
+	}, flags)
+}
+
 func TestResolveFeatures(t *testing.T) {
 	t.Parallel()
 

--- a/internal/features/features_test.go
+++ b/internal/features/features_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	logtest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -111,4 +112,70 @@ func TestFeatureDefinitionsRejectInvalidStructs(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+func TestResolveFeatures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cli        Source
+		env        Source
+		json       Source
+		wantActive []string
+		wantFlags  testFlags
+	}{
+		{
+			name:       "cli wins over env and json",
+			cli:        supplied("alpha"),
+			env:        supplied("beta"),
+			json:       supplied("delta"),
+			wantActive: []string{"alpha"},
+			wantFlags:  testFlags{Alpha: true},
+		},
+		{
+			name:       "env wins over json and splits values",
+			env:        supplied(" alpha, beta,, "),
+			json:       supplied("delta"),
+			wantActive: []string{"alpha", "beta"},
+			wantFlags:  testFlags{Alpha: true, Beta: true},
+		},
+		{
+			name:       "empty supplied cli clears lower surfaces",
+			cli:        Source{Supplied: true},
+			env:        supplied("alpha"),
+			json:       supplied("beta"),
+			wantActive: []string{},
+			wantFlags:  testFlags{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			flags, active := resolveTestFlags(t, tt.cli, tt.env, tt.json)
+
+			assert.Equal(t, tt.wantActive, active)
+			assert.Equal(t, tt.wantFlags, *flags)
+		})
+	}
+}
+
+func supplied(v ...string) Source {
+	return Source{Values: v, Supplied: true}
+}
+
+func resolveTestFlags(t *testing.T, cli, env, json Source) (*testFlags, []string) {
+	t.Helper()
+
+	defs, err := parseDefinitions(reflect.TypeFor[testFlags]())
+	require.NoError(t, err)
+
+	flags := &testFlags{}
+	logger, _ := logtest.NewNullLogger()
+	activated, err := resolveInto(defs, reflect.ValueOf(flags).Elem(), cli, env, json, logger)
+	require.NoError(t, err)
+
+	return flags, activated
 }

--- a/internal/features/resolve.go
+++ b/internal/features/resolve.go
@@ -14,6 +14,7 @@ import (
 type Source struct {
 	Values   []string
 	Supplied bool
+	aliasOf  map[string]string
 }
 
 func parseInput(raw string) []string {
@@ -60,13 +61,30 @@ func resolveInto(defs *definitions,
 		}
 		seen[name] = struct{}{}
 
+		// alias WARN fires here, not at parse time: only now has env won
+		nameSource := source
+		envVar, viaAlias := winner.aliasOf[name]
+		if viaAlias {
+			nameSource = "env_legacy_alias"
+			logger.WithFields(logrus.Fields{
+				"feature":   name,
+				"env":       envVar,
+				"source":    "env_legacy_alias",
+				"lifecycle": "deprecated_alias",
+			}).Warn("Legacy env var detected, use --features or K6_FEATURES instead")
+		}
+
 		idx, known := defs.byName[name]
 		if !known {
-			logger.WithFields(logrus.Fields{
+			fields := logrus.Fields{
 				"feature": name,
 				"outcome": "unknown",
-				"source":  source,
-			}).Error("Unknown feature flag")
+				"source":  nameSource,
+			}
+			if viaAlias {
+				fields["env"] = envVar
+			}
+			logger.WithFields(fields).Error("Unknown feature flag")
 			continue
 		}
 

--- a/internal/features/resolve.go
+++ b/internal/features/resolve.go
@@ -37,14 +37,15 @@ func resolveInto(defs *definitions,
 	}
 
 	var winner Source
+	var source string
 
 	switch {
 	case cli.Supplied:
-		winner = cli
+		winner, source = cli, "cli"
 	case env.Supplied:
-		winner = env
+		winner, source = env, "env"
 	case json.Supplied:
-		winner = json
+		winner, source = json, "json"
 	default:
 		forceGA(defs, target)
 		return []string{}, nil
@@ -61,6 +62,11 @@ func resolveInto(defs *definitions,
 
 		idx, known := defs.byName[name]
 		if !known {
+			logger.WithFields(logrus.Fields{
+				"feature": name,
+				"outcome": "unknown",
+				"source":  source,
+			}).Error("Unknown feature flag")
 			continue
 		}
 

--- a/internal/features/resolve.go
+++ b/internal/features/resolve.go
@@ -1,0 +1,93 @@
+package features
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Source is one configuration surface (CLI, env, or JSON).
+type Source struct {
+	Values   []string
+	Supplied bool
+}
+
+func parseInput(raw string) []string {
+	parts := strings.Split(raw, ",")
+	for i, s := range parts {
+		parts[i] = strings.TrimSpace(s)
+	}
+	return slices.DeleteFunc(parts, func(s string) bool { return s == "" })
+}
+
+// resolveInto activates flags from the winning surface (CLI > env > JSON) onto target.
+// target must be an addressable reflect.Value of defs.typ. Returns sorted activated names.
+func resolveInto(defs *definitions,
+	target reflect.Value,
+	cli, env, json Source,
+	logger logrus.FieldLogger,
+) ([]string, error) {
+	if target.Type() != defs.typ {
+		return nil, fmt.Errorf("features: resolveInto target type %s does not match definition type %s",
+			target.Type(), defs.typ)
+	}
+
+	var winner Source
+
+	switch {
+	case cli.Supplied:
+		winner = cli
+	case env.Supplied:
+		winner = env
+	case json.Supplied:
+		winner = json
+	default:
+		return []string{}, nil
+	}
+
+	activated := make(map[string]struct{})
+
+	seen := make(map[string]struct{})
+	for _, name := range parseValues(winner.Values) {
+		if _, dup := seen[name]; dup {
+			continue
+		}
+		seen[name] = struct{}{}
+
+		if _, known := defs.byName[name]; !known {
+			continue
+		}
+
+		activated[name] = struct{}{}
+	}
+
+	setFields(defs, target, activated)
+
+	return sortedKeys(activated), nil
+}
+
+func parseValues(vals []string) []string {
+	out := make([]string, 0, len(vals))
+	for _, v := range vals {
+		out = append(out, parseInput(v)...)
+	}
+	return out
+}
+
+func setFields(defs *definitions, target reflect.Value, names map[string]struct{}) {
+	for name := range names {
+		target.FieldByIndex(defs.definitions[defs.byName[name]].index).SetBool(true)
+	}
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	// keep a non-nil empty set so the activation set stays a stable []string
+	if len(m) == 0 {
+		return []string{}
+	}
+	return slices.Sorted(maps.Keys(m))
+}

--- a/internal/features/resolve.go
+++ b/internal/features/resolve.go
@@ -46,6 +46,7 @@ func resolveInto(defs *definitions,
 	case json.Supplied:
 		winner = json
 	default:
+		forceGA(defs, target)
 		return []string{}, nil
 	}
 
@@ -58,14 +59,18 @@ func resolveInto(defs *definitions,
 		}
 		seen[name] = struct{}{}
 
-		if _, known := defs.byName[name]; !known {
+		idx, known := defs.byName[name]
+		if !known {
 			continue
 		}
 
 		activated[name] = struct{}{}
+
+		logActivation(logger, name, defs.definitions[idx].flag.Lifecycle)
 	}
 
 	setFields(defs, target, activated)
+	forceGA(defs, target)
 
 	return sortedKeys(activated), nil
 }
@@ -78,9 +83,31 @@ func parseValues(vals []string) []string {
 	return out
 }
 
+func logActivation(logger logrus.FieldLogger, name string, lc Lifecycle) {
+	switch lc {
+	case Experimental:
+		logger.WithFields(logrus.Fields{"feature": name, "lifecycle": "experimental"}).
+			Info("Experimental feature enabled")
+	case GA:
+		logger.WithFields(logrus.Fields{"feature": name, "lifecycle": "ga"}).
+			Info("Feature is now available by default, please remove this flag")
+	case Deprecated:
+		logger.WithFields(logrus.Fields{"feature": name, "lifecycle": "deprecated"}).
+			Warn("Deprecated feature enabled")
+	}
+}
+
 func setFields(defs *definitions, target reflect.Value, names map[string]struct{}) {
 	for name := range names {
 		target.FieldByIndex(defs.definitions[defs.byName[name]].index).SetBool(true)
+	}
+}
+
+func forceGA(defs *definitions, target reflect.Value) {
+	for _, def := range defs.definitions {
+		if def.flag.Lifecycle == GA {
+			target.FieldByIndex(def.index).SetBool(true)
+		}
 	}
 }
 


### PR DESCRIPTION
## What?

Adds the feature-flag mechanics for the #5964 spec. We'll wire (flags, CLI, etc.) this in #6056.

## Why?

Provides infra for the CLI wiring.

## Note

The CI failures are not caused by this PR.

## Related

- #6057
- #6056
