### PR TITLE
feat: add remote write labels

### DIFF
--- a/internal/output/prometheusrw/remotewrite/config.go
+++ b/internal/output/prometheusrw/remotewrite/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	// Headers contains additional headers that should be included in the HTTP requests.
 	Headers map[string]string `json:"headers"`
 
+	// Labels contains additional labels that should be included in the remote write time series.
+	Labels map[string]string `json:"labels"`
+
 	// InsecureSkipTLSVerify skips TLS client side checks.
 	InsecureSkipTLSVerify null.Bool `json:"insecureSkipTLSVerify" envconfig:"K6_PROMETHEUS_RW_INSECURE_SKIP_TLS_VERIFY"`
 
@@ -224,6 +227,13 @@ func (conf Config) Apply(applied Config) Config {
 		maps.Copy(conf.Headers, applied.Headers)
 	}
 
+	if len(applied.Labels) > 0 {
+		if conf.Labels == nil {
+			conf.Labels = make(map[string]string)
+		}
+		maps.Copy(conf.Labels, applied.Labels)
+	}
+
 	if len(applied.TrendStats) > 0 {
 		conf.TrendStats = make([]string, len(applied.TrendStats))
 		copy(conf.TrendStats, applied.TrendStats)
@@ -291,6 +301,7 @@ func envMap(env map[string]string, prefix string) map[string]string {
 func parseEnvs(env map[string]string) (Config, error) {
 	c := Config{
 		Headers: make(map[string]string),
+		Labels:  make(map[string]string),
 	}
 
 	err := envconfig.Process("", &c, func(key string) (string, bool) {
@@ -313,6 +324,16 @@ func parseEnvs(env map[string]string) (Config, error) {
 				return c, fmt.Errorf("the provided header (%s) does not respect the expected format <header key>:<value>", kvPair)
 			}
 			c.Headers[header[0]] = header[1]
+		}
+	}
+
+	if labels, labelsDefined := env["K6_PROMETHEUS_RW_LABELS"]; labelsDefined {
+		for kvPair := range strings.SplitSeq(labels, ",") {
+			key, value, ok := strings.Cut(kvPair, "=")
+			if !ok {
+				return c, fmt.Errorf("the provided label (%s) does not respect the expected format <label key>=<value>", kvPair)
+			}
+			c.Labels[key] = value
 		}
 	}
 

--- a/internal/output/prometheusrw/remotewrite/config_test.go
+++ b/internal/output/prometheusrw/remotewrite/config_test.go
@@ -29,6 +29,9 @@ func TestConfigApply(t *testing.T) {
 		Headers: map[string]string{
 			"X-Header": "value",
 		},
+		Labels: map[string]string{
+			"test_id": "checkout",
+		},
 		TrendStats:   []string{"p(99)"},
 		StaleMarkers: null.BoolFrom(true),
 	}
@@ -295,6 +298,43 @@ func TestOptionHeaders(t *testing.T) {
 			"X-Scope-OrgID":  "my-org-id",
 			"another-header": "true",
 			"empty":          "",
+		},
+		TrendStats:   []string{"p(99)"},
+		StaleMarkers: null.BoolFrom(false),
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			c, err := GetConsolidatedConfig(
+				tc.jsonRaw, tc.env, tc.arg)
+			require.NoError(t, err)
+			assert.Equal(t, expconfig, c)
+		})
+	}
+}
+
+func TestOptionLabels(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		arg     string
+		env     map[string]string
+		jsonRaw json.RawMessage
+	}{
+		"JSON": {jsonRaw: json.RawMessage(`{"labels":{"environment":"production","server":"srv1"}}`)},
+		"Env":  {env: map[string]string{"K6_PROMETHEUS_RW_LABELS": "environment=production,server=srv1"}},
+		//nolint:gocritic
+		//"Arg":  {arg: "labels.environment=production,labels.server=srv1"},
+	}
+
+	expconfig := Config{
+		ServerURL:             null.StringFrom(defaultServerURL),
+		InsecureSkipTLSVerify: null.BoolFrom(false),
+		PushInterval:          types.NullDurationFrom(defaultPushInterval),
+		Headers:               make(map[string]string),
+		Labels: map[string]string{
+			"environment": "production",
+			"server":      "srv1",
 		},
 		TrendStats:   []string{"p(99)"},
 		StaleMarkers: null.BoolFrom(false),

--- a/internal/output/prometheusrw/remotewrite/prometheus.go
+++ b/internal/output/prometheusrw/remotewrite/prometheus.go
@@ -51,3 +51,29 @@ func MapSeries(series metrics.TimeSeries, suffix string) []*prompb.Label {
 	})
 	return lbls
 }
+
+func addLabels(labels []*prompb.Label, extra map[string]string) []*prompb.Label {
+	if len(extra) == 0 {
+		return labels
+	}
+
+	existing := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		existing[label.Name] = struct{}{}
+	}
+
+	for key, value := range extra {
+		if key == "" || value == "" || key == namelbl {
+			continue
+		}
+		if _, ok := existing[key]; ok {
+			continue
+		}
+		labels = append(labels, &prompb.Label{Name: key, Value: value})
+	}
+
+	slices.SortStableFunc(labels, func(i, j *prompb.Label) int {
+		return cmp.Compare(i.Name, j.Name)
+	})
+	return labels
+}

--- a/internal/output/prometheusrw/remotewrite/prometheus_test.go
+++ b/internal/output/prometheusrw/remotewrite/prometheus_test.go
@@ -89,3 +89,12 @@ func findNameLabel(labels []*prompb.Label) string {
 	// This should never happen whenever we use this test helper.
 	panic("__name__ label must be present")
 }
+
+func findLabelValue(labels []*prompb.Label, name string) string {
+	for _, l := range labels {
+		if l.Name == name {
+			return l.Value
+		}
+	}
+	return ""
+}

--- a/internal/output/prometheusrw/remotewrite/remotewrite.go
+++ b/internal/output/prometheusrw/remotewrite/remotewrite.go
@@ -134,6 +134,7 @@ func (o *Output) staleMarkers() []*prompb.TimeSeries {
 	staleMarkers := make([]*prompb.TimeSeries, 0, len(o.tsdb))
 	for _, swm := range o.tsdb {
 		series := swm.MapPrompb()
+		addTimeSeriesLabels(series, o.config.Labels)
 		// series' length is expected to be equal to 1 for most of the cases
 		// the unique exception where more than 1 is expected is when
 		// trend stats have been configured with multiple values.
@@ -300,9 +301,17 @@ func (o *Output) convertToPbSeries(samplesContainers []metrics.SampleContainer) 
 
 	pbseries := make([]*prompb.TimeSeries, 0, len(seen))
 	for s := range seen {
-		pbseries = append(pbseries, o.tsdb[s].MapPrompb()...)
+		series := o.tsdb[s].MapPrompb()
+		addTimeSeriesLabels(series, o.config.Labels)
+		pbseries = append(pbseries, series...)
 	}
 	return pbseries
+}
+
+func addTimeSeriesLabels(series []*prompb.TimeSeries, labels map[string]string) {
+	for _, s := range series {
+		s.Labels = addLabels(s.Labels, labels)
+	}
 }
 
 type seriesWithMeasure struct {

--- a/internal/output/prometheusrw/remotewrite/remotewrite_test.go
+++ b/internal/output/prometheusrw/remotewrite/remotewrite_test.go
@@ -170,6 +170,45 @@ func TestOutputConvertToPbSeries(t *testing.T) {
 	assert.Equal(t, exp, pbseries)
 }
 
+func TestOutputConvertToPbSeriesWithLabels(t *testing.T) {
+	t.Parallel()
+
+	registry := metrics.NewRegistry()
+	metric := registry.MustNewMetric("metric1", metrics.Counter)
+	tagset := registry.RootTagSet().With("environment", "script")
+
+	o := Output{
+		config: Config{
+			Labels: map[string]string{
+				"__name__":      "ignored",
+				"environment":   "config",
+				"server":        "srv1",
+				"empty_value":   "",
+				"ignored_empty": "",
+			},
+		},
+		tsdb: make(map[metrics.TimeSeries]*seriesWithMeasure),
+	}
+
+	pbseries := o.convertToPbSeries([]metrics.SampleContainer{
+		metrics.Sample{
+			TimeSeries: metrics.TimeSeries{
+				Metric: metric,
+				Tags:   tagset,
+			},
+			Time:  time.Unix(1, 0),
+			Value: 1,
+		},
+	})
+
+	require.Len(t, pbseries, 1)
+	assert.Equal(t, []*prompb.Label{
+		{Name: "__name__", Value: "k6_metric1_total"},
+		{Name: "environment", Value: "script"},
+		{Name: "server", Value: "srv1"},
+	}, pbseries[0].Labels)
+}
+
 //nolint:paralleltest,tparallel
 func TestOutputConvertToPbSeries_WithPreviousState(t *testing.T) {
 	t.Parallel()
@@ -376,6 +415,9 @@ func TestOutputStaleMarkers(t *testing.T) {
 	}
 
 	o := Output{
+		config: Config{
+			Labels: map[string]string{"server": "srv1"},
+		},
 		now: func() time.Time {
 			return time.Unix(1, 0)
 		},
@@ -406,6 +448,7 @@ func TestOutputStaleMarkers(t *testing.T) {
 	expTimestamp := time.Unix(1, int64(1*time.Millisecond)).UnixMilli()
 	for i, expName := range expNameLabels {
 		assert.Equal(t, expName, markers[i].Labels[0].Value)
+		assert.Equal(t, "srv1", findLabelValue(markers[i].Labels, "server"))
 		assert.Equal(t, expTimestamp, markers[i].Samples[0].Timestamp)
 		assert.True(t, math.IsNaN(markers[i].Samples[0].Value), "it isn't a StaleNaN value")
 	}


### PR DESCRIPTION
## What?

Add a `labels` option for the Prometheus remote write output.

It can be set from JSON config or with `K6_PROMETHEUS_RW_LABELS`, for example:

```bash
K6_PROMETHEUS_RW_LABELS="environment=production,server=srv1"
```

## Why?

This lets users attach static labels to all remote write time series without repeating those labels in every script.

Closes #3716

## Testing

- go test ./internal/output/prometheusrw/remotewrite
