### PR TITLE
Let renovate update Dockerfile in v1.x

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -114,6 +114,19 @@
       "enabled": true,
       "dependencyDashboardApproval": false,
       "description": "Override and enable only security updates for v1"
+    },
+    {
+      "description": "Dockerfiles packaging tool",
+      "matchBaseBranches": ["v1.x"],
+      "matchManagers": [
+        "docker"
+      ],
+      "matchFileNames": [
+        "Dockerfile"
+      ],
+      "extends": [
+        "schedule:weekly"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -116,7 +116,7 @@
       "description": "Override and enable only security updates for v1"
     },
     {
-      "description": "Dockerfiles packaging tool",
+      "description": "v1.x Dockerfile",
       "matchBaseBranches": ["v1.x"],
       "matchManagers": [
         "docker"


### PR DESCRIPTION
## What?

Configure renovate to bump images in Dockerfile

## Why?
So we do not have to do it manually, and they seem to not be marked as security which doesn't get catched by the previous rule.
## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
