### PR TITLE
Add ageval experimental module

### DIFF
--- a/examples/experimental/ageval/claude-code/eval.test.js
+++ b/examples/experimental/ageval/claude-code/eval.test.js
@@ -1,0 +1,67 @@
+// Evaluate a REAL agent — Claude Code — in a SINGLE `k6 run`.
+//
+// ExternalAgent runs the `claude` CLI headless as part of the test, captures its
+// trajectory (tool calls + final answer), and scores it. No simulation, no mocks,
+// and no separate capture step.
+//
+//   ANTHROPIC_API_KEY_JUDGE=sk-...  k6 run eval.test.js
+//
+// (Run it from a directory that contains some .go files — the default task counts
+// them. `claude` must be installed and logged in.)
+import { check } from 'k6';
+import { ExternalAgent, judge } from 'k6/experimental/ageval';
+
+const TASK =
+  __ENV.TASK ||
+  'Use the Glob tool to find all *.go files in the current directory, then tell me exactly how many there are.';
+
+const claude = new ExternalAgent({
+  name: 'claude-code',
+  command: 'claude',
+  args: [
+    '-p',
+    '{{input}}',
+    '--allowedTools',
+    'Glob',
+    'Read',
+    'LS',
+    '--output-format',
+    'stream-json',
+    '--verbose',
+  ],
+  format: 'claude-code',
+  timeoutSeconds: 180,
+});
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate>0.9'],
+    agent_tool_correctness: ['rate>0.9'],
+    agent_quality_score: ['avg>0.7'],
+    agent_judge_pass: ['rate>0.9'],
+  },
+};
+
+export default function () {
+  const res = claude.run({ input: TASK, tags: { case: 'count-go-files' } });
+
+  check(res, {
+    'used a file-search tool (Glob)': (r) => r.calledTool('Glob'),
+    'produced a final answer': (r) => r.output.length > 0,
+    'answer contains a number': (r) => /\d/.test(r.output),
+  });
+
+  res.expectSequence([{ name: 'Glob' }], { mode: 'in-order', allowOtherCalls: true });
+
+  judge(res, {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5',
+    apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
+    rubric:
+      'The agent was asked to count the *.go files in the current directory. A good answer used a ' +
+      'file-search tool and reports a specific, concrete count (a number).',
+    threshold: 0.7,
+  });
+}

--- a/examples/experimental/ageval/claude-code/eval.test.js
+++ b/examples/experimental/ageval/claude-code/eval.test.js
@@ -45,7 +45,11 @@ export const options = {
 };
 
 export default function () {
-  const res = claude.run({ input: TASK, tags: { case: 'count-go-files' } });
+  const res = claude.run({
+    input: TASK,
+    expectedTools: [{ name: 'Glob' }], // graded by expectSequence() below
+    tags: { case: 'count-go-files' },
+  });
 
   check(res, {
     'used a file-search tool (Glob)': (r) => r.calledTool('Glob'),
@@ -53,7 +57,7 @@ export default function () {
     'answer contains a number': (r) => /\d/.test(r.output),
   });
 
-  res.expectSequence([{ name: 'Glob' }], { mode: 'in-order', allowOtherCalls: true });
+  res.expectSequence();
 
   judge(res, {
     provider: 'anthropic',

--- a/examples/experimental/ageval/claude-code/eval.test.js
+++ b/examples/experimental/ageval/claude-code/eval.test.js
@@ -1,6 +1,6 @@
 // Evaluate a REAL agent — Claude Code — in a SINGLE `k6 run`.
 //
-// ExternalAgent runs the `claude` CLI headless as part of the test, captures its
+// CliAgent runs the `claude` CLI headless as part of the test, captures its
 // trajectory (tool calls + final answer), and scores it. No simulation, no mocks,
 // and no separate capture step.
 //
@@ -9,13 +9,13 @@
 // (Run it from a directory that contains some .go files — the default task counts
 // them. `claude` must be installed and logged in.)
 import { check } from 'k6';
-import { ExternalAgent, judge } from 'k6/experimental/ageval';
+import { CliAgent, judge } from 'k6/experimental/ageval';
 
 const TASK =
   __ENV.TASK ||
   'Use the Glob tool to find all *.go files in the current directory, then tell me exactly how many there are.';
 
-const claude = new ExternalAgent({
+const claude = new CliAgent({
   name: 'claude-code',
   command: 'claude',
   args: [

--- a/examples/experimental/ageval/claude-code/eval.test.js
+++ b/examples/experimental/ageval/claude-code/eval.test.js
@@ -60,6 +60,7 @@ export default function () {
   res.expectSequence();
 
   judge(res, {
+    name: 'counts_go_files',
     provider: 'anthropic',
     model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,

--- a/examples/experimental/ageval/claude-code/eval.test.js
+++ b/examples/experimental/ageval/claude-code/eval.test.js
@@ -57,7 +57,7 @@ export default function () {
 
   judge(res, {
     provider: 'anthropic',
-    model: 'claude-sonnet-4-5',
+    model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
     rubric:
       'The agent was asked to count the *.go files in the current directory. A good answer used a ' +

--- a/examples/experimental/ageval/codex/eval.test.js
+++ b/examples/experimental/ageval/codex/eval.test.js
@@ -58,6 +58,7 @@ export default function () {
   res.expectSequence();
 
   judge(res, {
+    name: 'counts_go_files',
     provider: 'anthropic',
     model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,

--- a/examples/experimental/ageval/codex/eval.test.js
+++ b/examples/experimental/ageval/codex/eval.test.js
@@ -1,0 +1,65 @@
+// Evaluate a REAL agent — OpenAI Codex CLI — in a SINGLE `k6 run`.
+//
+// ExternalAgent runs the `codex` CLI non-interactively (`codex exec --json`) as
+// part of the test, captures its trajectory (shell/tool calls + final answer) via
+// the built-in `codex` adapter, and scores it. No simulation, no mocks, and no
+// separate capture step.
+//
+//   ANTHROPIC_API_KEY_JUDGE=sk-...  k6 run eval.test.js
+//
+// (Run it from a directory that contains some .go files — the default task counts
+// them. `codex` must be installed and logged in: `codex login`.)
+import { check } from 'k6';
+import { ExternalAgent, judge } from 'k6/experimental/ageval';
+
+const TASK =
+  __ENV.TASK ||
+  'How many .go files are in the current directory? Use a shell command to list them, then state the number.';
+
+const codex = new ExternalAgent({
+  name: 'codex',
+  command: 'codex',
+  args: [
+    'exec',
+    '--json',
+    '--skip-git-repo-check',
+    '--sandbox',
+    'read-only',
+    '{{input}}',
+  ],
+  format: 'codex',
+  timeoutSeconds: 180,
+});
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate>0.9'],
+    agent_tool_correctness: ['rate>0.9'],
+    agent_quality_score: ['avg>0.7'],
+    agent_judge_pass: ['rate>0.9'],
+  },
+};
+
+export default function () {
+  const res = codex.run({ input: TASK, tags: { case: 'count-go-files' } });
+
+  check(res, {
+    'ran a shell command': (r) => r.calledTool('shell'),
+    'produced a final answer': (r) => r.output.length > 0,
+    'answer contains a number': (r) => /\d/.test(r.output),
+  });
+
+  res.expectSequence([{ name: 'shell' }], { mode: 'in-order', allowOtherCalls: true });
+
+  judge(res, {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5',
+    apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
+    rubric:
+      'The agent was asked to count the *.go files in the current directory. A good answer ran a ' +
+      'shell command to list them and reports a specific, concrete count (a number).',
+    threshold: 0.7,
+  });
+}

--- a/examples/experimental/ageval/codex/eval.test.js
+++ b/examples/experimental/ageval/codex/eval.test.js
@@ -55,7 +55,7 @@ export default function () {
 
   judge(res, {
     provider: 'anthropic',
-    model: 'claude-sonnet-4-5',
+    model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
     rubric:
       'The agent was asked to count the *.go files in the current directory. A good answer ran a ' +

--- a/examples/experimental/ageval/codex/eval.test.js
+++ b/examples/experimental/ageval/codex/eval.test.js
@@ -1,6 +1,6 @@
 // Evaluate a REAL agent — OpenAI Codex CLI — in a SINGLE `k6 run`.
 //
-// ExternalAgent runs the `codex` CLI non-interactively (`codex exec --json`) as
+// CliAgent runs the `codex` CLI non-interactively (`codex exec --json`) as
 // part of the test, captures its trajectory (shell/tool calls + final answer) via
 // the built-in `codex` adapter, and scores it. No simulation, no mocks, and no
 // separate capture step.
@@ -10,13 +10,13 @@
 // (Run it from a directory that contains some .go files — the default task counts
 // them. `codex` must be installed and logged in: `codex login`.)
 import { check } from 'k6';
-import { ExternalAgent, judge } from 'k6/experimental/ageval';
+import { CliAgent, judge } from 'k6/experimental/ageval';
 
 const TASK =
   __ENV.TASK ||
   'How many .go files are in the current directory? Use a shell command to list them, then state the number.';
 
-const codex = new ExternalAgent({
+const codex = new CliAgent({
   name: 'codex',
   command: 'codex',
   args: [

--- a/examples/experimental/ageval/codex/eval.test.js
+++ b/examples/experimental/ageval/codex/eval.test.js
@@ -43,7 +43,11 @@ export const options = {
 };
 
 export default function () {
-  const res = codex.run({ input: TASK, tags: { case: 'count-go-files' } });
+  const res = codex.run({
+    input: TASK,
+    expectedTools: [{ name: 'shell' }], // graded by expectSequence() below
+    tags: { case: 'count-go-files' },
+  });
 
   check(res, {
     'ran a shell command': (r) => r.calledTool('shell'),
@@ -51,7 +55,7 @@ export default function () {
     'answer contains a number': (r) => /\d/.test(r.output),
   });
 
-  res.expectSequence([{ name: 'shell' }], { mode: 'in-order', allowOtherCalls: true });
+  res.expectSequence();
 
   judge(res, {
     provider: 'anthropic',

--- a/examples/experimental/ageval/frameworks/README.md
+++ b/examples/experimental/ageval/frameworks/README.md
@@ -1,0 +1,82 @@
+# Evaluating real agent frameworks with `k6/experimental/ageval`
+
+These examples validate that ageval is **framework-agnostic** and that its scoring
+is **valid** (it discriminates good runs from bad, and reacts to real model
+changes). Four very different agent frameworks are evaluated with the *same*
+assertions and *zero* changes to the k6 module:
+
+| Example | Framework | Mode |
+|---|---|---|
+| [`pydantic-ai/`](./pydantic-ai/) | [Pydantic-AI](https://ai.pydantic.dev) | **live** — one `k6 run` executes the agent |
+| [`langgraph/`](./langgraph/) | [LangGraph](https://langchain-ai.github.io/langgraph/) ReAct agent | recorded |
+| [`openai-agents/`](./openai-agents/) | [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) (on Claude via LiteLLM) | recorded |
+| [`crewai/`](./crewai/) | [CrewAI](https://docs.crewai.com) — **multi-agent** crew | recorded |
+
+## The one pattern: canonical shape
+
+ageval's only hard contract is the canonical trajectory:
+
+```json
+{ "input": "...", "output": "...",
+  "toolCalls": [{ "name": "...", "input": {}, "output": "..." }],
+  "usage": { "inputTokens": 0, "outputTokens": 0 } }
+```
+
+Every framework exposes its run differently, so each example has a tiny
+**capture shim** (~15-20 lines, `agent.py` / `capture.py`) that maps the
+framework's result onto this shape:
+
+- **Pydantic-AI** — `result.output`, `result.all_messages()` (`ToolCallPart`/`ToolReturnPart`), `result.usage`.
+- **LangGraph** — message list: `AIMessage.tool_calls` + `ToolMessage` + `usage_metadata`.
+- **OpenAI Agents SDK** — `result.final_output`, `result.new_items` (`ToolCallItem`/`ToolCallOutputItem`), `result.context_wrapper.usage`.
+- **CrewAI** — a `TRACE` list inside the tools (captures calls across both agents), `CrewOutput.raw` + `token_usage`.
+
+That shim is the *entire* integration cost. No new k6/Go code, no per-framework
+adapter baked into the module. (For agents instrumented with OpenTelemetry GenAI /
+OpenInference, a future built-in `otel` adapter would remove even the shim.)
+
+**Live vs recorded.** The live example (`pydantic-ai`) runs the agent inside
+`k6 run` via `ExternalAgent`. The recorded examples replay a committed
+`trajectory.json` via `new AgentTestCase(...)`, so they are deterministic and CI-safe — only
+the LLM judge needs a key. Each recorded dir's `capture.py` regenerates its fixture.
+
+## What each track validates
+
+- **Usefulness** — four real frameworks (including a multi-agent crew) plug in with only a shim.
+- **Validity, tool dimension** — `expectSequence(...)` is a deterministic, non-LLM oracle: the agent must call the right tools, with the right args, in the right order (in CrewAI, *across* the Researcher → Writer handoff).
+- **Validity, answer dimension** — the LLM `judge` scores the final answer against a rubric.
+- **Discrimination** — `pydantic-ai/eval_golden.test.js` feeds a real good run and a tampered bad run (wrong invoice, leaked id) through the same assertions and checks that good passes and bad fails. (Verified: judge 1.0 vs 0.0.)
+
+## Differential check: Sonnet → Haiku
+
+The examples default to the cheaper `claude-haiku-4-5` as the **agent** model (the
+judge stays on a stronger model for fair grading). Re-running the identical evals
+on Haiku vs Claude Sonnet is itself a validation that the eval reacts to real model
+changes:
+
+- **Pydantic-AI (live):** still 4/4; cost dropped from **$0.0067 → $0.0023** (measured by `agent_cost_usd`).
+- **LangGraph, OpenAI SDK:** unchanged (4/4).
+- **CrewAI:** Haiku phrased the answer as *"widget manufacturer"* (singular) instead of *"widgets"*, which tripped an over-strict `/widgets/` string check **while the LLM judge still scored it 1.0**. Lesson the differential surfaced: pair a deterministic tool oracle with a semantic judge, and avoid brittle exact-string checks. (The check was loosened to `/widget/i`.)
+
+Set `AGENT_MODEL=claude-sonnet-4-5` to regenerate fixtures on Sonnet and compare.
+
+## Running everything
+
+```bash
+# build k6 once (from repo root)
+go build -o k6 .
+
+# recorded (deterministic; only the judge key needed)
+ANTHROPIC_API_KEY_JUDGE=sk-ant-...  ./k6 run examples/experimental/ageval/frameworks/langgraph/eval.test.js
+ANTHROPIC_API_KEY_JUDGE=sk-ant-...  ./k6 run examples/experimental/ageval/frameworks/openai-agents/eval.test.js
+ANTHROPIC_API_KEY_JUDGE=sk-ant-...  ./k6 run examples/experimental/ageval/frameworks/crewai/eval.test.js
+
+# discrimination
+ANTHROPIC_API_KEY_JUDGE=sk-ant-...  ./k6 run examples/experimental/ageval/frameworks/pydantic-ai/eval_golden.test.js
+
+# live (also runs the agent; needs the agent key + a venv — see pydantic-ai/README.md)
+cd examples/experimental/ageval/frameworks/pydantic-ai
+ANTHROPIC_API_KEY_AGENT=sk-ant-... ANTHROPIC_API_KEY_JUDGE=sk-ant-... PYTHON=./venv/bin/python  ../../../../../k6 run eval.test.js
+```
+
+`ANTHROPIC_API_KEY_AGENT` is used by the agent; `ANTHROPIC_API_KEY_JUDGE` by the judge.

--- a/examples/experimental/ageval/frameworks/README.md
+++ b/examples/experimental/ageval/frameworks/README.md
@@ -36,7 +36,7 @@ adapter baked into the module. (For agents instrumented with OpenTelemetry GenAI
 OpenInference, a future built-in `otel` adapter would remove even the shim.)
 
 **Live vs recorded.** The live example (`pydantic-ai`) runs the agent inside
-`k6 run` via `ExternalAgent`. The recorded examples replay a committed
+`k6 run` via `CliAgent`. The recorded examples replay a committed
 `trajectory.json` via `new AgentTestCase(...)`, so they are deterministic and CI-safe — only
 the LLM judge needs a key. Each recorded dir's `capture.py` regenerates its fixture.
 

--- a/examples/experimental/ageval/frameworks/crewai/README.md
+++ b/examples/experimental/ageval/frameworks/crewai/README.md
@@ -1,0 +1,25 @@
+# CrewAI × ageval (recorded, multi-agent)
+
+Evaluates a [CrewAI](https://docs.crewai.com) **multi-agent crew** with
+`k6/experimental/ageval`: a Researcher (tool: `lookup_company`) hands off to a
+Writer (tool: `publish_summary`). The captured `trajectory.json` spans **both
+agents' tool calls**, so the eval grades the cross-agent pipeline — `expectSequence`
+requires research *before* publishing. Replayed by `eval.test.js` (deterministic /
+CI-safe; only the judge key is needed). See [`../README.md`](../README.md) for the
+overall pattern.
+
+## Run (replay the committed fixture)
+
+```bash
+ANTHROPIC_API_KEY_JUDGE=sk-ant-...  k6 run eval.test.js
+```
+
+## Regenerate the fixture (live)
+
+```bash
+python3 -m venv venv && venv/bin/pip install "crewai[anthropic]"
+# CrewAI is chatty, so capture.py writes the file directly (not stdout):
+ANTHROPIC_API_KEY_AGENT=sk-ant-...  venv/bin/python capture.py        # writes ./trajectory.json
+```
+
+Defaults to `claude-haiku-4-5`; set `AGENT_MODEL=claude-sonnet-4-5` to compare models.

--- a/examples/experimental/ageval/frameworks/crewai/capture.py
+++ b/examples/experimental/ageval/frameworks/crewai/capture.py
@@ -1,0 +1,106 @@
+"""CrewAI MULTI-AGENT crew -> canonical ageval trajectory (printed as JSON).
+
+A two-agent crew on Claude: a Researcher (tool: lookup_company) hands off to a
+Writer (tool: publish_summary). This exercises ageval's multi-agent / sub-agent
+story: the trajectory spans BOTH agents' tool calls, and the eval grades the
+combined sequence. Tool calls are captured by a small TRACE list inside the tools
+(version-independent). CrewAI is chatty and some of its loggers bypass a stdout
+redirect, so this writes the JSON straight to a file (default ./trajectory.json)
+rather than stdout. Regenerate with:
+
+    ANTHROPIC_API_KEY_AGENT=sk-...  python capture.py [out.json]
+"""
+
+import contextlib
+import json
+import os
+import sys
+
+os.environ.setdefault("CREWAI_DISABLE_TELEMETRY", "true")
+
+from crewai import LLM, Agent, Crew, Process, Task  # noqa: E402
+from crewai.tools import tool  # noqa: E402
+
+MODEL = os.environ.get("AGENT_MODEL", "claude-haiku-4-5")
+API_KEY = os.environ.get("ANTHROPIC_API_KEY_AGENT") or os.environ.get("ANTHROPIC_API_KEY")
+
+FACTS = {"Acme Corp": {"founded": 1998, "industry": "widgets", "hq": "Springfield"}}
+TRACE = []  # ordered tool calls across both agents
+
+
+@tool("lookup_company")
+def lookup_company(name: str) -> str:
+    """Look up basic facts (founding year, industry, HQ) about a company by name."""
+    out = json.dumps(FACTS.get(name, {"error": "unknown company"}))
+    TRACE.append({"name": "lookup_company", "input": {"name": name}, "output": out})
+    return out
+
+
+@tool("publish_summary")
+def publish_summary(summary: str) -> str:
+    """Publish the final one-sentence company summary."""
+    TRACE.append({"name": "publish_summary", "input": {"summary": summary}, "output": "published"})
+    return "published"
+
+
+def main():
+    task_text = sys.argv[1] if len(sys.argv) > 1 else "Acme Corp"
+    if not API_KEY:
+        print("ANTHROPIC_API_KEY_AGENT (or ANTHROPIC_API_KEY) must be set", file=sys.stderr)
+        sys.exit(1)
+
+    llm = LLM(model=f"anthropic/{MODEL}", api_key=API_KEY)
+
+    researcher = Agent(
+        role="Company Researcher",
+        goal="Find accurate facts about a company using the lookup_company tool.",
+        backstory="You look up authoritative facts and never invent them.",
+        tools=[lookup_company],
+        llm=llm,
+        verbose=False,
+    )
+    writer = Agent(
+        role="Summary Writer",
+        goal="Write a concise one-sentence company summary and publish it.",
+        backstory="You turn researched facts into a single clear sentence.",
+        tools=[publish_summary],
+        llm=llm,
+        verbose=False,
+    )
+
+    research = Task(
+        description=f"Look up the company '{task_text}' and report its founding year and industry.",
+        expected_output="The company's founding year and industry.",
+        agent=researcher,
+    )
+    write = Task(
+        description="Write a one-sentence summary from the research, then publish it with publish_summary.",
+        expected_output="A one-sentence published summary.",
+        agent=writer,
+        context=[research],
+    )
+
+    crew = Crew(agents=[researcher, writer], tasks=[research, write], process=Process.sequential, verbose=False)
+
+    # Keep stdout clean for the JSON; send any crew/LLM chatter to stderr.
+    with contextlib.redirect_stdout(sys.stderr):
+        result = crew.kickoff()
+
+    usage = getattr(result, "token_usage", None)
+    in_tok = int(getattr(usage, "prompt_tokens", 0) or 0)
+    out_tok = int(getattr(usage, "completion_tokens", 0) or 0)
+    trajectory = {
+        "input": task_text,
+        "output": str(getattr(result, "raw", result)),
+        "model": MODEL,
+        "toolCalls": TRACE,
+        "usage": {"inputTokens": in_tok, "outputTokens": out_tok},
+    }
+    out_path = sys.argv[2] if len(sys.argv) > 2 else "trajectory.json"
+    with open(out_path, "w") as f:
+        json.dump(trajectory, f, indent=4)
+    print(f"wrote {out_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/ageval/frameworks/crewai/eval.test.js
+++ b/examples/experimental/ageval/frameworks/crewai/eval.test.js
@@ -1,0 +1,60 @@
+// Evaluate a recorded CrewAI MULTI-AGENT crew with k6/experimental/ageval.
+//
+// The crew (Researcher -> Writer, on Claude) is captured once by capture.py into
+// trajectory.json. The trajectory spans BOTH agents' tool calls, so this shows
+// ageval grading a multi-agent / sub-agent pipeline: the Researcher must look the
+// company up (lookup_company) BEFORE the Writer publishes (publish_summary), and
+// the final summary must contain the researched facts. Deterministic / CI-safe;
+// only the LLM judge key is needed.
+//
+//   ANTHROPIC_API_KEY_JUDGE=sk-ant-...  k6 run eval.test.js
+import { check } from 'k6';
+import { AgentTestCase, judge } from 'k6/experimental/ageval';
+
+const run = JSON.parse(open('./trajectory.json'));
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate>0.9'],
+    agent_tool_correctness: ['rate>0.9'],
+    agent_quality_score: ['avg>0.7'],
+    agent_judge_pass: ['rate>0.9'],
+  },
+};
+
+export default function () {
+  const res = new AgentTestCase({
+    name: 'crewai',
+    input: run.input,
+    output: run.output,
+    toolCalls: run.toolCalls,
+    usage: run.usage,
+    model: run.model,
+    // Cross-agent ordering: research must precede publishing.
+    expectedTools: [{ name: 'lookup_company' }, { name: 'publish_summary' }],
+    tags: { case: 'multi_agent_summary' },
+  });
+
+  check(res, {
+    'researcher looked up the company': (r) => r.calledTool('lookup_company'),
+    'writer published a summary': (r) => r.calledTool('publish_summary'),
+    'summary cites the industry': (r) => /widget/i.test(r.output), // 'widget' or 'widgets'
+    'summary cites the founding year': (r) => /1998/.test(r.output),
+  });
+
+  // No argument → grade against res.expectedTools (lookup_company before publish_summary).
+  res.expectSequence();
+
+  judge(res, {
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5',
+    apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
+    rubric:
+      'A two-agent crew was asked to research Acme Corp and publish a one-sentence summary. A good ' +
+      'result is a single concise sentence that correctly states Acme Corp is a widgets company ' +
+      'founded in 1998. Penalize invented facts, missing facts, or multi-sentence rambling.',
+    threshold: 0.7,
+  });
+}

--- a/examples/experimental/ageval/frameworks/crewai/eval.test.js
+++ b/examples/experimental/ageval/frameworks/crewai/eval.test.js
@@ -48,6 +48,7 @@ export default function () {
   res.expectSequence();
 
   judge(res, {
+    name: 'company_summary',
     provider: 'anthropic',
     model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,

--- a/examples/experimental/ageval/frameworks/crewai/trajectory.json
+++ b/examples/experimental/ageval/frameworks/crewai/trajectory.json
@@ -1,0 +1,25 @@
+{
+    "input": "Acme Corp",
+    "output": "**Final Answer:**\n\nAcme Corp is a widget manufacturer founded in 1998 and headquartered in Springfield.",
+    "model": "claude-haiku-4-5",
+    "toolCalls": [
+        {
+            "name": "lookup_company",
+            "input": {
+                "name": "Acme Corp"
+            },
+            "output": "{\"founded\": 1998, \"industry\": \"widgets\", \"hq\": \"Springfield\"}"
+        },
+        {
+            "name": "publish_summary",
+            "input": {
+                "summary": "Acme Corp is a widget manufacturer founded in 1998 and headquartered in Springfield."
+            },
+            "output": "published"
+        }
+    ],
+    "usage": {
+        "inputTokens": 5938,
+        "outputTokens": 468
+    }
+}

--- a/examples/experimental/ageval/frameworks/langgraph/README.md
+++ b/examples/experimental/ageval/frameworks/langgraph/README.md
@@ -1,0 +1,22 @@
+# LangGraph × ageval (recorded)
+
+Evaluates a [LangGraph](https://langchain-ai.github.io/langgraph/) ReAct agent
+(bank-support task) with `k6/experimental/ageval`. The run is captured once into
+`trajectory.json` (canonical ageval shape) and replayed by `eval.test.js`, so the
+test is deterministic and CI-safe — only the judge key is needed. See
+[`../README.md`](../README.md) for the overall pattern.
+
+## Run (replay the committed fixture)
+
+```bash
+ANTHROPIC_API_KEY_JUDGE=sk-ant-...  k6 run eval.test.js
+```
+
+## Regenerate the fixture (live)
+
+```bash
+python3 -m venv venv && venv/bin/pip install langgraph langchain-anthropic
+ANTHROPIC_API_KEY_AGENT=sk-ant-...  venv/bin/python capture.py > trajectory.json
+```
+
+Defaults to `claude-haiku-4-5`; set `AGENT_MODEL=claude-sonnet-4-5` to compare models.

--- a/examples/experimental/ageval/frameworks/langgraph/capture.py
+++ b/examples/experimental/ageval/frameworks/langgraph/capture.py
@@ -1,0 +1,88 @@
+"""LangGraph ReAct agent -> canonical ageval trajectory (printed as JSON).
+
+Same bank-support task as the other examples, built with LangGraph's prebuilt
+ReAct agent on Claude. The ~20-line `to_trajectory` shim maps LangGraph's message
+list (AIMessage.tool_calls + ToolMessage + usage_metadata) onto ageval's canonical
+shape. Regenerate the fixture with:
+
+    ANTHROPIC_API_KEY_AGENT=sk-...  python capture.py > trajectory.json
+"""
+
+import json
+import os
+import sys
+
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.tools import tool
+from langgraph.prebuilt import create_react_agent
+
+MODEL = os.environ.get("AGENT_MODEL", "claude-haiku-4-5")
+API_KEY = os.environ.get("ANTHROPIC_API_KEY_AGENT") or os.environ.get("ANTHROPIC_API_KEY")
+
+CUSTOMERS = {"alice@example.com": {"id": "cust_123", "name": "Alice", "plan": "Pro"}}
+INVOICES = {"INV-123": {"status": "paid", "amount": 99, "currency": "USD", "customer": "cust_123"}}
+
+
+@tool
+def get_customer(email: str) -> str:
+    """Look up a customer by their email address."""
+    return json.dumps(CUSTOMERS.get(email, {"error": "not found"}))
+
+
+@tool
+def get_invoice(invoice_id: str) -> str:
+    """Look up an invoice by its id."""
+    return json.dumps(INVOICES.get(invoice_id, {"error": "not found"}))
+
+
+def to_trajectory(task, messages):
+    calls = {}  # tool_call_id -> {name, input, output}
+    order = []
+    output = ""
+    in_tok = out_tok = 0
+    for msg in messages:
+        if isinstance(msg, AIMessage):
+            for tc in msg.tool_calls or []:
+                calls[tc["id"]] = {"name": tc["name"], "input": tc.get("args", {}), "output": ""}
+                order.append(tc["id"])
+            if isinstance(msg.content, str) and msg.content.strip():
+                output = msg.content  # last non-empty assistant text is the final answer
+            usage = getattr(msg, "usage_metadata", None) or {}
+            in_tok += usage.get("input_tokens", 0)
+            out_tok += usage.get("output_tokens", 0)
+        elif isinstance(msg, ToolMessage):
+            call = calls.get(msg.tool_call_id)
+            if call is not None:
+                content = msg.content
+                call["output"] = content if isinstance(content, str) else json.dumps(content)
+    return {
+        "input": task,
+        "output": output,
+        "model": MODEL,
+        "toolCalls": [calls[i] for i in order],
+        "usage": {"inputTokens": int(in_tok), "outputTokens": int(out_tok)},
+    }
+
+
+def main():
+    task = sys.argv[1] if len(sys.argv) > 1 else "Was invoice INV-123 for alice@example.com paid?"
+    if not API_KEY:
+        print("ANTHROPIC_API_KEY_AGENT (or ANTHROPIC_API_KEY) must be set", file=sys.stderr)
+        sys.exit(1)
+    model = ChatAnthropic(model=MODEL, api_key=API_KEY)
+    agent = create_react_agent(
+        model,
+        tools=[get_customer, get_invoice],
+        prompt=(
+            "You are a billing support agent. First call get_customer to look up the customer by "
+            "email, then call get_invoice to check the invoice status, then answer concisely. "
+            "Never reveal internal identifiers such as the customer id."
+        ),
+    )
+    result = agent.invoke({"messages": [{"role": "user", "content": task}]})
+    print(json.dumps(to_trajectory(task, result["messages"])))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/ageval/frameworks/langgraph/eval.test.js
+++ b/examples/experimental/ageval/frameworks/langgraph/eval.test.js
@@ -1,0 +1,57 @@
+// Evaluate a recorded LangGraph ReAct-agent run with k6/experimental/ageval.
+//
+// The agent run is captured once (see capture.py) into trajectory.json — a
+// canonical ageval trajectory. This test replays that fixture, so it is fully
+// deterministic and CI-safe: no agent provider key is needed, only the LLM judge
+// key. Same canonical shape, same assertions as the live Pydantic-AI example —
+// proving ageval is framework-agnostic.
+//
+//   ANTHROPIC_API_KEY_JUDGE=sk-ant-...  k6 run eval.test.js
+import { check } from 'k6';
+import { AgentTestCase, judge } from 'k6/experimental/ageval';
+
+const run = JSON.parse(open('./trajectory.json'));
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate>0.9'],
+    agent_tool_correctness: ['rate>0.9'],
+    agent_quality_score: ['avg>0.7'],
+    agent_judge_pass: ['rate>0.9'],
+  },
+};
+
+export default function () {
+  const res = new AgentTestCase({
+    name: 'langgraph',
+    input: run.input,
+    output: run.output,
+    toolCalls: run.toolCalls,
+    usage: run.usage,
+    model: run.model,
+    expectedTools: [{ name: 'get_customer' }, { name: 'get_invoice', input: { invoice_id: 'INV-123' } }],
+    tags: { case: 'invoice_paid' },
+  });
+
+  check(res, {
+    'called get_customer': (r) => r.calledTool('get_customer'),
+    'called get_invoice': (r) => r.calledTool('get_invoice'),
+    'mentions paid': (r) => /paid/i.test(r.output),
+    'hides internal id': (r) => !/cust_123/.test(r.output),
+  });
+
+  // No argument → grade against res.expectedTools.
+  res.expectSequence();
+
+  judge(res, {
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5',
+    apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
+    rubric:
+      'The user asked whether invoice INV-123 for alice@example.com was paid. A good answer states ' +
+      'the invoice is paid ($99), is concise, and does NOT expose the internal customer id (cust_123).',
+    threshold: 0.7,
+  });
+}

--- a/examples/experimental/ageval/frameworks/langgraph/eval.test.js
+++ b/examples/experimental/ageval/frameworks/langgraph/eval.test.js
@@ -46,6 +46,7 @@ export default function () {
   res.expectSequence();
 
   judge(res, {
+    name: 'invoice_paid',
     provider: 'anthropic',
     model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,

--- a/examples/experimental/ageval/frameworks/langgraph/trajectory.json
+++ b/examples/experimental/ageval/frameworks/langgraph/trajectory.json
@@ -1,0 +1,25 @@
+{
+    "input": "Was invoice INV-123 for alice@example.com paid?",
+    "output": "Yes, invoice INV-123 for alice@example.com has been **paid**. The invoice was for $99 USD.",
+    "model": "claude-haiku-4-5",
+    "toolCalls": [
+        {
+            "name": "get_customer",
+            "input": {
+                "email": "alice@example.com"
+            },
+            "output": "{\"id\": \"cust_123\", \"name\": \"Alice\", \"plan\": \"Pro\"}"
+        },
+        {
+            "name": "get_invoice",
+            "input": {
+                "invoice_id": "INV-123"
+            },
+            "output": "{\"status\": \"paid\", \"amount\": 99, \"currency\": \"USD\", \"customer\": \"cust_123\"}"
+        }
+    ],
+    "usage": {
+        "inputTokens": 1600,
+        "outputTokens": 157
+    }
+}

--- a/examples/experimental/ageval/frameworks/openai-agents/README.md
+++ b/examples/experimental/ageval/frameworks/openai-agents/README.md
@@ -1,0 +1,22 @@
+# OpenAI Agents SDK × ageval (recorded)
+
+Evaluates an [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/)
+agent (bank-support task) with `k6/experimental/ageval`. It runs on **Claude via
+the SDK's LiteLLM extension** — no OpenAI key needed. The run is captured once into
+`trajectory.json` and replayed by `eval.test.js` (deterministic / CI-safe; only the
+judge key is needed). See [`../README.md`](../README.md) for the overall pattern.
+
+## Run (replay the committed fixture)
+
+```bash
+ANTHROPIC_API_KEY_JUDGE=sk-ant-...  k6 run eval.test.js
+```
+
+## Regenerate the fixture (live)
+
+```bash
+python3 -m venv venv && venv/bin/pip install "openai-agents[litellm]"
+ANTHROPIC_API_KEY_AGENT=sk-ant-...  venv/bin/python capture.py > trajectory.json
+```
+
+Defaults to `claude-haiku-4-5`; set `AGENT_MODEL=claude-sonnet-4-5` to compare models.

--- a/examples/experimental/ageval/frameworks/openai-agents/capture.py
+++ b/examples/experimental/ageval/frameworks/openai-agents/capture.py
@@ -1,0 +1,108 @@
+"""OpenAI Agents SDK agent -> canonical ageval trajectory (printed as JSON).
+
+Same bank-support task as the other examples. The OpenAI Agents SDK is run on
+Claude via its LiteLLM extension (no OpenAI key needed). The `to_trajectory` shim
+maps result.final_output / result.new_items (ToolCallItem / ToolCallOutputItem) /
+result.context_wrapper.usage onto ageval's canonical shape. Regenerate with:
+
+    ANTHROPIC_API_KEY_AGENT=sk-...  python capture.py > trajectory.json
+"""
+
+import json
+import os
+import sys
+
+from agents import Agent, Runner, function_tool, set_tracing_disabled
+from agents.extensions.models.litellm_model import LitellmModel
+from agents.items import ToolCallItem, ToolCallOutputItem
+
+# We run on Claude via LiteLLM; disable the SDK's default trace export to OpenAI
+# (which would otherwise warn about a missing OpenAI key).
+set_tracing_disabled(True)
+
+MODEL = os.environ.get("AGENT_MODEL", "claude-haiku-4-5")
+API_KEY = os.environ.get("ANTHROPIC_API_KEY_AGENT") or os.environ.get("ANTHROPIC_API_KEY")
+
+CUSTOMERS = {"alice@example.com": {"id": "cust_123", "name": "Alice", "plan": "Pro"}}
+INVOICES = {"INV-123": {"status": "paid", "amount": 99, "currency": "USD", "customer": "cust_123"}}
+
+
+@function_tool
+def get_customer(email: str) -> str:
+    """Look up a customer by their email address."""
+    return json.dumps(CUSTOMERS.get(email, {"error": "not found"}))
+
+
+@function_tool
+def get_invoice(invoice_id: str) -> str:
+    """Look up an invoice by its id."""
+    return json.dumps(INVOICES.get(invoice_id, {"error": "not found"}))
+
+
+def _args_of(item):
+    raw = getattr(item, "raw_item", None)
+    raw_args = getattr(raw, "arguments", None)
+    if isinstance(raw_args, str):
+        try:
+            return json.loads(raw_args or "{}")
+        except json.JSONDecodeError:
+            return {}
+    return raw_args or {}
+
+
+def _output_of(item):
+    out = getattr(item, "output", None)
+    if out is None:
+        raw = getattr(item, "raw_item", None)
+        out = raw.get("output") if isinstance(raw, dict) else raw
+    return out if isinstance(out, str) else json.dumps(out)
+
+
+def to_trajectory(task, result):
+    calls = {}  # call_id -> {name, input, output}
+    order = []
+    for item in result.new_items:
+        if isinstance(item, ToolCallItem):
+            raw = getattr(item, "raw_item", None)
+            name = getattr(item, "tool_name", None) or getattr(raw, "name", "")
+            cid = getattr(item, "call_id", None) or getattr(raw, "call_id", "")
+            calls[cid] = {"name": name, "input": _args_of(item), "output": ""}
+            order.append(cid)
+        elif isinstance(item, ToolCallOutputItem):
+            cid = getattr(item, "call_id", "")
+            if cid in calls:
+                calls[cid]["output"] = _output_of(item)
+    usage = result.context_wrapper.usage
+    return {
+        "input": task,
+        "output": str(result.final_output),
+        "model": MODEL,
+        "toolCalls": [calls[i] for i in order],
+        "usage": {
+            "inputTokens": int(getattr(usage, "input_tokens", 0)),
+            "outputTokens": int(getattr(usage, "output_tokens", 0)),
+        },
+    }
+
+
+def main():
+    task = sys.argv[1] if len(sys.argv) > 1 else "Was invoice INV-123 for alice@example.com paid?"
+    if not API_KEY:
+        print("ANTHROPIC_API_KEY_AGENT (or ANTHROPIC_API_KEY) must be set", file=sys.stderr)
+        sys.exit(1)
+    agent = Agent(
+        name="billing-support",
+        instructions=(
+            "You are a billing support agent. First call get_customer to look up the customer by "
+            "email, then call get_invoice to check the invoice status, then answer concisely. "
+            "Never reveal internal identifiers such as the customer id."
+        ),
+        tools=[get_customer, get_invoice],
+        model=LitellmModel(model=f"anthropic/{MODEL}", api_key=API_KEY),
+    )
+    result = Runner.run_sync(agent, task)
+    print(json.dumps(to_trajectory(task, result)))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/ageval/frameworks/openai-agents/eval.test.js
+++ b/examples/experimental/ageval/frameworks/openai-agents/eval.test.js
@@ -1,0 +1,56 @@
+// Evaluate a recorded OpenAI Agents SDK run with k6/experimental/ageval.
+//
+// The agent (run on Claude via the SDK's LiteLLM extension) is captured once by
+// capture.py into trajectory.json — a canonical ageval trajectory. This test
+// replays that fixture, so it is deterministic and CI-safe (only the LLM judge
+// key is needed). Same canonical shape and assertions as the other frameworks.
+//
+//   ANTHROPIC_API_KEY_JUDGE=sk-ant-...  k6 run eval.test.js
+import { check } from 'k6';
+import { AgentTestCase, judge } from 'k6/experimental/ageval';
+
+const run = JSON.parse(open('./trajectory.json'));
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate>0.9'],
+    agent_tool_correctness: ['rate>0.9'],
+    agent_quality_score: ['avg>0.7'],
+    agent_judge_pass: ['rate>0.9'],
+  },
+};
+
+export default function () {
+  const res = new AgentTestCase({
+    name: 'openai-agents',
+    input: run.input,
+    output: run.output,
+    toolCalls: run.toolCalls,
+    usage: run.usage,
+    model: run.model,
+    expectedTools: [{ name: 'get_customer' }, { name: 'get_invoice', input: { invoice_id: 'INV-123' } }],
+    tags: { case: 'invoice_paid' },
+  });
+
+  check(res, {
+    'called get_customer': (r) => r.calledTool('get_customer'),
+    'called get_invoice': (r) => r.calledTool('get_invoice'),
+    'mentions paid': (r) => /paid/i.test(r.output),
+    'hides internal id': (r) => !/cust_123/.test(r.output),
+  });
+
+  // No argument → grade against res.expectedTools.
+  res.expectSequence();
+
+  judge(res, {
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5',
+    apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
+    rubric:
+      'The user asked whether invoice INV-123 for alice@example.com was paid. A good answer states ' +
+      'the invoice is paid ($99), is concise, and does NOT expose the internal customer id (cust_123).',
+    threshold: 0.7,
+  });
+}

--- a/examples/experimental/ageval/frameworks/openai-agents/eval.test.js
+++ b/examples/experimental/ageval/frameworks/openai-agents/eval.test.js
@@ -45,6 +45,7 @@ export default function () {
   res.expectSequence();
 
   judge(res, {
+    name: 'invoice_paid',
     provider: 'anthropic',
     model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,

--- a/examples/experimental/ageval/frameworks/openai-agents/trajectory.json
+++ b/examples/experimental/ageval/frameworks/openai-agents/trajectory.json
@@ -1,0 +1,25 @@
+{
+    "input": "Was invoice INV-123 for alice@example.com paid?",
+    "output": "Yes, invoice INV-123 has been paid. It was for $99 USD and the payment status is confirmed as paid.",
+    "model": "claude-haiku-4-5",
+    "toolCalls": [
+        {
+            "name": "get_customer",
+            "input": {
+                "email": "alice@example.com"
+            },
+            "output": "{\"id\": \"cust_123\", \"name\": \"Alice\", \"plan\": \"Pro\"}"
+        },
+        {
+            "name": "get_invoice",
+            "input": {
+                "invoice_id": "INV-123"
+            },
+            "output": "{\"status\": \"paid\", \"amount\": 99, \"currency\": \"USD\", \"customer\": \"cust_123\"}"
+        }
+    ],
+    "usage": {
+        "inputTokens": 1617,
+        "outputTokens": 141
+    }
+}

--- a/examples/experimental/ageval/frameworks/pydantic-ai/README.md
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/README.md
@@ -1,0 +1,57 @@
+# Pydantic-AI × ageval (live, single `k6 run`)
+
+Evaluates a **real [Pydantic-AI](https://ai.pydantic.dev) agent** end-to-end in one
+`k6 run`. `agent.py` is a small bank-support agent (two tools: `get_customer`,
+`get_invoice`) running on Claude; on each run it prints a **canonical ageval
+trajectory** as JSON. k6's `ExternalAgent` runs it and grades the result.
+
+This is the "framework app" pattern: ageval's only hard contract is the canonical
+shape `{ output, toolCalls:[{name,input,output}], usage }`. A ~15-line shim in
+`agent.py` (`to_trajectory`) maps Pydantic-AI's `result.output` /
+`result.all_messages()` (`ToolCallPart`/`ToolReturnPart`) / `result.usage` onto it.
+No new k6/Go code is required.
+
+## Setup
+
+```bash
+python3 -m venv venv
+venv/bin/pip install pydantic-ai
+```
+
+## Run (live)
+
+```bash
+cd examples/experimental/ageval/frameworks/pydantic-ai
+ANTHROPIC_API_KEY_AGENT=sk-ant-...  ANTHROPIC_API_KEY_JUDGE=sk-ant-... \
+PYTHON=./venv/bin/python  k6 run eval.test.js
+```
+
+`ANTHROPIC_API_KEY_AGENT` is used by the agent; `ANTHROPIC_API_KEY_JUDGE` by the
+LLM judge. `PYTHON` points `ExternalAgent` at the venv interpreter (defaults to
+`python3`). The agent defaults to the cheap `claude-haiku-4-5`
+(set `AGENT_MODEL=claude-sonnet-4-5` to compare). Verified result: 4/4 checks,
+`agent_tool_correctness` 100%, `agent_quality_score` 1.0, cost ~$0.002/run on Haiku
+(~$0.007 on Sonnet) — see the differential note in [`../README.md`](../README.md).
+
+## What it validates
+
+- **Usefulness** — a real third-party framework agent plugs in with only the shim.
+- **Validity (tool dimension)** — `expectSequence([get_customer, get_invoice{INV-123}])`
+  is a deterministic, non-LLM oracle: the agent must look the customer up *before*
+  the invoice and query the right id.
+- **Validity (answer dimension)** — the LLM `judge` scores the final answer.
+
+## Golden good-vs-bad (`eval_golden.test.js`)
+
+Proves the eval *discriminates* rather than rubber-stamps. Feeds two committed
+fixtures of the same task — `trajectory.good.json` (real run) and
+`trajectory.bad.json` (tampered: skips `get_customer`, wrong invoice, leaks the
+internal `cust_123` id, uncertain answer) — through the same assertions and checks
+that the good run passes and the bad run fails (deterministically, plus the judge).
+
+```bash
+ANTHROPIC_API_KEY_JUDGE=sk-ant-...  k6 run eval_golden.test.js   # 8/8 checks pass
+```
+
+Regenerate `trajectory.good.json`:
+`ANTHROPIC_API_KEY_AGENT=… ./venv/bin/python agent.py > trajectory.good.json`

--- a/examples/experimental/ageval/frameworks/pydantic-ai/README.md
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/README.md
@@ -3,7 +3,7 @@
 Evaluates a **real [Pydantic-AI](https://ai.pydantic.dev) agent** end-to-end in one
 `k6 run`. `agent.py` is a small bank-support agent (two tools: `get_customer`,
 `get_invoice`) running on Claude; on each run it prints a **canonical ageval
-trajectory** as JSON. k6's `ExternalAgent` runs it and grades the result.
+trajectory** as JSON. k6's `CliAgent` runs it and grades the result.
 
 This is the "framework app" pattern: ageval's only hard contract is the canonical
 shape `{ output, toolCalls:[{name,input,output}], usage }`. A ~15-line shim in
@@ -27,7 +27,7 @@ PYTHON=./venv/bin/python  k6 run eval.test.js
 ```
 
 `ANTHROPIC_API_KEY_AGENT` is used by the agent; `ANTHROPIC_API_KEY_JUDGE` by the
-LLM judge. `PYTHON` points `ExternalAgent` at the venv interpreter (defaults to
+LLM judge. `PYTHON` points `CliAgent` at the venv interpreter (defaults to
 `python3`). The agent defaults to the cheap `claude-haiku-4-5`
 (set `AGENT_MODEL=claude-sonnet-4-5` to compare). Verified result: 4/4 checks,
 `agent_tool_correctness` 100%, `agent_quality_score` 1.0, cost ~$0.002/run on Haiku

--- a/examples/experimental/ageval/frameworks/pydantic-ai/agent.py
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/agent.py
@@ -1,0 +1,91 @@
+"""Pydantic-AI bank-support agent that emits a canonical ageval trajectory.
+
+This is the ~15-line "capture shim" pattern: run a real framework agent, then map
+its result onto ageval's only hard contract — the canonical trajectory shape
+`{input, output, toolCalls:[{name,input,output}], usage}` — and print it as JSON.
+k6's ExternalAgent runs this and grades the result, all in one `k6 run`.
+
+    ANTHROPIC_API_KEY_AGENT=sk-...  python agent.py "Was invoice INV-123 for alice@example.com paid?"
+"""
+
+import json
+import os
+import sys
+
+from pydantic_ai import Agent
+from pydantic_ai.messages import ToolCallPart, ToolReturnPart
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.providers.anthropic import AnthropicProvider
+
+MODEL = os.environ.get("AGENT_MODEL", "claude-haiku-4-5")
+API_KEY = os.environ.get("ANTHROPIC_API_KEY_AGENT") or os.environ.get("ANTHROPIC_API_KEY")
+
+# Deterministic mock backend so the eval is reproducible.
+CUSTOMERS = {"alice@example.com": {"id": "cust_123", "name": "Alice", "plan": "Pro"}}
+INVOICES = {"INV-123": {"status": "paid", "amount": 99, "currency": "USD", "customer": "cust_123"}}
+
+agent = Agent(
+    AnthropicModel(MODEL, provider=AnthropicProvider(api_key=API_KEY)) if API_KEY else MODEL,
+    system_prompt=(
+        "You are a billing support agent. First call get_customer to look up the customer by "
+        "email, then call get_invoice to check the invoice status, then answer concisely. "
+        "Never reveal internal identifiers such as the customer id."
+    ),
+)
+
+
+@agent.tool_plain
+def get_customer(email: str) -> str:
+    """Look up a customer by their email address."""
+    return json.dumps(CUSTOMERS.get(email, {"error": "not found"}))
+
+
+@agent.tool_plain
+def get_invoice(invoice_id: str) -> str:
+    """Look up an invoice by its id."""
+    return json.dumps(INVOICES.get(invoice_id, {"error": "not found"}))
+
+
+def to_trajectory(task, result):
+    """Map a Pydantic-AI run onto the canonical ageval trajectory shape."""
+    calls = {}  # tool_call_id -> {name, input, output}
+    order = []
+    for msg in result.all_messages():
+        for part in getattr(msg, "parts", []):
+            if isinstance(part, ToolCallPart):
+                try:
+                    args = part.args_as_dict()
+                except Exception:
+                    args = {}
+                calls[part.tool_call_id] = {"name": part.tool_name, "input": args, "output": ""}
+                order.append(part.tool_call_id)
+            elif isinstance(part, ToolReturnPart):
+                call = calls.get(part.tool_call_id)
+                if call is not None:
+                    content = part.content
+                    call["output"] = content if isinstance(content, str) else json.dumps(content)
+    # result.usage is an attribute in pydantic-ai 2.x; older versions exposed a method.
+    usage = result.usage() if callable(getattr(result, "usage", None)) else result.usage
+    in_tok = getattr(usage, "input_tokens", None) or getattr(usage, "request_tokens", 0) or 0
+    out_tok = getattr(usage, "output_tokens", None) or getattr(usage, "response_tokens", 0) or 0
+    return {
+        "input": task,
+        "output": str(result.output),
+        "model": MODEL,
+        "toolCalls": [calls[i] for i in order],
+        "usage": {"inputTokens": int(in_tok), "outputTokens": int(out_tok)},
+    }
+
+
+def main():
+    task = sys.argv[1] if len(sys.argv) > 1 else "Was invoice INV-123 for alice@example.com paid?"
+    if not API_KEY:
+        print("ANTHROPIC_API_KEY_AGENT (or ANTHROPIC_API_KEY) must be set", file=sys.stderr)
+        sys.exit(1)
+    result = agent.run_sync(task)
+    # Only the canonical JSON goes to stdout; ExternalAgent parses it with JSON.parse.
+    print(json.dumps(to_trajectory(task, result)))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/ageval/frameworks/pydantic-ai/agent.py
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/agent.py
@@ -3,7 +3,7 @@
 This is the ~15-line "capture shim" pattern: run a real framework agent, then map
 its result onto ageval's only hard contract — the canonical trajectory shape
 `{input, output, toolCalls:[{name,input,output}], usage}` — and print it as JSON.
-k6's ExternalAgent runs this and grades the result, all in one `k6 run`.
+k6's CliAgent runs this and grades the result, all in one `k6 run`.
 
     ANTHROPIC_API_KEY_AGENT=sk-...  python agent.py "Was invoice INV-123 for alice@example.com paid?"
 """
@@ -83,7 +83,7 @@ def main():
         print("ANTHROPIC_API_KEY_AGENT (or ANTHROPIC_API_KEY) must be set", file=sys.stderr)
         sys.exit(1)
     result = agent.run_sync(task)
-    # Only the canonical JSON goes to stdout; ExternalAgent parses it with JSON.parse.
+    # Only the canonical JSON goes to stdout; CliAgent parses it with JSON.parse.
     print(json.dumps(to_trajectory(task, result)))
 
 

--- a/examples/experimental/ageval/frameworks/pydantic-ai/eval.test.js
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/eval.test.js
@@ -1,0 +1,73 @@
+// Evaluate a REAL Pydantic-AI agent in a SINGLE `k6 run`.
+//
+// ExternalAgent runs agent.py (a real Pydantic-AI bank-support agent on Claude),
+// which prints a canonical ageval trajectory as JSON; the `parse` callback hands
+// that straight back. We then assert the tool trajectory with a deterministic,
+// non-LLM oracle (expectSequence) and grade the answer quality with an LLM judge.
+//
+// This is the "framework app" pattern: ageval's only hard contract is the
+// canonical shape `{ output, toolCalls:[{name,input,output}], usage }`, so ANY
+// framework works once its run is mapped to that shape (see agent.py's ~15-line
+// shim). No new k6/Go code is needed.
+//
+// Prereqs:  python3 -m venv venv && venv/bin/pip install pydantic-ai
+// Run (from this directory):
+//   ANTHROPIC_API_KEY_AGENT=sk-...  ANTHROPIC_API_KEY_JUDGE=sk-... \
+//   PYTHON=./venv/bin/python  k6 run eval.test.js
+import { check } from 'k6';
+import { ExternalAgent, judge } from 'k6/experimental/ageval';
+
+const TASK = __ENV.TASK || 'Was invoice INV-123 for alice@example.com paid?';
+
+const agent = new ExternalAgent({
+  name: 'pydantic-ai',
+  command: __ENV.PYTHON || 'python3',
+  args: [`${__ENV.AGENT_DIR || '.'}/agent.py`, '{{input}}'],
+  parse: (stdout) => JSON.parse(stdout),
+  model: 'claude-haiku-4-5', // enables agent_cost_usd from the pricing registry
+  timeoutSeconds: 180,
+});
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate>0.9'],
+    agent_tool_correctness: ['rate>0.9'],
+    agent_quality_score: ['avg>0.7'],
+    agent_judge_pass: ['rate>0.9'],
+  },
+};
+
+export default function () {
+  // expectedTools (≈ DeepEval's expected_tools) is attached to the produced
+  // AgentTestCase, then graded by expectSequence() with no argument below.
+  const res = agent.run({
+    input: TASK,
+    expectedTools: [{ name: 'get_customer' }, { name: 'get_invoice', input: { invoice_id: 'INV-123' } }],
+    tags: { case: 'invoice_paid' },
+  });
+
+  check(res, {
+    'called get_customer': (r) => r.calledTool('get_customer'),
+    'called get_invoice': (r) => r.calledTool('get_invoice'),
+    'mentions paid': (r) => /paid/i.test(r.output),
+    'hides internal id': (r) => !/cust_123/.test(r.output),
+  });
+
+  // Deterministic oracle: with no argument, expectSequence() grades the recorded
+  // tool calls against res.expectedTools (the agent must look the customer up
+  // BEFORE the invoice, and query the specific invoice id). No LLM involved.
+  res.expectSequence();
+
+  judge(res, {
+    provider: 'anthropic',
+    model: 'claude-haiku-4-5',
+    apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
+    rubric:
+      'The user asked whether invoice INV-123 for alice@example.com was paid. A good answer states ' +
+      'the invoice is paid (amount $99), is concise, and does NOT expose the internal customer id ' +
+      '(cust_123). Penalize wrong/uncertain answers, refusals, or leaking the internal id.',
+    threshold: 0.7,
+  });
+}

--- a/examples/experimental/ageval/frameworks/pydantic-ai/eval.test.js
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/eval.test.js
@@ -40,7 +40,6 @@ export const options = {
 };
 
 export default function () {
-  // expectedTools (≈ DeepEval's expected_tools) is attached to the produced
   // AgentTestCase, then graded by expectSequence() with no argument below.
   const res = agent.run({
     input: TASK,

--- a/examples/experimental/ageval/frameworks/pydantic-ai/eval.test.js
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/eval.test.js
@@ -60,6 +60,7 @@ export default function () {
   res.expectSequence();
 
   judge(res, {
+    name: 'invoice_paid',
     provider: 'anthropic',
     model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,

--- a/examples/experimental/ageval/frameworks/pydantic-ai/eval.test.js
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/eval.test.js
@@ -1,6 +1,6 @@
 // Evaluate a REAL Pydantic-AI agent in a SINGLE `k6 run`.
 //
-// ExternalAgent runs agent.py (a real Pydantic-AI bank-support agent on Claude),
+// CliAgent runs agent.py (a real Pydantic-AI bank-support agent on Claude),
 // which prints a canonical ageval trajectory as JSON; the `parse` callback hands
 // that straight back. We then assert the tool trajectory with a deterministic,
 // non-LLM oracle (expectSequence) and grade the answer quality with an LLM judge.
@@ -15,11 +15,11 @@
 //   ANTHROPIC_API_KEY_AGENT=sk-...  ANTHROPIC_API_KEY_JUDGE=sk-... \
 //   PYTHON=./venv/bin/python  k6 run eval.test.js
 import { check } from 'k6';
-import { ExternalAgent, judge } from 'k6/experimental/ageval';
+import { CliAgent, judge } from 'k6/experimental/ageval';
 
 const TASK = __ENV.TASK || 'Was invoice INV-123 for alice@example.com paid?';
 
-const agent = new ExternalAgent({
+const agent = new CliAgent({
   name: 'pydantic-ai',
   command: __ENV.PYTHON || 'python3',
   args: [`${__ENV.AGENT_DIR || '.'}/agent.py`, '{{input}}'],

--- a/examples/experimental/ageval/frameworks/pydantic-ai/eval_golden.test.js
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/eval_golden.test.js
@@ -53,8 +53,8 @@ export default function () {
 
   const gSeq = g.expectSequence(SEQ, SEQ_OPTS);
   const bSeq = b.expectSequence(SEQ, SEQ_OPTS);
-  const gJudge = judge(g, { provider: 'anthropic', model: 'claude-haiku-4-5', apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE, rubric: RUBRIC, threshold: 0.7 });
-  const bJudge = judge(b, { provider: 'anthropic', model: 'claude-haiku-4-5', apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE, rubric: RUBRIC, threshold: 0.7 });
+  const gJudge = judge(g, { name: 'invoice_paid', provider: 'anthropic', model: 'claude-haiku-4-5', apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE, rubric: RUBRIC, threshold: 0.7 });
+  const bJudge = judge(b, { name: 'invoice_paid', provider: 'anthropic', model: 'claude-haiku-4-5', apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE, rubric: RUBRIC, threshold: 0.7 });
 
   console.log(`good: seq=${gSeq} judge=${gJudge.score} | bad: seq=${bSeq} judge=${bJudge.score} (${bJudge.reason})`);
 

--- a/examples/experimental/ageval/frameworks/pydantic-ai/eval_golden.test.js
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/eval_golden.test.js
@@ -1,0 +1,73 @@
+// Validity check: does ageval actually DISCRIMINATE good agent runs from bad ones,
+// or does it rubber-stamp everything?
+//
+// We feed two committed fixtures of the SAME task through the SAME assertions:
+//   - trajectory.good.json: a real captured Pydantic-AI run (correct tool order,
+//     correct answer, no leaked internal id).
+//   - trajectory.bad.json:  a tampered run (skips get_customer, queries the wrong
+//     invoice, leaks the internal customer id, gives an uncertain/wrong answer).
+//
+// A valid eval must PASS every assertion on the good run and FAIL them on the bad
+// run. The deterministic oracle (expectSequence + output regex) proves this with no
+// LLM in the loop; the LLM judge is asserted too as corroboration.
+//
+//   ANTHROPIC_API_KEY_JUDGE=sk-...  k6 run eval_golden.test.js
+import { check } from 'k6';
+import { AgentTestCase, judge } from 'k6/experimental/ageval';
+
+const good = JSON.parse(open('./trajectory.good.json'));
+const bad = JSON.parse(open('./trajectory.bad.json'));
+
+const SEQ = [{ name: 'get_customer' }, { name: 'get_invoice', args: { invoice_id: 'INV-123' } }];
+const SEQ_OPTS = { mode: 'in-order', allowOtherCalls: true };
+
+const RUBRIC =
+  'The user asked whether invoice INV-123 for alice@example.com was paid. A good answer clearly ' +
+  'states it is paid ($99), is concise, and does NOT expose the internal customer id (cust_123). ' +
+  'Penalize wrong/uncertain answers, refusals, or leaking the internal id.';
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  // The good run must clear these; the bad run is graded separately below.
+  thresholds: {
+    checks: ['rate>0.9'],
+  },
+};
+
+function load(t, tag) {
+  return new AgentTestCase({
+    name: 'pydantic-ai',
+    input: t.input,
+    output: t.output,
+    toolCalls: t.toolCalls,
+    usage: t.usage,
+    model: t.model,
+    tags: { case: tag },
+  });
+}
+
+export default function () {
+  const g = load(good, 'golden-good');
+  const b = load(bad, 'golden-bad');
+
+  const gSeq = g.expectSequence(SEQ, SEQ_OPTS);
+  const bSeq = b.expectSequence(SEQ, SEQ_OPTS);
+  const gJudge = judge(g, { provider: 'anthropic', model: 'claude-haiku-4-5', apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE, rubric: RUBRIC, threshold: 0.7 });
+  const bJudge = judge(b, { provider: 'anthropic', model: 'claude-haiku-4-5', apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE, rubric: RUBRIC, threshold: 0.7 });
+
+  console.log(`good: seq=${gSeq} judge=${gJudge.score} | bad: seq=${bSeq} judge=${bJudge.score} (${bJudge.reason})`);
+
+  check(null, {
+    // Deterministic oracle (no LLM) — this is the core validity proof.
+    'GOOD passes tool sequence': () => gSeq === true,
+    'GOOD mentions paid': () => /paid/i.test(g.output),
+    'GOOD hides internal id': () => !/cust_123/.test(g.output),
+    'BAD fails tool sequence': () => bSeq === false,
+    'BAD leaks internal id (detected)': () => /cust_123/.test(b.output),
+    // LLM judge corroborates the discrimination.
+    'GOOD judged pass': () => gJudge.passed === true,
+    'BAD judged fail': () => bJudge.passed === false,
+    'judge separates good from bad': () => gJudge.score > bJudge.score,
+  });
+}

--- a/examples/experimental/ageval/frameworks/pydantic-ai/trajectory.bad.json
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/trajectory.bad.json
@@ -1,0 +1,18 @@
+{
+    "input": "Was invoice INV-123 for alice@example.com paid?",
+    "output": "I'm not sure that invoice is paid. The customer record cust_123 looks unpaid to me.",
+    "model": "claude-haiku-4-5",
+    "toolCalls": [
+        {
+            "name": "get_invoice",
+            "input": {
+                "invoice_id": "INV-999"
+            },
+            "output": "{\"error\": \"not found\"}"
+        }
+    ],
+    "usage": {
+        "inputTokens": 1480,
+        "outputTokens": 96
+    }
+}

--- a/examples/experimental/ageval/frameworks/pydantic-ai/trajectory.good.json
+++ b/examples/experimental/ageval/frameworks/pydantic-ai/trajectory.good.json
@@ -1,0 +1,25 @@
+{
+    "input": "Was invoice INV-123 for alice@example.com paid?",
+    "output": "Yes, invoice INV-123 has been paid. It was for $99.00 USD and is associated with the account for alice@example.com.",
+    "model": "claude-haiku-4-5",
+    "toolCalls": [
+        {
+            "name": "get_customer",
+            "input": {
+                "email": "alice@example.com"
+            },
+            "output": "{\"id\": \"cust_123\", \"name\": \"Alice\", \"plan\": \"Pro\"}"
+        },
+        {
+            "name": "get_invoice",
+            "input": {
+                "invoice_id": "INV-123"
+            },
+            "output": "{\"status\": \"paid\", \"amount\": 99, \"currency\": \"USD\", \"customer\": \"cust_123\"}"
+        }
+    ],
+    "usage": {
+        "inputTokens": 1602,
+        "outputTokens": 136
+    }
+}

--- a/examples/experimental/ageval/grafana-assistant/README.md
+++ b/examples/experimental/ageval/grafana-assistant/README.md
@@ -1,0 +1,75 @@
+# Evaluating the Grafana Assistant (k6 authoring) over its REST API with k6 experimental module ageval
+
+This evaluates the **real Grafana Assistant** — its "k6 Script Authoring" behavior —
+by calling its local **A2A REST endpoint** from k6 and grading the result with
+`k6/experimental/ageval`. One `k6 run`: k6 POSTs the A2A `message/stream` request,
+parses the SSE trajectory (`step.toolCall` / `step.message` / `step.complete`) into
+`{output, toolCalls, usage}`, feeds it to `fromAgentRun`, and grades with
+`check` + an LLM-as-judge — emitting the standard `agent_*` metrics (and you can
+run it under VUs to measure quality + latency/cost under load).
+
+## Why the llmspec env (not `mise run up`)
+
+The default `mise run up` stack runs production-shaped auth (`ASSISTANT_USE_AUTH_API=true`,
+needs a cloud **ID token**). The **llmspec env** runs local auth and seeds
+everything, so a service-account token works:
+
+```bash
+# from grafana-assistant-app/
+mise run llmspec:env:up        # assistant A2A on http://localhost:9191
+```
+
+## Auth recipe (the gotchas)
+
+The A2A chat endpoint has three gates; the script + these steps clear all three:
+
+1. **Terms** — `setup()` PUTs `/api/v1/settings/accept-terms`.
+2. **Agent-task auth** — the agent needs a forwardable **Grafana service-account
+   token**, sent as **both** `Authorization: Bearer <glsa>` **and** `X-Grafana-API-Key`
+   (basic `admin:admin` is *not* enough — it gives "no authentication credentials").
+   Mint one against the local Grafana (`:3300`, admin:admin):
+
+   ```bash
+   G=http://localhost:3300
+   SAID=$(curl -s -u admin:admin -X POST $G/api/serviceaccounts \
+     -H 'Content-Type: application/json' -d '{"name":"ageval-k6","role":"Admin"}' \
+     | sed -n 's/.*"id":\([0-9]*\).*/\1/p')
+   GLSA=$(curl -s -u admin:admin -X POST $G/api/serviceaccounts/$SAID/tokens \
+     -H 'Content-Type: application/json' -d '{"name":"ageval-k6-tok"}' \
+     | sed -n 's/.*"key":"\([^"]*\)".*/\1/p')
+   ```
+3. **LLM creds** — the env's `.env` must have the model provider creds (the same
+   ones llmspec uses).
+
+## Run
+
+```bash
+ANTHROPIC_API_KEY_JUDGE=sk-ant-... \
+A2A_URL=http://localhost:9191/api/v1/a2a \
+GRAFANA_TOKEN="$GLSA" ORG_ID=1 \
+  k6 run examples/experimental/ageval/grafana-assistant/k6_authoring.test.js
+```
+
+`GRAFANA_TOKEN` may be a `glsa_…` service-account token (sent as Bearer +
+`X-Grafana-API-Key`) or `basic:user:pass` (HTTP Basic). For the agent task it must
+be a service-account token.
+
+## Result (verified)
+
+A real run produced a valid k6 script and graded green:
+
+```
+✓ produced a response
+✓ authored a k6 script (tool or text)
+✓ script imports k6/http
+✓ includes thresholds
+agent_quality_score: avg=1      agent_judge_pass: 100%
+```
+
+## Caveat: `k6_script_handler` is a frontend tool
+
+The assistant's k6-authoring tool (`k6_script_handler`) executes in the **browser**.
+Over pure backend REST it isn't in the tool set, so the assistant returns the script
+**in its message text** (which this eval grades). The script accepts either the
+tool call *or* an inline script. To exercise the real `k6_script_handler` tool call,
+use the frontend / `--browser-tools` runtime (as llmspec's strict k6 scenario does).

--- a/examples/experimental/ageval/grafana-assistant/README.md
+++ b/examples/experimental/ageval/grafana-assistant/README.md
@@ -4,7 +4,7 @@ This evaluates the **real Grafana Assistant** — its "k6 Script Authoring" beha
 by calling its local **A2A REST endpoint** from k6 and grading the result with
 `k6/experimental/ageval`. One `k6 run`: k6 POSTs the A2A `message/stream` request,
 parses the SSE trajectory (`step.toolCall` / `step.message` / `step.complete`) into
-`{output, toolCalls, usage}`, feeds it to `fromAgentRun`, and grades with
+`{output, toolCalls, usage}`, wraps it in `new AgentTestCase(...)`, and grades with
 `check` + an LLM-as-judge — emitting the standard `agent_*` metrics (and you can
 run it under VUs to measure quality + latency/cost under load).
 

--- a/examples/experimental/ageval/grafana-assistant/k6_authoring.test.js
+++ b/examples/experimental/ageval/grafana-assistant/k6_authoring.test.js
@@ -175,6 +175,7 @@ export default function () {
   });
 
   judge(res, {
+    name: 'k6_authoring',
     provider: 'anthropic',
     model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,

--- a/examples/experimental/ageval/grafana-assistant/k6_authoring.test.js
+++ b/examples/experimental/ageval/grafana-assistant/k6_authoring.test.js
@@ -1,0 +1,188 @@
+// Eval the Grafana Assistant's "k6 Script Authoring" behavior over its local
+// A2A REST endpoint, using k6/experimental/ageval.
+//
+// k6 calls the assistant directly (POST /api/v1/a2a, A2A/JSON-RPC, SSE), parses
+// the streamed trajectory (step.toolCall / step.message / step.complete) into the
+// ageval shape, then grades it with fromAgentRun + check/expectSequence/judge —
+// emitting the standard agent_* metrics. Because it runs in k6, you can also run
+// it under VUs/ramping to measure the assistant's quality + latency/cost under
+// concurrency.
+//
+// Target the llmspec env (local auth, seeded terms/creds), NOT bare `mise run up`:
+//   mise run llmspec:env:up          # assistant A2A on http://localhost:9191
+//
+// Run:
+//   ANTHROPIC_API_KEY_JUDGE=sk-... \
+//   A2A_URL=http://localhost:9191/api/v1/a2a \
+//   GRAFANA_TOKEN=<sa-or-key>  ORG_ID=1  GRAFANA_USER=test@grafana.com \
+//   k6 run k6_authoring.test.js
+import http from 'k6/http';
+import { check } from 'k6';
+import encoding from 'k6/encoding';
+import { fromAgentRun, judge } from 'k6/experimental/ageval';
+
+const A2A_URL = __ENV.A2A_URL || 'http://localhost:9191/api/v1/a2a';
+const TASK =
+  __ENV.TASK ||
+  'Write a k6 load test script for https://api.example.com/users with 10 virtual users for 1 minute, ' +
+    'including a check that the response status is 200 and a p95 latency threshold. Just generate it directly.';
+
+// Grafana credential. The local llmspec env uses HTTP Basic admin:admin
+// (llmspec's `--grafana-api-key=basic:admin:admin`); a service-account token is
+// sent as Bearer instead. Mirror llmspec's applyGrafanaAuth.
+const GRAFANA_TOKEN = __ENV.GRAFANA_TOKEN || 'basic:admin:admin';
+function authHeaders() {
+  if (GRAFANA_TOKEN.indexOf('basic:') === 0) {
+    return { Authorization: 'Basic ' + encoding.b64encode(GRAFANA_TOKEN.slice(6)) };
+  }
+  return { Authorization: `Bearer ${GRAFANA_TOKEN}`, 'X-Grafana-API-Key': GRAFANA_TOKEN };
+}
+
+const HEADERS = Object.assign(
+  {
+    'Content-Type': 'application/json',
+    Accept: 'text/event-stream',
+    'X-App-Source': 'assistant',
+    'X-Scope-OrgID': __ENV.ORG_ID || '1',
+    'X-Grafana-URL': __ENV.GRAFANA_URL || 'http://grafana:3000',
+    'X-Grafana-User': __ENV.GRAFANA_USER || 'admin',
+    'X-Grafana-User-ID': __ENV.GRAFANA_USER_ID || '1',
+  },
+  authHeaders(),
+);
+
+// setup accepts the Assistant terms & conditions once for this tenant/identity
+// (the gate that otherwise returns 403 TERMS_NOT_ACCEPTED).
+export function setup() {
+  const url = A2A_URL.replace(/\/a2a$/, '/settings/accept-terms');
+  const res = http.put(url, JSON.stringify({ acceptedTermsAndConditions: true }), {
+    headers: Object.assign({}, HEADERS, { Accept: 'application/json' }),
+  });
+  console.log(`accept-terms: HTTP ${res.status}`);
+}
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    checks: ['rate>0.9'],
+    agent_quality_score: ['avg>0.7'],
+    agent_judge_pass: ['rate>0.9'],
+  },
+};
+
+// callAssistant POSTs an A2A message/stream request and returns the raw SSE body.
+function callAssistant(task) {
+  const payload = JSON.stringify({
+    jsonrpc: '2.0',
+    id: '1',
+    method: 'message/stream',
+    params: {
+      message: {
+        kind: 'message',
+        role: 'user',
+        messageId: `k6-${__VU}-${__ITER}`,
+        parts: [{ kind: 'text', text: task }],
+      },
+    },
+  });
+  const res = http.post(A2A_URL, payload, { headers: HEADERS, timeout: '180s' });
+  return res.body || '';
+}
+
+// parseA2A turns the A2A SSE stream into the ageval trajectory shape.
+function parseA2A(body) {
+  const toolCalls = [];
+  const byId = {};
+  let output = '';
+  let usage = { inputTokens: 0, outputTokens: 0 };
+
+  for (const line of body.split('\n')) {
+    const s = line.trim();
+    if (!s.startsWith('data:')) continue;
+    let ev;
+    try {
+      ev = JSON.parse(s.slice(5).trim());
+    } catch (_) {
+      continue;
+    }
+    const r = ev.result;
+    if (!r) continue;
+
+    if (r.kind === 'artifact-update' && r.artifact) {
+      const art = r.artifact;
+      const parts = art.parts || [];
+      if (art.name === 'step.toolCall') {
+        for (const p of parts) {
+          if (p.kind === 'data' && p.data && p.data.toolName) {
+            const tc = { _id: p.data.toolId, name: p.data.toolName, input: p.data.inputs || {}, output: '' };
+            toolCalls.push(tc);
+            if (p.data.toolId) byId[p.data.toolId] = tc;
+          }
+        }
+      } else if (art.name === 'step.message') {
+        for (const p of parts) {
+          if (p.kind === 'text' && p.text) output += p.text;
+        }
+      } else if (art.name === 'step.toolResult') {
+        for (const p of parts) {
+          if (p.kind === 'data' && p.data && byId[p.data.toolId]) {
+            const v = p.data.result;
+            byId[p.data.toolId].output = typeof v === 'string' ? v : JSON.stringify(v);
+          }
+        }
+      } else if (art.name === 'step.complete' && art.metadata && art.metadata['agent-traceability']) {
+        const u = art.metadata['agent-traceability'].usage || {};
+        usage.inputTokens += u.inputTokens || 0;
+        usage.outputTokens += u.outputTokens || 0;
+      }
+    } else if (r.kind === 'status-update' && r.status && r.status.message && r.status.message.parts) {
+      // Final assistant message (final answer, or a failure reason).
+      for (const p of r.status.message.parts) {
+        if (p.kind === 'text' && p.text) output = p.text;
+      }
+    }
+  }
+  return { output, toolCalls, usage };
+}
+
+export default function () {
+  const body = callAssistant(TASK);
+  const run = parseA2A(body);
+
+  const res = fromAgentRun({
+    name: 'grafana-assistant',
+    input: TASK,
+    output: run.output,
+    toolCalls: run.toolCalls,
+    usage: run.usage,
+    tags: { case: 'k6-authoring' },
+  });
+
+  // Print the trajectory so you can see what the assistant produced.
+  console.log(`\n===== tool calls (${run.toolCalls.length}): ${run.toolCalls.map((c) => c.name).join(', ') || '(none)'}`);
+  console.log(`===== assistant output (the generated k6 script) =====\n${res.output}\n===== end output =====\n`);
+
+  check(res, {
+    'produced a response': (r) => r.output.length > 0,
+    // k6_script_handler is a frontend/browser tool; over backend REST it may not
+    // execute, so we accept either the tool call OR an inline script in the text.
+    'authored a k6 script (tool or text)': (r) =>
+      r.calledTool('k6_script_handler') || /export\s+default\s+function/.test(r.output),
+    'script imports k6/http': (r) =>
+      r.calledTool('k6_script_handler') || /k6\/http/.test(r.output),
+    'includes thresholds': (r) => r.calledTool('k6_script_handler') || /thresholds/.test(r.output),
+  });
+
+  judge(res, {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5',
+    apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
+    rubric:
+      'The user asked the Grafana Assistant to author a k6 load test (10 VUs, 1 minute, a status==200 ' +
+      'check, and a p95 latency threshold). A good response produces a complete, runnable k6 script — ' +
+      'export default function, an http request, a check(), and an options.thresholds block — matching ' +
+      'the requested load. Penalize refusals, non-k6 output, or scripts missing checks/thresholds.',
+    threshold: 0.7,
+  });
+}

--- a/examples/experimental/ageval/grafana-assistant/k6_authoring.test.js
+++ b/examples/experimental/ageval/grafana-assistant/k6_authoring.test.js
@@ -176,7 +176,7 @@ export default function () {
 
   judge(res, {
     provider: 'anthropic',
-    model: 'claude-sonnet-4-5',
+    model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
     rubric:
       'The user asked the Grafana Assistant to author a k6 load test (10 VUs, 1 minute, a status==200 ' +

--- a/examples/experimental/ageval/grafana-assistant/k6_authoring.test.js
+++ b/examples/experimental/ageval/grafana-assistant/k6_authoring.test.js
@@ -3,7 +3,7 @@
 //
 // k6 calls the assistant directly (POST /api/v1/a2a, A2A/JSON-RPC, SSE), parses
 // the streamed trajectory (step.toolCall / step.message / step.complete) into the
-// ageval shape, then grades it with fromAgentRun + check/expectSequence/judge —
+// ageval shape, then grades it with AgentTestCase + check/expectSequence/judge —
 // emitting the standard agent_* metrics. Because it runs in k6, you can also run
 // it under VUs/ramping to measure the assistant's quality + latency/cost under
 // concurrency.
@@ -19,7 +19,7 @@
 import http from 'k6/http';
 import { check } from 'k6';
 import encoding from 'k6/encoding';
-import { fromAgentRun, judge } from 'k6/experimental/ageval';
+import { AgentTestCase, judge } from 'k6/experimental/ageval';
 
 const A2A_URL = __ENV.A2A_URL || 'http://localhost:9191/api/v1/a2a';
 const TASK =
@@ -150,7 +150,7 @@ export default function () {
   const body = callAssistant(TASK);
   const run = parseA2A(body);
 
-  const res = fromAgentRun({
+  const res = new AgentTestCase({
     name: 'grafana-assistant',
     input: TASK,
     output: run.output,

--- a/examples/experimental/ageval/real_agent.js
+++ b/examples/experimental/ageval/real_agent.js
@@ -1,0 +1,67 @@
+// Demo of the "real agent" mode of k6/experimental/ageval.
+//
+// Instead of simulating an agent (see self_contained.js, which uses
+// AgentSimulator + mocked tools), here you feed in a REAL agent's recorded
+// trajectory — its final output and the tools it actually called — and evaluate
+// it directly. No agent model call happens; only the LLM-as-judge runs.
+//
+// This is how you wire ageval into your production agent: run your agent however
+// you like (your app, your framework, a captured transcript), collect its output
+// + tool calls, and assert/score them here. Every run still emits the standard
+// agent_* metrics for k6 Cloud / Grafana.
+//
+//   ANTHROPIC_API_KEY_JUDGE=sk-...  k6 run real_agent.js
+import { check } from 'k6';
+import { fromAgentRun, judge } from 'k6/experimental/ageval';
+
+export const options = {
+  vus: 1,
+  iterations: 1,
+  thresholds: {
+    agent_tool_correctness: ['rate>0.9'],
+    agent_quality_score: ['avg>0.7'],
+    agent_judge_pass: ['rate>0.9'],
+  },
+};
+
+// Pretend this is what your real agent produced for the request
+// "Was invoice INV-123 for alice@example.com paid?". In practice you'd load this
+// from your agent's run (an API response, a logged transcript, a SharedArray of
+// captured cases, etc.).
+const recordedRun = {
+  model: 'claude-sonnet-4-5', // optional: enables token/cost metrics
+  output: 'Invoice INV-123 is paid ($99 USD).',
+  toolCalls: [
+    { name: 'get_customer', input: { email: 'alice@example.com' }, output: '{"id":"cust_123","plan":"Pro"}' },
+    { name: 'get_invoice', input: { invoice_id: 'INV-123' }, output: '{"status":"paid","amount":99}' },
+  ],
+  usage: { inputTokens: 1500, outputTokens: 120 }, // optional
+  durationMs: 5300, // optional
+  tags: { case: 'invoice_paid', source: 'production' },
+};
+
+export default function () {
+  const res = fromAgentRun(recordedRun);
+
+  check(res, {
+    'called get_customer': (r) => r.calledTool('get_customer'),
+    'called get_invoice': (r) => r.calledTool('get_invoice'),
+    'mentions paid': (r) => /paid/i.test(r.output),
+    'hides internal id': (r) => !/cust_123/.test(r.output),
+  });
+
+  res.expectSequence(
+    [{ name: 'get_customer' }, { name: 'get_invoice', args: { invoice_id: 'INV-123' } }],
+    { mode: 'in-order', allowOtherCalls: true },
+  );
+
+  judge(res, {
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-5',
+    apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
+    rubric:
+      'The answer must state the invoice is paid, must not expose the internal customer id ' +
+      '(cust_123), and must be concise.',
+    threshold: 0.7,
+  });
+}

--- a/examples/experimental/ageval/real_agent.js
+++ b/examples/experimental/ageval/real_agent.js
@@ -54,6 +54,10 @@ export default function () {
   res.expectSequence();
 
   judge(res, {
+    // name tags agent_quality_score / agent_judge_pass with metric:"answer_quality",
+    // so multiple judge() rubrics stay distinguishable in dashboards. The judge's own
+    // spend is emitted separately as agent_judge_cost_usd / agent_judge_tokens.
+    name: 'answer_quality',
     provider: 'anthropic',
     model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,

--- a/examples/experimental/ageval/real_agent.js
+++ b/examples/experimental/ageval/real_agent.js
@@ -12,7 +12,7 @@
 //
 //   ANTHROPIC_API_KEY_JUDGE=sk-...  k6 run real_agent.js
 import { check } from 'k6';
-import { fromAgentRun, judge } from 'k6/experimental/ageval';
+import { AgentTestCase, judge } from 'k6/experimental/ageval';
 
 export const options = {
   vus: 1,
@@ -35,13 +35,14 @@ const recordedRun = {
     { name: 'get_customer', input: { email: 'alice@example.com' }, output: '{"id":"cust_123","plan":"Pro"}' },
     { name: 'get_invoice', input: { invoice_id: 'INV-123' }, output: '{"status":"paid","amount":99}' },
   ],
+  expectedTools: [{ name: 'get_customer' }, { name: 'get_invoice', input: { invoice_id: 'INV-123' } }],
   usage: { inputTokens: 1500, outputTokens: 120 }, // optional
   durationMs: 5300, // optional
   tags: { case: 'invoice_paid', source: 'production' },
 };
 
 export default function () {
-  const res = fromAgentRun(recordedRun);
+  const res = new AgentTestCase(recordedRun);
 
   check(res, {
     'called get_customer': (r) => r.calledTool('get_customer'),
@@ -50,10 +51,7 @@ export default function () {
     'hides internal id': (r) => !/cust_123/.test(r.output),
   });
 
-  res.expectSequence(
-    [{ name: 'get_customer' }, { name: 'get_invoice', args: { invoice_id: 'INV-123' } }],
-    { mode: 'in-order', allowOtherCalls: true },
-  );
+  res.expectSequence();
 
   judge(res, {
     provider: 'anthropic',

--- a/examples/experimental/ageval/real_agent.js
+++ b/examples/experimental/ageval/real_agent.js
@@ -29,7 +29,7 @@ export const options = {
 // from your agent's run (an API response, a logged transcript, a SharedArray of
 // captured cases, etc.).
 const recordedRun = {
-  model: 'claude-sonnet-4-5', // optional: enables token/cost metrics
+  model: 'claude-haiku-4-5', // optional: enables token/cost metrics
   output: 'Invoice INV-123 is paid ($99 USD).',
   toolCalls: [
     { name: 'get_customer', input: { email: 'alice@example.com' }, output: '{"id":"cust_123","plan":"Pro"}' },
@@ -57,7 +57,7 @@ export default function () {
 
   judge(res, {
     provider: 'anthropic',
-    model: 'claude-sonnet-4-5',
+    model: 'claude-haiku-4-5',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
     rubric:
       'The answer must state the invoice is paid, must not expose the internal customer id ' +

--- a/examples/experimental/ageval/self_contained.js
+++ b/examples/experimental/ageval/self_contained.js
@@ -1,0 +1,86 @@
+// Self-contained demo of the experimental k6/experimental/ageval module.
+//
+// It runs a small "support agent" against the Anthropic API with two mocked
+// tools, asserts on the tool-call trajectory with check() and expectSequence(),
+// and scores the final answer with an LLM-as-judge. Every run emits standard k6
+// metrics (agent_duration, agent_tokens, agent_cost_usd, agent_tool_correctness,
+// agent_quality_score, agent_judge_pass) that visualize in k6 Cloud / Grafana.
+//
+// Run it with:
+//   ANTHROPIC_API_KEY=sk-...  ANTHROPIC_API_KEY_JUDGE=sk-...  k6 run self_contained.js
+import { check } from 'k6';
+import { Agent, judge } from 'k6/experimental/ageval';
+
+export const options = {
+  vus: 1,
+  iterations: 2,
+  thresholds: {
+    agent_tool_correctness: ['rate>0.9'],
+    agent_quality_score: ['avg>0.6'],
+    agent_judge_pass: ['rate>0.5'],
+    agent_duration: ['p(95)<30000'],
+    agent_cost_usd: ['count<1'],
+  },
+};
+
+const getCustomer = {
+  name: 'get_customer',
+  description: 'Look up a customer by email. Returns id, email and plan.',
+  inputSchema: {
+    type: 'object',
+    properties: { email: { type: 'string', description: 'Customer email' } },
+    required: ['email'],
+  },
+  mock: (input) => JSON.stringify({ id: 'cust_123', email: input.email, plan: 'Pro' }),
+};
+
+const getInvoice = {
+  name: 'get_invoice',
+  description: 'Look up an invoice by its id. Returns status, amount and currency.',
+  inputSchema: {
+    type: 'object',
+    properties: { invoice_id: { type: 'string', description: 'Invoice id, e.g. INV-123' } },
+    required: ['invoice_id'],
+  },
+  mock: (input) => JSON.stringify({ invoice_id: input.invoice_id, status: 'paid', amount: 99, currency: 'USD' }),
+};
+
+const supportAgent = new Agent({
+  provider: 'anthropic',
+  model: 'claude-opus-4-8',
+  apiKey: __ENV.ANTHROPIC_API_KEY,
+  systemPrompt:
+    'You are a billing support agent. Use the available tools to answer the user. ' +
+    'Look up the customer, then the invoice. Be concise, state whether the invoice is paid, ' +
+    'and never expose the internal customer id.',
+  tools: [getCustomer, getInvoice],
+});
+
+export default function () {
+  const res = supportAgent.run({
+    input: 'Was invoice INV-123 for alice@example.com paid?',
+    tags: { case: 'invoice_paid' },
+  });
+
+  check(res, {
+    'called get_customer': (r) => r.calledTool('get_customer'),
+    'called get_invoice': (r) => r.calledTool('get_invoice'),
+    'mentions paid': (r) => /paid/i.test(r.output),
+    'hides internal id': (r) => !/cust_123/.test(r.output),
+  });
+
+  res.expectSequence(
+    [{ name: 'get_customer' }, { name: 'get_invoice' }],
+    { mode: 'in-order', allowOtherCalls: true },
+  );
+
+  judge(res, {
+    provider: 'anthropic',
+    model: 'claude-opus-4-8',
+    apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,
+    rubric:
+      'The answer must be concise, must say the invoice is paid, must not expose the internal ' +
+      'customer id (cust_123), and must not invent next steps or information not provided by tools.',
+    threshold: 0.7,
+  });
+}

--- a/examples/experimental/ageval/self_contained.js
+++ b/examples/experimental/ageval/self_contained.js
@@ -59,7 +59,6 @@ const supportAgent = new AgentSimulator({
 export default function () {
   const res = supportAgent.run({
     input: 'Was invoice INV-123 for alice@example.com paid?',
-    // expectedTools (≈ DeepEval's expected_tools) is graded by expectSequence() below.
     expectedTools: [{ name: 'get_customer' }, { name: 'get_invoice' }],
     tags: { case: 'invoice_paid' },
   });

--- a/examples/experimental/ageval/self_contained.js
+++ b/examples/experimental/ageval/self_contained.js
@@ -9,7 +9,7 @@
 // Run it with:
 //   ANTHROPIC_API_KEY=sk-...  ANTHROPIC_API_KEY_JUDGE=sk-...  k6 run self_contained.js
 import { check } from 'k6';
-import { Agent, judge } from 'k6/experimental/ageval';
+import { AgentSimulator, judge } from 'k6/experimental/ageval';
 
 export const options = {
   vus: 1,
@@ -45,7 +45,7 @@ const getInvoice = {
   mock: (input) => JSON.stringify({ invoice_id: input.invoice_id, status: 'paid', amount: 99, currency: 'USD' }),
 };
 
-const supportAgent = new Agent({
+const supportAgent = new AgentSimulator({
   provider: 'anthropic',
   model: 'claude-opus-4-8',
   apiKey: __ENV.ANTHROPIC_API_KEY,

--- a/examples/experimental/ageval/self_contained.js
+++ b/examples/experimental/ageval/self_contained.js
@@ -59,6 +59,8 @@ const supportAgent = new AgentSimulator({
 export default function () {
   const res = supportAgent.run({
     input: 'Was invoice INV-123 for alice@example.com paid?',
+    // expectedTools (≈ DeepEval's expected_tools) is graded by expectSequence() below.
+    expectedTools: [{ name: 'get_customer' }, { name: 'get_invoice' }],
     tags: { case: 'invoice_paid' },
   });
 
@@ -69,10 +71,8 @@ export default function () {
     'hides internal id': (r) => !/cust_123/.test(r.output),
   });
 
-  res.expectSequence(
-    [{ name: 'get_customer' }, { name: 'get_invoice' }],
-    { mode: 'in-order', allowOtherCalls: true },
-  );
+  // No argument → grade the trajectory against res.expectedTools (in-order).
+  res.expectSequence();
 
   judge(res, {
     provider: 'anthropic',

--- a/examples/experimental/ageval/self_contained.js
+++ b/examples/experimental/ageval/self_contained.js
@@ -74,6 +74,7 @@ export default function () {
   res.expectSequence();
 
   judge(res, {
+    name: 'support_answer',
     provider: 'anthropic',
     model: 'claude-opus-4-8',
     apiKey: __ENV.ANTHROPIC_API_KEY_JUDGE || __ENV.ANTHROPIC_API_KEY,

--- a/internal/js/jsmodules.go
+++ b/internal/js/jsmodules.go
@@ -12,6 +12,7 @@ import (
 	"go.k6.io/k6/v2/internal/js/modules/k6/data"
 	"go.k6.io/k6/v2/internal/js/modules/k6/encoding"
 	"go.k6.io/k6/v2/internal/js/modules/k6/execution"
+	"go.k6.io/k6/v2/internal/js/modules/k6/experimental/ageval"
 	"go.k6.io/k6/v2/internal/js/modules/k6/experimental/csv"
 	"go.k6.io/k6/v2/internal/js/modules/k6/experimental/fs"
 	"go.k6.io/k6/v2/internal/js/modules/k6/experimental/streams"
@@ -47,6 +48,7 @@ func getInternalJSModules() map[string]any {
 		"k6/ws":          ws.New(),
 
 		// Experimental modules
+		"k6/experimental/ageval":  ageval.New(),
 		"k6/experimental/csv":     csv.New(),
 		"k6/experimental/fs":      fs.New(),
 		"k6/experimental/streams": streams.New(),

--- a/internal/js/modules/k6/experimental/ageval/README.md
+++ b/internal/js/modules/k6/experimental/ageval/README.md
@@ -1,0 +1,235 @@
+# k6/experimental/ageval
+
+Evaluate LLM **agents** as part of a `k6` test run — load-testing's reliability tooling,
+applied to agentic AI.
+
+`ageval` lets you run an agent (real or simulated) inside a k6 script, assert on **what
+it did** (which tools it called, in what order, with what arguments), score **how well it
+did** with an LLM-as-judge, and emit the results as first-class k6 metrics. Because it's
+just k6, you get the whole k6 machinery for free: thresholds (pass/fail CI gates),
+parallel VUs, tags, and every output (cloud dashboards, JSON, Prometheus, …).
+
+```js
+import { check } from 'k6';
+import { CliAgent, judge } from 'k6/experimental/ageval';
+
+// Drive your REAL agent binary; its stdout is parsed into a gradeable trajectory.
+const agent = new CliAgent({
+  command: __ENV.AGENT_BIN,
+  args: ['eval', '{{input}}'], // {{input}} is replaced with the run() input
+  env: { ANTHROPIC_API_KEY: __ENV.ANTHROPIC_API_KEY },
+  format: 'claude-code', // built-in output parser (or supply parse: below)
+  model: 'claude-haiku-4-5',
+});
+
+export default function () {
+  const run = agent.run({
+    input: 'Type "kubernetes" into the search box and click Search',
+    expectedTools: [{ name: 'fillinput' }, { name: 'clickelement' }],
+    tags: { case: 'search' },
+  });
+
+  // Assert on the trajectory.
+  check(run, {
+    'used fillinput': (r) => r.callsOf('fillinput').length >= 1,
+    'clicked the button': (r) => r.callsOf('clickelement').length >= 1,
+  });
+  run.expectSequence(); // grades against expectedTools → agent_tool_correctness
+
+  // Score quality with an LLM judge.
+  judge(run, {
+    name: 'search_quality',
+    model: 'claude-haiku-4-5',
+    apiKey: __ENV.ANTHROPIC_API_KEY,
+    rubric: 'A good run inspects the page, uses fillinput for the field and clickelement for the button.',
+    threshold: 0.7,
+  });
+}
+```
+
+## Core idea: the `AgentTestCase`
+
+Everything centers on one object, the **`AgentTestCase`** — a normalized record of a
+single agent run that `check()`, `expectSequence()`, and `judge()` all operate on. You get
+one in three ways, depending on how much of the agent you want to run for real:
+
+| Source | What runs | Use when |
+| --- | --- | --- |
+| **`CliAgent`** | Your **real** agent binary, spawned as a subprocess; its stdout is parsed into a trajectory. | You want to evaluate the actual production agent, not a re-implementation. |
+| **`new AgentTestCase({...})`** | Nothing — you supply a trajectory you already have. | You already have a run (an HTTP/API response, a log) and just want to grade it. |
+| **`AgentSimulator`** | A built-in agent loop you configure in JS (provider/model/prompt/tools), with mock tool handlers. | You want a fast, self-contained agent defined entirely in the test. |
+
+All three produce the same `AgentTestCase`, so your assertions and judges are identical
+regardless of source.
+
+### AgentTestCase API
+
+Fields: `input`, `output`, `toolCalls` (`[{ name, input, output }]`), `expectedTools`,
+`usage` (`{ inputTokens, outputTokens }`), `steps`, `duration`.
+
+Methods:
+- `calledTool(name)` → bool
+- `callsOf(name)` → `[{ name, input, output }]`
+- `toolSequence()` → `[string]`
+- `stepReports()` / `failedSteps()` → the `report_step` calls (and the failed ones)
+- `expectSequence(expected?, opts?)` → grades the actual tool order against an expected
+  sequence and emits `agent_tool_correctness`. With no argument it uses the
+  `expectedTools` attached at `run()` time.
+
+## `CliAgent` — evaluate your real agent
+
+Spawns your real agent as a subprocess and turns its output into an `AgentTestCase`, so the
+agent runs as part of a single `k6 run` — no separate capture step, and you grade the
+actual production agent rather than a re-implementation.
+
+```js
+import { CliAgent } from 'k6/experimental/ageval';
+
+const agent = new CliAgent({
+  command: __ENV.AGENT_BIN,        // the binary to run
+  args: ['eval', '{{input}}'],     // {{input}} is replaced with run() input; else input goes to stdin
+  env: { ANTHROPIC_API_KEY: __ENV.ANTHROPIC_API_KEY },
+  format: 'claude-code',           // built-in output parser; or use parse: below
+  // parse: (stdout) => ({ output, toolCalls: [{name, input, output}], usage: {inputTokens, outputTokens} }),
+  model: 'claude-haiku-4-5',       // label only (tags the metrics)
+  timeoutSeconds: 300,
+});
+
+const run = agent.run({ input: 'Do the thing', expectedTools: [{ name: 'fillinput' }] });
+```
+
+Output parsing is either a built-in **`format`** adapter or a custom **`parse(stdout)`**
+callback. A `parse` callback (and `new AgentTestCase({...})`, below) expects this shape:
+
+```json
+{ "output": "...", "toolCalls": [{ "name": "...", "input": {}, "output": "..." }],
+  "usage": { "inputTokens": 0, "outputTokens": 0 } }
+```
+
+Built-in `format` adapters: `claude-code`, `codex`, `a2a`, `openai`, `anthropic`.
+
+## `AgentTestCase` — grade a trajectory you already have
+
+When the agent ran somewhere else (you have its response from an HTTP/API call, a log, or a
+previous step), build an `AgentTestCase` directly from the trajectory and grade it — no
+agent is run.
+
+```js
+import http from 'k6/http';
+import { check } from 'k6';
+import { AgentTestCase, judge } from 'k6/experimental/ageval';
+
+export default function () {
+  const res = http.post('https://my-agent.internal/run', JSON.stringify({ task: '...' }));
+
+  // Adapt your API response into the trajectory shape, or pass a raw body + `format`.
+  const run = new AgentTestCase({
+    input: '...',
+    output: res.json('answer'),
+    toolCalls: res.json('tool_calls'), // [{ name, input, output }]
+    usage: { inputTokens: res.json('usage.in'), outputTokens: res.json('usage.out') },
+    expectedTools: [{ name: 'search' }],
+  });
+
+  check(run, { 'searched first': (r) => r.toolSequence()[0] === 'search' });
+  run.expectSequence();
+  judge(run, { name: 'answer_quality', model: 'claude-haiku-4-5', apiKey: __ENV.ANTHROPIC_API_KEY, rubric: '...' });
+}
+```
+
+## `AgentSimulator` — a self-contained agent in the test
+
+When you don't have a separate agent to run, `AgentSimulator` is a built-in agent loop you
+configure entirely in JS (provider/model/prompt/tools) with mock tool handlers.
+
+```js
+import { AgentSimulator } from 'k6/experimental/ageval';
+
+const agent = new AgentSimulator({
+  provider: 'anthropic',     // default 'anthropic' (only provider today)
+  model: 'claude-haiku-4-5', // required; see Supported models
+  apiKey: __ENV.ANTHROPIC_API_KEY,
+  systemPrompt: '...',
+  maxSteps: 30,              // default 30
+  name: 'agent',             // tag value; default 'agent'
+  baseURL: '...',            // optional, override the API endpoint
+  tools: [
+    {
+      name: 'fillinput',
+      description: 'Fill a form field',
+      inputSchema: { type: 'object', properties: { selector: { type: 'string' }, text: { type: 'string' } } },
+      mock: (input) => `Input filled: ${input.selector}`, // what the tool "returns"
+    },
+    // ...
+  ],
+});
+
+const run = agent.run({ input: 'Do the thing', expectedTools: [{ name: 'fillinput' }] });
+```
+
+`agent.run({ input, mocks?, expectedTools?, tags? })` runs the loop and returns an
+`AgentTestCase`. `mocks` lets a single run override a tool's `mock` handler.
+
+## `judge()`
+
+LLM-as-judge (GEval-style): scores an `AgentTestCase` against a natural-language rubric on
+a 0..1 scale, returns `{ score, reason, passed }`, and emits the quality metrics.
+
+```js
+const verdict = judge(run, {
+  name: 'search_quality',          // REQUIRED — the eval label (emitted as the `eval` tag)
+  provider: 'anthropic',
+  model: 'claude-haiku-4-5',       // required
+  apiKey: __ENV.ANTHROPIC_API_KEY, // required
+  rubric: 'A good run ...',        // required
+  threshold: 0.7,                  // default 0.7; score >= threshold → passed
+  input: '...',                    // optional, overrides what the judge sees
+  actualOutput: '...',             // optional
+});
+```
+
+`name` is mandatory because the rubric and reason are not metrics — `name` is what makes
+each eval identifiable in dashboards and downstream tooling. The judge also logs a
+parseable `ageval_eval {json}` line carrying the name/score/passed/reason.
+
+## Metrics
+
+All metrics are tagged with `eval` (the judge `name`), `threshold`, the agent/judge
+`model`, plus any `tags` you pass to `run()` (e.g. `case`). Tool/usage metrics add `tool`
+and `direction` tags.
+
+| Metric | Type | Meaning |
+| --- | --- | --- |
+| `agent_duration` | Trend (time) | wall-clock per run |
+| `agent_steps` | Trend | LLM round-trips |
+| `agent_tool_calls` | Counter | tool invocations (tag: `tool`) |
+| `agent_tokens` | Counter | agent token usage (tag: `direction`=input/output) |
+| `agent_cost_usd` | Counter | agent spend |
+| `agent_tool_correctness` | Rate | `expectSequence()` pass rate |
+| `agent_quality_score` | Trend | judge score (0..1) |
+| `agent_judge_pass` | Rate | judge pass rate (score ≥ threshold) |
+| `agent_judge_tokens` | Counter | judge token usage |
+| `agent_judge_cost_usd` | Counter | judge spend |
+
+Gate them in CI with k6 thresholds:
+
+```js
+export const options = {
+  thresholds: {
+    checks: ['rate>0.9'],
+    agent_quality_score: ['avg>0.7'],
+    agent_judge_pass: ['rate>0.9'],
+    agent_tool_correctness: ['rate>0.9'],
+  },
+};
+```
+
+## Supported models
+
+Anthropic (provider `anthropic`): `claude-opus-4-8`, `claude-opus-4-7`,
+`claude-sonnet-4-6`, `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-fable-5`. Token
+costs are built in, so `agent_cost_usd` / `agent_judge_cost_usd` are computed for you.
+
+## Status
+
+Experimental. The module is registered as `k6/experimental/ageval`; the API may change.

--- a/internal/js/modules/k6/experimental/ageval/adapters.go
+++ b/internal/js/modules/k6/experimental/ageval/adapters.go
@@ -19,7 +19,7 @@ type trajectory struct {
 // adapters maps a `format` name to a converter from a raw payload (an agent's
 // stdout, an HTTP response body, etc.) into a normalized trajectory. New agent
 // wire formats are added here once, rather than re-parsed in every test script.
-// The `parse` callback on ExternalAgent remains the escape hatch for bespoke
+// The `parse` callback on CliAgent remains the escape hatch for bespoke
 // formats not worth a built-in adapter.
 //
 //nolint:gochecknoglobals // package-level registry, like the provider registry

--- a/internal/js/modules/k6/experimental/ageval/adapters.go
+++ b/internal/js/modules/k6/experimental/ageval/adapters.go
@@ -1,0 +1,423 @@
+package ageval
+
+import (
+	"encoding/json"
+	"sort"
+	"strings"
+)
+
+// trajectory is the normalized agent run an adapter produces from a raw payload.
+// It is the single intermediate shape that every wire format maps into before
+// becoming a RunResult.
+type trajectory struct {
+	output    string
+	toolCalls []ToolCall
+	inTok     int64
+	outTok    int64
+}
+
+// adapters maps a `format` name to a converter from a raw payload (an agent's
+// stdout, an HTTP response body, etc.) into a normalized trajectory. New agent
+// wire formats are added here once, rather than re-parsed in every test script.
+// The `parse` callback on ExternalAgent remains the escape hatch for bespoke
+// formats not worth a built-in adapter.
+//
+//nolint:gochecknoglobals // package-level registry, like the provider registry
+var adapters = map[string]func(string) trajectory{
+	"claude-code": adapterClaudeCode,
+	"codex":       adapterCodex,
+	"a2a":         adapterA2A,
+	"openai":      adapterOpenAI,
+	"anthropic":   adapterAnthropic,
+}
+
+func lookupAdapter(name string) (func(string) trajectory, bool) {
+	fn, ok := adapters[name]
+	return fn, ok
+}
+
+// adapterNames returns the supported format names, sorted, for error messages.
+func adapterNames() []string {
+	out := make([]string, 0, len(adapters))
+	for name := range adapters {
+		out = append(out, name)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// --- claude-code: `claude --output-format stream-json` (JSONL) ---
+
+type ccBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Input     json.RawMessage `json:"input"`
+	ToolUseID string          `json:"tool_use_id"`
+	Content   json.RawMessage `json:"content"`
+}
+
+type ccEvent struct {
+	Type    string `json:"type"`
+	Message struct {
+		Content []ccBlock `json:"content"`
+	} `json:"message"`
+	Result *string `json:"result"`
+	Usage  *struct {
+		InputTokens   int64 `json:"input_tokens"`
+		OutputTokens  int64 `json:"output_tokens"`
+		CacheRead     int64 `json:"cache_read_input_tokens"`
+		CacheCreation int64 `json:"cache_creation_input_tokens"`
+	} `json:"usage"`
+}
+
+func adapterClaudeCode(jsonl string) trajectory {
+	t := trajectory{toolCalls: []ToolCall{}}
+	byID := map[string]int{}
+	for line := range strings.SplitSeq(jsonl, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var e ccEvent
+		if json.Unmarshal([]byte(line), &e) != nil {
+			continue
+		}
+		switch e.Type {
+		case "assistant":
+			ccHandleAssistant(e.Message.Content, &t.toolCalls, byID, &t.output)
+		case "user":
+			ccHandleToolResults(e.Message.Content, t.toolCalls, byID)
+		case "result":
+			if e.Result != nil {
+				t.output = *e.Result
+			}
+			if e.Usage != nil {
+				t.inTok = e.Usage.InputTokens + e.Usage.CacheRead + e.Usage.CacheCreation
+				t.outTok = e.Usage.OutputTokens
+			}
+		}
+	}
+	return t
+}
+
+func ccHandleAssistant(content []ccBlock, toolCalls *[]ToolCall, byID map[string]int, output *string) {
+	for _, b := range content {
+		switch b.Type {
+		case blockToolUse:
+			*toolCalls = append(*toolCalls, ToolCall{Name: normalizeMCPToolName(b.Name), Input: rawToMap(b.Input)})
+			byID[b.ID] = len(*toolCalls) - 1
+		case blockText:
+			if b.Text != "" {
+				*output = b.Text
+			}
+		}
+	}
+}
+
+func ccHandleToolResults(content []ccBlock, toolCalls []ToolCall, byID map[string]int) {
+	for _, b := range content {
+		if b.Type != blockToolResult {
+			continue
+		}
+		if idx, ok := byID[b.ToolUseID]; ok {
+			toolCalls[idx].Output = stringifyJSONContent(b.Content)
+		}
+	}
+}
+
+// --- codex: `codex exec --json` (JSONL thread events) ---
+
+type codexItem struct {
+	Type string `json:"type"`
+	Text string `json:"text"` // agent_message
+	// command_execution
+	Command          string `json:"command"`
+	AggregatedOutput string `json:"aggregated_output"`
+	// mcp_tool_call
+	Tool      string          `json:"tool"`
+	Arguments json.RawMessage `json:"arguments"`
+	Result    json.RawMessage `json:"result"`
+}
+
+type codexEvent struct {
+	Type  string     `json:"type"`
+	Item  *codexItem `json:"item"`
+	Usage *struct {
+		InputTokens  int64 `json:"input_tokens"` // already includes cached_input_tokens
+		OutputTokens int64 `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+// adapterCodex parses Codex CLI's `codex exec --json` JSONL stream. Each line is a
+// thread event; `item.completed` carries the finished items (a shell command, an
+// MCP tool call, the agent's message), and `turn.completed` carries token usage.
+func adapterCodex(jsonl string) trajectory {
+	t := trajectory{toolCalls: []ToolCall{}}
+	for line := range strings.SplitSeq(jsonl, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var e codexEvent
+		if json.Unmarshal([]byte(line), &e) != nil {
+			continue
+		}
+		switch {
+		case e.Type == "item.completed" && e.Item != nil:
+			codexHandleItem(e.Item, &t)
+		case e.Type == "turn.completed" && e.Usage != nil:
+			t.inTok += e.Usage.InputTokens
+			t.outTok += e.Usage.OutputTokens
+		}
+	}
+	return t
+}
+
+func codexHandleItem(item *codexItem, t *trajectory) {
+	switch item.Type {
+	case "agent_message":
+		if item.Text != "" {
+			t.output = item.Text // keep the last message as the final answer
+		}
+	case "reasoning":
+		// internal chain-of-thought, not a tool call or answer — ignore.
+	case "command_execution":
+		t.toolCalls = append(t.toolCalls, ToolCall{
+			Name:   "shell",
+			Input:  map[string]any{"command": item.Command},
+			Output: item.AggregatedOutput,
+		})
+	case "mcp_tool_call":
+		t.toolCalls = append(t.toolCalls, ToolCall{
+			Name:   item.Tool,
+			Input:  rawToMap(item.Arguments),
+			Output: stringifyJSONContent(item.Result),
+		})
+	default:
+		// file_change, web_search, todo_list, etc. — record under the item type so
+		// they're still visible to trajectory assertions and metrics.
+		t.toolCalls = append(t.toolCalls, ToolCall{Name: item.Type, Input: map[string]any{}})
+	}
+}
+
+// --- a2a: Grafana Assistant A2A protocol (JSON-RPC over SSE) ---
+
+type a2aPart struct {
+	Kind string `json:"kind"`
+	Text string `json:"text"`
+	Data struct {
+		ToolID   string          `json:"toolId"`
+		ToolName string          `json:"toolName"`
+		Inputs   json.RawMessage `json:"inputs"`
+		Result   json.RawMessage `json:"result"`
+	} `json:"data"`
+}
+
+type a2aArtifact struct {
+	Name     string    `json:"name"`
+	Parts    []a2aPart `json:"parts"`
+	Metadata struct {
+		Trace struct {
+			Usage struct {
+				InputTokens  int64 `json:"inputTokens"`
+				OutputTokens int64 `json:"outputTokens"`
+			} `json:"usage"`
+		} `json:"agent-traceability"`
+	} `json:"metadata"`
+}
+
+type a2aEvent struct {
+	Result *struct {
+		Kind     string       `json:"kind"`
+		Artifact *a2aArtifact `json:"artifact"`
+		Status   *struct {
+			Message *struct {
+				Parts []a2aPart `json:"parts"`
+			} `json:"message"`
+		} `json:"status"`
+	} `json:"result"`
+}
+
+func adapterA2A(sse string) trajectory {
+	t := trajectory{toolCalls: []ToolCall{}}
+	byID := map[string]int{}
+	for line := range strings.SplitSeq(sse, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		var e a2aEvent
+		if json.Unmarshal([]byte(strings.TrimSpace(line[len("data:"):])), &e) != nil || e.Result == nil {
+			continue
+		}
+		switch {
+		case e.Result.Kind == "artifact-update" && e.Result.Artifact != nil:
+			a2aHandleArtifact(e.Result.Artifact, &t, byID)
+		case e.Result.Kind == "status-update" && e.Result.Status != nil && e.Result.Status.Message != nil:
+			for _, p := range e.Result.Status.Message.Parts {
+				if p.Kind == "text" && p.Text != "" {
+					t.output = p.Text
+				}
+			}
+		}
+	}
+	return t
+}
+
+func a2aHandleArtifact(art *a2aArtifact, t *trajectory, byID map[string]int) {
+	switch art.Name {
+	case "step.toolCall":
+		for _, p := range art.Parts {
+			if p.Kind == "data" && p.Data.ToolName != "" {
+				t.toolCalls = append(t.toolCalls, ToolCall{Name: p.Data.ToolName, Input: rawToMap(p.Data.Inputs)})
+				byID[p.Data.ToolID] = len(t.toolCalls) - 1
+			}
+		}
+	case "step.message":
+		for _, p := range art.Parts {
+			if p.Kind == "text" && p.Text != "" {
+				t.output += p.Text
+			}
+		}
+	case "step.toolResult":
+		for _, p := range art.Parts {
+			if idx, ok := byID[p.Data.ToolID]; ok {
+				t.toolCalls[idx].Output = stringifyJSONContent(p.Data.Result)
+			}
+		}
+	case "step.complete":
+		t.inTok += art.Metadata.Trace.Usage.InputTokens
+		t.outTok += art.Metadata.Trace.Usage.OutputTokens
+	}
+}
+
+// --- openai: a Chat Completions response object ---
+
+type openAIResp struct {
+	Choices []struct {
+		Message struct {
+			Content   string `json:"content"`
+			ToolCalls []struct {
+				ID       string `json:"id"`
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"message"`
+	} `json:"choices"`
+	Usage struct {
+		PromptTokens     int64 `json:"prompt_tokens"`
+		CompletionTokens int64 `json:"completion_tokens"`
+	} `json:"usage"`
+}
+
+func adapterOpenAI(body string) trajectory {
+	t := trajectory{toolCalls: []ToolCall{}, inTok: 0, outTok: 0}
+	var r openAIResp
+	if json.Unmarshal([]byte(body), &r) != nil {
+		return t
+	}
+	t.inTok = r.Usage.PromptTokens
+	t.outTok = r.Usage.CompletionTokens
+	if len(r.Choices) == 0 {
+		return t
+	}
+	msg := r.Choices[0].Message
+	t.output = msg.Content
+	for _, tc := range msg.ToolCalls {
+		t.toolCalls = append(t.toolCalls, ToolCall{Name: tc.Function.Name, Input: jsonStrToMap(tc.Function.Arguments)})
+	}
+	return t
+}
+
+// --- anthropic: a Messages API response object ---
+
+type anthropicResp struct {
+	Content []struct {
+		Type  string          `json:"type"`
+		Text  string          `json:"text"`
+		Name  string          `json:"name"`
+		Input json.RawMessage `json:"input"`
+	} `json:"content"`
+	Usage struct {
+		InputTokens  int64 `json:"input_tokens"`
+		OutputTokens int64 `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+func adapterAnthropic(body string) trajectory {
+	t := trajectory{toolCalls: []ToolCall{}}
+	var r anthropicResp
+	if json.Unmarshal([]byte(body), &r) != nil {
+		return t
+	}
+	t.inTok = r.Usage.InputTokens
+	t.outTok = r.Usage.OutputTokens
+	for _, b := range r.Content {
+		switch b.Type {
+		case blockText:
+			if b.Text != "" {
+				t.output = b.Text
+			}
+		case blockToolUse:
+			t.toolCalls = append(t.toolCalls, ToolCall{Name: b.Name, Input: rawToMap(b.Input)})
+		}
+	}
+	return t
+}
+
+// --- shared helpers ---
+
+// normalizeMCPToolName strips the "mcp__<server>__" prefix Claude Code adds to
+// MCP tool calls, so assertions use the server's own tool names.
+func normalizeMCPToolName(name string) string {
+	parts := strings.Split(name, "__")
+	if len(parts) >= 3 && parts[0] == "mcp" {
+		return strings.Join(parts[2:], "__")
+	}
+	return name
+}
+
+// stringifyJSONContent renders a tool result content (a string, an array of
+// `{text}` blocks, or any JSON) as a plain string.
+func stringifyJSONContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var blocks []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) == nil {
+		parts := make([]string, 0, len(blocks))
+		for _, b := range blocks {
+			parts = append(parts, b.Text)
+		}
+		return strings.Join(parts, "\n")
+	}
+	return string(raw)
+}
+
+// rawToMap unmarshals a JSON object into map[string]any (empty on failure).
+func rawToMap(raw json.RawMessage) map[string]any {
+	m := map[string]any{}
+	if len(raw) > 0 {
+		_ = json.Unmarshal(raw, &m)
+	}
+	return m
+}
+
+// jsonStrToMap unmarshals a JSON-string-encoded object into map[string]any.
+func jsonStrToMap(s string) map[string]any {
+	m := map[string]any{}
+	if s != "" {
+		_ = json.Unmarshal([]byte(s), &m)
+	}
+	return m
+}

--- a/internal/js/modules/k6/experimental/ageval/adapters.go
+++ b/internal/js/modules/k6/experimental/ageval/adapters.go
@@ -8,7 +8,7 @@ import (
 
 // trajectory is the normalized agent run an adapter produces from a raw payload.
 // It is the single intermediate shape that every wire format maps into before
-// becoming a RunResult.
+// becoming an AgentTestCase.
 type trajectory struct {
 	output    string
 	toolCalls []ToolCall

--- a/internal/js/modules/k6/experimental/ageval/adapters_test.go
+++ b/internal/js/modules/k6/experimental/ageval/adapters_test.go
@@ -97,13 +97,13 @@ func TestAdapterAnthropic(t *testing.T) {
 	assert.Equal(t, int64(9), tr.outTok)
 }
 
-func TestFromAgentRunWithFormatAdapter(t *testing.T) {
+func TestAgentTestCaseWithFormatAdapter(t *testing.T) {
 	t.Parallel()
 	ts := newTestSetup(t)
-	// fromAgentRun({ format: 'a2a', raw: <sse> }) should parse via the adapter.
+	// new AgentTestCase({ format: 'a2a', raw: <sse> }) should parse via the adapter.
 	require.NoError(t, ts.rt.VU.Runtime().Set("a2aRaw", a2aFixture))
 	v, err := ts.rt.VU.Runtime().RunString(`
-		const r = fromAgentRun({ format: "a2a", raw: a2aRaw, input: "make a script", tags: { case: "fmt" } });
+		const r = new AgentTestCase({ format: "a2a", raw: a2aRaw, input: "make a script", tags: { case: "fmt" } });
 		[r.calledTool("get_documentation"), r.toolCalls.length, r.output, r.usage.inputTokens];
 	`)
 	require.NoError(t, err)
@@ -122,7 +122,7 @@ func TestFromAgentRunWithFormatAdapter(t *testing.T) {
 func TestUnknownFormatThrows(t *testing.T) {
 	t.Parallel()
 	ts := newTestSetup(t)
-	_, err := ts.rt.VU.Runtime().RunString(`fromAgentRun({ format: "nope", raw: "x" });`)
+	_, err := ts.rt.VU.Runtime().RunString(`new AgentTestCase({ format: "nope", raw: "x" });`)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), fmt.Sprintf("unknown format %q", "nope"))
 }

--- a/internal/js/modules/k6/experimental/ageval/adapters_test.go
+++ b/internal/js/modules/k6/experimental/ageval/adapters_test.go
@@ -1,0 +1,128 @@
+package ageval
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdapterClaudeCode(t *testing.T) {
+	t.Parallel()
+	tr := adapterClaudeCode(cannedTranscript)
+	assert.Equal(t, "The script is valid.", tr.output)
+	require.Len(t, tr.toolCalls, 1)
+	assert.Equal(t, "validate_script", tr.toolCalls[0].Name) // mcp__k6__validate_script normalized
+	assert.Equal(t, "valid", tr.toolCalls[0].Output)
+	assert.Equal(t, "export default function(){}", tr.toolCalls[0].Input["script"])
+	assert.Equal(t, int64(150), tr.inTok) // 100 input + 50 cache_read
+	assert.Equal(t, int64(20), tr.outTok)
+}
+
+func TestNormalizeMCPToolName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "validate_script", normalizeMCPToolName("mcp__k6__validate_script"))
+	assert.Equal(t, "Read", normalizeMCPToolName("Read")) // non-MCP names unchanged
+}
+
+// codexFixture is a `codex exec --json` JSONL stream: a shell command, an MCP tool
+// call, an agent message, and turn usage (matching codex-cli 0.140 output).
+const codexFixture = `{"type":"thread.started","thread_id":"t-1"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"ls *.go","status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"ls *.go","aggregated_output":"a.go\nb.go\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"mcp_tool_call","tool":"validate_script","arguments":{"script":"x"},"result":"valid"}}
+{"type":"item.completed","item":{"id":"item_2","type":"reasoning","text":"thinking..."}}
+{"type":"item.completed","item":{"id":"item_3","type":"agent_message","text":"There are 2 .go files."}}
+{"type":"turn.completed","usage":{"input_tokens":42698,"cached_input_tokens":28928,"output_tokens":510,"reasoning_output_tokens":408}}
+`
+
+func TestAdapterCodex(t *testing.T) {
+	t.Parallel()
+	tr := adapterCodex(codexFixture)
+	assert.Equal(t, "There are 2 .go files.", tr.output)
+	require.Len(t, tr.toolCalls, 2) // shell + mcp_tool_call; reasoning ignored
+	assert.Equal(t, "shell", tr.toolCalls[0].Name)
+	assert.Equal(t, "ls *.go", tr.toolCalls[0].Input["command"])
+	assert.Equal(t, "a.go\nb.go\n", tr.toolCalls[0].Output)
+	assert.Equal(t, "validate_script", tr.toolCalls[1].Name)
+	assert.Equal(t, "x", tr.toolCalls[1].Input["script"])
+	assert.Equal(t, "valid", tr.toolCalls[1].Output)
+	assert.Equal(t, int64(42698), tr.inTok) // input_tokens already includes cached
+	assert.Equal(t, int64(510), tr.outTok)  // output_tokens already includes reasoning
+}
+
+const a2aFixture = `data: {"jsonrpc":"2.0","result":{"kind":"status-update","status":{"state":"working"}}}
+data: {"jsonrpc":"2.0","result":{"kind":"artifact-update","artifact":{"name":"step.toolCall","parts":[{"kind":"data","data":{"toolId":"t1","toolName":"get_documentation","inputs":{"slug":"using-k6/http"}}}]}}}
+data: {"jsonrpc":"2.0","result":{"kind":"artifact-update","artifact":{"name":"step.complete","metadata":{"agent-traceability":{"usage":{"inputTokens":1200,"outputTokens":300}}}}}}
+data: {"jsonrpc":"2.0","result":{"kind":"artifact-update","artifact":{"name":"step.toolResult","parts":[{"kind":"data","data":{"toolId":"t1","result":"docs..."}}]}}}
+data: {"jsonrpc":"2.0","result":{"kind":"artifact-update","artifact":{"name":"step.message","parts":[{"kind":"text","text":"Here is your k6 script."}]}}}
+data: {"jsonrpc":"2.0","result":{"kind":"status-update","status":{"state":"completed"}}}
+`
+
+func TestAdapterA2A(t *testing.T) {
+	t.Parallel()
+	tr := adapterA2A(a2aFixture)
+	assert.Equal(t, "Here is your k6 script.", tr.output)
+	require.Len(t, tr.toolCalls, 1)
+	assert.Equal(t, "get_documentation", tr.toolCalls[0].Name)
+	assert.Equal(t, "using-k6/http", tr.toolCalls[0].Input["slug"])
+	assert.Equal(t, "docs...", tr.toolCalls[0].Output)
+	assert.Equal(t, int64(1200), tr.inTok)
+	assert.Equal(t, int64(300), tr.outTok)
+}
+
+func TestAdapterOpenAI(t *testing.T) {
+	t.Parallel()
+	body := `{"choices":[{"message":{"content":"done","tool_calls":[{"id":"c1","function":{"name":"get_weather","arguments":"{\"city\":\"Paris\"}"}}]}}],"usage":{"prompt_tokens":40,"completion_tokens":12}}`
+	tr := adapterOpenAI(body)
+	assert.Equal(t, "done", tr.output)
+	require.Len(t, tr.toolCalls, 1)
+	assert.Equal(t, "get_weather", tr.toolCalls[0].Name)
+	assert.Equal(t, "Paris", tr.toolCalls[0].Input["city"])
+	assert.Equal(t, int64(40), tr.inTok)
+	assert.Equal(t, int64(12), tr.outTok)
+}
+
+func TestAdapterAnthropic(t *testing.T) {
+	t.Parallel()
+	body := `{"content":[{"type":"text","text":"all done"},{"type":"tool_use","name":"get_invoice","input":{"id":"INV-1"}}],"usage":{"input_tokens":80,"output_tokens":9}}`
+	tr := adapterAnthropic(body)
+	assert.Equal(t, "all done", tr.output)
+	require.Len(t, tr.toolCalls, 1)
+	assert.Equal(t, "get_invoice", tr.toolCalls[0].Name)
+	assert.Equal(t, "INV-1", tr.toolCalls[0].Input["id"])
+	assert.Equal(t, int64(80), tr.inTok)
+	assert.Equal(t, int64(9), tr.outTok)
+}
+
+func TestFromAgentRunWithFormatAdapter(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+	// fromAgentRun({ format: 'a2a', raw: <sse> }) should parse via the adapter.
+	require.NoError(t, ts.rt.VU.Runtime().Set("a2aRaw", a2aFixture))
+	v, err := ts.rt.VU.Runtime().RunString(`
+		const r = fromAgentRun({ format: "a2a", raw: a2aRaw, input: "make a script", tags: { case: "fmt" } });
+		[r.calledTool("get_documentation"), r.toolCalls.length, r.output, r.usage.inputTokens];
+	`)
+	require.NoError(t, err)
+	rt := ts.rt.VU.Runtime()
+	arr := v.ToObject(rt)
+	assert.True(t, arr.Get("0").ToBoolean())
+	assert.Equal(t, int64(1), arr.Get("1").ToInteger())
+	assert.Equal(t, "Here is your k6 script.", arr.Get("2").String())
+	assert.Equal(t, int64(1200), arr.Get("3").ToInteger())
+
+	samples := drainSamples(ts.samples)
+	require.Len(t, samples["agent_tool_calls"], 1)
+	require.Len(t, samples["agent_tokens"], 2)
+}
+
+func TestUnknownFormatThrows(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+	_, err := ts.rt.VU.Runtime().RunString(`fromAgentRun({ format: "nope", raw: "x" });`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("unknown format %q", "nope"))
+}

--- a/internal/js/modules/k6/experimental/ageval/agent.go
+++ b/internal/js/modules/k6/experimental/ageval/agent.go
@@ -24,9 +24,9 @@ const (
 	defaultAgentName      = "agent"
 )
 
-// Agent is the JS-facing agent. It is created via `new Agent({...})` and exposes
+// AgentSimulator is the JS-facing agent. It is created via `new AgentSimulator({...})` and exposes
 // a single `run(opts)` method.
-type Agent struct {
+type AgentSimulator struct {
 	mi *ModuleInstance
 	rt *sobek.Runtime
 
@@ -44,11 +44,11 @@ type Agent struct {
 	registry       *toolRegistry
 }
 
-// newAgent is the `new Agent({...})` constructor.
-func (mi *ModuleInstance) newAgent(call sobek.ConstructorCall) *sobek.Object {
+// newAgentSimulator is the `new AgentSimulator({...})` constructor.
+func (mi *ModuleInstance) newAgentSimulator(call sobek.ConstructorCall) *sobek.Object {
 	rt := mi.vu.Runtime()
 	if len(call.Arguments) < 1 || common.IsNullish(call.Argument(0)) {
-		common.Throw(rt, errors.New("Agent constructor requires a config object"))
+		common.Throw(rt, errors.New("AgentSimulator constructor requires a config object"))
 	}
 	cfg := call.Argument(0).ToObject(rt)
 
@@ -67,7 +67,7 @@ func (mi *ModuleInstance) newAgent(call sobek.ConstructorCall) *sobek.Object {
 			modelName, providerName, strings.Join(supported, ", ")))
 	}
 
-	a := &Agent{
+	a := &AgentSimulator{
 		mi:             mi,
 		rt:             rt,
 		name:           getString(cfg, "name", defaultAgentName),
@@ -84,7 +84,7 @@ func (mi *ModuleInstance) newAgent(call sobek.ConstructorCall) *sobek.Object {
 		registry:       newToolRegistry(),
 	}
 	if a.apiKey == "" {
-		common.Throw(rt, errors.New("Agent config requires a non-empty apiKey"))
+		common.Throw(rt, errors.New("AgentSimulator config requires a non-empty apiKey"))
 	}
 
 	mi.parseTools(cfg.Get("tools"), a.registry)
@@ -96,7 +96,7 @@ func (mi *ModuleInstance) newAgent(call sobek.ConstructorCall) *sobek.Object {
 // applySkills merges each skill's instructions into the system prompt and
 // registers its tools. A skill is `{ name, instructions, tools }` — the
 // lightweight Claude-API tool-use notion of a skill (instructions + tools).
-func (a *Agent) applySkills(v sobek.Value) {
+func (a *AgentSimulator) applySkills(v sobek.Value) {
 	if v == nil || common.IsNullish(v) {
 		return
 	}
@@ -124,7 +124,7 @@ type runMocks map[string]sobek.Value
 // Run executes the agent loop synchronously and returns a RunResult. Blocking is
 // intentional and idiomatic (like http.request): we run on the VU goroutine and
 // hold the runtime, so JS mock handlers can be called directly.
-func (a *Agent) Run(opts sobek.Value) sobek.Value {
+func (a *AgentSimulator) Run(opts sobek.Value) sobek.Value {
 	state := a.mi.vu.State()
 	if state == nil {
 		common.Throw(a.rt, errInitContext)
@@ -168,7 +168,9 @@ func (a *Agent) Run(opts sobek.Value) sobek.Value {
 // converse runs the model/tool loop, filling result and returning total token
 // usage. It stops on end_turn, the configured terminalTool, maxSteps, or a turn
 // with no tool calls.
-func (a *Agent) converse(input string, mocks runMocks, tags *metrics.TagSet, result *RunResult) (int64, int64) {
+func (a *AgentSimulator) converse(
+	input string, mocks runMocks, tags *metrics.TagSet, result *RunResult,
+) (int64, int64) {
 	messages := []message{{role: roleUser, blocks: []block{{kind: blockText, text: input}}}}
 	var totalIn, totalOut int64
 
@@ -204,7 +206,7 @@ func (a *Agent) converse(input string, mocks runMocks, tags *metrics.TagSet, res
 // handleBlocks processes the model's reply blocks: records text/tool calls,
 // dispatches tools, emits the tool-call metric, and returns the tool-result
 // blocks plus whether the terminal tool was hit.
-func (a *Agent) handleBlocks(
+func (a *AgentSimulator) handleBlocks(
 	blocks []block, mocks runMocks, tags *metrics.TagSet, result *RunResult, asst *message,
 ) ([]block, bool) {
 	var toolResults []block
@@ -230,7 +232,7 @@ func (a *Agent) handleBlocks(
 
 // dispatch resolves a tool call to a result string. Order: per-run mock override
 // → the tool's own mock → a generic ack → an error for unknown tools.
-func (a *Agent) dispatch(name string, input map[string]any, mocks runMocks) string {
+func (a *AgentSimulator) dispatch(name string, input map[string]any, mocks runMocks) string {
 	if v, ok := mocks[name]; ok && v != nil && !sobek.IsUndefined(v) {
 		return a.resolveMock(v, input)
 	}
@@ -244,7 +246,7 @@ func (a *Agent) dispatch(name string, input map[string]any, mocks runMocks) stri
 }
 
 // resolveMock turns a mock value (callable or static) into a tool-result string.
-func (a *Agent) resolveMock(v sobek.Value, input map[string]any) string {
+func (a *AgentSimulator) resolveMock(v sobek.Value, input map[string]any) string {
 	if fn, ok := sobek.AssertFunction(v); ok {
 		res, err := fn(sobek.Undefined(), a.rt.ToValue(input))
 		if err != nil {
@@ -255,7 +257,7 @@ func (a *Agent) resolveMock(v sobek.Value, input map[string]any) string {
 	return toResultString(v)
 }
 
-func (a *Agent) parseRunMocks(v sobek.Value) runMocks {
+func (a *AgentSimulator) parseRunMocks(v sobek.Value) runMocks {
 	out := runMocks{}
 	if v == nil || common.IsNullish(v) {
 		return out
@@ -267,7 +269,7 @@ func (a *Agent) parseRunMocks(v sobek.Value) runMocks {
 	return out
 }
 
-func (a *Agent) baseTags(userTags sobek.Value) *metrics.TagSet {
+func (a *AgentSimulator) baseTags(userTags sobek.Value) *metrics.TagSet {
 	state := a.mi.vu.State()
 	tags := state.Tags.GetCurrentValues().Tags.With("agent", a.name).With("model", a.model)
 	if userTags != nil && !common.IsNullish(userTags) {

--- a/internal/js/modules/k6/experimental/ageval/agent.go
+++ b/internal/js/modules/k6/experimental/ageval/agent.go
@@ -121,9 +121,14 @@ func (a *AgentSimulator) applySkills(v sobek.Value) {
 // runMocks holds per-run tool result overrides (string or JS callable).
 type runMocks map[string]sobek.Value
 
-// Run executes the agent loop synchronously and returns a RunResult. Blocking is
+// Run executes the agent loop synchronously and returns an AgentTestCase. Blocking is
 // intentional and idiomatic (like http.request): we run on the VU goroutine and
 // hold the runtime, so JS mock handlers can be called directly.
+//
+//	run({ input, mocks?, expectedTools?: [{ name, input? }], tags? })
+//
+// expectedTools is attached to the returned AgentTestCase so expectSequence() can
+// grade against it with no argument.
 func (a *AgentSimulator) Run(opts sobek.Value) sobek.Value {
 	state := a.mi.vu.State()
 	if state == nil {
@@ -140,7 +145,7 @@ func (a *AgentSimulator) Run(opts sobek.Value) sobek.Value {
 	mocks := a.parseRunMocks(o.Get("mocks"))
 	tags := a.baseTags(o.Get("tags"))
 
-	result := &RunResult{
+	result := &AgentTestCase{
 		vu:             a.mi.vu,
 		rt:             a.rt,
 		metrics:        a.mi.metrics,
@@ -148,6 +153,7 @@ func (a *AgentSimulator) Run(opts sobek.Value) sobek.Value {
 		stepReportTool: a.stepReportTool,
 		Input:          input,
 		ToolCalls:      []ToolCall{},
+		ExpectedTools:  parseToolCalls(a.rt, o.Get("expectedTools")),
 	}
 
 	start := time.Now()
@@ -170,7 +176,7 @@ func (a *AgentSimulator) Run(opts sobek.Value) sobek.Value {
 // usage. It stops on end_turn, the configured terminalTool, maxSteps, or a turn
 // with no tool calls.
 func (a *AgentSimulator) converse(
-	input string, mocks runMocks, tags *metrics.TagSet, result *RunResult,
+	input string, mocks runMocks, tags *metrics.TagSet, result *AgentTestCase,
 ) (int64, int64) {
 	messages := []message{{role: roleUser, blocks: []block{{kind: blockText, text: input}}}}
 	var totalIn, totalOut int64
@@ -208,7 +214,7 @@ func (a *AgentSimulator) converse(
 // dispatches tools, emits the tool-call metric, and returns the tool-result
 // blocks plus whether the terminal tool was hit.
 func (a *AgentSimulator) handleBlocks(
-	blocks []block, mocks runMocks, tags *metrics.TagSet, result *RunResult, asst *message,
+	blocks []block, mocks runMocks, tags *metrics.TagSet, result *AgentTestCase, asst *message,
 ) ([]block, bool) {
 	var toolResults []block
 	hitTerminal := false

--- a/internal/js/modules/k6/experimental/ageval/agent.go
+++ b/internal/js/modules/k6/experimental/ageval/agent.go
@@ -1,0 +1,310 @@
+package ageval
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/v2/js/common"
+	"go.k6.io/k6/v2/metrics"
+)
+
+// errInitContext is thrown when run()/judge() are called outside a VU iteration.
+var errInitContext = errors.New("agent.run() must be called in the VU (default) function, not in the init context")
+
+const (
+	defaultMaxSteps       = 30
+	defaultMaxTokens      = 2048
+	defaultStepReportTool = "report_step"
+	defaultAgentName      = "agent"
+)
+
+// Agent is the JS-facing agent. It is created via `new Agent({...})` and exposes
+// a single `run(opts)` method.
+type Agent struct {
+	mi *ModuleInstance
+	rt *sobek.Runtime
+
+	name           string
+	prov           provider
+	info           modelInfo
+	model          string
+	apiKey         string
+	baseURL        string
+	system         string
+	maxSteps       int
+	maxTokens      int
+	terminalTool   string
+	stepReportTool string
+	registry       *toolRegistry
+}
+
+// newAgent is the `new Agent({...})` constructor.
+func (mi *ModuleInstance) newAgent(call sobek.ConstructorCall) *sobek.Object {
+	rt := mi.vu.Runtime()
+	if len(call.Arguments) < 1 || common.IsNullish(call.Argument(0)) {
+		common.Throw(rt, errors.New("Agent constructor requires a config object"))
+	}
+	cfg := call.Argument(0).ToObject(rt)
+
+	providerName := getString(cfg, "provider", "anthropic")
+	prov, ok := lookupProvider(providerName)
+	if !ok {
+		common.Throw(rt, fmt.Errorf("unknown provider %q (supported: anthropic)", providerName))
+	}
+
+	modelName := getString(cfg, "model", "")
+	info, ok := prov.model(modelName)
+	if !ok {
+		supported := prov.modelNames()
+		sort.Strings(supported)
+		common.Throw(rt, fmt.Errorf("unsupported model %q for provider %q (supported: %s)",
+			modelName, providerName, strings.Join(supported, ", ")))
+	}
+
+	a := &Agent{
+		mi:             mi,
+		rt:             rt,
+		name:           getString(cfg, "name", defaultAgentName),
+		prov:           prov,
+		info:           info,
+		model:          modelName,
+		apiKey:         getString(cfg, "apiKey", ""),
+		baseURL:        getString(cfg, "baseURL", ""),
+		system:         getString(cfg, "systemPrompt", ""),
+		maxSteps:       getInt(cfg, "maxSteps", defaultMaxSteps),
+		maxTokens:      getInt(cfg, "maxTokens", defaultMaxTokens),
+		terminalTool:   getString(cfg, "terminalTool", ""),
+		stepReportTool: getString(cfg, "stepReportTool", defaultStepReportTool),
+		registry:       newToolRegistry(),
+	}
+	if a.apiKey == "" {
+		common.Throw(rt, errors.New("Agent config requires a non-empty apiKey"))
+	}
+
+	mi.parseTools(cfg.Get("tools"), a.registry)
+	a.applySkills(cfg.Get("skills"))
+
+	return rt.ToValue(a).ToObject(rt)
+}
+
+// applySkills merges each skill's instructions into the system prompt and
+// registers its tools. A skill is `{ name, instructions, tools }` — the
+// lightweight Claude-API tool-use notion of a skill (instructions + tools).
+func (a *Agent) applySkills(v sobek.Value) {
+	if v == nil || common.IsNullish(v) {
+		return
+	}
+	arr := v.ToObject(a.rt)
+	n := int(arr.Get("length").ToInteger())
+	for i := range n {
+		item := arr.Get(strconv.Itoa(i))
+		if item == nil || sobek.IsUndefined(item) {
+			continue
+		}
+		obj := item.ToObject(a.rt)
+		if instr := getString(obj, "instructions", ""); instr != "" {
+			if a.system != "" {
+				a.system += "\n\n"
+			}
+			a.system += instr
+		}
+		a.mi.parseTools(obj.Get("tools"), a.registry)
+	}
+}
+
+// runMocks holds per-run tool result overrides (string or JS callable).
+type runMocks map[string]sobek.Value
+
+// Run executes the agent loop synchronously and returns a RunResult. Blocking is
+// intentional and idiomatic (like http.request): we run on the VU goroutine and
+// hold the runtime, so JS mock handlers can be called directly.
+func (a *Agent) Run(opts sobek.Value) sobek.Value {
+	state := a.mi.vu.State()
+	if state == nil {
+		common.Throw(a.rt, errInitContext)
+	}
+	if opts == nil || common.IsNullish(opts) {
+		common.Throw(a.rt, errors.New("agent.run() requires an options object with an `input`"))
+	}
+	o := opts.ToObject(a.rt)
+	input := getString(o, "input", "")
+	if input == "" {
+		common.Throw(a.rt, errors.New("agent.run() requires a non-empty `input`"))
+	}
+	mocks := a.parseRunMocks(o.Get("mocks"))
+	tags := a.baseTags(o.Get("tags"))
+
+	result := &RunResult{
+		vu:             a.mi.vu,
+		rt:             a.rt,
+		metrics:        a.mi.metrics,
+		tags:           tags,
+		stepReportTool: a.stepReportTool,
+		ToolCalls:      []ToolCall{},
+	}
+
+	start := time.Now()
+	totalIn, totalOut := a.converse(input, mocks, tags, result)
+	result.Usage = RunUsage{InputTokens: totalIn, OutputTokens: totalOut}
+	result.Duration = float64(time.Since(start)) / float64(time.Millisecond)
+
+	m := a.mi.metrics
+	pushSample(a.mi.vu, m.duration, tags, result.Duration)
+	pushSample(a.mi.vu, m.steps, tags, float64(result.Steps))
+	pushSample(a.mi.vu, m.tokens, tags.With("direction", "input"), float64(totalIn))
+	pushSample(a.mi.vu, m.tokens, tags.With("direction", "output"), float64(totalOut))
+	cost := float64(totalIn)/1e6*a.info.inUSDPerMTok + float64(totalOut)/1e6*a.info.outUSDPerMTok
+	pushSample(a.mi.vu, m.cost, tags, cost)
+
+	return a.rt.ToValue(result).ToObject(a.rt)
+}
+
+// converse runs the model/tool loop, filling result and returning total token
+// usage. It stops on end_turn, the configured terminalTool, maxSteps, or a turn
+// with no tool calls.
+func (a *Agent) converse(input string, mocks runMocks, tags *metrics.TagSet, result *RunResult) (int64, int64) {
+	messages := []message{{role: roleUser, blocks: []block{{kind: blockText, text: input}}}}
+	var totalIn, totalOut int64
+
+	for step := range a.maxSteps {
+		rep, err := a.prov.createMessage(a.mi.vu.Context(), conversation{
+			model:     a.model,
+			apiKey:    a.apiKey,
+			baseURL:   a.baseURL,
+			system:    a.system,
+			maxTokens: a.maxTokens,
+			messages:  messages,
+			tools:     a.registry.schemas(),
+		})
+		if err != nil {
+			common.Throw(a.rt, fmt.Errorf("agent model call failed: %w", err))
+		}
+		result.Steps = step + 1
+		totalIn += rep.usage.inputTokens
+		totalOut += rep.usage.outputTokens
+
+		asst := message{role: roleAssistant}
+		toolResults, hitTerminal := a.handleBlocks(rep.blocks, mocks, tags, result, &asst)
+		messages = append(messages, asst)
+
+		if rep.stopReason == "end_turn" || hitTerminal || len(toolResults) == 0 {
+			break
+		}
+		messages = append(messages, message{role: roleUser, blocks: toolResults})
+	}
+	return totalIn, totalOut
+}
+
+// handleBlocks processes the model's reply blocks: records text/tool calls,
+// dispatches tools, emits the tool-call metric, and returns the tool-result
+// blocks plus whether the terminal tool was hit.
+func (a *Agent) handleBlocks(
+	blocks []block, mocks runMocks, tags *metrics.TagSet, result *RunResult, asst *message,
+) ([]block, bool) {
+	var toolResults []block
+	hitTerminal := false
+	for _, b := range blocks {
+		switch b.kind {
+		case blockText:
+			result.Output = b.text
+			asst.blocks = append(asst.blocks, b)
+		case blockToolUse:
+			asst.blocks = append(asst.blocks, b)
+			out := a.dispatch(b.name, b.input, mocks)
+			result.ToolCalls = append(result.ToolCalls, ToolCall{Name: b.name, Input: b.input, Output: out})
+			pushSample(a.mi.vu, a.mi.metrics.toolCalls, tags.With("tool", b.name), 1)
+			toolResults = append(toolResults, block{kind: blockToolResult, toolUseID: b.id, content: out})
+			if a.terminalTool != "" && b.name == a.terminalTool {
+				hitTerminal = true
+			}
+		}
+	}
+	return toolResults, hitTerminal
+}
+
+// dispatch resolves a tool call to a result string. Order: per-run mock override
+// → the tool's own mock → a generic ack → an error for unknown tools.
+func (a *Agent) dispatch(name string, input map[string]any, mocks runMocks) string {
+	if v, ok := mocks[name]; ok && v != nil && !sobek.IsUndefined(v) {
+		return a.resolveMock(v, input)
+	}
+	if t, ok := a.registry.get(name); ok {
+		if t.mock != nil && !sobek.IsUndefined(t.mock) && !sobek.IsNull(t.mock) {
+			return a.resolveMock(t.mock, input)
+		}
+		return "Tool executed"
+	}
+	return fmt.Sprintf("Error: tool %q is not available", name)
+}
+
+// resolveMock turns a mock value (callable or static) into a tool-result string.
+func (a *Agent) resolveMock(v sobek.Value, input map[string]any) string {
+	if fn, ok := sobek.AssertFunction(v); ok {
+		res, err := fn(sobek.Undefined(), a.rt.ToValue(input))
+		if err != nil {
+			common.Throw(a.rt, fmt.Errorf("tool mock handler threw: %w", err))
+		}
+		return toResultString(res)
+	}
+	return toResultString(v)
+}
+
+func (a *Agent) parseRunMocks(v sobek.Value) runMocks {
+	out := runMocks{}
+	if v == nil || common.IsNullish(v) {
+		return out
+	}
+	obj := v.ToObject(a.rt)
+	for _, k := range obj.Keys() {
+		out[k] = obj.Get(k)
+	}
+	return out
+}
+
+func (a *Agent) baseTags(userTags sobek.Value) *metrics.TagSet {
+	state := a.mi.vu.State()
+	tags := state.Tags.GetCurrentValues().Tags.With("agent", a.name).With("model", a.model)
+	if userTags != nil && !common.IsNullish(userTags) {
+		obj := userTags.ToObject(a.rt)
+		for _, k := range obj.Keys() {
+			tags = tags.With(k, obj.Get(k).String())
+		}
+	}
+	return tags
+}
+
+func toResultString(v sobek.Value) string {
+	if v == nil || sobek.IsUndefined(v) || sobek.IsNull(v) {
+		return ""
+	}
+	exported := v.Export()
+	if s, ok := exported.(string); ok {
+		return s
+	}
+	if b, err := json.Marshal(exported); err == nil {
+		return string(b)
+	}
+	return v.String()
+}
+
+func getString(obj *sobek.Object, key, def string) string {
+	v := obj.Get(key)
+	if v == nil || sobek.IsUndefined(v) || sobek.IsNull(v) {
+		return def
+	}
+	return v.String()
+}
+
+func getInt(obj *sobek.Object, key string, def int) int {
+	v := obj.Get(key)
+	if v == nil || sobek.IsUndefined(v) || sobek.IsNull(v) {
+		return def
+	}
+	return int(v.ToInteger())
+}

--- a/internal/js/modules/k6/experimental/ageval/agent.go
+++ b/internal/js/modules/k6/experimental/ageval/agent.go
@@ -146,6 +146,7 @@ func (a *AgentSimulator) Run(opts sobek.Value) sobek.Value {
 		metrics:        a.mi.metrics,
 		tags:           tags,
 		stepReportTool: a.stepReportTool,
+		Input:          input,
 		ToolCalls:      []ToolCall{},
 	}
 

--- a/internal/js/modules/k6/experimental/ageval/agent_test.go
+++ b/internal/js/modules/k6/experimental/ageval/agent_test.go
@@ -15,7 +15,7 @@ func TestAgentRunRecordsTrajectoryAndMetrics(t *testing.T) {
 
 	_, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
 		globalThis.calledWith = null;
-		const agent = new Agent({
+		const agent = new AgentSimulator({
 			provider: "anthropic",
 			model: "claude-sonnet-4-5",
 			apiKey: "test",
@@ -65,7 +65,7 @@ func TestAgentExpectSequenceEmitsCorrectness(t *testing.T) {
 	srv := cannedServer(t, toolUseResponse, endTurnResponse)
 
 	v, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
-		const agent = new Agent({
+		const agent = new AgentSimulator({
 			model: "claude-sonnet-4-5", apiKey: "t", baseURL: %q,
 			tools: [{ name: "echo", description: "d", mock: () => "ok" }],
 		});
@@ -86,7 +86,7 @@ func TestAgentExpectSequenceEmitsCorrectness(t *testing.T) {
 func TestAgentRejectsUnsupportedModel(t *testing.T) {
 	t.Parallel()
 	ts := newTestSetup(t)
-	_, err := ts.rt.VU.Runtime().RunString(`new Agent({ model: "gpt-4", apiKey: "t" });`)
+	_, err := ts.rt.VU.Runtime().RunString(`new AgentSimulator({ model: "gpt-4", apiKey: "t" });`)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unsupported model")
 }
@@ -97,7 +97,7 @@ func TestAgentSkillMergesToolsAndInstructions(t *testing.T) {
 	srv := cannedServer(t, endTurnResponse)
 
 	_, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
-		const agent = new Agent({
+		const agent = new AgentSimulator({
 			model: "claude-sonnet-4-5", apiKey: "t", baseURL: %q,
 			systemPrompt: "base",
 			skills: [{ name: "s", instructions: "do the thing", tools: [{ name: "skilltool", description: "d", mock: () => "x" }] }],

--- a/internal/js/modules/k6/experimental/ageval/agent_test.go
+++ b/internal/js/modules/k6/experimental/ageval/agent_test.go
@@ -1,0 +1,110 @@
+package ageval
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAgentRunRecordsTrajectoryAndMetrics(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+	srv := cannedServer(t, toolUseResponse, endTurnResponse)
+
+	_, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
+		globalThis.calledWith = null;
+		const agent = new Agent({
+			provider: "anthropic",
+			model: "claude-sonnet-4-5",
+			apiKey: "test",
+			baseURL: %q,
+			systemPrompt: "be helpful",
+			tools: [{
+				name: "echo",
+				description: "echoes",
+				inputSchema: { type: "object", properties: { msg: { type: "string" } } },
+				mock: (input) => { globalThis.calledWith = input.msg; return "echoed: " + input.msg; },
+			}],
+		});
+		globalThis.r = agent.run({ input: "say hi", tags: { case: "smoke" } });
+	`, srv.URL))
+	require.NoError(t, err)
+
+	rt := ts.rt.VU.Runtime()
+	assert.Equal(t, "hi", rt.Get("calledWith").String())
+
+	r := rt.Get("r").ToObject(rt)
+	assert.Equal(t, "all done, invoice paid", r.Get("output").String())
+	assert.Equal(t, int64(2), r.Get("steps").ToInteger())
+
+	// Trajectory recorded.
+	require.NoError(t, rt.Set("res", r))
+	v, err := rt.RunString(`res.toolCalls.length === 1 && res.calledTool("echo") && res.toolCalls[0].output === "echoed: hi"`)
+	require.NoError(t, err)
+	assert.True(t, v.ToBoolean())
+
+	// Token usage summed across both model calls.
+	assert.Equal(t, int64(22), r.Get("usage").ToObject(rt).Get("inputTokens").ToInteger())
+	assert.Equal(t, int64(11), r.Get("usage").ToObject(rt).Get("outputTokens").ToInteger())
+
+	samples := drainSamples(ts.samples)
+	assert.Len(t, samples["agent_duration"], 1)
+	assert.Equal(t, []float64{2}, samples["agent_steps"])
+	assert.Equal(t, []float64{1}, samples["agent_tool_calls"])
+	require.Len(t, samples["agent_tokens"], 2) // input + output
+	require.Len(t, samples["agent_cost_usd"], 1)
+	// cost = 22/1e6*3 + 11/1e6*15
+	assert.InDelta(t, 22.0/1e6*3+11.0/1e6*15, samples["agent_cost_usd"][0], 1e-12)
+}
+
+func TestAgentExpectSequenceEmitsCorrectness(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+	srv := cannedServer(t, toolUseResponse, endTurnResponse)
+
+	v, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
+		const agent = new Agent({
+			model: "claude-sonnet-4-5", apiKey: "t", baseURL: %q,
+			tools: [{ name: "echo", description: "d", mock: () => "ok" }],
+		});
+		const r = agent.run({ input: "go" });
+		const good = r.expectSequence([{ name: "echo", args: { msg: "hi" } }], { mode: "in-order" });
+		const bad  = r.expectSequence([{ name: "missing" }], { mode: "in-order" });
+		[good, bad];
+	`, srv.URL))
+	require.NoError(t, err)
+	arr := v.ToObject(ts.rt.VU.Runtime())
+	assert.True(t, arr.Get("0").ToBoolean())
+	assert.False(t, arr.Get("1").ToBoolean())
+
+	samples := drainSamples(ts.samples)
+	assert.ElementsMatch(t, []float64{1, 0}, samples["agent_tool_correctness"])
+}
+
+func TestAgentRejectsUnsupportedModel(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+	_, err := ts.rt.VU.Runtime().RunString(`new Agent({ model: "gpt-4", apiKey: "t" });`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported model")
+}
+
+func TestAgentSkillMergesToolsAndInstructions(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+	srv := cannedServer(t, endTurnResponse)
+
+	_, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
+		const agent = new Agent({
+			model: "claude-sonnet-4-5", apiKey: "t", baseURL: %q,
+			systemPrompt: "base",
+			skills: [{ name: "s", instructions: "do the thing", tools: [{ name: "skilltool", description: "d", mock: () => "x" }] }],
+		});
+		globalThis.r2 = agent.run({ input: "go" });
+	`, srv.URL))
+	require.NoError(t, err)
+	// The run completes (end_turn immediately); the skill tool is registered without error.
+	assert.NotNil(t, ts.rt.VU.Runtime().Get("r2"))
+}

--- a/internal/js/modules/k6/experimental/ageval/agent_test.go
+++ b/internal/js/modules/k6/experimental/ageval/agent_test.go
@@ -70,6 +70,9 @@ func TestAgentExpectSequenceEmitsCorrectness(t *testing.T) {
 			tools: [{ name: "echo", description: "d", mock: () => "ok" }],
 		});
 		const r = agent.run({ input: "go" });
+		// Explicit expectSequence([...]) form (still supported, also used by the ABT repo
+		// and the golden example): two different expected sequences on one run exercise
+		// both pass and fail. The no-arg expectedTools form is covered separately.
 		const good = r.expectSequence([{ name: "echo", args: { msg: "hi" } }], { mode: "in-order" });
 		const bad  = r.expectSequence([{ name: "missing" }], { mode: "in-order" });
 		[good, bad];

--- a/internal/js/modules/k6/experimental/ageval/anthropic.go
+++ b/internal/js/modules/k6/experimental/ageval/anthropic.go
@@ -1,0 +1,243 @@
+package ageval
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// anthropicVersion is the required API version header value.
+const anthropicVersion = "2023-06-01"
+
+// defaultBaseURL is the Anthropic API host. It is overridable per call so tests
+// can point at an httptest server without any network access.
+const defaultBaseURL = "https://api.anthropic.com"
+
+// modelSonnet45 is the legacy-but-active model used by the ABT eval suite.
+const modelSonnet45 = "claude-sonnet-4-5"
+
+// anthropicProvider implements provider over the raw Messages API. We use a
+// minimal net/http client rather than the official SDK to keep k6's dependency
+// surface unchanged; the wire shape used here is small and stable.
+type anthropicProvider struct {
+	client  *http.Client
+	baseURL string
+	models  map[string]modelInfo
+}
+
+func newAnthropicProvider() *anthropicProvider {
+	return &anthropicProvider{
+		client:  &http.Client{Timeout: 120 * time.Second},
+		baseURL: defaultBaseURL,
+		// Pricing in USD per million tokens. Model IDs are pinned (no
+		// "-latest") for reproducible evals. Sourced from the claude-api
+		// reference, 2026-06.
+		models: map[string]modelInfo{
+			"claude-opus-4-8":   {wireModel: "claude-opus-4-8", inUSDPerMTok: 5, outUSDPerMTok: 25, maxOutput: 32000},
+			"claude-opus-4-7":   {wireModel: "claude-opus-4-7", inUSDPerMTok: 5, outUSDPerMTok: 25, maxOutput: 32000},
+			"claude-sonnet-4-6": {wireModel: "claude-sonnet-4-6", inUSDPerMTok: 3, outUSDPerMTok: 15, maxOutput: 32000},
+			modelSonnet45:       {wireModel: modelSonnet45, inUSDPerMTok: 3, outUSDPerMTok: 15, maxOutput: 8192},
+			"claude-haiku-4-5":  {wireModel: "claude-haiku-4-5", inUSDPerMTok: 1, outUSDPerMTok: 5, maxOutput: 8192},
+			"claude-fable-5":    {wireModel: "claude-fable-5", inUSDPerMTok: 10, outUSDPerMTok: 50, maxOutput: 32000},
+		},
+	}
+}
+
+func (p *anthropicProvider) name() string { return "anthropic" }
+
+func (p *anthropicProvider) model(name string) (modelInfo, bool) {
+	m, ok := p.models[name]
+	return m, ok
+}
+
+// modelNames returns the supported model names for error messages.
+func (p *anthropicProvider) modelNames() []string {
+	out := make([]string, 0, len(p.models))
+	for name := range p.models {
+		out = append(out, name)
+	}
+	return out
+}
+
+// --- wire types (Anthropic Messages API) ---
+
+type apiBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+	// tool_use
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+	// tool_result
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content,omitempty"`
+}
+
+type apiMessage struct {
+	Role    string     `json:"role"`
+	Content []apiBlock `json:"content"`
+}
+
+type apiTool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"input_schema"`
+}
+
+type apiRequest struct {
+	Model     string       `json:"model"`
+	MaxTokens int          `json:"max_tokens"`
+	System    string       `json:"system,omitempty"`
+	Messages  []apiMessage `json:"messages"`
+	Tools     []apiTool    `json:"tools,omitempty"`
+}
+
+type apiResponse struct {
+	Content    []apiBlock `json:"content"`
+	StopReason string     `json:"stop_reason"`
+	Usage      struct {
+		InputTokens  int64 `json:"input_tokens"`
+		OutputTokens int64 `json:"output_tokens"`
+	} `json:"usage"`
+}
+
+type apiError struct {
+	Type  string `json:"type"`
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error"`
+}
+
+// createMessage performs a single blocking Messages API call and normalizes the
+// response into a reply.
+func (p *anthropicProvider) createMessage(ctx context.Context, conv conversation) (reply, error) {
+	info, ok := p.model(conv.model)
+	if !ok {
+		return reply{}, fmt.Errorf("unsupported model %q", conv.model)
+	}
+	maxTokens := conv.maxTokens
+	if maxTokens <= 0 || maxTokens > info.maxOutput {
+		maxTokens = info.maxOutput
+	}
+
+	body := apiRequest{
+		Model:     info.wireModel,
+		MaxTokens: maxTokens,
+		System:    conv.system,
+		Messages:  toAPIMessages(conv.messages),
+		Tools:     toAPITools(conv.tools),
+	}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return reply{}, err
+	}
+
+	baseURL := conv.baseURL
+	if baseURL == "" {
+		baseURL = p.baseURL
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/v1/messages", bytes.NewReader(raw))
+	if err != nil {
+		return reply{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", conv.apiKey)
+	req.Header.Set("Anthropic-Version", anthropicVersion)
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return reply{}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return reply{}, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		var ae apiError
+		if json.Unmarshal(respBody, &ae) == nil && ae.Error.Message != "" {
+			return reply{}, fmt.Errorf("anthropic API error (%d): %s", resp.StatusCode, ae.Error.Message)
+		}
+		return reply{}, fmt.Errorf("anthropic API error (%d): %s", resp.StatusCode, string(respBody))
+	}
+
+	var ar apiResponse
+	if err := json.Unmarshal(respBody, &ar); err != nil {
+		return reply{}, fmt.Errorf("decoding anthropic response: %w", err)
+	}
+
+	return fromAPIResponse(ar), nil
+}
+
+func toAPIMessages(msgs []message) []apiMessage {
+	out := make([]apiMessage, 0, len(msgs))
+	for _, m := range msgs {
+		am := apiMessage{Role: m.role, Content: make([]apiBlock, 0, len(m.blocks))}
+		for _, b := range m.blocks {
+			switch b.kind {
+			case blockText:
+				am.Content = append(am.Content, apiBlock{Type: blockText, Text: b.text})
+			case blockToolUse:
+				input := b.input
+				if input == nil {
+					input = map[string]any{}
+				}
+				rawInput, err := json.Marshal(input)
+				if err != nil {
+					rawInput = []byte("{}")
+				}
+				am.Content = append(am.Content, apiBlock{
+					Type: blockToolUse, ID: b.id, Name: b.name, Input: rawInput,
+				})
+			case blockToolResult:
+				am.Content = append(am.Content, apiBlock{
+					Type: blockToolResult, ToolUseID: b.toolUseID, Content: b.content,
+				})
+			}
+		}
+		out = append(out, am)
+	}
+	return out
+}
+
+func toAPITools(tools []toolSchema) []apiTool {
+	if len(tools) == 0 {
+		return nil
+	}
+	out := make([]apiTool, 0, len(tools))
+	for _, t := range tools {
+		schema := t.inputSchema
+		if schema == nil {
+			schema = map[string]any{"type": "object", "properties": map[string]any{}}
+		}
+		out = append(out, apiTool{Name: t.name, Description: t.description, InputSchema: schema})
+	}
+	return out
+}
+
+func fromAPIResponse(ar apiResponse) reply {
+	r := reply{
+		stopReason: ar.StopReason,
+		usage:      usage{inputTokens: ar.Usage.InputTokens, outputTokens: ar.Usage.OutputTokens},
+	}
+	for _, b := range ar.Content {
+		switch b.Type {
+		case blockText:
+			r.blocks = append(r.blocks, block{kind: blockText, text: b.Text})
+		case blockToolUse:
+			input := map[string]any{}
+			if len(b.Input) > 0 {
+				_ = json.Unmarshal(b.Input, &input)
+			}
+			r.blocks = append(r.blocks, block{kind: blockToolUse, id: b.ID, name: b.Name, input: input})
+		}
+	}
+	return r
+}

--- a/internal/js/modules/k6/experimental/ageval/anthropic.go
+++ b/internal/js/modules/k6/experimental/ageval/anthropic.go
@@ -150,7 +150,11 @@ func (p *anthropicProvider) createMessage(ctx context.Context, conv conversation
 	req.Header.Set("X-Api-Key", conv.apiKey)
 	req.Header.Set("Anthropic-Version", anthropicVersion)
 
-	resp, err := p.client.Do(req)
+	// The request URL is built from operator-supplied configuration (the model
+	// provider endpoint, defaulting to the official Anthropic API; baseURL is
+	// only overridable by the test author, who already controls the whole
+	// script), not from untrusted external input, so this is not an SSRF risk.
+	resp, err := p.client.Do(req) //nolint:gosec // G704: baseURL is operator config, not attacker-controlled
 	if err != nil {
 		return reply{}, err
 	}

--- a/internal/js/modules/k6/experimental/ageval/anthropic_test.go
+++ b/internal/js/modules/k6/experimental/ageval/anthropic_test.go
@@ -1,0 +1,69 @@
+package ageval
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnthropicCreateMessageToolUse(t *testing.T) {
+	t.Parallel()
+	srv := cannedServer(t, toolUseResponse)
+	p := newAnthropicProvider()
+
+	rep, err := p.createMessage(context.Background(), conversation{
+		model:    modelSonnet45,
+		apiKey:   "test-key",
+		baseURL:  srv.URL,
+		system:   "be helpful",
+		messages: []message{{role: roleUser, blocks: []block{{kind: blockText, text: "hi"}}}},
+		tools:    []toolSchema{{name: "echo", description: "echo", inputSchema: map[string]any{"type": "object"}}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "tool_use", rep.stopReason)
+	assert.Equal(t, int64(10), rep.usage.inputTokens)
+	assert.Equal(t, int64(5), rep.usage.outputTokens)
+
+	require.Len(t, rep.blocks, 2)
+	assert.Equal(t, blockText, rep.blocks[0].kind)
+	assert.Equal(t, blockToolUse, rep.blocks[1].kind)
+	assert.Equal(t, "echo", rep.blocks[1].name)
+	assert.Equal(t, "hi", rep.blocks[1].input["msg"])
+}
+
+func TestAnthropicCreateMessageError(t *testing.T) {
+	t.Parallel()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"authentication_error","message":"bad key"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	p := newAnthropicProvider()
+	_, err := p.createMessage(context.Background(), conversation{
+		model:    modelSonnet45,
+		apiKey:   "k",
+		baseURL:  srv.URL,
+		messages: []message{{role: roleUser, blocks: []block{{kind: blockText, text: "x"}}}},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad key")
+}
+
+func TestAnthropicModelRegistry(t *testing.T) {
+	t.Parallel()
+	p := newAnthropicProvider()
+
+	info, ok := p.model(modelSonnet45)
+	require.True(t, ok)
+	assert.Equal(t, 3.0, info.inUSDPerMTok)
+	assert.Equal(t, 15.0, info.outUSDPerMTok)
+
+	_, ok = p.model("gpt-4")
+	assert.False(t, ok)
+	assert.NotEmpty(t, p.modelNames())
+}

--- a/internal/js/modules/k6/experimental/ageval/external.go
+++ b/internal/js/modules/k6/experimental/ageval/external.go
@@ -3,7 +3,6 @@ package ageval
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os/exec"
@@ -102,20 +101,20 @@ func (a *ExternalAgent) Run(opts sobek.Value) sobek.Value {
 		common.Throw(a.rt, err)
 	}
 
-	output, toolCalls, inTok, outTok := a.parseOutput(stdout)
+	tr := a.parseOutput(stdout)
 	tags := a.mi.realRunTags(state, a.name, a.model, o.Get("tags"))
 
 	result := a.mi.newRealRunResult(a.rt, realRunData{
 		tags:           tags,
 		stepReportTool: a.stepReportTool,
 		input:          input,
-		output:         output,
+		output:         tr.output,
 		model:          a.model,
-		toolCalls:      toolCalls,
-		inTok:          inTok,
-		outTok:         outTok,
+		toolCalls:      tr.toolCalls,
+		inTok:          tr.inTok,
+		outTok:         tr.outTok,
 		durationMs:     float64(elapsed) / float64(time.Millisecond),
-		steps:          len(toolCalls),
+		steps:          len(tr.toolCalls),
 	})
 	return a.rt.ToValue(result).ToObject(a.rt)
 }
@@ -175,155 +174,41 @@ func (a *ExternalAgent) execCommand(input string) (string, time.Duration, error)
 }
 
 // parseOutput turns the command's stdout into a trajectory using the custom
-// parse callback, the built-in format, or (default) the raw text as the output.
-func (a *ExternalAgent) parseOutput(stdout string) (string, []ToolCall, int64, int64) {
+// parse callback, a built-in format adapter, or (default) the raw text as the
+// output.
+func (a *ExternalAgent) parseOutput(stdout string) trajectory {
 	if a.parse != nil {
 		res, err := a.parse(sobek.Undefined(), a.rt.ToValue(stdout))
 		if err != nil {
 			common.Throw(a.rt, fmt.Errorf("ExternalAgent parse callback threw: %w", err))
 		}
-		if res == nil || common.IsNullish(res) {
-			return "", nil, 0, 0
-		}
-		obj := res.ToObject(a.rt)
-		var inTok, outTok int64
-		if uv := obj.Get("usage"); uv != nil && !common.IsNullish(uv) {
-			uo := uv.ToObject(a.rt)
-			inTok = int64(getInt(uo, "inputTokens", 0))
-			outTok = int64(getInt(uo, "outputTokens", 0))
-		}
-		return getString(obj, "output", ""), parseToolCalls(a.rt, obj.Get("toolCalls")), inTok, outTok
+		return trajectoryFromJS(a.rt, res)
 	}
-	if a.format == "claude-code" {
-		return parseClaudeCodeTranscript(stdout)
+	if a.format != "" {
+		adapter, ok := lookupAdapter(a.format)
+		if !ok {
+			common.Throw(a.rt, fmt.Errorf("unknown format %q (supported: %s)",
+				a.format, strings.Join(adapterNames(), ", ")))
+		}
+		return adapter(stdout)
 	}
-	return strings.TrimSpace(stdout), nil, 0, 0
+	return trajectory{output: strings.TrimSpace(stdout)}
 }
 
-// --- Claude Code stream-json transcript parsing ---
-
-type ccBlock struct {
-	Type      string          `json:"type"`
-	Text      string          `json:"text"`
-	ID        string          `json:"id"`
-	Name      string          `json:"name"`
-	Input     json.RawMessage `json:"input"`
-	ToolUseID string          `json:"tool_use_id"`
-	Content   json.RawMessage `json:"content"`
-}
-
-type ccEvent struct {
-	Type    string `json:"type"`
-	Message struct {
-		Content []ccBlock `json:"content"`
-	} `json:"message"`
-	Result *string `json:"result"`
-	Usage  *struct {
-		InputTokens   int64 `json:"input_tokens"`
-		OutputTokens  int64 `json:"output_tokens"`
-		CacheRead     int64 `json:"cache_read_input_tokens"`
-		CacheCreation int64 `json:"cache_creation_input_tokens"`
-	} `json:"usage"`
-}
-
-// parseClaudeCodeTranscript parses a Claude Code `--output-format stream-json`
-// transcript (JSONL) into a trajectory, normalizing mcp__<server>__<tool> names.
-func parseClaudeCodeTranscript(jsonl string) (string, []ToolCall, int64, int64) {
-	var (
-		output        string
-		toolCalls     = []ToolCall{}
-		byID          = map[string]int{}
-		inTok, outTok int64
-	)
-	for line := range strings.SplitSeq(jsonl, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		var e ccEvent
-		if json.Unmarshal([]byte(line), &e) != nil {
-			continue
-		}
-		switch e.Type {
-		case "assistant":
-			ccHandleAssistant(e.Message.Content, &toolCalls, byID, &output)
-		case "user":
-			ccHandleToolResults(e.Message.Content, toolCalls, byID)
-		case "result":
-			if e.Result != nil {
-				output = *e.Result
-			}
-			if e.Usage != nil {
-				inTok = e.Usage.InputTokens + e.Usage.CacheRead + e.Usage.CacheCreation
-				outTok = e.Usage.OutputTokens
-			}
-		}
+// trajectoryFromJS converts the object returned by a `parse` callback or passed
+// to fromAgentRun into a trajectory.
+func trajectoryFromJS(rt *sobek.Runtime, v sobek.Value) trajectory {
+	if v == nil || common.IsNullish(v) {
+		return trajectory{}
 	}
-	return output, toolCalls, inTok, outTok
-}
-
-// ccHandleAssistant records tool calls and the latest text from an assistant event.
-func ccHandleAssistant(content []ccBlock, toolCalls *[]ToolCall, byID map[string]int, output *string) {
-	for _, b := range content {
-		switch b.Type {
-		case blockToolUse:
-			input := map[string]any{}
-			if len(b.Input) > 0 {
-				_ = json.Unmarshal(b.Input, &input)
-			}
-			*toolCalls = append(*toolCalls, ToolCall{Name: normalizeMCPToolName(b.Name), Input: input})
-			byID[b.ID] = len(*toolCalls) - 1
-		case blockText:
-			if b.Text != "" {
-				*output = b.Text
-			}
-		}
+	obj := v.ToObject(rt)
+	t := trajectory{output: getString(obj, "output", ""), toolCalls: parseToolCalls(rt, obj.Get("toolCalls"))}
+	if uv := obj.Get("usage"); uv != nil && !common.IsNullish(uv) {
+		uo := uv.ToObject(rt)
+		t.inTok = int64(getInt(uo, "inputTokens", 0))
+		t.outTok = int64(getInt(uo, "outputTokens", 0))
 	}
-}
-
-// ccHandleToolResults attaches tool_result outputs to their matching tool calls.
-func ccHandleToolResults(content []ccBlock, toolCalls []ToolCall, byID map[string]int) {
-	for _, b := range content {
-		if b.Type != blockToolResult {
-			continue
-		}
-		if idx, ok := byID[b.ToolUseID]; ok {
-			toolCalls[idx].Output = stringifyJSONContent(b.Content)
-		}
-	}
-}
-
-// normalizeMCPToolName strips the "mcp__<server>__" prefix Claude Code adds to
-// MCP tool calls, so assertions use the server's own tool names.
-func normalizeMCPToolName(name string) string {
-	parts := strings.Split(name, "__")
-	if len(parts) >= 3 && parts[0] == "mcp" {
-		return strings.Join(parts[2:], "__")
-	}
-	return name
-}
-
-// stringifyJSONContent renders a tool_result `content` (string or array of
-// blocks) as a plain string.
-func stringifyJSONContent(raw json.RawMessage) string {
-	if len(raw) == 0 {
-		return ""
-	}
-	var s string
-	if json.Unmarshal(raw, &s) == nil {
-		return s
-	}
-	var blocks []struct {
-		Text string `json:"text"`
-	}
-	if json.Unmarshal(raw, &blocks) == nil {
-		parts := make([]string, 0, len(blocks))
-		for _, b := range blocks {
-			parts = append(parts, b.Text)
-		}
-		return strings.Join(parts, "\n")
-	}
-	return string(raw)
+	return t
 }
 
 func tail(s string, n int) string {

--- a/internal/js/modules/k6/experimental/ageval/external.go
+++ b/internal/js/modules/k6/experimental/ageval/external.go
@@ -22,7 +22,7 @@ const (
 )
 
 // ExternalAgent runs a real agent CLI as a subprocess, captures its output, and
-// turns it into a RunResult — so the agent runs as part of a single `k6 run`
+// turns it into an AgentTestCase — so the agent runs as part of a single `k6 run`
 // (no separate capture step). Output is parsed by a built-in `format` (currently
 // "claude-code") or a custom `parse(stdout)` JS callback.
 type ExternalAgent struct {
@@ -81,7 +81,12 @@ func (mi *ModuleInstance) newExternalAgent(call sobek.ConstructorCall) *sobek.Ob
 }
 
 // Run executes the agent command with the given input, parses its output, and
-// returns a RunResult. Blocking (like http.request) — runs on the VU goroutine.
+// returns an AgentTestCase. Blocking (like http.request) — runs on the VU goroutine.
+//
+//	run({ input, expectedTools?: [{ name, input? }], tags? })
+//
+// expectedTools is attached to the returned AgentTestCase so expectSequence() can
+// grade against it with no argument.
 func (a *ExternalAgent) Run(opts sobek.Value) sobek.Value {
 	state := a.mi.vu.State()
 	if state == nil {
@@ -104,7 +109,7 @@ func (a *ExternalAgent) Run(opts sobek.Value) sobek.Value {
 	tr := a.parseOutput(stdout)
 	tags := a.mi.realRunTags(state, a.name, a.model, o.Get("tags"))
 
-	result := a.mi.newRealRunResult(a.rt, realRunData{
+	result := a.mi.newRealAgentTestCase(a.rt, realRunData{
 		tags:           tags,
 		stepReportTool: a.stepReportTool,
 		input:          input,
@@ -116,6 +121,7 @@ func (a *ExternalAgent) Run(opts sobek.Value) sobek.Value {
 		durationMs:     float64(elapsed) / float64(time.Millisecond),
 		steps:          len(tr.toolCalls),
 	})
+	result.ExpectedTools = parseToolCalls(a.rt, o.Get("expectedTools"))
 	return a.rt.ToValue(result).ToObject(a.rt)
 }
 
@@ -196,7 +202,7 @@ func (a *ExternalAgent) parseOutput(stdout string) trajectory {
 }
 
 // trajectoryFromJS converts the object returned by a `parse` callback or passed
-// to fromAgentRun into a trajectory.
+// to new AgentTestCase({...}) into a trajectory.
 func trajectoryFromJS(rt *sobek.Runtime, v sobek.Value) trajectory {
 	if v == nil || common.IsNullish(v) {
 		return trajectory{}

--- a/internal/js/modules/k6/experimental/ageval/external.go
+++ b/internal/js/modules/k6/experimental/ageval/external.go
@@ -21,11 +21,11 @@ const (
 	inputToken = "{{input}}"
 )
 
-// ExternalAgent runs a real agent CLI as a subprocess, captures its output, and
+// CliAgent runs a real agent CLI as a subprocess, captures its output, and
 // turns it into an AgentTestCase — so the agent runs as part of a single `k6 run`
 // (no separate capture step). Output is parsed by a built-in `format` (currently
 // "claude-code") or a custom `parse(stdout)` JS callback.
-type ExternalAgent struct {
+type CliAgent struct {
 	mi *ModuleInstance
 	rt *sobek.Runtime
 
@@ -41,23 +41,23 @@ type ExternalAgent struct {
 	timeoutSec     int
 }
 
-// newExternalAgent is the `new ExternalAgent({...})` constructor.
+// newCliAgent is the `new CliAgent({...})` constructor.
 //
 //	{ command, args?, env?, cwd?, format? ("claude-code"), parse?(stdout)->trajectory,
 //	  model?, name?, stepReportTool?, timeoutSeconds? }
-func (mi *ModuleInstance) newExternalAgent(call sobek.ConstructorCall) *sobek.Object {
+func (mi *ModuleInstance) newCliAgent(call sobek.ConstructorCall) *sobek.Object {
 	rt := mi.vu.Runtime()
 	if len(call.Arguments) < 1 || common.IsNullish(call.Argument(0)) {
-		common.Throw(rt, errors.New("ExternalAgent constructor requires a config object"))
+		common.Throw(rt, errors.New("CliAgent constructor requires a config object"))
 	}
 	cfg := call.Argument(0).ToObject(rt)
 
 	command := getString(cfg, "command", "")
 	if command == "" {
-		common.Throw(rt, errors.New("ExternalAgent config requires a non-empty `command`"))
+		common.Throw(rt, errors.New("CliAgent config requires a non-empty `command`"))
 	}
 
-	a := &ExternalAgent{
+	a := &CliAgent{
 		mi:             mi,
 		rt:             rt,
 		name:           getString(cfg, "name", "external-agent"),
@@ -74,7 +74,7 @@ func (mi *ModuleInstance) newExternalAgent(call sobek.ConstructorCall) *sobek.Ob
 		if fn, ok := sobek.AssertFunction(p); ok {
 			a.parse = fn
 		} else {
-			common.Throw(rt, errors.New("ExternalAgent `parse` must be a function"))
+			common.Throw(rt, errors.New("CliAgent `parse` must be a function"))
 		}
 	}
 	return rt.ToValue(a).ToObject(rt)
@@ -87,7 +87,7 @@ func (mi *ModuleInstance) newExternalAgent(call sobek.ConstructorCall) *sobek.Ob
 //
 // expectedTools is attached to the returned AgentTestCase so expectSequence() can
 // grade against it with no argument.
-func (a *ExternalAgent) Run(opts sobek.Value) sobek.Value {
+func (a *CliAgent) Run(opts sobek.Value) sobek.Value {
 	state := a.mi.vu.State()
 	if state == nil {
 		common.Throw(a.rt, errInitContext)
@@ -126,7 +126,7 @@ func (a *ExternalAgent) Run(opts sobek.Value) sobek.Value {
 }
 
 // execCommand runs the agent CLI and returns its stdout and wall-clock duration.
-func (a *ExternalAgent) execCommand(input string) (string, time.Duration, error) {
+func (a *CliAgent) execCommand(input string) (string, time.Duration, error) {
 	ctx := a.mi.vu.Context()
 	if a.timeoutSec > 0 {
 		var cancel context.CancelFunc
@@ -182,11 +182,11 @@ func (a *ExternalAgent) execCommand(input string) (string, time.Duration, error)
 // parseOutput turns the command's stdout into a trajectory using the custom
 // parse callback, a built-in format adapter, or (default) the raw text as the
 // output.
-func (a *ExternalAgent) parseOutput(stdout string) trajectory {
+func (a *CliAgent) parseOutput(stdout string) trajectory {
 	if a.parse != nil {
 		res, err := a.parse(sobek.Undefined(), a.rt.ToValue(stdout))
 		if err != nil {
-			common.Throw(a.rt, fmt.Errorf("ExternalAgent parse callback threw: %w", err))
+			common.Throw(a.rt, fmt.Errorf("CliAgent parse callback threw: %w", err))
 		}
 		return trajectoryFromJS(a.rt, res)
 	}

--- a/internal/js/modules/k6/experimental/ageval/external.go
+++ b/internal/js/modules/k6/experimental/ageval/external.go
@@ -1,0 +1,369 @@
+package ageval
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/v2/js/common"
+)
+
+const (
+	defaultExternalTimeoutSec = 300
+	// inputToken is replaced in args with the run input; if absent, the input is
+	// written to the command's stdin instead.
+	inputToken = "{{input}}"
+)
+
+// ExternalAgent runs a real agent CLI as a subprocess, captures its output, and
+// turns it into a RunResult — so the agent runs as part of a single `k6 run`
+// (no separate capture step). Output is parsed by a built-in `format` (currently
+// "claude-code") or a custom `parse(stdout)` JS callback.
+type ExternalAgent struct {
+	mi *ModuleInstance
+	rt *sobek.Runtime
+
+	name           string
+	command        string
+	args           []string
+	env            map[string]string
+	cwd            string
+	format         string
+	parse          sobek.Callable
+	model          string
+	stepReportTool string
+	timeoutSec     int
+}
+
+// newExternalAgent is the `new ExternalAgent({...})` constructor.
+//
+//	{ command, args?, env?, cwd?, format? ("claude-code"), parse?(stdout)->trajectory,
+//	  model?, name?, stepReportTool?, timeoutSeconds? }
+func (mi *ModuleInstance) newExternalAgent(call sobek.ConstructorCall) *sobek.Object {
+	rt := mi.vu.Runtime()
+	if len(call.Arguments) < 1 || common.IsNullish(call.Argument(0)) {
+		common.Throw(rt, errors.New("ExternalAgent constructor requires a config object"))
+	}
+	cfg := call.Argument(0).ToObject(rt)
+
+	command := getString(cfg, "command", "")
+	if command == "" {
+		common.Throw(rt, errors.New("ExternalAgent config requires a non-empty `command`"))
+	}
+
+	a := &ExternalAgent{
+		mi:             mi,
+		rt:             rt,
+		name:           getString(cfg, "name", "external-agent"),
+		command:        command,
+		args:           toStringSlice(rt, cfg.Get("args")),
+		env:            toStringMap(rt, cfg.Get("env")),
+		cwd:            getString(cfg, "cwd", ""),
+		format:         getString(cfg, "format", ""),
+		model:          getString(cfg, "model", ""),
+		stepReportTool: getString(cfg, "stepReportTool", defaultStepReportTool),
+		timeoutSec:     getInt(cfg, "timeoutSeconds", defaultExternalTimeoutSec),
+	}
+	if p := cfg.Get("parse"); p != nil && !common.IsNullish(p) {
+		if fn, ok := sobek.AssertFunction(p); ok {
+			a.parse = fn
+		} else {
+			common.Throw(rt, errors.New("ExternalAgent `parse` must be a function"))
+		}
+	}
+	return rt.ToValue(a).ToObject(rt)
+}
+
+// Run executes the agent command with the given input, parses its output, and
+// returns a RunResult. Blocking (like http.request) — runs on the VU goroutine.
+func (a *ExternalAgent) Run(opts sobek.Value) sobek.Value {
+	state := a.mi.vu.State()
+	if state == nil {
+		common.Throw(a.rt, errInitContext)
+	}
+	if opts == nil || common.IsNullish(opts) {
+		common.Throw(a.rt, errors.New("run() requires an options object with an `input`"))
+	}
+	o := opts.ToObject(a.rt)
+	input := getString(o, "input", "")
+	if input == "" {
+		common.Throw(a.rt, errors.New("run() requires a non-empty `input`"))
+	}
+
+	stdout, elapsed, err := a.execCommand(input)
+	if err != nil {
+		common.Throw(a.rt, err)
+	}
+
+	output, toolCalls, inTok, outTok := a.parseOutput(stdout)
+	tags := a.mi.realRunTags(state, a.name, a.model, o.Get("tags"))
+
+	result := a.mi.newRealRunResult(a.rt, realRunData{
+		tags:           tags,
+		stepReportTool: a.stepReportTool,
+		input:          input,
+		output:         output,
+		model:          a.model,
+		toolCalls:      toolCalls,
+		inTok:          inTok,
+		outTok:         outTok,
+		durationMs:     float64(elapsed) / float64(time.Millisecond),
+		steps:          len(toolCalls),
+	})
+	return a.rt.ToValue(result).ToObject(a.rt)
+}
+
+// execCommand runs the agent CLI and returns its stdout and wall-clock duration.
+func (a *ExternalAgent) execCommand(input string) (string, time.Duration, error) {
+	ctx := a.mi.vu.Context()
+	if a.timeoutSec > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(a.timeoutSec)*time.Second)
+		defer cancel()
+	}
+
+	args := make([]string, len(a.args))
+	substituted := false
+	for i, arg := range a.args {
+		if strings.Contains(arg, inputToken) {
+			args[i] = strings.ReplaceAll(arg, inputToken, input)
+			substituted = true
+		} else {
+			args[i] = arg
+		}
+	}
+
+	// The command and args come from the test author (the same trust level as the
+	// k6 script itself), not from untrusted external input.
+	cmd := exec.CommandContext(ctx, a.command, args...) //nolint:gosec // G204: command is operator-supplied
+	if a.cwd != "" {
+		cmd.Dir = a.cwd
+	}
+	// Leaving cmd.Env nil makes the child inherit the parent environment (so the
+	// agent CLI sees its own credentials, PATH, etc.). Only build an explicit
+	// env when extra vars are supplied. cmd.Environ() avoids importing os.
+	if len(a.env) > 0 {
+		env := cmd.Environ()
+		for k, v := range a.env {
+			env = append(env, k+"="+v)
+		}
+		cmd.Env = env
+	}
+	if !substituted {
+		cmd.Stdin = strings.NewReader(input)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	runErr := cmd.Run()
+	elapsed := time.Since(start)
+	if runErr != nil {
+		return "", elapsed, fmt.Errorf("external agent %q failed: %w: %s",
+			a.command, runErr, tail(stderr.String(), 500))
+	}
+	return stdout.String(), elapsed, nil
+}
+
+// parseOutput turns the command's stdout into a trajectory using the custom
+// parse callback, the built-in format, or (default) the raw text as the output.
+func (a *ExternalAgent) parseOutput(stdout string) (string, []ToolCall, int64, int64) {
+	if a.parse != nil {
+		res, err := a.parse(sobek.Undefined(), a.rt.ToValue(stdout))
+		if err != nil {
+			common.Throw(a.rt, fmt.Errorf("ExternalAgent parse callback threw: %w", err))
+		}
+		if res == nil || common.IsNullish(res) {
+			return "", nil, 0, 0
+		}
+		obj := res.ToObject(a.rt)
+		var inTok, outTok int64
+		if uv := obj.Get("usage"); uv != nil && !common.IsNullish(uv) {
+			uo := uv.ToObject(a.rt)
+			inTok = int64(getInt(uo, "inputTokens", 0))
+			outTok = int64(getInt(uo, "outputTokens", 0))
+		}
+		return getString(obj, "output", ""), parseToolCalls(a.rt, obj.Get("toolCalls")), inTok, outTok
+	}
+	if a.format == "claude-code" {
+		return parseClaudeCodeTranscript(stdout)
+	}
+	return strings.TrimSpace(stdout), nil, 0, 0
+}
+
+// --- Claude Code stream-json transcript parsing ---
+
+type ccBlock struct {
+	Type      string          `json:"type"`
+	Text      string          `json:"text"`
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Input     json.RawMessage `json:"input"`
+	ToolUseID string          `json:"tool_use_id"`
+	Content   json.RawMessage `json:"content"`
+}
+
+type ccEvent struct {
+	Type    string `json:"type"`
+	Message struct {
+		Content []ccBlock `json:"content"`
+	} `json:"message"`
+	Result *string `json:"result"`
+	Usage  *struct {
+		InputTokens   int64 `json:"input_tokens"`
+		OutputTokens  int64 `json:"output_tokens"`
+		CacheRead     int64 `json:"cache_read_input_tokens"`
+		CacheCreation int64 `json:"cache_creation_input_tokens"`
+	} `json:"usage"`
+}
+
+// parseClaudeCodeTranscript parses a Claude Code `--output-format stream-json`
+// transcript (JSONL) into a trajectory, normalizing mcp__<server>__<tool> names.
+func parseClaudeCodeTranscript(jsonl string) (string, []ToolCall, int64, int64) {
+	var (
+		output        string
+		toolCalls     = []ToolCall{}
+		byID          = map[string]int{}
+		inTok, outTok int64
+	)
+	for line := range strings.SplitSeq(jsonl, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var e ccEvent
+		if json.Unmarshal([]byte(line), &e) != nil {
+			continue
+		}
+		switch e.Type {
+		case "assistant":
+			ccHandleAssistant(e.Message.Content, &toolCalls, byID, &output)
+		case "user":
+			ccHandleToolResults(e.Message.Content, toolCalls, byID)
+		case "result":
+			if e.Result != nil {
+				output = *e.Result
+			}
+			if e.Usage != nil {
+				inTok = e.Usage.InputTokens + e.Usage.CacheRead + e.Usage.CacheCreation
+				outTok = e.Usage.OutputTokens
+			}
+		}
+	}
+	return output, toolCalls, inTok, outTok
+}
+
+// ccHandleAssistant records tool calls and the latest text from an assistant event.
+func ccHandleAssistant(content []ccBlock, toolCalls *[]ToolCall, byID map[string]int, output *string) {
+	for _, b := range content {
+		switch b.Type {
+		case blockToolUse:
+			input := map[string]any{}
+			if len(b.Input) > 0 {
+				_ = json.Unmarshal(b.Input, &input)
+			}
+			*toolCalls = append(*toolCalls, ToolCall{Name: normalizeMCPToolName(b.Name), Input: input})
+			byID[b.ID] = len(*toolCalls) - 1
+		case blockText:
+			if b.Text != "" {
+				*output = b.Text
+			}
+		}
+	}
+}
+
+// ccHandleToolResults attaches tool_result outputs to their matching tool calls.
+func ccHandleToolResults(content []ccBlock, toolCalls []ToolCall, byID map[string]int) {
+	for _, b := range content {
+		if b.Type != blockToolResult {
+			continue
+		}
+		if idx, ok := byID[b.ToolUseID]; ok {
+			toolCalls[idx].Output = stringifyJSONContent(b.Content)
+		}
+	}
+}
+
+// normalizeMCPToolName strips the "mcp__<server>__" prefix Claude Code adds to
+// MCP tool calls, so assertions use the server's own tool names.
+func normalizeMCPToolName(name string) string {
+	parts := strings.Split(name, "__")
+	if len(parts) >= 3 && parts[0] == "mcp" {
+		return strings.Join(parts[2:], "__")
+	}
+	return name
+}
+
+// stringifyJSONContent renders a tool_result `content` (string or array of
+// blocks) as a plain string.
+func stringifyJSONContent(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if json.Unmarshal(raw, &s) == nil {
+		return s
+	}
+	var blocks []struct {
+		Text string `json:"text"`
+	}
+	if json.Unmarshal(raw, &blocks) == nil {
+		parts := make([]string, 0, len(blocks))
+		for _, b := range blocks {
+			parts = append(parts, b.Text)
+		}
+		return strings.Join(parts, "\n")
+	}
+	return string(raw)
+}
+
+func tail(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[len(s)-n:]
+}
+
+// toStringSlice converts a JS array to []string.
+func toStringSlice(rt *sobek.Runtime, v sobek.Value) []string {
+	if v == nil || common.IsNullish(v) {
+		return nil
+	}
+	arr := v.ToObject(rt)
+	lengthVal := arr.Get("length")
+	if lengthVal == nil {
+		return nil
+	}
+	n := int(lengthVal.ToInteger())
+	out := make([]string, 0, n)
+	for i := range n {
+		item := arr.Get(strconv.Itoa(i))
+		if item == nil || sobek.IsUndefined(item) {
+			continue
+		}
+		out = append(out, item.String())
+	}
+	return out
+}
+
+// toStringMap converts a JS object to map[string]string.
+func toStringMap(rt *sobek.Runtime, v sobek.Value) map[string]string {
+	if v == nil || common.IsNullish(v) {
+		return nil
+	}
+	obj := v.ToObject(rt)
+	out := map[string]string{}
+	for _, k := range obj.Keys() {
+		out[k] = obj.Get(k).String()
+	}
+	return out
+}

--- a/internal/js/modules/k6/experimental/ageval/external_test.go
+++ b/internal/js/modules/k6/experimental/ageval/external_test.go
@@ -21,12 +21,12 @@ const cannedTranscript = `{"type":"system","subtype":"init"}
 // the command-failure path; the os/exec helper-process idiom is avoided because
 // k6's linter forbids direct os.* usage.
 
-func TestExternalAgentCommandFailureThrows(t *testing.T) {
+func TestCliAgentCommandFailureThrows(t *testing.T) {
 	t.Parallel()
 	ts := newTestSetup(t)
 
 	_, err := ts.rt.VU.Runtime().RunString(`
-		const a = new ExternalAgent({ command: "this-command-does-not-exist-ageval", format: "claude-code" });
+		const a = new CliAgent({ command: "this-command-does-not-exist-ageval", format: "claude-code" });
 		a.run({ input: "x" });
 	`)
 	require.Error(t, err)

--- a/internal/js/modules/k6/experimental/ageval/external_test.go
+++ b/internal/js/modules/k6/experimental/ageval/external_test.go
@@ -1,0 +1,53 @@
+package ageval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cannedTranscript is a minimal Claude Code stream-json transcript: one MCP tool
+// call (validate_script) plus a final result.
+const cannedTranscript = `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"mcp__k6__validate_script","input":{"script":"export default function(){}"}}]}}
+{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"valid"}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"The script is valid."}]}}
+{"type":"result","subtype":"success","result":"The script is valid.","usage":{"input_tokens":100,"output_tokens":20,"cache_read_input_tokens":50},"duration_ms":1234}
+`
+
+// The successful exec+parse path is exercised end-to-end by the live examples
+// (examples/.../claude-code and mcp-k6/eval). Here we unit-test the parser and
+// the command-failure path; the os/exec helper-process idiom is avoided because
+// k6's linter forbids direct os.* usage.
+
+func TestExternalAgentCommandFailureThrows(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+
+	_, err := ts.rt.VU.Runtime().RunString(`
+		const a = new ExternalAgent({ command: "this-command-does-not-exist-ageval", format: "claude-code" });
+		a.run({ input: "x" });
+	`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed")
+}
+
+func TestParseClaudeCodeTranscript(t *testing.T) {
+	t.Parallel()
+	output, toolCalls, inTok, outTok := parseClaudeCodeTranscript(cannedTranscript)
+	assert.Equal(t, "The script is valid.", output)
+	require.Len(t, toolCalls, 1)
+	assert.Equal(t, "validate_script", toolCalls[0].Name)
+	assert.Equal(t, "valid", toolCalls[0].Output)
+	assert.Equal(t, "export default function(){}", toolCalls[0].Input["script"])
+	assert.Equal(t, int64(150), inTok)
+	assert.Equal(t, int64(20), outTok)
+}
+
+func TestNormalizeMCPToolName(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "validate_script", normalizeMCPToolName("mcp__k6__validate_script"))
+	assert.Equal(t, "get_documentation", normalizeMCPToolName("mcp__k6__get_documentation"))
+	assert.Equal(t, "Read", normalizeMCPToolName("Read")) // non-MCP tools unchanged
+}

--- a/internal/js/modules/k6/experimental/ageval/external_test.go
+++ b/internal/js/modules/k6/experimental/ageval/external_test.go
@@ -32,22 +32,3 @@ func TestExternalAgentCommandFailureThrows(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed")
 }
-
-func TestParseClaudeCodeTranscript(t *testing.T) {
-	t.Parallel()
-	output, toolCalls, inTok, outTok := parseClaudeCodeTranscript(cannedTranscript)
-	assert.Equal(t, "The script is valid.", output)
-	require.Len(t, toolCalls, 1)
-	assert.Equal(t, "validate_script", toolCalls[0].Name)
-	assert.Equal(t, "valid", toolCalls[0].Output)
-	assert.Equal(t, "export default function(){}", toolCalls[0].Input["script"])
-	assert.Equal(t, int64(150), inTok)
-	assert.Equal(t, int64(20), outTok)
-}
-
-func TestNormalizeMCPToolName(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, "validate_script", normalizeMCPToolName("mcp__k6__validate_script"))
-	assert.Equal(t, "get_documentation", normalizeMCPToolName("mcp__k6__get_documentation"))
-	assert.Equal(t, "Read", normalizeMCPToolName("Read")) // non-MCP tools unchanged
-}

--- a/internal/js/modules/k6/experimental/ageval/helpers_test.go
+++ b/internal/js/modules/k6/experimental/ageval/helpers_test.go
@@ -1,0 +1,90 @@
+package ageval
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/v2/js/modulestest"
+	"go.k6.io/k6/v2/lib"
+	"go.k6.io/k6/v2/metrics"
+)
+
+// testSetup wires a module instance into a VU-context runtime and exposes the
+// module's exports (Agent, judge) as runtime globals so tests can drive them
+// from JS, exactly as a real script would.
+type testSetup struct {
+	rt      *modulestest.Runtime
+	mi      *ModuleInstance
+	samples chan metrics.SampleContainer
+}
+
+func newTestSetup(t testing.TB) *testSetup {
+	t.Helper()
+	rt := modulestest.NewRuntime(t)
+
+	// Build the instance while the init environment (and registry) is present.
+	registry := rt.VU.InitEnvField.Registry
+	mi, ok := New().NewModuleInstance(rt.VU).(*ModuleInstance)
+	require.True(t, ok)
+
+	for name, export := range mi.Exports().Named {
+		require.NoError(t, rt.VU.Runtime().Set(name, export))
+	}
+
+	samples := make(chan metrics.SampleContainer, 1000)
+	state := &lib.State{
+		Options:        lib.Options{},
+		BuiltinMetrics: rt.BuiltinMetrics,
+		Tags:           lib.NewVUStateTags(registry.RootTagSet()),
+		Samples:        samples,
+	}
+	rt.MoveToVUContext(state)
+
+	return &testSetup{rt: rt, mi: mi, samples: samples}
+}
+
+// drainSamples reads all currently buffered samples and indexes their values by
+// metric name.
+func drainSamples(ch chan metrics.SampleContainer) map[string][]float64 {
+	out := map[string][]float64{}
+	for {
+		select {
+		case sc := <-ch:
+			for _, s := range sc.GetSamples() {
+				out[s.Metric.Name] = append(out[s.Metric.Name], s.Value)
+			}
+		default:
+			return out
+		}
+	}
+}
+
+// cannedServer returns an httptest server that replies with the given response
+// bodies in order, one per request. The last body repeats if exhausted.
+func cannedServer(t testing.TB, bodies ...string) *httptest.Server {
+	t.Helper()
+	var i int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		body := bodies[len(bodies)-1]
+		if i < len(bodies) {
+			body = bodies[i]
+		}
+		i++
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+const (
+	toolUseResponse = `{"content":[{"type":"text","text":"working"},` +
+		`{"type":"tool_use","id":"tu_1","name":"echo","input":{"msg":"hi"}}],` +
+		`"stop_reason":"tool_use","usage":{"input_tokens":10,"output_tokens":5}}`
+	endTurnResponse = `{"content":[{"type":"text","text":"all done, invoice paid"}],` +
+		`"stop_reason":"end_turn","usage":{"input_tokens":12,"output_tokens":6}}`
+	judgeResponse = `{"content":[{"type":"text","text":"{\"score\": 0.9, \"reason\": \"good\"}"}],` +
+		`"stop_reason":"end_turn","usage":{"input_tokens":3,"output_tokens":4}}`
+)

--- a/internal/js/modules/k6/experimental/ageval/judge.go
+++ b/internal/js/modules/k6/experimental/ageval/judge.go
@@ -56,7 +56,12 @@ func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.V
 	threshold := getFloat(o, "threshold", defaultJudgeThreshold)
 
 	rr := mi.exportRunResult(resultVal)
+	// The task/prompt the agent was given. Default to the run's own input so the
+	// judge always sees what the agent was asked to do, not just what it did.
 	input := getString(o, "input", "")
+	if input == "" && rr != nil {
+		input = rr.Input
+	}
 	actual := getString(o, "actualOutput", "")
 	if actual == "" && rr != nil {
 		actual = serializeTrajectory(rr)

--- a/internal/js/modules/k6/experimental/ageval/judge.go
+++ b/internal/js/modules/k6/experimental/ageval/judge.go
@@ -25,12 +25,15 @@ type judgeResult struct {
 // agent_quality_score (Trend) and agent_judge_pass (Rate) metrics, and returns
 // `{ score, reason, passed }`.
 //
-// `name` tags agent_quality_score / agent_judge_pass with metric=<name> so several
-// judge() calls (different rubrics) are distinguishable in dashboards. The judge's
-// own spend is emitted as agent_judge_tokens / agent_judge_cost_usd, tagged with the
-// judge model (separate from the agent's agent_tokens / agent_cost_usd).
+// `name` is REQUIRED: it tags agent_quality_score / agent_judge_pass (and the judge
+// cost/token metrics) with eval=<name> so each eval is identifiable in dashboards and
+// downstream tools — which matters because the rubric/reason are not metrics. The
+// judge also logs a parseable line (ageval_eval {json}) carrying name/score/passed/
+// reason, so the reason is recoverable from k6 logs even under --local-execution.
+// The judge's own spend is emitted as agent_judge_tokens / agent_judge_cost_usd,
+// tagged with the judge model (separate from the agent's agent_tokens/agent_cost_usd).
 //
-// opts: { provider, model, apiKey, rubric, name?, threshold?, input?, actualOutput?, baseURL? }
+// opts: { name, provider, model, apiKey, rubric, threshold?, input?, actualOutput?, baseURL? }
 func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.Value {
 	rt := mi.vu.Runtime()
 	if mi.vu.State() == nil {
@@ -41,6 +44,10 @@ func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.V
 	}
 	o := opts.ToObject(rt)
 
+	name := getString(o, "name", "")
+	if name == "" {
+		common.Throw(rt, errors.New("judge() requires a non-empty `name` (the eval label; emitted as the `eval` tag)"))
+	}
 	rubric := getString(o, "rubric", "")
 	if rubric == "" {
 		common.Throw(rt, errors.New("judge() requires a non-empty `rubric`"))
@@ -86,10 +93,7 @@ func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.V
 	score, reason := parseJudgeReply(rep)
 	passed := score >= threshold
 
-	tags := mi.judgeTags(rr)
-	if name := getString(o, "name", ""); name != "" {
-		tags = tags.With("metric", name)
-	}
+	tags := mi.judgeTags(rr).With("eval", name)
 	pushSample(mi.vu, mi.metrics.qualityScore, tags, score)
 	passVal := 0.0
 	if passed {
@@ -97,8 +101,32 @@ func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.V
 	}
 	pushSample(mi.vu, mi.metrics.judgePass, tags, passVal)
 	mi.emitJudgeCost(tags, prov, modelName, rep.usage)
+	mi.logEval(name, score, passed, reason)
 
 	return rt.ToValue(judgeResult{Score: score, Reason: reason, Passed: passed}).ToObject(rt)
+}
+
+// logEvalPrefix marks judge result log lines so tools can find and parse them
+// (the JSON after the prefix carries name/score/passed/reason). Logged because the
+// rubric/reason can't be metric tags, yet logs are streamed to the cloud even under
+// --local-execution.
+const logEvalPrefix = "ageval_eval"
+
+func (mi *ModuleInstance) logEval(name string, score float64, passed bool, reason string) {
+	state := mi.vu.State()
+	if state == nil || state.Logger == nil {
+		return
+	}
+	payload, err := json.Marshal(struct {
+		Name   string  `json:"name"`
+		Score  float64 `json:"score"`
+		Passed bool    `json:"passed"`
+		Reason string  `json:"reason"`
+	}{name, score, passed, reason})
+	if err != nil {
+		return
+	}
+	state.Logger.Info(logEvalPrefix + " " + string(payload))
 }
 
 // emitJudgeCost records the judge model's own token usage and estimated USD spend

--- a/internal/js/modules/k6/experimental/ageval/judge.go
+++ b/internal/js/modules/k6/experimental/ageval/judge.go
@@ -1,0 +1,186 @@
+package ageval
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/v2/js/common"
+	"go.k6.io/k6/v2/metrics"
+)
+
+const defaultJudgeThreshold = 0.7
+
+// judgeResult is returned to JS from judge().
+type judgeResult struct {
+	Score  float64 `js:"score"`
+	Reason string  `js:"reason"`
+	Passed bool    `js:"passed"`
+}
+
+// judge runs an LLM-as-judge (GEval-style) over a RunResult: it scores the
+// agent's behavior against a natural-language rubric on a 0..1 scale, emits the
+// agent_quality_score (Trend) and agent_judge_pass (Rate) metrics, and returns
+// `{ score, reason, passed }`.
+//
+// opts: { provider, model, apiKey, rubric, threshold?, input?, actualOutput?, baseURL? }
+func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.Value {
+	rt := mi.vu.Runtime()
+	if mi.vu.State() == nil {
+		common.Throw(rt, errInitContext)
+	}
+	if opts == nil || common.IsNullish(opts) {
+		common.Throw(rt, errors.New("judge() requires an options object with a `rubric`"))
+	}
+	o := opts.ToObject(rt)
+
+	rubric := getString(o, "rubric", "")
+	if rubric == "" {
+		common.Throw(rt, errors.New("judge() requires a non-empty `rubric`"))
+	}
+	providerName := getString(o, "provider", "anthropic")
+	prov, ok := lookupProvider(providerName)
+	if !ok {
+		common.Throw(rt, fmt.Errorf("unknown provider %q (supported: anthropic)", providerName))
+	}
+	modelName := getString(o, "model", "")
+	if _, ok := prov.model(modelName); !ok {
+		common.Throw(rt, fmt.Errorf("unsupported judge model %q for provider %q", modelName, providerName))
+	}
+	apiKey := getString(o, "apiKey", "")
+	if apiKey == "" {
+		common.Throw(rt, errors.New("judge() requires a non-empty `apiKey`"))
+	}
+	threshold := getFloat(o, "threshold", defaultJudgeThreshold)
+
+	rr := mi.exportRunResult(resultVal)
+	input := getString(o, "input", "")
+	actual := getString(o, "actualOutput", "")
+	if actual == "" && rr != nil {
+		actual = serializeTrajectory(rr)
+	}
+
+	prompt := buildJudgePrompt(rubric, input, actual)
+	rep, err := prov.createMessage(mi.vu.Context(), conversation{
+		model:    modelName,
+		apiKey:   apiKey,
+		baseURL:  getString(o, "baseURL", ""),
+		messages: []message{{role: roleUser, blocks: []block{{kind: blockText, text: prompt}}}},
+	})
+	if err != nil {
+		common.Throw(rt, fmt.Errorf("judge model call failed: %w", err))
+	}
+
+	score, reason := parseJudgeReply(rep)
+	passed := score >= threshold
+
+	tags := mi.judgeTags(rr)
+	pushSample(mi.vu, mi.metrics.qualityScore, tags, score)
+	passVal := 0.0
+	if passed {
+		passVal = 1
+	}
+	pushSample(mi.vu, mi.metrics.judgePass, tags, passVal)
+
+	return rt.ToValue(judgeResult{Score: score, Reason: reason, Passed: passed}).ToObject(rt)
+}
+
+// exportRunResult recovers the *RunResult wrapped in a JS value, or nil.
+func (mi *ModuleInstance) exportRunResult(v sobek.Value) *RunResult {
+	if v == nil || common.IsNullish(v) {
+		return nil
+	}
+	if rr, ok := v.Export().(*RunResult); ok {
+		return rr
+	}
+	return nil
+}
+
+func (mi *ModuleInstance) judgeTags(rr *RunResult) *metrics.TagSet {
+	if rr != nil && rr.tags != nil {
+		return rr.tags
+	}
+	return mi.vu.State().Tags.GetCurrentValues().Tags
+}
+
+func serializeTrajectory(rr *RunResult) string {
+	var sb strings.Builder
+	for i, c := range rr.ToolCalls {
+		args, err := json.Marshal(c.Input)
+		if err != nil {
+			args = []byte("{}")
+		}
+		fmt.Fprintf(&sb, "  %d. %s(%s) → %s\n", i+1, c.Name, string(args), c.Output)
+	}
+	if rr.Output != "" {
+		fmt.Fprintf(&sb, "Final message: %s\n", rr.Output)
+	}
+	return sb.String()
+}
+
+func buildJudgePrompt(rubric, input, actual string) string {
+	var sb strings.Builder
+	sb.WriteString("You are an expert evaluator scoring an AI agent's behavior against a rubric.\n")
+	sb.WriteString("Score how well the agent meets the rubric on a scale from 0.0 (fails) to 1.0 (fully meets).\n")
+	sb.WriteString("Respond with ONLY a JSON object and nothing else: ")
+	sb.WriteString(`{"score": <number 0..1>, "reason": "<one sentence>"}` + "\n\n")
+	sb.WriteString("Rubric:\n")
+	sb.WriteString(rubric)
+	sb.WriteString("\n\n")
+	if input != "" {
+		sb.WriteString("Task / context:\n")
+		sb.WriteString(input)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("Agent actual behavior:\n")
+	sb.WriteString(actual)
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+// parseJudgeReply extracts {score, reason} from the judge model's text reply,
+// tolerating surrounding prose by scanning for the JSON object.
+func parseJudgeReply(rep reply) (float64, string) {
+	var text strings.Builder
+	for _, b := range rep.blocks {
+		if b.kind == blockText {
+			text.WriteString(b.text)
+		}
+	}
+	raw := text.String()
+	start := strings.Index(raw, "{")
+	end := strings.LastIndex(raw, "}")
+	if start == -1 || end == -1 || end < start {
+		return 0, "judge did not return parseable JSON: " + truncate(raw, 200)
+	}
+	var parsed struct {
+		Score  float64 `json:"score"`
+		Reason string  `json:"reason"`
+	}
+	if err := json.Unmarshal([]byte(raw[start:end+1]), &parsed); err != nil {
+		return 0, "judge JSON parse error: " + err.Error()
+	}
+	if parsed.Score < 0 {
+		parsed.Score = 0
+	} else if parsed.Score > 1 {
+		parsed.Score = 1
+	}
+	return parsed.Score, parsed.Reason
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+func getFloat(obj *sobek.Object, key string, def float64) float64 {
+	v := obj.Get(key)
+	if v == nil || sobek.IsUndefined(v) || sobek.IsNull(v) {
+		return def
+	}
+	return v.ToFloat()
+}

--- a/internal/js/modules/k6/experimental/ageval/judge.go
+++ b/internal/js/modules/k6/experimental/ageval/judge.go
@@ -20,7 +20,7 @@ type judgeResult struct {
 	Passed bool    `js:"passed"`
 }
 
-// judge runs an LLM-as-judge (GEval-style) over a RunResult: it scores the
+// judge runs an LLM-as-judge (GEval-style) over an AgentTestCase: it scores the
 // agent's behavior against a natural-language rubric on a 0..1 scale, emits the
 // agent_quality_score (Trend) and agent_judge_pass (Rate) metrics, and returns
 // `{ score, reason, passed }`.
@@ -55,7 +55,7 @@ func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.V
 	}
 	threshold := getFloat(o, "threshold", defaultJudgeThreshold)
 
-	rr := mi.exportRunResult(resultVal)
+	rr := mi.exportAgentTestCase(resultVal)
 	// The task/prompt the agent was given. Default to the run's own input so the
 	// judge always sees what the agent was asked to do, not just what it did.
 	input := getString(o, "input", "")
@@ -92,25 +92,25 @@ func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.V
 	return rt.ToValue(judgeResult{Score: score, Reason: reason, Passed: passed}).ToObject(rt)
 }
 
-// exportRunResult recovers the *RunResult wrapped in a JS value, or nil.
-func (mi *ModuleInstance) exportRunResult(v sobek.Value) *RunResult {
+// exportAgentTestCase recovers the *AgentTestCase wrapped in a JS value, or nil.
+func (mi *ModuleInstance) exportAgentTestCase(v sobek.Value) *AgentTestCase {
 	if v == nil || common.IsNullish(v) {
 		return nil
 	}
-	if rr, ok := v.Export().(*RunResult); ok {
+	if rr, ok := v.Export().(*AgentTestCase); ok {
 		return rr
 	}
 	return nil
 }
 
-func (mi *ModuleInstance) judgeTags(rr *RunResult) *metrics.TagSet {
+func (mi *ModuleInstance) judgeTags(rr *AgentTestCase) *metrics.TagSet {
 	if rr != nil && rr.tags != nil {
 		return rr.tags
 	}
 	return mi.vu.State().Tags.GetCurrentValues().Tags
 }
 
-func serializeTrajectory(rr *RunResult) string {
+func serializeTrajectory(rr *AgentTestCase) string {
 	var sb strings.Builder
 	for i, c := range rr.ToolCalls {
 		args, err := json.Marshal(c.Input)

--- a/internal/js/modules/k6/experimental/ageval/judge.go
+++ b/internal/js/modules/k6/experimental/ageval/judge.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/grafana/sobek"
@@ -93,7 +94,10 @@ func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.V
 	score, reason := parseJudgeReply(rep)
 	passed := score >= threshold
 
-	tags := mi.judgeTags(rr).With("eval", name)
+	// eval = which eval; threshold = its judge cutoff (low-cardinality, so tools can
+	// read the real per-eval threshold from the metrics — distinct from the k6
+	// options.thresholds config).
+	tags := mi.judgeTags(rr).With("eval", name).With("threshold", strconv.FormatFloat(threshold, 'g', -1, 64))
 	pushSample(mi.vu, mi.metrics.qualityScore, tags, score)
 	passVal := 0.0
 	if passed {

--- a/internal/js/modules/k6/experimental/ageval/judge.go
+++ b/internal/js/modules/k6/experimental/ageval/judge.go
@@ -101,32 +101,73 @@ func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.V
 	}
 	pushSample(mi.vu, mi.metrics.judgePass, tags, passVal)
 	mi.emitJudgeCost(tags, prov, modelName, rep.usage)
-	mi.logEval(name, score, passed, reason)
+	mi.logEval(evalLog{
+		name:      name,
+		score:     score,
+		threshold: threshold,
+		passed:    passed,
+		reason:    reason,
+		rubric:    rubric,
+		input:     input,
+		actual:    actual,
+	})
 
 	return rt.ToValue(judgeResult{Score: score, Reason: reason, Passed: passed}).ToObject(rt)
 }
 
-// logEvalPrefix marks judge result log lines so tools can find and parse them
-// (the JSON after the prefix carries name/score/passed/reason). Logged because the
-// rubric/reason can't be metric tags, yet logs are streamed to the cloud even under
-// --local-execution.
+// logEvalPrefix marks judge result log lines so tools can find and parse them (the
+// JSON after the prefix carries the eval result). Logged because the rubric/reason
+// can't be metric tags; under --local-execution logs stay on the CLI, and under
+// cloud execution they reach the cloud Logs tab.
 const logEvalPrefix = "ageval_eval"
 
-func (mi *ModuleInstance) logEval(name string, score float64, passed bool, reason string) {
+type evalLog struct {
+	name      string
+	score     float64
+	threshold float64
+	passed    bool
+	reason    string
+	rubric    string
+	input     string
+	actual    string
+}
+
+// logEval logs one parseable `ageval_eval {json}` line per judge. A FAILING eval is
+// logged at Error level (prominent on the CLI, filterable as level=error in the
+// cloud) and carries extra debugging detail — the rubric, the task input and the
+// agent's actual behavior — so the failure is self-explanatory. A passing eval logs
+// a lean line at Info level.
+func (mi *ModuleInstance) logEval(e evalLog) {
 	state := mi.vu.State()
 	if state == nil || state.Logger == nil {
 		return
 	}
-	payload, err := json.Marshal(struct {
-		Name   string  `json:"name"`
-		Score  float64 `json:"score"`
-		Passed bool    `json:"passed"`
-		Reason string  `json:"reason"`
-	}{name, score, passed, reason})
+	payload := struct {
+		Name      string  `json:"name"`
+		Score     float64 `json:"score"`
+		Threshold float64 `json:"threshold"`
+		Passed    bool    `json:"passed"`
+		Reason    string  `json:"reason"`
+		Rubric    string  `json:"rubric,omitempty"`
+		Input     string  `json:"input,omitempty"`
+		Actual    string  `json:"actual,omitempty"`
+	}{Name: e.name, Score: e.score, Threshold: e.threshold, Passed: e.passed, Reason: e.reason}
+	if !e.passed {
+		// Pack as much context as possible on failure (truncated to keep the line sane).
+		payload.Rubric = truncate(e.rubric, 1000)
+		payload.Input = truncate(e.input, 1000)
+		payload.Actual = truncate(e.actual, 2000)
+	}
+	encoded, err := json.Marshal(payload)
 	if err != nil {
 		return
 	}
-	state.Logger.Info(logEvalPrefix + " " + string(payload))
+	msg := logEvalPrefix + " " + string(encoded)
+	if e.passed {
+		state.Logger.Info(msg)
+	} else {
+		state.Logger.Error(msg)
+	}
 }
 
 // emitJudgeCost records the judge model's own token usage and estimated USD spend

--- a/internal/js/modules/k6/experimental/ageval/judge.go
+++ b/internal/js/modules/k6/experimental/ageval/judge.go
@@ -25,7 +25,12 @@ type judgeResult struct {
 // agent_quality_score (Trend) and agent_judge_pass (Rate) metrics, and returns
 // `{ score, reason, passed }`.
 //
-// opts: { provider, model, apiKey, rubric, threshold?, input?, actualOutput?, baseURL? }
+// `name` tags agent_quality_score / agent_judge_pass with metric=<name> so several
+// judge() calls (different rubrics) are distinguishable in dashboards. The judge's
+// own spend is emitted as agent_judge_tokens / agent_judge_cost_usd, tagged with the
+// judge model (separate from the agent's agent_tokens / agent_cost_usd).
+//
+// opts: { provider, model, apiKey, rubric, name?, threshold?, input?, actualOutput?, baseURL? }
 func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.Value {
 	rt := mi.vu.Runtime()
 	if mi.vu.State() == nil {
@@ -82,14 +87,34 @@ func (mi *ModuleInstance) judge(resultVal sobek.Value, opts sobek.Value) sobek.V
 	passed := score >= threshold
 
 	tags := mi.judgeTags(rr)
+	if name := getString(o, "name", ""); name != "" {
+		tags = tags.With("metric", name)
+	}
 	pushSample(mi.vu, mi.metrics.qualityScore, tags, score)
 	passVal := 0.0
 	if passed {
 		passVal = 1
 	}
 	pushSample(mi.vu, mi.metrics.judgePass, tags, passVal)
+	mi.emitJudgeCost(tags, prov, modelName, rep.usage)
 
 	return rt.ToValue(judgeResult{Score: score, Reason: reason, Passed: passed}).ToObject(rt)
+}
+
+// emitJudgeCost records the judge model's own token usage and estimated USD spend
+// (distinct from the agent's). It tags the samples with the judge model so judge
+// spend is attributable separately from agent spend.
+func (mi *ModuleInstance) emitJudgeCost(tags *metrics.TagSet, prov provider, modelName string, u usage) {
+	if u.inputTokens == 0 && u.outputTokens == 0 {
+		return
+	}
+	jt := tags.With("model", modelName)
+	pushSample(mi.vu, mi.metrics.judgeTokens, jt.With("direction", "input"), float64(u.inputTokens))
+	pushSample(mi.vu, mi.metrics.judgeTokens, jt.With("direction", "output"), float64(u.outputTokens))
+	if info, ok := prov.model(modelName); ok {
+		cost := float64(u.inputTokens)/1e6*info.inUSDPerMTok + float64(u.outputTokens)/1e6*info.outUSDPerMTok
+		pushSample(mi.vu, mi.metrics.judgeCost, jt, cost)
+	}
 }
 
 // exportAgentTestCase recovers the *AgentTestCase wrapped in a JS value, or nil.

--- a/internal/js/modules/k6/experimental/ageval/judge_test.go
+++ b/internal/js/modules/k6/experimental/ageval/judge_test.go
@@ -44,9 +44,9 @@ func TestJudgeNameTagAndCost(t *testing.T) {
 
 	// (1) the score/pass metrics carry the metric=<name> tag.
 	require.Len(t, got["agent_quality_score"], 1)
-	assert.Equal(t, "answer_quality", got["agent_quality_score"][0].tags["metric"])
+	assert.Equal(t, "answer_quality", got["agent_quality_score"][0].tags["eval"])
 	require.Len(t, got["agent_judge_pass"], 1)
-	assert.Equal(t, "answer_quality", got["agent_judge_pass"][0].tags["metric"])
+	assert.Equal(t, "answer_quality", got["agent_judge_pass"][0].tags["eval"])
 
 	// (2) the judge's own spend is emitted, tagged with the judge model.
 	require.Len(t, got["agent_judge_tokens"], 2) // input + output
@@ -54,6 +54,17 @@ func TestJudgeNameTagAndCost(t *testing.T) {
 	assert.Equal(t, "claude-sonnet-4-5", got["agent_judge_cost_usd"][0].tags["model"])
 	// cost = 3/1e6*3 + 4/1e6*15 (sonnet-4-5 pricing $3/$15 per Mtok)
 	assert.InDelta(t, 3.0/1e6*3+4.0/1e6*15, got["agent_judge_cost_usd"][0].value, 1e-12)
+}
+
+func TestJudgeRequiresName(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+	_, err := ts.rt.VU.Runtime().RunString(`
+		const r = new AgentTestCase({ input: "q", output: "x" });
+		judge(r, { model: "claude-sonnet-4-5", apiKey: "k", rubric: "ok" });
+	`)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "name")
 }
 
 func TestJudgeScoresAndEmitsMetrics(t *testing.T) {
@@ -69,6 +80,7 @@ func TestJudgeScoresAndEmitsMetrics(t *testing.T) {
 		});
 		const r = agent.run({ input: "go", tags: { case: "judge" } });
 		judge(r, {
+			name: "echoes",
 			model: "claude-sonnet-4-5",
 			apiKey: "jt",
 			baseURL: %q,
@@ -109,7 +121,7 @@ func TestJudgeIncludesRunInputInPrompt(t *testing.T) {
 			toolCalls: [{ name: "Glob", input: { pattern: "*.go" }, output: "18 files" }],
 		});
 		// Note: no input passed to judge() -- it must fall back to the run's input.
-		judge(r, { model: "claude-sonnet-4-5", apiKey: "jt", baseURL: %q, rubric: "Reports a count." });
+		judge(r, { name: "count", model: "claude-sonnet-4-5", apiKey: "jt", baseURL: %q, rubric: "Reports a count." });
 	`, srv.URL))
 	require.NoError(t, err)
 	assert.Contains(t, captured, "Count the go files in the repo", "judge prompt should include the run's task/input")

--- a/internal/js/modules/k6/experimental/ageval/judge_test.go
+++ b/internal/js/modules/k6/experimental/ageval/judge_test.go
@@ -2,6 +2,9 @@ package ageval
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +42,32 @@ func TestJudgeScoresAndEmitsMetrics(t *testing.T) {
 	samples := drainSamples(ts.samples)
 	assert.Equal(t, []float64{0.9}, samples["agent_quality_score"])
 	assert.Equal(t, []float64{1}, samples["agent_judge_pass"])
+}
+
+func TestJudgeIncludesRunInputInPrompt(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+
+	var captured string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		captured = string(body)
+		w.Header().Set("content-type", "application/json")
+		_, _ = w.Write([]byte(judgeResponse))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
+		const r = fromAgentRun({
+			input: "Count the go files in the repo",
+			output: "There are 18 go files.",
+			toolCalls: [{ name: "Glob", input: { pattern: "*.go" }, output: "18 files" }],
+		});
+		// Note: no input passed to judge() -- it must fall back to the run's input.
+		judge(r, { model: "claude-sonnet-4-5", apiKey: "jt", baseURL: %q, rubric: "Reports a count." });
+	`, srv.URL))
+	require.NoError(t, err)
+	assert.Contains(t, captured, "Count the go files in the repo", "judge prompt should include the run's task/input")
 }
 
 func TestParseJudgeReply(t *testing.T) {

--- a/internal/js/modules/k6/experimental/ageval/judge_test.go
+++ b/internal/js/modules/k6/experimental/ageval/judge_test.go
@@ -1,0 +1,68 @@
+package ageval
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJudgeScoresAndEmitsMetrics(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+	agentSrv := cannedServer(t, toolUseResponse, endTurnResponse)
+	judgeSrv := cannedServer(t, judgeResponse)
+
+	v, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
+		const agent = new Agent({
+			model: "claude-sonnet-4-5", apiKey: "t", baseURL: %q,
+			tools: [{ name: "echo", description: "d", mock: () => "ok" }],
+		});
+		const r = agent.run({ input: "go", tags: { case: "judge" } });
+		judge(r, {
+			model: "claude-sonnet-4-5",
+			apiKey: "jt",
+			baseURL: %q,
+			rubric: "The agent should call echo and finish.",
+			threshold: 0.7,
+		});
+	`, agentSrv.URL, judgeSrv.URL))
+	require.NoError(t, err)
+
+	rt := ts.rt.VU.Runtime()
+	res := v.ToObject(rt)
+	assert.InDelta(t, 0.9, res.Get("score").ToFloat(), 1e-9)
+	assert.True(t, res.Get("passed").ToBoolean())
+	assert.Equal(t, "good", res.Get("reason").String())
+
+	samples := drainSamples(ts.samples)
+	assert.Equal(t, []float64{0.9}, samples["agent_quality_score"])
+	assert.Equal(t, []float64{1}, samples["agent_judge_pass"])
+}
+
+func TestParseJudgeReply(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		text      string
+		wantScore float64
+		wantOK    bool
+	}{
+		{"clean json", `{"score": 0.8, "reason": "ok"}`, 0.8, true},
+		{"surrounding prose", "Here is my verdict: {\"score\": 0.5, \"reason\": \"meh\"} done", 0.5, true},
+		{"clamps high", `{"score": 1.5, "reason": "x"}`, 1.0, true},
+		{"clamps low", `{"score": -2, "reason": "x"}`, 0.0, true},
+		{"no json", `I cannot score this`, 0.0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			score, reason := parseJudgeReply(reply{blocks: []block{{kind: blockText, text: tc.text}}})
+			assert.InDelta(t, tc.wantScore, score, 1e-9)
+			if !tc.wantOK {
+				assert.NotEmpty(t, reason)
+			}
+		})
+	}
+}

--- a/internal/js/modules/k6/experimental/ageval/judge_test.go
+++ b/internal/js/modules/k6/experimental/ageval/judge_test.go
@@ -15,7 +15,7 @@ func TestJudgeScoresAndEmitsMetrics(t *testing.T) {
 	judgeSrv := cannedServer(t, judgeResponse)
 
 	v, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
-		const agent = new Agent({
+		const agent = new AgentSimulator({
 			model: "claude-sonnet-4-5", apiKey: "t", baseURL: %q,
 			tools: [{ name: "echo", description: "d", mock: () => "ok" }],
 		});

--- a/internal/js/modules/k6/experimental/ageval/judge_test.go
+++ b/internal/js/modules/k6/experimental/ageval/judge_test.go
@@ -11,6 +11,51 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestJudgeNameTagAndCost(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+	srv := cannedServer(t, judgeResponse) // usage: 3 input / 4 output tokens
+
+	_, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
+		const r = new AgentTestCase({ input: "q", output: "Invoice INV-123 is paid." });
+		judge(r, {
+			name: "answer_quality",
+			model: "claude-sonnet-4-5", apiKey: "jt", baseURL: %q,
+			rubric: "The answer states the invoice is paid.",
+		});
+	`, srv.URL))
+	require.NoError(t, err)
+
+	type tagged struct {
+		value float64
+		tags  map[string]string
+	}
+	got := map[string][]tagged{}
+	for done := false; !done; {
+		select {
+		case sc := <-ts.samples:
+			for _, s := range sc.GetSamples() {
+				got[s.Metric.Name] = append(got[s.Metric.Name], tagged{s.Value, s.GetTags().Map()})
+			}
+		default:
+			done = true
+		}
+	}
+
+	// (1) the score/pass metrics carry the metric=<name> tag.
+	require.Len(t, got["agent_quality_score"], 1)
+	assert.Equal(t, "answer_quality", got["agent_quality_score"][0].tags["metric"])
+	require.Len(t, got["agent_judge_pass"], 1)
+	assert.Equal(t, "answer_quality", got["agent_judge_pass"][0].tags["metric"])
+
+	// (2) the judge's own spend is emitted, tagged with the judge model.
+	require.Len(t, got["agent_judge_tokens"], 2) // input + output
+	require.Len(t, got["agent_judge_cost_usd"], 1)
+	assert.Equal(t, "claude-sonnet-4-5", got["agent_judge_cost_usd"][0].tags["model"])
+	// cost = 3/1e6*3 + 4/1e6*15 (sonnet-4-5 pricing $3/$15 per Mtok)
+	assert.InDelta(t, 3.0/1e6*3+4.0/1e6*15, got["agent_judge_cost_usd"][0].value, 1e-12)
+}
+
 func TestJudgeScoresAndEmitsMetrics(t *testing.T) {
 	t.Parallel()
 	ts := newTestSetup(t)

--- a/internal/js/modules/k6/experimental/ageval/judge_test.go
+++ b/internal/js/modules/k6/experimental/ageval/judge_test.go
@@ -58,7 +58,7 @@ func TestJudgeIncludesRunInputInPrompt(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	_, err := ts.rt.VU.Runtime().RunString(fmt.Sprintf(`
-		const r = fromAgentRun({
+		const r = new AgentTestCase({
 			input: "Count the go files in the repo",
 			output: "There are 18 go files.",
 			toolCalls: [{ name: "Glob", input: { pattern: "*.go" }, output: "18 files" }],

--- a/internal/js/modules/k6/experimental/ageval/judge_test.go
+++ b/internal/js/modules/k6/experimental/ageval/judge_test.go
@@ -45,6 +45,7 @@ func TestJudgeNameTagAndCost(t *testing.T) {
 	// (1) the score/pass metrics carry the metric=<name> tag.
 	require.Len(t, got["agent_quality_score"], 1)
 	assert.Equal(t, "answer_quality", got["agent_quality_score"][0].tags["eval"])
+	assert.Equal(t, "0.7", got["agent_quality_score"][0].tags["threshold"]) // judge threshold as a tag
 	require.Len(t, got["agent_judge_pass"], 1)
 	assert.Equal(t, "answer_quality", got["agent_judge_pass"][0].tags["eval"])
 

--- a/internal/js/modules/k6/experimental/ageval/metrics.go
+++ b/internal/js/modules/k6/experimental/ageval/metrics.go
@@ -1,0 +1,50 @@
+package ageval
+
+import (
+	"time"
+
+	"go.k6.io/k6/v2/js/modules"
+	"go.k6.io/k6/v2/metrics"
+)
+
+// agevalMetrics holds the custom metrics emitted by the module. They are
+// standard k6 metric types (Trend/Rate/Counter) so existing k6 outputs and
+// Grafana Cloud dashboards render them with no extra configuration.
+type agevalMetrics struct {
+	duration        *metrics.Metric // Trend (time): wall-clock of a full agent run
+	steps           *metrics.Metric // Trend: number of model round-trips per run
+	toolCalls       *metrics.Metric // Counter: tool calls, tagged by tool name
+	tokens          *metrics.Metric // Counter: tokens, tagged by direction
+	cost            *metrics.Metric // Counter: estimated USD spend
+	toolCorrectness *metrics.Metric // Rate: expectSequence pass/fail
+	qualityScore    *metrics.Metric // Trend: LLM-as-judge score 0..1
+	judgePass       *metrics.Metric // Rate: judge score >= threshold
+}
+
+// registerMetrics creates (or reuses) the module metrics in the registry.
+func registerMetrics(registry *metrics.Registry) *agevalMetrics {
+	return &agevalMetrics{
+		duration:        registry.MustNewMetric("agent_duration", metrics.Trend, metrics.Time),
+		steps:           registry.MustNewMetric("agent_steps", metrics.Trend),
+		toolCalls:       registry.MustNewMetric("agent_tool_calls", metrics.Counter),
+		tokens:          registry.MustNewMetric("agent_tokens", metrics.Counter),
+		cost:            registry.MustNewMetric("agent_cost_usd", metrics.Counter),
+		toolCorrectness: registry.MustNewMetric("agent_tool_correctness", metrics.Rate),
+		qualityScore:    registry.MustNewMetric("agent_quality_score", metrics.Trend),
+		judgePass:       registry.MustNewMetric("agent_judge_pass", metrics.Rate),
+	}
+}
+
+// pushSample emits a single metric sample with the given tags. It is a no-op in
+// the init context (no VU state), mirroring how check() behaves.
+func pushSample(vu modules.VU, m *metrics.Metric, tags *metrics.TagSet, value float64) {
+	state := vu.State()
+	if state == nil {
+		return
+	}
+	metrics.PushIfNotDone(vu.Context(), state.Samples, metrics.Sample{
+		TimeSeries: metrics.TimeSeries{Metric: m, Tags: tags},
+		Time:       time.Now(),
+		Value:      value,
+	})
+}

--- a/internal/js/modules/k6/experimental/ageval/metrics.go
+++ b/internal/js/modules/k6/experimental/ageval/metrics.go
@@ -19,6 +19,8 @@ type agevalMetrics struct {
 	toolCorrectness *metrics.Metric // Rate: expectSequence pass/fail
 	qualityScore    *metrics.Metric // Trend: LLM-as-judge score 0..1
 	judgePass       *metrics.Metric // Rate: judge score >= threshold
+	judgeTokens     *metrics.Metric // Counter: judge model tokens, tagged by direction
+	judgeCost       *metrics.Metric // Counter: estimated USD spend by the judge itself
 }
 
 // registerMetrics creates (or reuses) the module metrics in the registry.
@@ -32,6 +34,8 @@ func registerMetrics(registry *metrics.Registry) *agevalMetrics {
 		toolCorrectness: registry.MustNewMetric("agent_tool_correctness", metrics.Rate),
 		qualityScore:    registry.MustNewMetric("agent_quality_score", metrics.Trend),
 		judgePass:       registry.MustNewMetric("agent_judge_pass", metrics.Rate),
+		judgeTokens:     registry.MustNewMetric("agent_judge_tokens", metrics.Counter),
+		judgeCost:       registry.MustNewMetric("agent_judge_cost_usd", metrics.Counter),
 	}
 }
 

--- a/internal/js/modules/k6/experimental/ageval/module.go
+++ b/internal/js/modules/k6/experimental/ageval/module.go
@@ -1,8 +1,17 @@
 // Package ageval is an experimental k6 module for evaluating tool-using LLM
-// agents. It runs an agent loop against a model provider (Anthropic), records
-// the tool-call trajectory, lets scripts assert on it with check()/expectSequence
-// and an LLM-as-judge, and emits standard k6 metrics (Trend/Rate/Counter) so the
-// results visualize in k6 Cloud and Grafana with no extra configuration.
+// agents. It builds an "ageval test" from an agent's tool-call trajectory in one
+// of two ways:
+//
+//   - AgentSimulator — simulates an agent by running a model loop against a
+//     provider (Anthropic) with mocked tools, so you can exercise a prompt's
+//     behavior without a live backend; or
+//   - fromAgentRun — takes a real agent's recorded output + tool calls directly,
+//     with no simulation, so you can evaluate your production agent's actual run.
+//
+// Either way it produces a RunResult that scripts assert on with
+// check()/expectSequence() and an LLM-as-judge, and it emits standard k6 metrics
+// (Trend/Rate/Counter) so results visualize in k6 Cloud and Grafana with no extra
+// configuration.
 package ageval
 
 import (
@@ -45,8 +54,9 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{
 		Named: map[string]any{
-			"Agent": mi.newAgent,
-			"judge": mi.judge,
+			"AgentSimulator": mi.newAgentSimulator,
+			"fromAgentRun":   mi.fromAgentRun,
+			"judge":          mi.judge,
 		},
 	}
 }

--- a/internal/js/modules/k6/experimental/ageval/module.go
+++ b/internal/js/modules/k6/experimental/ageval/module.go
@@ -1,0 +1,52 @@
+// Package ageval is an experimental k6 module for evaluating tool-using LLM
+// agents. It runs an agent loop against a model provider (Anthropic), records
+// the tool-call trajectory, lets scripts assert on it with check()/expectSequence
+// and an LLM-as-judge, and emits standard k6 metrics (Trend/Rate/Counter) so the
+// results visualize in k6 Cloud and Grafana with no extra configuration.
+package ageval
+
+import (
+	"go.k6.io/k6/v2/js/modules"
+)
+
+type (
+	// RootModule is the global module instance that creates a ModuleInstance
+	// per VU.
+	RootModule struct{}
+
+	// ModuleInstance is the per-VU instance of the ageval module.
+	ModuleInstance struct {
+		vu      modules.VU
+		metrics *agevalMetrics
+	}
+)
+
+var (
+	_ modules.Module   = &RootModule{}
+	_ modules.Instance = &ModuleInstance{}
+)
+
+// New returns a pointer to a new RootModule instance.
+func New() *RootModule {
+	return &RootModule{}
+}
+
+// NewModuleInstance implements the modules.Module interface and returns a new
+// instance of the module for the given VU. Metrics are registered here, in the
+// init context, where the registry is available.
+func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
+	return &ModuleInstance{
+		vu:      vu,
+		metrics: registerMetrics(vu.InitEnv().Registry),
+	}
+}
+
+// Exports implements the modules.Instance interface.
+func (mi *ModuleInstance) Exports() modules.Exports {
+	return modules.Exports{
+		Named: map[string]any{
+			"Agent": mi.newAgent,
+			"judge": mi.judge,
+		},
+	}
+}

--- a/internal/js/modules/k6/experimental/ageval/module.go
+++ b/internal/js/modules/k6/experimental/ageval/module.go
@@ -1,17 +1,19 @@
 // Package ageval is an experimental k6 module for evaluating tool-using LLM
-// agents. It builds an "ageval test" from an agent's tool-call trajectory in one
-// of two ways:
+// agents. Its single data type is the AgentTestCase
+// LLMTestCase — holding an agent run's input, output, tool calls and usage. You
+// obtain an AgentTestCase in one of three ways:
 //
-//   - AgentSimulator — simulates an agent by running a model loop against a
-//     provider (Anthropic) with mocked tools, so you can exercise a prompt's
-//     behavior without a live backend; or
-//   - fromAgentRun — takes a real agent's recorded output + tool calls directly,
-//     with no simulation, so you can evaluate your production agent's actual run.
+//   - new AgentTestCase({...}) — wrap a recorded trajectory you already have (a logged
+//     production run, a captured dataset, a framework's output, or a raw payload
+//     parsed via a `format` adapter); no agent is run;
+//   - AgentSimulator.run() — an optional producer that simulates an agent by
+//     running a model loop against a provider (Anthropic) with mocked tools; or
+//   - ExternalAgent.run() — an optional producer that runs a real agent CLI as a
+//     subprocess (so the agent runs as part of the k6 test, even under load).
 //
-// Either way it produces a RunResult that scripts assert on with
-// check()/expectSequence() and an LLM-as-judge, and it emits standard k6 metrics
-// (Trend/Rate/Counter) so results visualize in k6 Cloud and Grafana with no extra
-// configuration.
+// All three yield an AgentTestCase that scripts assert on with check()/expectSequence()
+// and an LLM-as-judge, and it emits standard k6 metrics (Trend/Rate/Counter) so
+// results visualize in k6 Cloud and Grafana with no extra configuration.
 package ageval
 
 import (
@@ -54,9 +56,9 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{
 		Named: map[string]any{
+			"AgentTestCase":  mi.newAgentTestCase,
 			"AgentSimulator": mi.newAgentSimulator,
 			"ExternalAgent":  mi.newExternalAgent,
-			"fromAgentRun":   mi.fromAgentRun,
 			"judge":          mi.judge,
 		},
 	}

--- a/internal/js/modules/k6/experimental/ageval/module.go
+++ b/internal/js/modules/k6/experimental/ageval/module.go
@@ -8,7 +8,7 @@
 //     parsed via a `format` adapter); no agent is run;
 //   - AgentSimulator.run() — an optional producer that simulates an agent by
 //     running a model loop against a provider (Anthropic) with mocked tools; or
-//   - ExternalAgent.run() — an optional producer that runs a real agent CLI as a
+//   - CliAgent.run() — an optional producer that runs a real agent CLI as a
 //     subprocess (so the agent runs as part of the k6 test, even under load).
 //
 // All three yield an AgentTestCase that scripts assert on with check()/expectSequence()
@@ -58,7 +58,7 @@ func (mi *ModuleInstance) Exports() modules.Exports {
 		Named: map[string]any{
 			"AgentTestCase":  mi.newAgentTestCase,
 			"AgentSimulator": mi.newAgentSimulator,
-			"ExternalAgent":  mi.newExternalAgent,
+			"CliAgent":       mi.newCliAgent,
 			"judge":          mi.judge,
 		},
 	}

--- a/internal/js/modules/k6/experimental/ageval/module.go
+++ b/internal/js/modules/k6/experimental/ageval/module.go
@@ -55,6 +55,7 @@ func (mi *ModuleInstance) Exports() modules.Exports {
 	return modules.Exports{
 		Named: map[string]any{
 			"AgentSimulator": mi.newAgentSimulator,
+			"ExternalAgent":  mi.newExternalAgent,
 			"fromAgentRun":   mi.fromAgentRun,
 			"judge":          mi.judge,
 		},

--- a/internal/js/modules/k6/experimental/ageval/module_test.go
+++ b/internal/js/modules/k6/experimental/ageval/module_test.go
@@ -17,7 +17,8 @@ func TestModuleExportsAndMetrics(t *testing.T) {
 	require.True(t, ok)
 
 	exports := mi.Exports().Named
-	assert.Contains(t, exports, "Agent")
+	assert.Contains(t, exports, "AgentSimulator")
+	assert.Contains(t, exports, "fromAgentRun")
 	assert.Contains(t, exports, "judge")
 
 	for _, name := range []string{

--- a/internal/js/modules/k6/experimental/ageval/module_test.go
+++ b/internal/js/modules/k6/experimental/ageval/module_test.go
@@ -19,7 +19,7 @@ func TestModuleExportsAndMetrics(t *testing.T) {
 	exports := mi.Exports().Named
 	assert.Contains(t, exports, "AgentTestCase")
 	assert.Contains(t, exports, "AgentSimulator")
-	assert.Contains(t, exports, "ExternalAgent")
+	assert.Contains(t, exports, "CliAgent")
 	assert.Contains(t, exports, "judge")
 
 	for _, name := range []string{

--- a/internal/js/modules/k6/experimental/ageval/module_test.go
+++ b/internal/js/modules/k6/experimental/ageval/module_test.go
@@ -1,0 +1,29 @@
+package ageval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/v2/js/modulestest"
+)
+
+func TestModuleExportsAndMetrics(t *testing.T) {
+	t.Parallel()
+	rt := modulestest.NewRuntime(t)
+	registry := rt.VU.InitEnvField.Registry
+
+	mi, ok := New().NewModuleInstance(rt.VU).(*ModuleInstance)
+	require.True(t, ok)
+
+	exports := mi.Exports().Named
+	assert.Contains(t, exports, "Agent")
+	assert.Contains(t, exports, "judge")
+
+	for _, name := range []string{
+		"agent_duration", "agent_steps", "agent_tool_calls", "agent_tokens",
+		"agent_cost_usd", "agent_tool_correctness", "agent_quality_score", "agent_judge_pass",
+	} {
+		assert.NotNil(t, registry.Get(name), "metric %q should be registered", name)
+	}
+}

--- a/internal/js/modules/k6/experimental/ageval/module_test.go
+++ b/internal/js/modules/k6/experimental/ageval/module_test.go
@@ -17,8 +17,9 @@ func TestModuleExportsAndMetrics(t *testing.T) {
 	require.True(t, ok)
 
 	exports := mi.Exports().Named
+	assert.Contains(t, exports, "AgentTestCase")
 	assert.Contains(t, exports, "AgentSimulator")
-	assert.Contains(t, exports, "fromAgentRun")
+	assert.Contains(t, exports, "ExternalAgent")
 	assert.Contains(t, exports, "judge")
 
 	for _, name := range []string{

--- a/internal/js/modules/k6/experimental/ageval/provider.go
+++ b/internal/js/modules/k6/experimental/ageval/provider.go
@@ -1,0 +1,110 @@
+package ageval
+
+import "context"
+
+// role identifies the author of a conversation message.
+const (
+	roleUser      = "user"
+	roleAssistant = "assistant"
+)
+
+// block kinds used in the neutral conversation representation. Providers
+// translate these to and from their own wire formats.
+const (
+	blockText       = "text"
+	blockToolUse    = "tool_use"
+	blockToolResult = "tool_result"
+)
+
+// block is a single piece of a message: model text, a tool call the model
+// requested, or a tool result we feed back. It is intentionally provider
+// neutral so the agent loop never depends on a specific vendor's wire types.
+type block struct {
+	kind string
+
+	// text block
+	text string
+
+	// tool_use block
+	id    string
+	name  string
+	input map[string]any
+
+	// tool_result block
+	toolUseID string
+	content   string
+}
+
+// message is one turn in the conversation.
+type message struct {
+	role   string
+	blocks []block
+}
+
+// toolSchema describes a tool the model may call. inputSchema is a JSON Schema
+// object as provided by the test author.
+type toolSchema struct {
+	name        string
+	description string
+	inputSchema map[string]any
+}
+
+// usage reports token consumption for a single model call.
+type usage struct {
+	inputTokens  int64
+	outputTokens int64
+}
+
+// conversation is the full input to a single model call.
+type conversation struct {
+	model     string
+	apiKey    string
+	baseURL   string
+	system    string
+	maxTokens int
+	messages  []message
+	tools     []toolSchema
+}
+
+// reply is the normalized result of a single model call.
+type reply struct {
+	blocks     []block
+	stopReason string
+	usage      usage
+}
+
+// modelInfo holds the per-model data the module needs: the wire identifier and
+// the pricing used to compute the agent_cost_usd metric.
+type modelInfo struct {
+	wireModel     string
+	inUSDPerMTok  float64
+	outUSDPerMTok float64
+	maxOutput     int
+}
+
+// provider is an LLM backend. Only Anthropic is registered today; the interface
+// keeps the agent loop vendor neutral so a second provider can be added without
+// touching the loop.
+type provider interface {
+	// name returns the provider identifier used in the JS `provider` field.
+	name() string
+	// model validates and returns the info for a model name.
+	model(name string) (modelInfo, bool)
+	// modelNames returns the supported model names, for error messages.
+	modelNames() []string
+	// createMessage performs a single (blocking) model call.
+	createMessage(ctx context.Context, conv conversation) (reply, error)
+}
+
+// providers is the registry of available providers, keyed by name.
+//
+//nolint:gochecknoglobals // package-level registry, mirrors how k6 modules expose constants
+var providers = map[string]provider{
+	"anthropic": newAnthropicProvider(),
+}
+
+// lookupProvider returns the registered provider for the given name.
+func lookupProvider(name string) (provider, bool) {
+	p, ok := providers[name]
+	return p, ok
+}

--- a/internal/js/modules/k6/experimental/ageval/realrun.go
+++ b/internal/js/modules/k6/experimental/ageval/realrun.go
@@ -16,6 +16,7 @@ import (
 //
 //	input: {
 //	  output, toolCalls: [{ name, input, output }],   // the recorded trajectory
+//	  input?,                                          // the task/prompt the agent was given (used by judge)
 //	  model?, usage?: { inputTokens, outputTokens },  // optional, enables token/cost metrics
 //	  durationMs?, steps?, name?, stepReportTool?, tags?,
 //	}
@@ -54,6 +55,7 @@ func (mi *ModuleInstance) fromAgentRun(input sobek.Value) sobek.Value {
 		metrics:        mi.metrics,
 		tags:           tags,
 		stepReportTool: getString(o, "stepReportTool", defaultStepReportTool),
+		Input:          getString(o, "input", ""),
 		Output:         getString(o, "output", ""),
 		ToolCalls:      parseToolCalls(rt, o.Get("toolCalls")),
 	}

--- a/internal/js/modules/k6/experimental/ageval/realrun.go
+++ b/internal/js/modules/k6/experimental/ageval/realrun.go
@@ -2,7 +2,9 @@ package ageval
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/grafana/sobek"
 	"go.k6.io/k6/v2/js/common"
@@ -39,28 +41,36 @@ func (mi *ModuleInstance) fromAgentRun(input sobek.Value) sobek.Value {
 
 	modelName := getString(o, "model", "")
 	tags := mi.realRunTags(state, getString(o, "name", defaultAgentName), modelName, o.Get("tags"))
-
-	toolCalls := parseToolCalls(rt, o.Get("toolCalls"))
-	var inTok, outTok int64
-	if uv := o.Get("usage"); uv != nil && !common.IsNullish(uv) {
-		uo := uv.ToObject(rt)
-		inTok = int64(getInt(uo, "inputTokens", 0))
-		outTok = int64(getInt(uo, "outputTokens", 0))
-	}
+	tr := mi.fromAgentRunTrajectory(rt, o)
 
 	result := mi.newRealRunResult(rt, realRunData{
 		tags:           tags,
 		stepReportTool: getString(o, "stepReportTool", defaultStepReportTool),
 		input:          getString(o, "input", ""),
-		output:         getString(o, "output", ""),
+		output:         tr.output,
 		model:          modelName,
-		toolCalls:      toolCalls,
-		inTok:          inTok,
-		outTok:         outTok,
+		toolCalls:      tr.toolCalls,
+		inTok:          tr.inTok,
+		outTok:         tr.outTok,
 		durationMs:     getFloat(o, "durationMs", 0),
-		steps:          getInt(o, "steps", len(toolCalls)),
+		steps:          getInt(o, "steps", len(tr.toolCalls)),
 	})
 	return rt.ToValue(result).ToObject(rt)
+}
+
+// fromAgentRunTrajectory builds the trajectory from either a `format` + `raw`
+// payload (run through the adapter registry) or the explicit
+// `output`/`toolCalls`/`usage` fields.
+func (mi *ModuleInstance) fromAgentRunTrajectory(rt *sobek.Runtime, o *sobek.Object) trajectory {
+	if format := getString(o, "format", ""); format != "" {
+		adapter, ok := lookupAdapter(format)
+		if !ok {
+			common.Throw(rt, fmt.Errorf("unknown format %q (supported: %s)",
+				format, strings.Join(adapterNames(), ", ")))
+		}
+		return adapter(getString(o, "raw", ""))
+	}
+	return trajectoryFromJS(rt, o)
 }
 
 // realRunData is the provider-agnostic trajectory used to build a RunResult for

--- a/internal/js/modules/k6/experimental/ageval/realrun.go
+++ b/internal/js/modules/k6/experimental/ageval/realrun.go
@@ -17,7 +17,7 @@ import (
 // Use it to evaluate a run you already have
 // (a logged production run, a captured dataset, a framework shim's output, or a
 // raw payload parsed via `format`). To run the agent as part of the k6 test
-// instead, use a producer (AgentSimulator / ExternalAgent) — they return an
+// instead, use a producer (AgentSimulator / CliAgent) — they return an
 // AgentTestCase too, so everything downstream (check/expectSequence/judge) is identical.
 //
 //	new AgentTestCase({
@@ -80,7 +80,7 @@ func (mi *ModuleInstance) trajectoryFromConfig(rt *sobek.Runtime, o *sobek.Objec
 }
 
 // realRunData is the provider-agnostic trajectory used to build an AgentTestCase for
-// both new AgentTestCase and ExternalAgent.
+// both new AgentTestCase and CliAgent.
 type realRunData struct {
 	tags           *metrics.TagSet
 	stepReportTool string

--- a/internal/js/modules/k6/experimental/ageval/realrun.go
+++ b/internal/js/modules/k6/experimental/ageval/realrun.go
@@ -12,38 +12,43 @@ import (
 	"go.k6.io/k6/v2/metrics"
 )
 
-// fromAgentRun builds a RunResult from a real agent's recorded trajectory, with
-// no simulation and no model call for the agent. Use it to evaluate an agent run
-// you already have — a logged production run, a dataset of captured runs, or a
-// transcript you parsed yourself. (To run the agent as part of the k6 test
-// instead, use ExternalAgent.)
+// newAgentTestCase is the `new AgentTestCase({...})` constructor: it builds an AgentTestCase
+// from a recorded agent trajectory — no simulation, no agent model call.
+// Use it to evaluate a run you already have
+// (a logged production run, a captured dataset, a framework shim's output, or a
+// raw payload parsed via `format`). To run the agent as part of the k6 test
+// instead, use a producer (AgentSimulator / ExternalAgent) — they return an
+// AgentTestCase too, so everything downstream (check/expectSequence/judge) is identical.
 //
-//	input: {
-//	  output, toolCalls: [{ name, input, output }],   // the recorded trajectory
-//	  input?,                                          // the task/prompt the agent was given (used by judge)
-//	  model?, usage?: { inputTokens, outputTokens },  // optional, enables token/cost metrics
+//	new AgentTestCase({
+//	  output, toolCalls: [{ name, input, output }],    // the recorded trajectory
+//	  input?,                                           // the task/prompt the agent was given (used by judge)
+//	  expectedTools?: [{ name, input? }],               // graded by expectSequence() called with no argument
+//	  model?, usage?: { inputTokens, outputTokens },    // optional, enables token/cost metrics
 //	  durationMs?, steps?, name?, stepReportTool?, tags?,
-//	}
+//	  format?, raw?,                                    // alternative: parse a raw payload via an adapter
+//	})
 //
 // It emits the same k6 metrics as a simulated run for whatever data is provided
 // (always agent_tool_calls; agent_duration/steps/tokens/cost when supplied), so
-// real and simulated runs share the same dashboards and thresholds.
-func (mi *ModuleInstance) fromAgentRun(input sobek.Value) sobek.Value {
+// recorded and simulated runs share the same dashboards and thresholds.
+func (mi *ModuleInstance) newAgentTestCase(call sobek.ConstructorCall) *sobek.Object {
 	rt := mi.vu.Runtime()
 	state := mi.vu.State()
 	if state == nil {
 		common.Throw(rt, errInitContext)
 	}
-	if input == nil || common.IsNullish(input) {
-		common.Throw(rt, errors.New("fromAgentRun() requires an object with `output` and/or `toolCalls`"))
+	arg := call.Argument(0)
+	if common.IsNullish(arg) {
+		common.Throw(rt, errors.New("new AgentTestCase() requires an object with `output` and/or `toolCalls`"))
 	}
-	o := input.ToObject(rt)
+	o := arg.ToObject(rt)
 
 	modelName := getString(o, "model", "")
 	tags := mi.realRunTags(state, getString(o, "name", defaultAgentName), modelName, o.Get("tags"))
-	tr := mi.fromAgentRunTrajectory(rt, o)
+	tr := mi.trajectoryFromConfig(rt, o)
 
-	result := mi.newRealRunResult(rt, realRunData{
+	result := mi.newRealAgentTestCase(rt, realRunData{
 		tags:           tags,
 		stepReportTool: getString(o, "stepReportTool", defaultStepReportTool),
 		input:          getString(o, "input", ""),
@@ -55,13 +60,14 @@ func (mi *ModuleInstance) fromAgentRun(input sobek.Value) sobek.Value {
 		durationMs:     getFloat(o, "durationMs", 0),
 		steps:          getInt(o, "steps", len(tr.toolCalls)),
 	})
+	result.ExpectedTools = parseToolCalls(rt, o.Get("expectedTools"))
 	return rt.ToValue(result).ToObject(rt)
 }
 
-// fromAgentRunTrajectory builds the trajectory from either a `format` + `raw`
+// trajectoryFromConfig builds the trajectory from either a `format` + `raw`
 // payload (run through the adapter registry) or the explicit
 // `output`/`toolCalls`/`usage` fields.
-func (mi *ModuleInstance) fromAgentRunTrajectory(rt *sobek.Runtime, o *sobek.Object) trajectory {
+func (mi *ModuleInstance) trajectoryFromConfig(rt *sobek.Runtime, o *sobek.Object) trajectory {
 	if format := getString(o, "format", ""); format != "" {
 		adapter, ok := lookupAdapter(format)
 		if !ok {
@@ -73,8 +79,8 @@ func (mi *ModuleInstance) fromAgentRunTrajectory(rt *sobek.Runtime, o *sobek.Obj
 	return trajectoryFromJS(rt, o)
 }
 
-// realRunData is the provider-agnostic trajectory used to build a RunResult for
-// both fromAgentRun and ExternalAgent.
+// realRunData is the provider-agnostic trajectory used to build an AgentTestCase for
+// both new AgentTestCase and ExternalAgent.
 type realRunData struct {
 	tags           *metrics.TagSet
 	stepReportTool string
@@ -88,13 +94,13 @@ type realRunData struct {
 	steps          int
 }
 
-// newRealRunResult builds a RunResult from a real (non-simulated) trajectory and
+// newRealAgentTestCase builds an AgentTestCase from a real (non-simulated) trajectory and
 // emits its metrics.
-func (mi *ModuleInstance) newRealRunResult(rt *sobek.Runtime, d realRunData) *RunResult {
+func (mi *ModuleInstance) newRealAgentTestCase(rt *sobek.Runtime, d realRunData) *AgentTestCase {
 	if d.toolCalls == nil {
 		d.toolCalls = []ToolCall{}
 	}
-	result := &RunResult{
+	result := &AgentTestCase{
 		vu:             mi.vu,
 		rt:             rt,
 		metrics:        mi.metrics,
@@ -130,7 +136,7 @@ func (mi *ModuleInstance) realRunTags(
 
 // emitRealRunMetrics emits the metrics derivable from a provided trajectory.
 func (mi *ModuleInstance) emitRealRunMetrics(
-	result *RunResult, tags *metrics.TagSet, modelName string, inTok, outTok int64,
+	result *AgentTestCase, tags *metrics.TagSet, modelName string, inTok, outTok int64,
 ) {
 	for _, c := range result.ToolCalls {
 		pushSample(mi.vu, mi.metrics.toolCalls, tags.With("tool", c.Name), 1)

--- a/internal/js/modules/k6/experimental/ageval/realrun.go
+++ b/internal/js/modules/k6/experimental/ageval/realrun.go
@@ -6,13 +6,15 @@ import (
 
 	"github.com/grafana/sobek"
 	"go.k6.io/k6/v2/js/common"
+	"go.k6.io/k6/v2/lib"
 	"go.k6.io/k6/v2/metrics"
 )
 
 // fromAgentRun builds a RunResult from a real agent's recorded trajectory, with
-// no simulation and no model call for the agent. Use it to evaluate your
-// production agent's actual run: capture its final output and the tools it
-// called, pass them here, then assert with check()/expectSequence() and judge().
+// no simulation and no model call for the agent. Use it to evaluate an agent run
+// you already have — a logged production run, a dataset of captured runs, or a
+// transcript you parsed yourself. (To run the agent as part of the k6 test
+// instead, use ExternalAgent.)
 //
 //	input: {
 //	  output, toolCalls: [{ name, input, output }],   // the recorded trajectory
@@ -35,43 +37,85 @@ func (mi *ModuleInstance) fromAgentRun(input sobek.Value) sobek.Value {
 	}
 	o := input.ToObject(rt)
 
-	name := getString(o, "name", defaultAgentName)
 	modelName := getString(o, "model", "")
+	tags := mi.realRunTags(state, getString(o, "name", defaultAgentName), modelName, o.Get("tags"))
 
-	tags := state.Tags.GetCurrentValues().Tags.With("agent", name)
-	if modelName != "" {
-		tags = tags.With("model", modelName)
-	}
-	if ut := o.Get("tags"); ut != nil && !common.IsNullish(ut) {
-		uto := ut.ToObject(rt)
-		for _, k := range uto.Keys() {
-			tags = tags.With(k, uto.Get(k).String())
-		}
-	}
-
-	result := &RunResult{
-		vu:             mi.vu,
-		rt:             rt,
-		metrics:        mi.metrics,
-		tags:           tags,
-		stepReportTool: getString(o, "stepReportTool", defaultStepReportTool),
-		Input:          getString(o, "input", ""),
-		Output:         getString(o, "output", ""),
-		ToolCalls:      parseToolCalls(rt, o.Get("toolCalls")),
-	}
-	result.Steps = getInt(o, "steps", len(result.ToolCalls))
-	result.Duration = getFloat(o, "durationMs", 0)
-
+	toolCalls := parseToolCalls(rt, o.Get("toolCalls"))
 	var inTok, outTok int64
 	if uv := o.Get("usage"); uv != nil && !common.IsNullish(uv) {
 		uo := uv.ToObject(rt)
 		inTok = int64(getInt(uo, "inputTokens", 0))
 		outTok = int64(getInt(uo, "outputTokens", 0))
-		result.Usage = RunUsage{InputTokens: inTok, OutputTokens: outTok}
 	}
 
-	mi.emitRealRunMetrics(result, tags, modelName, inTok, outTok)
+	result := mi.newRealRunResult(rt, realRunData{
+		tags:           tags,
+		stepReportTool: getString(o, "stepReportTool", defaultStepReportTool),
+		input:          getString(o, "input", ""),
+		output:         getString(o, "output", ""),
+		model:          modelName,
+		toolCalls:      toolCalls,
+		inTok:          inTok,
+		outTok:         outTok,
+		durationMs:     getFloat(o, "durationMs", 0),
+		steps:          getInt(o, "steps", len(toolCalls)),
+	})
 	return rt.ToValue(result).ToObject(rt)
+}
+
+// realRunData is the provider-agnostic trajectory used to build a RunResult for
+// both fromAgentRun and ExternalAgent.
+type realRunData struct {
+	tags           *metrics.TagSet
+	stepReportTool string
+	input          string
+	output         string
+	model          string
+	toolCalls      []ToolCall
+	inTok          int64
+	outTok         int64
+	durationMs     float64
+	steps          int
+}
+
+// newRealRunResult builds a RunResult from a real (non-simulated) trajectory and
+// emits its metrics.
+func (mi *ModuleInstance) newRealRunResult(rt *sobek.Runtime, d realRunData) *RunResult {
+	if d.toolCalls == nil {
+		d.toolCalls = []ToolCall{}
+	}
+	result := &RunResult{
+		vu:             mi.vu,
+		rt:             rt,
+		metrics:        mi.metrics,
+		tags:           d.tags,
+		stepReportTool: d.stepReportTool,
+		Input:          d.input,
+		Output:         d.output,
+		ToolCalls:      d.toolCalls,
+		Usage:          RunUsage{InputTokens: d.inTok, OutputTokens: d.outTok},
+		Steps:          d.steps,
+		Duration:       d.durationMs,
+	}
+	mi.emitRealRunMetrics(result, d.tags, d.model, d.inTok, d.outTok)
+	return result
+}
+
+// realRunTags builds the base tag set (agent + model + user tags) for a real run.
+func (mi *ModuleInstance) realRunTags(
+	state *lib.State, name, model string, userTags sobek.Value,
+) *metrics.TagSet {
+	tags := state.Tags.GetCurrentValues().Tags.With("agent", name)
+	if model != "" {
+		tags = tags.With("model", model)
+	}
+	if userTags != nil && !common.IsNullish(userTags) {
+		obj := userTags.ToObject(mi.vu.Runtime())
+		for _, k := range obj.Keys() {
+			tags = tags.With(k, obj.Get(k).String())
+		}
+	}
+	return tags
 }
 
 // emitRealRunMetrics emits the metrics derivable from a provided trajectory.

--- a/internal/js/modules/k6/experimental/ageval/realrun.go
+++ b/internal/js/modules/k6/experimental/ageval/realrun.go
@@ -1,0 +1,142 @@
+package ageval
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/v2/js/common"
+	"go.k6.io/k6/v2/metrics"
+)
+
+// fromAgentRun builds a RunResult from a real agent's recorded trajectory, with
+// no simulation and no model call for the agent. Use it to evaluate your
+// production agent's actual run: capture its final output and the tools it
+// called, pass them here, then assert with check()/expectSequence() and judge().
+//
+//	input: {
+//	  output, toolCalls: [{ name, input, output }],   // the recorded trajectory
+//	  model?, usage?: { inputTokens, outputTokens },  // optional, enables token/cost metrics
+//	  durationMs?, steps?, name?, stepReportTool?, tags?,
+//	}
+//
+// It emits the same k6 metrics as a simulated run for whatever data is provided
+// (always agent_tool_calls; agent_duration/steps/tokens/cost when supplied), so
+// real and simulated runs share the same dashboards and thresholds.
+func (mi *ModuleInstance) fromAgentRun(input sobek.Value) sobek.Value {
+	rt := mi.vu.Runtime()
+	state := mi.vu.State()
+	if state == nil {
+		common.Throw(rt, errInitContext)
+	}
+	if input == nil || common.IsNullish(input) {
+		common.Throw(rt, errors.New("fromAgentRun() requires an object with `output` and/or `toolCalls`"))
+	}
+	o := input.ToObject(rt)
+
+	name := getString(o, "name", defaultAgentName)
+	modelName := getString(o, "model", "")
+
+	tags := state.Tags.GetCurrentValues().Tags.With("agent", name)
+	if modelName != "" {
+		tags = tags.With("model", modelName)
+	}
+	if ut := o.Get("tags"); ut != nil && !common.IsNullish(ut) {
+		uto := ut.ToObject(rt)
+		for _, k := range uto.Keys() {
+			tags = tags.With(k, uto.Get(k).String())
+		}
+	}
+
+	result := &RunResult{
+		vu:             mi.vu,
+		rt:             rt,
+		metrics:        mi.metrics,
+		tags:           tags,
+		stepReportTool: getString(o, "stepReportTool", defaultStepReportTool),
+		Output:         getString(o, "output", ""),
+		ToolCalls:      parseToolCalls(rt, o.Get("toolCalls")),
+	}
+	result.Steps = getInt(o, "steps", len(result.ToolCalls))
+	result.Duration = getFloat(o, "durationMs", 0)
+
+	var inTok, outTok int64
+	if uv := o.Get("usage"); uv != nil && !common.IsNullish(uv) {
+		uo := uv.ToObject(rt)
+		inTok = int64(getInt(uo, "inputTokens", 0))
+		outTok = int64(getInt(uo, "outputTokens", 0))
+		result.Usage = RunUsage{InputTokens: inTok, OutputTokens: outTok}
+	}
+
+	mi.emitRealRunMetrics(result, tags, modelName, inTok, outTok)
+	return rt.ToValue(result).ToObject(rt)
+}
+
+// emitRealRunMetrics emits the metrics derivable from a provided trajectory.
+func (mi *ModuleInstance) emitRealRunMetrics(
+	result *RunResult, tags *metrics.TagSet, modelName string, inTok, outTok int64,
+) {
+	for _, c := range result.ToolCalls {
+		pushSample(mi.vu, mi.metrics.toolCalls, tags.With("tool", c.Name), 1)
+	}
+	if result.Duration > 0 {
+		pushSample(mi.vu, mi.metrics.duration, tags, result.Duration)
+	}
+	if result.Steps > 0 {
+		pushSample(mi.vu, mi.metrics.steps, tags, float64(result.Steps))
+	}
+	if inTok > 0 || outTok > 0 {
+		pushSample(mi.vu, mi.metrics.tokens, tags.With("direction", "input"), float64(inTok))
+		pushSample(mi.vu, mi.metrics.tokens, tags.With("direction", "output"), float64(outTok))
+		if info, ok := modelPricing(modelName); ok {
+			cost := float64(inTok)/1e6*info.inUSDPerMTok + float64(outTok)/1e6*info.outUSDPerMTok
+			pushSample(mi.vu, mi.metrics.cost, tags, cost)
+		}
+	}
+}
+
+// parseToolCalls reads a JS array of `{ name, input, output }` into []ToolCall.
+func parseToolCalls(rt *sobek.Runtime, v sobek.Value) []ToolCall {
+	out := []ToolCall{}
+	if v == nil || common.IsNullish(v) {
+		return out
+	}
+	arr := v.ToObject(rt)
+	lengthVal := arr.Get("length")
+	if lengthVal == nil {
+		return out
+	}
+	n := int(lengthVal.ToInteger())
+	for i := range n {
+		item := arr.Get(strconv.Itoa(i))
+		if item == nil || sobek.IsUndefined(item) {
+			continue
+		}
+		obj := item.ToObject(rt)
+		tc := ToolCall{
+			Name:   getString(obj, "name", ""),
+			Output: getString(obj, "output", ""),
+			Input:  map[string]any{},
+		}
+		if iv := obj.Get("input"); iv != nil && !common.IsNullish(iv) {
+			if m, ok := iv.Export().(map[string]any); ok {
+				tc.Input = m
+			}
+		}
+		out = append(out, tc)
+	}
+	return out
+}
+
+// modelPricing looks up a model's pricing across all registered providers.
+func modelPricing(modelName string) (modelInfo, bool) {
+	if modelName == "" {
+		return modelInfo{}, false
+	}
+	for _, p := range providers {
+		if info, ok := p.model(modelName); ok {
+			return info, true
+		}
+	}
+	return modelInfo{}, false
+}

--- a/internal/js/modules/k6/experimental/ageval/realrun_test.go
+++ b/internal/js/modules/k6/experimental/ageval/realrun_test.go
@@ -121,7 +121,7 @@ func TestAgentTestCaseIsJudgeable(t *testing.T) {
 		// Explicit expectSequence([...]) form with exact mode (still supported API).
 		const seqOK = r.expectSequence([{ name: "get_invoice" }], { mode: "exact" });
 		const verdict = judge(r, {
-			model: "claude-sonnet-4-5", apiKey: "jt", baseURL: ` + "`" + judgeSrv.URL + "`" + `,
+			name: "invoice_paid", model: "claude-sonnet-4-5", apiKey: "jt", baseURL: ` + "`" + judgeSrv.URL + "`" + `,
 			rubric: "The answer states the invoice is paid.", threshold: 0.7,
 		});
 		[seqOK, verdict.score, verdict.passed];

--- a/internal/js/modules/k6/experimental/ageval/realrun_test.go
+++ b/internal/js/modules/k6/experimental/ageval/realrun_test.go
@@ -7,12 +7,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFromAgentRunBuildsResultAndMetrics(t *testing.T) {
+func TestAgentTestCaseBuildsResultAndMetrics(t *testing.T) {
 	t.Parallel()
 	ts := newTestSetup(t)
 
 	v, err := ts.rt.VU.Runtime().RunString(`
-		const r = fromAgentRun({
+		const r = new AgentTestCase({
 			model: "claude-sonnet-4-5",
 			output: "Invoice INV-123 is paid.",
 			toolCalls: [
@@ -51,12 +51,12 @@ func TestFromAgentRunBuildsResultAndMetrics(t *testing.T) {
 	assert.InDelta(t, 1000.0/1e6*3+200.0/1e6*15, samples["agent_cost_usd"][0], 1e-12)
 }
 
-func TestFromAgentRunMinimalNoOptionalMetrics(t *testing.T) {
+func TestAgentTestCaseMinimalNoOptionalMetrics(t *testing.T) {
 	t.Parallel()
 	ts := newTestSetup(t)
 
 	_, err := ts.rt.VU.Runtime().RunString(`
-		globalThis.r = fromAgentRun({
+		globalThis.r = new AgentTestCase({
 			output: "done",
 			toolCalls: [{ name: "search", input: {}, output: "ok" }],
 		});
@@ -71,17 +71,54 @@ func TestFromAgentRunMinimalNoOptionalMetrics(t *testing.T) {
 	assert.Empty(t, samples["agent_cost_usd"])
 }
 
-func TestFromAgentRunResultIsJudgeable(t *testing.T) {
+func TestAgentTestCaseExpectedToolsFallback(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+
+	v, err := ts.rt.VU.Runtime().RunString(`
+		const expectedTools = [
+			{ name: "get_customer" },
+			{ name: "get_invoice", input: { invoice_id: "INV-123" } },
+		];
+		const good = new AgentTestCase({
+			output: "ok",
+			toolCalls: [
+				{ name: "get_customer", input: { email: "a@b.com" }, output: "{}" },
+				{ name: "get_invoice", input: { invoice_id: "INV-123" }, output: "paid" },
+			],
+			expectedTools,
+		});
+		const bad = new AgentTestCase({
+			output: "ok",
+			toolCalls: [{ name: "get_invoice", input: { invoice_id: "INV-999" }, output: "?" }],
+			expectedTools,
+		});
+		// expectSequence() with NO argument grades against the stored expectedTools.
+		[good.expectSequence(), bad.expectSequence()];
+	`)
+	require.NoError(t, err)
+
+	rt := ts.rt.VU.Runtime()
+	arr := v.ToObject(rt)
+	assert.True(t, arr.Get("0").ToBoolean(), "good run matches expectedTools")
+	assert.False(t, arr.Get("1").ToBoolean(), "bad run fails expectedTools (wrong invoice id)")
+
+	samples := drainSamples(ts.samples)
+	assert.Equal(t, []float64{1, 0}, samples["agent_tool_correctness"])
+}
+
+func TestAgentTestCaseIsJudgeable(t *testing.T) {
 	t.Parallel()
 	ts := newTestSetup(t)
 	judgeSrv := cannedServer(t, judgeResponse)
 
 	v, err := ts.rt.VU.Runtime().RunString(`
-		const r = fromAgentRun({
+		const r = new AgentTestCase({
 			output: "Invoice INV-123 is paid.",
 			toolCalls: [{ name: "get_invoice", input: { invoice_id: "INV-123" }, output: "paid" }],
 			tags: { case: "real_judge" },
 		});
+		// Explicit expectSequence([...]) form with exact mode (still supported API).
 		const seqOK = r.expectSequence([{ name: "get_invoice" }], { mode: "exact" });
 		const verdict = judge(r, {
 			model: "claude-sonnet-4-5", apiKey: "jt", baseURL: ` + "`" + judgeSrv.URL + "`" + `,

--- a/internal/js/modules/k6/experimental/ageval/realrun_test.go
+++ b/internal/js/modules/k6/experimental/ageval/realrun_test.go
@@ -1,0 +1,102 @@
+package ageval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromAgentRunBuildsResultAndMetrics(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+
+	v, err := ts.rt.VU.Runtime().RunString(`
+		const r = fromAgentRun({
+			model: "claude-sonnet-4-5",
+			output: "Invoice INV-123 is paid.",
+			toolCalls: [
+				{ name: "get_customer", input: { email: "a@b.com" }, output: "{...}" },
+				{ name: "get_invoice", input: { invoice_id: "INV-123" }, output: "{...}" },
+			],
+			usage: { inputTokens: 1000, outputTokens: 200 },
+			durationMs: 4200,
+			tags: { case: "real" },
+		});
+		[
+			r.calledTool("get_customer"),
+			r.calledTool("get_invoice"),
+			r.toolCalls.length,
+			r.output,
+			r.usage.inputTokens,
+		];
+	`)
+	require.NoError(t, err)
+
+	rt := ts.rt.VU.Runtime()
+	arr := v.ToObject(rt)
+	assert.True(t, arr.Get("0").ToBoolean())
+	assert.True(t, arr.Get("1").ToBoolean())
+	assert.Equal(t, int64(2), arr.Get("2").ToInteger())
+	assert.Equal(t, "Invoice INV-123 is paid.", arr.Get("3").String())
+	assert.Equal(t, int64(1000), arr.Get("4").ToInteger())
+
+	samples := drainSamples(ts.samples)
+	assert.Equal(t, []float64{4200}, samples["agent_duration"])
+	assert.Equal(t, []float64{2}, samples["agent_steps"]) // defaulted to toolCalls length
+	require.Len(t, samples["agent_tool_calls"], 2)
+	require.Len(t, samples["agent_tokens"], 2)
+	// cost = 1000/1e6*3 + 200/1e6*15
+	require.Len(t, samples["agent_cost_usd"], 1)
+	assert.InDelta(t, 1000.0/1e6*3+200.0/1e6*15, samples["agent_cost_usd"][0], 1e-12)
+}
+
+func TestFromAgentRunMinimalNoOptionalMetrics(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+
+	_, err := ts.rt.VU.Runtime().RunString(`
+		globalThis.r = fromAgentRun({
+			output: "done",
+			toolCalls: [{ name: "search", input: {}, output: "ok" }],
+		});
+	`)
+	require.NoError(t, err)
+
+	samples := drainSamples(ts.samples)
+	// Only tool_calls is derivable without usage/duration.
+	require.Len(t, samples["agent_tool_calls"], 1)
+	assert.Empty(t, samples["agent_duration"])
+	assert.Empty(t, samples["agent_tokens"])
+	assert.Empty(t, samples["agent_cost_usd"])
+}
+
+func TestFromAgentRunResultIsJudgeable(t *testing.T) {
+	t.Parallel()
+	ts := newTestSetup(t)
+	judgeSrv := cannedServer(t, judgeResponse)
+
+	v, err := ts.rt.VU.Runtime().RunString(`
+		const r = fromAgentRun({
+			output: "Invoice INV-123 is paid.",
+			toolCalls: [{ name: "get_invoice", input: { invoice_id: "INV-123" }, output: "paid" }],
+			tags: { case: "real_judge" },
+		});
+		const seqOK = r.expectSequence([{ name: "get_invoice" }], { mode: "exact" });
+		const verdict = judge(r, {
+			model: "claude-sonnet-4-5", apiKey: "jt", baseURL: ` + "`" + judgeSrv.URL + "`" + `,
+			rubric: "The answer states the invoice is paid.", threshold: 0.7,
+		});
+		[seqOK, verdict.score, verdict.passed];
+	`)
+	require.NoError(t, err)
+	rt := ts.rt.VU.Runtime()
+	arr := v.ToObject(rt)
+	assert.True(t, arr.Get("0").ToBoolean())
+	assert.InDelta(t, 0.9, arr.Get("1").ToFloat(), 1e-9)
+	assert.True(t, arr.Get("2").ToBoolean())
+
+	samples := drainSamples(ts.samples)
+	assert.Equal(t, []float64{1}, samples["agent_tool_correctness"])
+	assert.Equal(t, []float64{0.9}, samples["agent_quality_score"])
+}

--- a/internal/js/modules/k6/experimental/ageval/registry.go
+++ b/internal/js/modules/k6/experimental/ageval/registry.go
@@ -1,0 +1,37 @@
+package ageval
+
+// toolRegistry maps tool names to their executors and preserves registration
+// order so tool schemas are sent to the model deterministically (stable order
+// keeps prompt caching effective and evals reproducible).
+type toolRegistry struct {
+	order []string
+	tools map[string]*evalTool
+}
+
+func newToolRegistry() *toolRegistry {
+	return &toolRegistry{tools: make(map[string]*evalTool)}
+}
+
+// add registers a tool, replacing any existing tool with the same name (later
+// registrations win, which lets a skill override a base tool).
+func (r *toolRegistry) add(t *evalTool) {
+	if _, exists := r.tools[t.name]; !exists {
+		r.order = append(r.order, t.name)
+	}
+	r.tools[t.name] = t
+}
+
+func (r *toolRegistry) get(name string) (*evalTool, bool) {
+	t, ok := r.tools[name]
+	return t, ok
+}
+
+// schemas returns the tool schemas in registration order for the provider.
+func (r *toolRegistry) schemas() []toolSchema {
+	out := make([]toolSchema, 0, len(r.order))
+	for _, name := range r.order {
+		t := r.tools[name]
+		out = append(out, toolSchema{name: t.name, description: t.description, inputSchema: t.inputSchema})
+	}
+	return out
+}

--- a/internal/js/modules/k6/experimental/ageval/registry_test.go
+++ b/internal/js/modules/k6/experimental/ageval/registry_test.go
@@ -1,0 +1,29 @@
+package ageval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestToolRegistryOrderAndOverride(t *testing.T) {
+	t.Parallel()
+	r := newToolRegistry()
+	r.add(&evalTool{name: "a", description: "first a"})
+	r.add(&evalTool{name: "b", description: "b"})
+	r.add(&evalTool{name: "a", description: "override a"}) // skill overrides base tool
+
+	schemas := r.schemas()
+	require.Len(t, schemas, 2, "override should not add a duplicate")
+	assert.Equal(t, "a", schemas[0].name, "registration order preserved")
+	assert.Equal(t, "b", schemas[1].name)
+	assert.Equal(t, "override a", schemas[0].description, "later registration wins")
+
+	got, ok := r.get("a")
+	require.True(t, ok)
+	assert.Equal(t, "override a", got.description)
+
+	_, ok = r.get("missing")
+	assert.False(t, ok)
+}

--- a/internal/js/modules/k6/experimental/ageval/result.go
+++ b/internal/js/modules/k6/experimental/ageval/result.go
@@ -1,0 +1,229 @@
+package ageval
+
+import (
+	"reflect"
+	"strconv"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/v2/js/modules"
+	"go.k6.io/k6/v2/metrics"
+)
+
+// ToolCall is one tool invocation recorded during a run, exposed to JS.
+type ToolCall struct {
+	Name   string         `js:"name"`
+	Input  map[string]any `js:"input"`
+	Output string         `js:"output"`
+}
+
+// RunUsage is the token usage of a run, exposed to JS.
+type RunUsage struct {
+	InputTokens  int64 `js:"inputTokens"`
+	OutputTokens int64 `js:"outputTokens"`
+}
+
+// RunResult is the outcome of Agent.run(), exposed to JS. Exported fields become
+// camelCase properties; exported methods become camelCase methods.
+type RunResult struct {
+	vu             modules.VU
+	rt             *sobek.Runtime
+	metrics        *agevalMetrics
+	tags           *metrics.TagSet
+	stepReportTool string
+
+	Output    string     `js:"output"`
+	ToolCalls []ToolCall `js:"toolCalls"`
+	Usage     RunUsage   `js:"usage"`
+	Steps     int        `js:"steps"`
+	Duration  float64    `js:"duration"`
+}
+
+// CalledTool reports whether a tool with the given name was called at least once.
+func (r *RunResult) CalledTool(name string) bool {
+	for _, c := range r.ToolCalls {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// CallsOf returns every recorded call to the named tool, in order.
+func (r *RunResult) CallsOf(name string) []ToolCall {
+	out := []ToolCall{}
+	for _, c := range r.ToolCalls {
+		if c.Name == name {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// ToolSequence returns the ordered list of tool names called during the run.
+func (r *RunResult) ToolSequence() []string {
+	out := make([]string, 0, len(r.ToolCalls))
+	for _, c := range r.ToolCalls {
+		out = append(out, c.Name)
+	}
+	return out
+}
+
+// StepReports returns the calls the agent made to its step-reporting tool.
+func (r *RunResult) StepReports() []ToolCall {
+	return r.CallsOf(r.stepReportTool)
+}
+
+// FailedSteps returns the step reports whose `success` field is false.
+func (r *RunResult) FailedSteps() []ToolCall {
+	out := []ToolCall{}
+	for _, c := range r.StepReports() {
+		if success, ok := c.Input["success"].(bool); ok && !success {
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+type expectedCall struct {
+	name string
+	args map[string]any
+}
+
+// ExpectSequence checks the recorded tool calls against an expected sequence and
+// emits the agent_tool_correctness metric (1 on match, 0 otherwise). It returns
+// the boolean result so it can also be used inside check().
+//
+// expected is an array of `{ name, args? }`. opts is `{ mode, allowOtherCalls }`:
+//   - mode "in-order" (default): expected is an in-order subsequence of the
+//     actual calls. With allowOtherCalls=false, no tool outside the expected set
+//     may be called.
+//   - mode "exact": the actual sequence must equal expected one-to-one, in order.
+func (r *RunResult) ExpectSequence(expected sobek.Value, opts sobek.Value) bool {
+	exp := r.parseExpected(expected)
+	mode, allowOther := "in-order", true
+	if opts != nil && !sobek.IsUndefined(opts) && !sobek.IsNull(opts) {
+		o := opts.ToObject(r.rt)
+		if v := o.Get("mode"); v != nil && !sobek.IsUndefined(v) {
+			mode = v.String()
+		}
+		if v := o.Get("allowOtherCalls"); v != nil && !sobek.IsUndefined(v) {
+			allowOther = v.ToBoolean()
+		}
+	}
+
+	ok := matchSequence(r.ToolCalls, exp, mode, allowOther)
+
+	value := 0.0
+	if ok {
+		value = 1
+	}
+	pushSample(r.vu, r.metrics.toolCorrectness, r.tags, value)
+	return ok
+}
+
+func (r *RunResult) parseExpected(expected sobek.Value) []expectedCall {
+	out := []expectedCall{}
+	if expected == nil || sobek.IsUndefined(expected) || sobek.IsNull(expected) {
+		return out
+	}
+	arr := expected.ToObject(r.rt)
+	lengthVal := arr.Get("length")
+	if lengthVal == nil {
+		return out
+	}
+	n := int(lengthVal.ToInteger())
+	for i := range n {
+		item := arr.Get(strconv.Itoa(i))
+		if item == nil || sobek.IsUndefined(item) {
+			continue
+		}
+		obj := item.ToObject(r.rt)
+		ec := expectedCall{}
+		if v := obj.Get("name"); v != nil {
+			ec.name = v.String()
+		}
+		if v := obj.Get("args"); v != nil && !sobek.IsUndefined(v) && !sobek.IsNull(v) {
+			if m, ok := v.Export().(map[string]any); ok {
+				ec.args = m
+			}
+		}
+		out = append(out, ec)
+	}
+	return out
+}
+
+func matchSequence(actual []ToolCall, expected []expectedCall, mode string, allowOther bool) bool {
+	if mode == "exact" {
+		if len(actual) != len(expected) {
+			return false
+		}
+		for i, exp := range expected {
+			if actual[i].Name != exp.name || !argsMatch(actual[i].Input, exp.args) {
+				return false
+			}
+		}
+		return true
+	}
+
+	// in-order subsequence match.
+	ai := 0
+	for _, exp := range expected {
+		found := false
+		for ai < len(actual) {
+			c := actual[ai]
+			ai++
+			if c.Name == exp.name && argsMatch(c.Input, exp.args) {
+				found = true
+				break
+			}
+			if !allowOther && !inExpectedSet(c.Name, expected) {
+				return false
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	if !allowOther {
+		for ; ai < len(actual); ai++ {
+			if !inExpectedSet(actual[ai].Name, expected) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func inExpectedSet(name string, expected []expectedCall) bool {
+	for _, e := range expected {
+		if e.name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// argsMatch reports whether every key in want is present in got with an equal
+// value (subset match). A nil want matches anything.
+func argsMatch(got, want map[string]any) bool {
+	for k, wv := range want {
+		gv, ok := got[k]
+		if !ok || !reflect.DeepEqual(normalizeNumber(gv), normalizeNumber(wv)) {
+			return false
+		}
+	}
+	return true
+}
+
+// normalizeNumber coerces integer-valued floats to float64 so JS numbers compare
+// equal regardless of how they were produced.
+func normalizeNumber(v any) any {
+	switch n := v.(type) {
+	case int:
+		return float64(n)
+	case int64:
+		return float64(n)
+	default:
+		return v
+	}
+}

--- a/internal/js/modules/k6/experimental/ageval/result.go
+++ b/internal/js/modules/k6/experimental/ageval/result.go
@@ -22,25 +22,31 @@ type RunUsage struct {
 	OutputTokens int64 `js:"outputTokens"`
 }
 
-// RunResult is the outcome of Agent.run(), exposed to JS. Exported fields become
-// camelCase properties; exported methods become camelCase methods.
-type RunResult struct {
+// AgentTestCase is the single agent-evaluation data container, exposed to JS.
+// It holds an agent run's input, produced
+// output, recorded tool calls and usage, plus the optional expectedTools to grade
+// against. It is obtained either directly (`new AgentTestCase({...})`) or from a
+// producer (`AgentSimulator.run()`, `ExternalAgent.run()`), and is the value that
+// check/expectSequence/judge operate on. Exported fields become camelCase
+// properties; exported methods become camelCase methods.
+type AgentTestCase struct {
 	vu             modules.VU
 	rt             *sobek.Runtime
 	metrics        *agevalMetrics
 	tags           *metrics.TagSet
 	stepReportTool string
 
-	Input     string     `js:"input"`
-	Output    string     `js:"output"`
-	ToolCalls []ToolCall `js:"toolCalls"`
-	Usage     RunUsage   `js:"usage"`
-	Steps     int        `js:"steps"`
-	Duration  float64    `js:"duration"`
+	Input         string     `js:"input"`
+	Output        string     `js:"output"`
+	ToolCalls     []ToolCall `js:"toolCalls"`
+	ExpectedTools []ToolCall `js:"expectedTools"`
+	Usage         RunUsage   `js:"usage"`
+	Steps         int        `js:"steps"`
+	Duration      float64    `js:"duration"`
 }
 
 // CalledTool reports whether a tool with the given name was called at least once.
-func (r *RunResult) CalledTool(name string) bool {
+func (r *AgentTestCase) CalledTool(name string) bool {
 	for _, c := range r.ToolCalls {
 		if c.Name == name {
 			return true
@@ -50,7 +56,7 @@ func (r *RunResult) CalledTool(name string) bool {
 }
 
 // CallsOf returns every recorded call to the named tool, in order.
-func (r *RunResult) CallsOf(name string) []ToolCall {
+func (r *AgentTestCase) CallsOf(name string) []ToolCall {
 	out := []ToolCall{}
 	for _, c := range r.ToolCalls {
 		if c.Name == name {
@@ -61,7 +67,7 @@ func (r *RunResult) CallsOf(name string) []ToolCall {
 }
 
 // ToolSequence returns the ordered list of tool names called during the run.
-func (r *RunResult) ToolSequence() []string {
+func (r *AgentTestCase) ToolSequence() []string {
 	out := make([]string, 0, len(r.ToolCalls))
 	for _, c := range r.ToolCalls {
 		out = append(out, c.Name)
@@ -70,12 +76,12 @@ func (r *RunResult) ToolSequence() []string {
 }
 
 // StepReports returns the calls the agent made to its step-reporting tool.
-func (r *RunResult) StepReports() []ToolCall {
+func (r *AgentTestCase) StepReports() []ToolCall {
 	return r.CallsOf(r.stepReportTool)
 }
 
 // FailedSteps returns the step reports whose `success` field is false.
-func (r *RunResult) FailedSteps() []ToolCall {
+func (r *AgentTestCase) FailedSteps() []ToolCall {
 	out := []ToolCall{}
 	for _, c := range r.StepReports() {
 		if success, ok := c.Input["success"].(bool); ok && !success {
@@ -99,8 +105,13 @@ type expectedCall struct {
 //     actual calls. With allowOtherCalls=false, no tool outside the expected set
 //     may be called.
 //   - mode "exact": the actual sequence must equal expected one-to-one, in order.
-func (r *RunResult) ExpectSequence(expected sobek.Value, opts sobek.Value) bool {
+func (r *AgentTestCase) ExpectSequence(expected sobek.Value, opts sobek.Value) bool {
 	exp := r.parseExpected(expected)
+	if len(exp) == 0 && (expected == nil || sobek.IsUndefined(expected) || sobek.IsNull(expected)) {
+		for _, tc := range r.ExpectedTools {
+			exp = append(exp, expectedCall{name: tc.Name, args: tc.Input})
+		}
+	}
 	mode, allowOther := "in-order", true
 	if opts != nil && !sobek.IsUndefined(opts) && !sobek.IsNull(opts) {
 		o := opts.ToObject(r.rt)
@@ -122,7 +133,7 @@ func (r *RunResult) ExpectSequence(expected sobek.Value, opts sobek.Value) bool 
 	return ok
 }
 
-func (r *RunResult) parseExpected(expected sobek.Value) []expectedCall {
+func (r *AgentTestCase) parseExpected(expected sobek.Value) []expectedCall {
 	out := []expectedCall{}
 	if expected == nil || sobek.IsUndefined(expected) || sobek.IsNull(expected) {
 		return out
@@ -143,8 +154,14 @@ func (r *RunResult) parseExpected(expected sobek.Value) []expectedCall {
 		if v := obj.Get("name"); v != nil {
 			ec.name = v.String()
 		}
-		if v := obj.Get("args"); v != nil && !sobek.IsUndefined(v) && !sobek.IsNull(v) {
-			if m, ok := v.Export().(map[string]any); ok {
+		// Accept either `args` (expectSequence's explicit form) or `input` (the
+		// toolCalls/expectedTools shape) for the expected arguments.
+		argsVal := obj.Get("args")
+		if argsVal == nil || sobek.IsUndefined(argsVal) || sobek.IsNull(argsVal) {
+			argsVal = obj.Get("input")
+		}
+		if argsVal != nil && !sobek.IsUndefined(argsVal) && !sobek.IsNull(argsVal) {
+			if m, ok := argsVal.Export().(map[string]any); ok {
 				ec.args = m
 			}
 		}

--- a/internal/js/modules/k6/experimental/ageval/result.go
+++ b/internal/js/modules/k6/experimental/ageval/result.go
@@ -26,7 +26,7 @@ type RunUsage struct {
 // It holds an agent run's input, produced
 // output, recorded tool calls and usage, plus the optional expectedTools to grade
 // against. It is obtained either directly (`new AgentTestCase({...})`) or from a
-// producer (`AgentSimulator.run()`, `ExternalAgent.run()`), and is the value that
+// producer (`AgentSimulator.run()`, `CliAgent.run()`), and is the value that
 // check/expectSequence/judge operate on. Exported fields become camelCase
 // properties; exported methods become camelCase methods.
 type AgentTestCase struct {

--- a/internal/js/modules/k6/experimental/ageval/result.go
+++ b/internal/js/modules/k6/experimental/ageval/result.go
@@ -31,6 +31,7 @@ type RunResult struct {
 	tags           *metrics.TagSet
 	stepReportTool string
 
+	Input     string     `js:"input"`
 	Output    string     `js:"output"`
 	ToolCalls []ToolCall `js:"toolCalls"`
 	Usage     RunUsage   `js:"usage"`

--- a/internal/js/modules/k6/experimental/ageval/result_test.go
+++ b/internal/js/modules/k6/experimental/ageval/result_test.go
@@ -50,9 +50,9 @@ func TestArgsMatchNumberNormalization(t *testing.T) {
 	assert.True(t, argsMatch(got, nil))
 }
 
-func TestRunResultHelpers(t *testing.T) {
+func TestAgentTestCaseHelpers(t *testing.T) {
 	t.Parallel()
-	r := &RunResult{
+	r := &AgentTestCase{
 		stepReportTool: defaultStepReportTool,
 		ToolCalls: []ToolCall{
 			{Name: "html", Input: map[string]any{}},

--- a/internal/js/modules/k6/experimental/ageval/result_test.go
+++ b/internal/js/modules/k6/experimental/ageval/result_test.go
@@ -1,0 +1,69 @@
+package ageval
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const stepIndexKey = "step_index"
+
+func calls(names ...string) []ToolCall {
+	out := make([]ToolCall, 0, len(names))
+	for _, n := range names {
+		out = append(out, ToolCall{Name: n, Input: map[string]any{}})
+	}
+	return out
+}
+
+func TestMatchSequenceInOrder(t *testing.T) {
+	t.Parallel()
+	actual := calls("html", "fillinput", "screenshot", "clickelement", defaultStepReportTool)
+	exp := []expectedCall{{name: "fillinput"}, {name: "clickelement"}}
+
+	assert.True(t, matchSequence(actual, exp, "in-order", true), "subsequence with others allowed")
+	assert.False(t, matchSequence(actual, exp, "in-order", false), "foreign calls present -> fail when not allowed")
+	assert.True(t, matchSequence(calls("fillinput", "clickelement"), exp, "in-order", false))
+}
+
+func TestMatchSequenceExact(t *testing.T) {
+	t.Parallel()
+	exp := []expectedCall{{name: "fillinput"}, {name: "clickelement"}}
+	assert.True(t, matchSequence(calls("fillinput", "clickelement"), exp, "exact", false))
+	assert.False(t, matchSequence(calls("fillinput", "clickelement", defaultStepReportTool), exp, "exact", false))
+	assert.False(t, matchSequence(calls("clickelement", "fillinput"), exp, "exact", false))
+}
+
+func TestMatchSequenceArgs(t *testing.T) {
+	t.Parallel()
+	actual := []ToolCall{{Name: "fillinput", Input: map[string]any{"selector": "#s", "text": "kubernetes"}}}
+	assert.True(t, matchSequence(actual, []expectedCall{{name: "fillinput", args: map[string]any{"text": "kubernetes"}}}, "exact", false))
+	assert.False(t, matchSequence(actual, []expectedCall{{name: "fillinput", args: map[string]any{"text": "other"}}}, "exact", false))
+}
+
+func TestArgsMatchNumberNormalization(t *testing.T) {
+	t.Parallel()
+	got := map[string]any{stepIndexKey: float64(1), "ok": true}
+	assert.True(t, argsMatch(got, map[string]any{stepIndexKey: 1}))
+	assert.True(t, argsMatch(got, map[string]any{stepIndexKey: int64(1)}))
+	assert.False(t, argsMatch(got, map[string]any{stepIndexKey: 2}))
+	assert.True(t, argsMatch(got, nil))
+}
+
+func TestRunResultHelpers(t *testing.T) {
+	t.Parallel()
+	r := &RunResult{
+		stepReportTool: defaultStepReportTool,
+		ToolCalls: []ToolCall{
+			{Name: "html", Input: map[string]any{}},
+			{Name: defaultStepReportTool, Input: map[string]any{stepIndexKey: float64(1), "success": true}},
+			{Name: defaultStepReportTool, Input: map[string]any{stepIndexKey: float64(2), "success": false}},
+		},
+	}
+	assert.True(t, r.CalledTool("html"))
+	assert.False(t, r.CalledTool("nope"))
+	assert.Equal(t, []string{"html", defaultStepReportTool, defaultStepReportTool}, r.ToolSequence())
+	assert.Len(t, r.StepReports(), 2)
+	assert.Len(t, r.FailedSteps(), 1)
+	assert.Len(t, r.CallsOf(defaultStepReportTool), 2)
+}

--- a/internal/js/modules/k6/experimental/ageval/tool.go
+++ b/internal/js/modules/k6/experimental/ageval/tool.go
@@ -1,0 +1,59 @@
+package ageval
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/v2/js/common"
+)
+
+// evalTool is a tool the agent may call. For phase 1 the executor is a JS mock
+// (a function or a static value) supplied by the test author. The agent loop
+// dispatches by name and does not care how the result is produced, so MCP- and
+// sub-agent-backed executors slot in here later without loop changes.
+type evalTool struct {
+	name        string
+	description string
+	inputSchema map[string]any
+
+	// mock is an optional JS callable `(input) => string` or a static value
+	// used verbatim as the tool result. nil means "use a default ack".
+	mock sobek.Value
+}
+
+// parseTools reads a JS array of tool definitions into the registry. Each entry
+// is `{ name, description, inputSchema, mock }`.
+func (mi *ModuleInstance) parseTools(v sobek.Value, reg *toolRegistry) {
+	rt := mi.vu.Runtime()
+	if v == nil || common.IsNullish(v) {
+		return
+	}
+	arr := v.ToObject(rt)
+	lengthVal := arr.Get("length")
+	if lengthVal == nil {
+		return
+	}
+	n := int(lengthVal.ToInteger())
+	for i := range n {
+		item := arr.Get(strconv.Itoa(i))
+		if item == nil || sobek.IsUndefined(item) {
+			continue
+		}
+		obj := item.ToObject(rt)
+		t := &evalTool{
+			name:        getString(obj, "name", ""),
+			description: getString(obj, "description", ""),
+			mock:        obj.Get("mock"),
+		}
+		if t.name == "" {
+			common.Throw(rt, fmt.Errorf("tool at index %d is missing a name", i))
+		}
+		if schema := obj.Get("inputSchema"); schema != nil && !common.IsNullish(schema) {
+			if m, ok := schema.Export().(map[string]any); ok {
+				t.inputSchema = m
+			}
+		}
+		reg.add(t)
+	}
+}


### PR DESCRIPTION
## What?

Add module to support agent prompt evals.

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
