### PR TITLE
chore: prepare workflows for get-vault-secrets v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -652,7 +652,9 @@ jobs:
           mv "dist/k6-$VERSION-linux-amd64.rpm" "dist/k6-$VERSION-amd64.rpm"
           mv "dist/k6-$VERSION-linux-amd64.deb" "dist/k6-$VERSION-amd64.deb"
       - uses: grafana/shared-workflows/actions/get-vault-secrets@a53fc80bc30b0a16a262520465db899fa3af08b7 # get-vault-secrets/v1.3.2
+        id: get-secrets
         with:
+          export_env: false
           repo_secrets: |
             IAM_ROLE_ARN=deploy:packager-iam-role
             AWS_CF_DISTRIBUTION=cloudfront:AWS_CF_DISTRIBUTION
@@ -662,9 +664,14 @@ jobs:
       - uses: grafana/shared-workflows/actions/aws-auth@85022085ed5314601c05d10e846de56bdd71e369 # aws-auth/v1.0.3
         with:
           aws-region: "us-east-2"
-          role-arn: ${{ env.IAM_ROLE_ARN }}
+          role-arn: ${{ fromJSON(steps.get-secrets.outputs.secrets).IAM_ROLE_ARN }}
           set-creds-in-environment: true
       - name: Setup docker compose environment
+        env:
+          AWS_CF_DISTRIBUTION: ${{ fromJSON(steps.get-secrets.outputs.secrets).AWS_CF_DISTRIBUTION }}
+          PGP_SIGN_KEY_PASSPHRASE: ${{ fromJSON(steps.get-secrets.outputs.secrets).PGP_SIGN_KEY_PASSPHRASE }}
+          PGP_SIGN_KEY: ${{ fromJSON(steps.get-secrets.outputs.secrets).PGP_SIGN_KEY }}
+          S3_BUCKET: ${{ fromJSON(steps.get-secrets.outputs.secrets).S3_BUCKET }}
         run: |
           cat > packaging/.env <<EOF
           AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}


### PR DESCRIPTION
## What?

Opts the release build workflow's `get-vault-secrets` usage into the upcoming v2 behavior: adds an explicit `id`, sets `export_env: false`, and reads each secret from the step's `secrets` output via `fromJSON(...)` instead of `env.NAME` — wiring the docker-compose step's secrets through a per-step `env:` block.

## Why?

v2 of `grafana/shared-workflows/actions/get-vault-secrets` will no longer auto-export retrieved secrets as environment variables. This change makes `build.yml` forward-compatible before v2 lands.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes. _(N/A — CI workflow change)_
- [ ] I have run linter and tests locally (`make check`) and all pass. _(N/A — workflow-only change)_