### PR TITLE
Skip code CI for docs-only and release-notes-only PRs

### DIFF
--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'release notes/**'
   schedule:
     # At 06:00 AM UTC from Monday through Friday
     - cron:  '0 6 * * 1-5'

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'docs/**'
   schedule:
     # At 06:00 AM UTC from Monday through Friday
     - cron:  '0 6 * * 1-5'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'release notes/**'
 
 defaults:
   run:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ on:
     tags:
       - v*
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 defaults:
   run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,8 @@ on:
   # Enable manually triggering this workflow via the API or web UI
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 defaults:
   run:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'release notes/**'
 
 defaults:
   run:

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'release notes/**'
 
 defaults:
   run:

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'release notes/**'
 
 defaults:
   run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 defaults:
   run:

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'release notes/**'
 
 defaults:
   run:

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -2,6 +2,8 @@ name: Web Platform Tests
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 defaults:
   run:

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 
 defaults:
   run:

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     paths-ignore:
       - 'docs/**'
+      - 'release notes/**'
 
 defaults:
   run:


### PR DESCRIPTION
## What?

Adds a `paths-ignore` filter to the `pull_request` trigger of the code CI workflows so they no longer run when a PR only touches documentation or release notes.

Affected workflows: `test`, `lint`, `build`, `browser_e2e`, `test-browser`, `wpt`, `xk6`. Each now ignores PRs whose changes are entirely under `docs/**` or `release notes/**`. (`tc39` already has its own path filter.)

## Why?

Running the full Go, browser, and conformance suites on documentation-only or release-notes-only changes wastes CI time and resources without testing anything meaningful. GitHub skips a workflow only when every changed file matches the ignored paths, so any PR that also touches code still runs the complete suite.

## Checklist

- [x] I have performed a self-review of my code.
