### PR TITLE
ci: force legacy x/net/http2 implementation on the gotip test job

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -39,4 +39,15 @@ runs:
             unset args[2]
           fi
         fi
+        if [[ ${USE_GOTIP} == 'true' ]]; then
+          # Under Go 1.27+, golang.org/x/net/http2 switches to a "wrapping
+          # implementation" that delegates to net/http. With it, ConfigureTransport
+          # no longer forces HTTP/2 over custom dialers, and HTTP/2 errors surface as
+          # unexported net/http/internal/http2 types that lib/netext/httpext can no
+          # longer classify (only StreamError has an upstream errors.As bridge;
+          # ConnectionError and GoAwayError do not). Force the legacy x/net
+          # implementation until k6 adapts. See Dependencies.md / the http2 error
+          # handling in lib/netext/httpext/error_codes.go.
+          args+=("-tags" "http2legacy")
+        fi
         go test "${args[@]}" -timeout 1600s `go list ./... | grep -v browser/tests`


### PR DESCRIPTION
## What?

Force pre gotip behaviour in x/net/http2 to get tests to pass for now.

## Why?

Under Go 1.27+, golang.org/x/net/http2 compiles its "wrapping implementation" (build tag `go1.27 && !http2legacy`) that delegates to net/http instead of its own transport. Two consequences break the lib/netext/httpext error-code tests on gotip:

  * ConfigureTransport becomes a no-op, so it no longer advertises "h2" over a Transport that has a custom TLSClientConfig/DialContext, and HTTP/2 is silently not negotiated (needs ForceAttemptHTTP2 now).
  * Even when HTTP/2 is negotiated, errors surface as unexported net/http/internal/http2 types. errorCodeForError can no longer match them via its golang.org/x/net/http2 type switch, so every HTTP/2 error collapses to the default code. Upstream added an errors.As bridge for StreamError only; ConnectionError and GoAwayError have none.

Until k6 adapts (and upstream grows the missing As bridges), force the original x/net implementation on the gotip job via `-tags http2legacy`. This is a no-op on Go <= 1.26, which already use that implementation.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
