### PR TITLE
fix: trim trailing slash from cloud login stack input

### DIFF
--- a/internal/cmd/cloud_login.go
+++ b/internal/cmd/cloud_login.go
@@ -312,6 +312,9 @@ func validateTokenV6(
 // normalizeStackURL converts a stack slug to a full URL if needed.
 // The stackInput can be either a full URL (e.g., https://my-team.grafana.net) or just a slug (e.g., my-team).
 func normalizeStackURL(stackInput string) string {
+	// A trailing slash is passed verbatim to the Grafana Cloud API and makes it
+	// reject the stack with a 403, so drop it before doing anything else.
+	stackInput = strings.TrimRight(stackInput, "/")
 	// If it's already a full URL, return it as is
 	if strings.HasPrefix(stackInput, "http://") || strings.HasPrefix(stackInput, "https://") {
 		return stackInput

--- a/internal/cmd/cloud_login_test.go
+++ b/internal/cmd/cloud_login_test.go
@@ -61,6 +61,65 @@ func TestMaskToken(t *testing.T) {
 	}
 }
 
+func TestNormalizeStackURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "full URL is kept as is",
+			input:    "https://my-team.grafana.net",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "full URL with trailing slash is trimmed",
+			input:    "https://my-team.grafana.net/",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "slug is expanded to a full URL",
+			input:    "my-team",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "slug with trailing slash is trimmed then expanded",
+			input:    "my-team/",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "grafana.net suffix is stripped from a slug",
+			input:    "my-team.grafana.net",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "grafana.net suffix with trailing slash is stripped from a slug",
+			input:    "my-team.grafana.net/",
+			expected: "https://my-team.grafana.net",
+		},
+		{
+			name:     "localhost URL is kept as is",
+			input:    "http://localhost:8080",
+			expected: "http://localhost:8080",
+		},
+		{
+			name:     "localhost URL with trailing slash is trimmed",
+			input:    "http://localhost:8080/",
+			expected: "http://localhost:8080",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.expected, normalizeStackURL(tc.input))
+		})
+	}
+}
+
 func TestPrintConfigTokenOutput(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What?

Trim trailing slashes from the stack input in `normalizeStackURL` before the URL/slug handling runs.

## Why?

`k6 cloud login` fails with `403 Stack not found` when the stack is entered as a full URL with a trailing slash, e.g. `https://foobar.grafana.net/`. The trailing slash is currently kept and passed verbatim to the Grafana Cloud API, which doesn't recognize the value and rejects it. Dropping the same `/` makes the login succeed, as reported in #5894.

While verifying this I also hit a related slug case: an input like `foobar.grafana.net/` skips the `.grafana.net` suffix strip (it ends in `/`, not `.grafana.net`) and ends up as `https://foobar.grafana.net/.grafana.net`. A single `strings.TrimRight(stackInput, "/")` at the top of `normalizeStackURL` covers both: the full-URL 403 case and the malformed slug.

## Verification

I exercised `normalizeStackURL` in isolation rather than against a live login, with a new table test (`TestNormalizeStackURL`) covering full URL, slug, and localhost forms, each with and without a trailing slash. The new test fails on `master` (the slug-with-slash case produces `https://my-team/.grafana.net`) and passes with the fix. `go test ./internal/cmd/...`, `gofmt`, and `go vet` are all clean.

Fixes #5894

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.
