### PR TITLE
Add feature brief process

### DIFF
--- a/.github/scripts/check-feature-briefs.sh
+++ b/.github/scripts/check-feature-briefs.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# check-feature-briefs.sh — validate feature briefs in docs/features/
+#
+# Usage:
+#   ./check-feature-briefs.sh               # check all briefs (local default)
+#   ./check-feature-briefs.sh path/to/a.md  # check specific file(s) (used by CI)
+#
+# Rules enforced:
+#   1. Total prose ≤ 1,200 words   (hard limit, error)
+#      Total prose ≤   800 words   (soft target, warning)
+#   2. "## Problem" section ≤ 3 sentences  (heuristic: counts . ! ? terminators)
+#   3. "## Cost of inaction" section must be present and non-empty
+#
+# Prose is defined as all text after stripping:
+#   - Markdown heading lines  (lines starting with #)
+#   - HTML comments           (<!-- ... -->, including multi-line)
+#
+# README.md and 000-TEMPLATE.md are always excluded.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+BRIEFS_DIR="$REPO_ROOT/docs/features"
+
+SKIP_PATTERN="README\.md$|000-TEMPLATE\.md$"
+
+# ──────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────
+
+# strip_comments FILE — print file contents with HTML comments removed
+strip_comments() {
+  awk '
+    {
+      line = $0
+      while (1) {
+        if (in_comment) {
+          idx = index(line, "-->")
+          if (idx == 0) { line = ""; break }
+          line = substr(line, idx + 3)
+          in_comment = 0
+        } else {
+          idx = index(line, "<!--")
+          if (idx == 0) break
+          before = substr(line, 1, idx - 1)
+          rest   = substr(line, idx + 4)
+          end_idx = index(rest, "-->")
+          if (end_idx > 0) {
+            line = before substr(rest, end_idx + 3)
+          } else {
+            printf "%s", before
+            in_comment = 1
+            line = ""
+            break
+          }
+        }
+      }
+      print line
+    }
+  ' in_comment=0 "$1"
+}
+
+# prose_text FILE — file with comments and heading lines stripped
+prose_text() {
+  strip_comments "$1" | grep -v '^[[:space:]]*#'
+}
+
+# section_text FILE HEADING — text of the section starting at HEADING, up to next ## heading
+section_text() {
+  local file="$1"
+  local heading="$2"
+  strip_comments "$file" | awk -v heading="$heading" '
+    BEGIN { found=0 }
+    /^##[[:space:]]/ {
+      if (found) exit
+      if (tolower($0) ~ tolower(heading)) { found=1; next }
+    }
+    found { print }
+  '
+}
+
+# ──────────────────────────────────────────────
+# Build the file list
+# ──────────────────────────────────────────────
+
+if [[ $# -gt 0 ]]; then
+  files=("$@")
+else
+  # No args: scan all .md files in docs/features/
+  mapfile -t files < <(find "$BRIEFS_DIR" -maxdepth 1 -name '*.md' | sort)
+fi
+
+# Filter out excluded files
+filtered=()
+for f in "${files[@]}"; do
+  if echo "$f" | grep -qE "$SKIP_PATTERN"; then
+    continue
+  fi
+  if [[ ! -f "$f" ]]; then
+    echo "::warning::File not found, skipping: $f"
+    continue
+  fi
+  filtered+=("$f")
+done
+
+if [[ ${#filtered[@]} -eq 0 ]]; then
+  echo "No feature briefs to check."
+  exit 0
+fi
+
+# ──────────────────────────────────────────────
+# Validate each brief
+# ──────────────────────────────────────────────
+
+failed=0
+
+for f in "${filtered[@]}"; do
+  echo "Checking: $f"
+
+  # 1. Word count -----------------------------------------------------------
+  word_count=$(prose_text "$f" | wc -w | tr -d '[:space:]')
+
+  if [[ "$word_count" -gt 1200 ]]; then
+    echo "::error file=$f::Word count is $word_count (limit: 1200). Trim the prose."
+    failed=1
+  elif [[ "$word_count" -gt 800 ]]; then
+    echo "::warning file=$f::Word count is $word_count (soft target: ≤800). Consider trimming."
+  fi
+
+  # 2. Problem sentence count -----------------------------------------------
+  # Heuristic: count sentence-terminating punctuation (. ! ?) that is followed
+  # by whitespace or end of string. HTML comments already stripped by section_text.
+  problem_text=$(section_text "$f" "## Problem")
+  sentence_count=$(echo "$problem_text" | grep -oE '[.!?]([[:space:]]|$)' | wc -l | tr -d '[:space:]')
+
+  if [[ "$sentence_count" -gt 3 ]]; then
+    echo "::error file=$f::Problem statement has ~$sentence_count sentences (limit: 3)."
+    failed=1
+  fi
+
+  # 3. Cost of inaction — present and non-empty -----------------------------
+  coi_text=$(section_text "$f" "## Cost of inaction" | tr -d '[:space:]')
+
+  if [[ -z "$coi_text" ]]; then
+    echo "::error file=$f::\"Cost of inaction\" section is missing or empty. It is required."
+    failed=1
+  fi
+
+done
+
+if [[ "$failed" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "All briefs OK."

--- a/.github/workflows/feature-briefs.yml
+++ b/.github/workflows/feature-briefs.yml
@@ -1,0 +1,37 @@
+name: Feature briefs
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'docs/features/**'
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  check-size:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Validate changed feature briefs
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          files=$(git diff --name-only --diff-filter=AM "$BASE" "$HEAD" -- 'docs/features/*.md' \
+            | grep -vE '(README|000-TEMPLATE)\.md$' || true)
+          if [ -z "$files" ]; then
+            echo "No feature briefs added or changed in this PR."
+            exit 0
+          fi
+          echo "Checking:"; echo "$files"
+          # xargs passes each file as a separate argument to the script
+          echo "$files" | xargs ./.github/scripts/check-feature-briefs.sh

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,3 +6,6 @@
 # It turned out to be less noisy if the author picks manually every time
 # the best reviewers based on the context of the working area.
 /release\ notes/
+
+# Feature briefs are owned by the maintainers (k6-core) and product.
+/docs/features/ @grafana/k6-core @andrewslotin

--- a/docs/features/000-TEMPLATE.md
+++ b/docs/features/000-TEMPLATE.md
@@ -1,0 +1,23 @@
+# Title
+
+<!-- Brief title for the feature (replace this heading). -->
+
+## Problem
+
+<!-- ≤ 3 sentences. What user problem does this solve? -->
+
+## Significance
+
+<!-- Why does this problem matter? Who is affected and how? -->
+
+## Cost of inaction
+
+<!-- 2–3 sentences. What happens to users, the business, or the team if we don't solve this? -->
+
+## Desired state
+
+<!-- What does the world look like once this is solved? Keep it outcome-focused, not implementation-focused. -->
+
+## Out of scope
+
+<!-- Anything explicitly not covered by this proposal. Optional — remove if not applicable. -->

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -1,0 +1,31 @@
+# Feature briefs
+
+A feature brief is a short Markdown document that describes a user problem and explains why it matters. You submit it as a pull request and the team reviews it before any implementation work begins. Keeping briefs in the repo means the whole proposal history lives alongside the code.
+
+## When to write one
+
+Write a brief for new features or significant changes to existing behaviour. You do **not** need one for bug fixes, small improvements, or refactors.
+
+## How to submit
+
+1. Copy [`000-TEMPLATE.md`](000-TEMPLATE.md) to a new file named `NNN-short-title.md`, where `NNN` is the next available number (e.g. `007-websocket-multiplexing.md`).
+2. Fill in every section, deleting the HTML comment guidance as you go.
+3. Open a PR that adds only that file under `docs/features/`.
+
+## Review process
+
+Briefs are reviewed as pull requests, with discussion happening in the PR comments. Once a brief is merged we treat it as final, so any follow-up changes go into a new brief.
+
+## Constraints
+
+| Constraint | Limit |
+|---|---|
+| Total prose | 1,200 words (soft target: 800) |
+| Problem statement | ≤ 3 sentences |
+| "Cost of inaction" section | Required |
+
+The word count is enforced in CI. Template headings and HTML comments do not count towards it.
+
+---
+
+For general contribution guidelines see [`CONTRIBUTING.md`](../../CONTRIBUTING.md).


### PR DESCRIPTION
## What?

Introduces an in-repo "feature brief" process under `docs/features/`:

- `000-TEMPLATE.md` — the brief template.
- `README.md` — when to write a brief, how to submit one, the review process, and size constraints.
- `.github/scripts/check-feature-briefs.sh` + `.github/workflows/feature-briefs.yml` — CI that enforces the size limits on changed briefs.

## Why?

We want contributors to have a simple way to propose new features and significant changes
before any code gets written. Keeping these proposals in the repo means they're reviewed
as regular pull requests and their discussion stays in version control, so anyone in the
community can follow how a feature was decided.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
