### PR TITLE
fix(ci): pin browser E2E Go version to go.mod

### DIFF
--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.x
+          go-version-file: go.mod
       - name: Install Go tip
         if: matrix.go == 'tip'
         env:


### PR DESCRIPTION
## Summary

- E2E workflow has been red on master since the go.mod bump to `go 1.25.11` (commit `1cdd6b731`, Jun 3): `actions/setup-go` with `go-version: 1.x` resolves to `1.25.10` on `ubuntu-latest`, `windows-latest`, and `macos-latest`, so `go build .` fails with `go.mod requires go >= 1.25.11 (running go 1.25.10; GOTOOLCHAIN=local)`.
- Switching to `go-version-file: go.mod` makes setup-go install the exact version declared in `go.mod`, eliminating the drift. This matches how `lint.yml`, `test.yml`, `xk6.yml`, `tc39.yml`, and `wpt.yml` already pin their Go version explicitly.
- The `ubuntu-24.04-arm` runner happens to resolve `1.x` to `1.26.3` today, which is why only three of the four `stable` matrix jobs were failing.

## Test plan

- [ ] All four `test (stable, …)` jobs build and run successfully on this PR
- [ ] `test (tip, …)` jobs still build (tip is installed separately and unaffected)