### PR TITLE
fix: Work around issue when trying to use inspect/archive with secrets

### DIFF
--- a/internal/cmd/archive.go
+++ b/internal/cmd/archive.go
@@ -97,6 +97,9 @@ An archive is a fully self-contained test run, and can be executed identically e
 		Example: exampleText,
 		Args:    cobra.ExactArgs(1),
 		RunE:    c.run,
+		// archive only reads a test's structure and never uses real secret
+		// values, so it may default to the dummy secret source.
+		Annotations: map[string]string{secretsOptionalAnnotation: "true"},
 	}
 
 	archiveCmd.Flags().SortFlags = false

--- a/internal/cmd/inspect.go
+++ b/internal/cmd/inspect.go
@@ -20,6 +20,9 @@ func getCmdInspect(gs *state.GlobalState) *cobra.Command {
 		Short: "Inspect a script or archive",
 		Long:  `Inspect a script or archive.`,
 		Args:  cobra.ExactArgs(1),
+		// inspect only reads a test's structure and never uses real secret
+		// values, so it may default to the dummy secret source.
+		Annotations: map[string]string{secretsOptionalAnnotation: "true"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			test, err := loadLocalTest(gs, cmd, args)
 			if err != nil {

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -25,9 +25,16 @@ import (
 
 	_ "go.k6.io/k6/v2/internal/secretsource" // import it to register internal secret sources
 	cloudsecrets "go.k6.io/k6/v2/internal/secretsource/cloud"
+	dummysecrets "go.k6.io/k6/v2/internal/secretsource/dummy"
 )
 
 const waitLoggerCloseTimeout = time.Second * 5
+
+// secretsOptionalAnnotation marks commands that only read a test's structure
+// and never use real secret values (inspect, archive). For these,
+// persistentPreRunE defaults to the dummy secret source when the user provided
+// none, so they don't fail on scripts that call secrets.get() during init.
+const secretsOptionalAnnotation = "k6_secrets_optional" //nolint:gosec // G101: annotation key, not a credential
 
 func getRootUsageTemplate() string {
 	return `{{.Short}}
@@ -156,6 +163,15 @@ func (c *rootCommand) persistentPreRunE(cmd *cobra.Command, _ []string) error {
 		if f == nil || f.Value.String() != "true" {
 			c.globalState.Flags.SecretSource = append(c.globalState.Flags.SecretSource, "cloud")
 		}
+	}
+
+	// For 'k6 inspect' and 'k6 archive', a script's secrets are never actually
+	// used, but its init code may still call secrets.get(). Default to the
+	// 'dummy' secret source (which returns random values) when the user provided
+	// none, so these commands don't fail on secret-using scripts.
+	if secretsAreOptional(cmd) && len(c.globalState.Flags.SecretSource) == 0 {
+		dummysecrets.Register()
+		c.globalState.Flags.SecretSource = []string{dummysecrets.Name}
 	}
 
 	err := c.setupLoggers(c.stopLoggersCh)
@@ -538,6 +554,13 @@ func isCloudRunWithLocalExecution(cmd *cobra.Command) bool {
 		return false
 	}
 	return localExecution
+}
+
+// secretsAreOptional returns true when the command being executed only reads a
+// test's structure and never uses real secret values, as declared by the
+// secretsOptionalAnnotation on the command.
+func secretsAreOptional(cmd *cobra.Command) bool {
+	return cmd != nil && cmd.Annotations[secretsOptionalAnnotation] == "true"
 }
 
 // hasCloudSecretSource returns true if the 'cloud' secret source type appears in sources.

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -2663,6 +2663,75 @@ func TestMultipleSecretSources(t *testing.T) {
 	assert.Contains(t, stderr, `level=info msg="trigger exception on wrong key" ***SECRET_REDACTED***=console`)
 }
 
+// TestInspectAndArchiveDefaultDummySecretSource verifies that 'k6 inspect' and
+// 'k6 archive' default to the 'dummy' secret source when none is provided, so a
+// script that accesses secrets during init no longer fails with
+// "no secret sources are configured". 'k6 run' keeps requiring a real source.
+func TestInspectAndArchiveDefaultDummySecretSource(t *testing.T) {
+	t.Parallel()
+
+	// The secret is read during the init context, which inspect and archive
+	// execute while reading the test's options.
+	script := `
+		import secrets from "k6/secrets";
+		const token = await secrets.get("x");
+		export const options = {};
+		export default function () {}
+	`
+
+	t.Run("inspect succeeds without a secret source", func(t *testing.T) {
+		t.Parallel()
+		ts := NewGlobalTestState(t)
+		require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "script.js"), []byte(script), 0o644))
+		ts.CmdArgs = []string{"k6", "inspect", "script.js"}
+		ts.ReparseFlags()
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		assert.NotContains(t, ts.Stderr.String(), "no secret sources are configured")
+		assert.Contains(t, ts.Stdout.String(), "discardResponseBodies")
+	})
+
+	t.Run("archive succeeds without a secret source", func(t *testing.T) {
+		t.Parallel()
+		ts := NewGlobalTestState(t)
+		require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "script.js"), []byte(script), 0o644))
+		ts.CmdArgs = []string{"k6", "archive", "-O", "-", "script.js"}
+		ts.ReparseFlags()
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		assert.NotContains(t, ts.Stderr.String(), "no secret sources are configured")
+		assert.NotEmpty(t, ts.Stdout.Bytes())
+	})
+
+	t.Run("explicit secret source is still honored by inspect", func(t *testing.T) {
+		t.Parallel()
+		ts := NewGlobalTestState(t)
+		require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "script.js"), []byte(script), 0o644))
+		ts.CmdArgs = []string{"k6", "inspect", "--secret-source=mock=x=real", "script.js"}
+		ts.ReparseFlags()
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		assert.NotContains(t, ts.Stderr.String(), "no secret sources are configured")
+		assert.Contains(t, ts.Stdout.String(), "discardResponseBodies")
+	})
+
+	t.Run("run still requires a real secret source", func(t *testing.T) {
+		t.Parallel()
+		ts := NewGlobalTestState(t)
+		require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "script.js"), []byte(script), 0o644))
+		ts.ExpectedExitCode = int(exitcodes.ScriptException)
+		ts.CmdArgs = []string{"k6", "run", "script.js"}
+		ts.ReparseFlags()
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		assert.Contains(t, ts.Stderr.String(), "no secret sources are configured")
+	})
+}
+
 // TestK6SecretSourceEnvVar covers the K6_SECRET_SOURCE environment variable, which is
 // treated as a single complete source spec equivalent to one --secret-source flag value.
 func TestK6SecretSourceEnvVar(t *testing.T) {

--- a/internal/secretsource/dummy/dummy.go
+++ b/internal/secretsource/dummy/dummy.go
@@ -1,0 +1,91 @@
+// Package dummy implements a secret source that returns random values for any
+// secret that is requested.
+//
+// The sole purpose of this package is to allow subcommands like inspect and
+// archive to operate on scripts that request secrets at the top level context,
+// for example:
+//
+//	import secrets from 'k6/secrets';
+//
+//	const secretValue = await secrets.get('secret_name');
+//
+//	export default function() { }
+//
+// Since inspect and archive need the actual value of the top-level options
+// constant, it needs to partially evaluate the input script. Since there's no
+// way to decide whether a particular portion of the program will run when
+// trying to evaluate the options constant (halting problem), we have to assume
+// they will be evaluated. In the name of UX, other secret sources will return
+// an error when a non-existent secret is requested, meaning you cannot use
+// something like `mock` to supply the need for a secret source.
+//
+// Considering all of that, this secret source returns a random value for any
+// and all secrets requested. Why random data? Because of the way JavaScript
+// works, it's possible to have functions execute during initialization. Since
+// those functions can have arbitrary logic in them (like validating that the
+// string is not empty despite having received no error), we have to return
+// *something*. Since this is a secret, the user should have no way of
+// validating the value, so returning a random string should cover the majority
+// of normal use cases. This will still fail for example in case the secrets
+// are used to build the options value, which is completely possible. We will
+// treat that as a known limitation of inspect and archive. If you are doing
+// that, please don't.
+package dummy
+
+import (
+	"crypto/rand"
+	"sync"
+
+	"go.k6.io/k6/v2/secretsource"
+)
+
+// Name is the external name of the secrets source, so that it can be
+// referenced by other parts of the code.
+const Name = "dummy"
+
+// Registration must happen exactly once. We want to avoid the init() route
+// because we don't want to make this secret source generally available.
+//
+// Declare a global variable that makes sure the registration happens at most
+// one time, at export the Register() function that allows the rest of the code
+// to trigger it.
+var register sync.Once //nolint:gochecknoglobals // See above.
+
+// Register adds "dummy" to the list of known secret sources on demand.
+func Register() {
+	register.Do(func() {
+		secretsource.RegisterExtension(Name, newSecretSourceFromParams)
+	})
+}
+
+func newSecretSourceFromParams(_ secretsource.Params) (secretsource.Source, error) {
+	return &secretSource{}, nil
+}
+
+type secretSource struct{}
+
+// secretSource implements the secretsource.Source interface.
+var _ secretsource.Source = &secretSource{}
+
+func (secretSource) Description() string {
+	return "this is a dummy secret source"
+}
+
+func (secretSource) Get(_ string) (string, error) {
+	return generateRandomString(16)
+}
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func generateRandomString(length int) (string, error) {
+	buf := make([]byte, length)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+
+	for i := range buf {
+		buf[i] = charset[int(buf[i])%len(charset)]
+	}
+
+	return string(buf), nil
+}


### PR DESCRIPTION
This program:

	import secrets from 'k6/secrets';

	const secretValue = await secrets.get('secret_name');

	export default function() { }

works with `k6 run` as long as there's a configured secret source, for example, mock:

```
$ k6 run --quiet --summary-mode=disabled --secret-source=mock=secret_name=value script.js
<no output>
```

but it fails when trying to use `k6 inspect` naively:

```
$ k6 inspect script.js
ERRO[0000] no secret sources are configured              hint="script exception"
```

From the point of view of a user this is confusing: why does inspect need to access secrets if the command is supposed to simply inspect an script?

It works if you supply a secrets source:

```
$ k6 inspect --secret-source=mock=secret_name=value script.js
{
    ...
}
```

which is arguably even more confusing, because the `inspect` command seems to be issuing the `secrets.get` call (it is) and using the secret value (it's not in this example, but it might).

Even more confusing still:

```
$ k6 inspect --secret-source=mock=another_name=value script.js
ERRO[0000] no value                                      hint="script exception"
```

In the name of UX, secret sources are expected to return an error when a non-existent secret is requested. Because it's not reasonable to enumerate all necessary secrets when calling inspect (halting problem), this workaround does not work. In the general case, it's also not possible to connect k6 to a secret source that actually has those secrets (for example, the user might not have enough access).

The underlying issue is that inspect and archive need the actual value of the top-level options constant. Because of that, they need to partially evaluate the input script. Since there's no way to decide whether a particular portion of the program will run when trying to evaluate the options constant (halting problem again), we have to assume they will be evaluated.

Considering all of that, add a "dummy" secret source that returns an empty value for any and all secrets requested. This will still fail in case the secrets are actually used to build the options value, which is completely possible. We will treat that as a known limitation of inspect and archive. If you are doing that, please don't.

For the _specific case_ of inspect and archive, hook that dummy secret source if no source was provided. If a source was provided, we will assume the user knows what they are doing and not change that behavior.

## What?

<!-- A short (or detailed) description of what this PR does. -->

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
