### PR TITLE
Fix misleading cloud secrets error with K6_CLOUD_PUSH_REF_ID

### DIFF
--- a/internal/secretsource/cloud/cloud.go
+++ b/internal/secretsource/cloud/cloud.go
@@ -72,6 +72,22 @@ func (cs *SecretSource) Description() string {
 	return "Grafana Cloud k6 secret source"
 }
 
+// notConfiguredError explains why no secrets configuration is available. When a test run is
+// reused via the K6_CLOUD_PUSH_REF_ID env var, CreateTestRun is skipped (see #5814) so the
+// config can't come from its response and must instead be supplied via the K6_CLOUD_SECRETS_*
+// env vars; otherwise the generic 'k6 cloud run --local-execution' guidance applies (#6050).
+func (cs *SecretSource) notConfiguredError() error {
+	const prefix = "cloud secrets not configured: no secrets configuration available. "
+	if cs.params.Environment["K6_CLOUD_PUSH_REF_ID"] != "" {
+		return errors.New(prefix +
+			"When an existing test run is reused via K6_CLOUD_PUSH_REF_ID, set " +
+			"K6_CLOUD_SECRETS_TOKEN and K6_CLOUD_SECRETS_ENDPOINT to enable cloud secrets")
+	}
+	return errors.New(prefix +
+		"Make sure you're using 'k6 cloud run --local-execution' and the cloud API " +
+		"returned secrets configuration")
+}
+
 // ensureInitialized builds (or rebuilds) the URL source from configPtr.
 func (cs *SecretSource) ensureInitialized() (secretsource.Source, error) {
 	cs.mu.Lock()
@@ -90,9 +106,7 @@ func (cs *SecretSource) ensureInitialized() (secretsource.Source, error) {
 	cs.initErr = nil
 
 	if current == nil {
-		cs.initErr = errors.New("cloud secrets not configured: no secrets configuration available. " +
-			"Make sure you're using 'k6 cloud run --local-execution' and the cloud API " +
-			"returned secrets configuration")
+		cs.initErr = cs.notConfiguredError()
 		return nil, cs.initErr
 	}
 

--- a/internal/secretsource/cloud/cloud_test.go
+++ b/internal/secretsource/cloud/cloud_test.go
@@ -49,6 +49,32 @@ func TestCloudSecretsRequiresConfig(t *testing.T) {
 	require.Contains(t, err.Error(), "cloud secrets not configured")
 }
 
+// TestCloudSecretsNotConfiguredMessage verifies the "not configured" error adapts to context:
+// the reuse-specific guidance appears only when K6_CLOUD_PUSH_REF_ID is set, otherwise the
+// generic 'k6 cloud run --local-execution' message is used.
+func TestCloudSecretsNotConfiguredMessage(t *testing.T) {
+	t.Parallel()
+
+	// Without K6_CLOUD_PUSH_REF_ID: generic guidance.
+	generic, err := New(makeParams())
+	require.NoError(t, err)
+	_, err = generic.Get("test-key")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Make sure you're using 'k6 cloud run --local-execution'")
+	require.NotContains(t, err.Error(), "K6_CLOUD_PUSH_REF_ID")
+
+	// With K6_CLOUD_PUSH_REF_ID: reuse-specific guidance.
+	params := makeParams()
+	params.Environment = map[string]string{"K6_CLOUD_PUSH_REF_ID": "12345"}
+	reused, err := New(params)
+	require.NoError(t, err)
+	_, err = reused.Get("test-key")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "K6_CLOUD_PUSH_REF_ID")
+	require.Contains(t, err.Error(), "K6_CLOUD_SECRETS_TOKEN")
+	require.NotContains(t, err.Error(), "Make sure you're using 'k6 cloud run --local-execution'")
+}
+
 // TestCloudSecretsDescription verifies the extension is registered with the expected description.
 func TestCloudSecretsDescription(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## What?

Make the `cloud secrets not configured` error accurate when a test run is reused via `K6_CLOUD_PUSH_REF_ID` under `k6 cloud run --local-execution`. In that case `secrets.get()` now returns a message pointing to `K6_CLOUD_SECRETS_TOKEN` / `K6_CLOUD_SECRETS_ENDPOINT`, instead of the misleading "make sure you're using `k6 cloud run --local-execution`" text (which the user already is).

The cloud secret source selects the message itself by reading the `K6_CLOUD_PUSH_REF_ID` env var from its params (`internal/secretsource/cloud/cloud.go`); the reuse-specific guidance appears only when that env var is set, and the original generic message is unchanged otherwise. Covered by a unit test in `internal/secretsource/cloud`.

## Why?

#5814 (fixing #5813) made `k6 cloud run --local-execution` skip `CreateTestRun` when `K6_CLOUD_PUSH_REF_ID` is set, to avoid creating orphan test runs. That `CreateTestRun` response is the *only* place the cloud secret source is configured from the cloud API, so reusing a run left the source unconfigured and `secrets.get()` failed with a message instructing the user to do what they were already doing (#6050).

There is no cloud API to fetch per-run secrets config for an existing run without creating a new one, so secrets in this path must be supplied via `K6_CLOUD_SECRETS_TOKEN` / `K6_CLOUD_SECRETS_ENDPOINT` (the PLZ operator path, which I verified still works). This keeps #5814 intact and makes the error accurate and actionable. The reuse case is detected by reading the `K6_CLOUD_PUSH_REF_ID` env var the source already has access to (the documented way to reuse a run), which keeps the change self-contained to the secret source with no cross-package plumbing.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Closes #6050
- Regression introduced by: #5814
- Original issue behind #5814: #5813