### PR TITLE
ci: centralize CI Go versions into .github/go-versions.env

### DIFF
--- a/.github/actions/go-versions/action.yml
+++ b/.github/actions/go-versions/action.yml
@@ -1,0 +1,22 @@
+name: "Go versions"
+description: "Expose the central Go versions (current and N-1) from .github/go-versions.env"
+
+outputs:
+  current:
+    description: "Current Go version (e.g. 1.26.x)."
+    value: ${{ steps.read.outputs.current }}
+  prev:
+    description: "Previous (N-1) Go version (e.g. 1.25.x)."
+    value: ${{ steps.read.outputs.prev }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Read go-versions.env
+      id: read
+      shell: bash
+      run: |
+        set -euo pipefail
+        source "${GITHUB_ACTION_PATH}/../../go-versions.env"
+        echo "current=${GO_VERSION_CURRENT}" >> "$GITHUB_OUTPUT"
+        echo "prev=${GO_VERSION_PREV}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/lint/action.yml
+++ b/.github/actions/lint/action.yml
@@ -4,10 +4,13 @@ description: Run golangci-lint with the k6 ruleset
 runs:
   using: composite
   steps:
+    - name: Resolve Go versions
+      id: go_versions
+      uses: ./.github/actions/go-versions
     - name: Install Go
       uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
-        go-version: 1.26.x
+        go-version: ${{ steps.go_versions.outputs.current }}
         check-latest: true
     - name: Get golangci-lint version and download rules
       shell: bash

--- a/.github/go-versions.env
+++ b/.github/go-versions.env
@@ -1,0 +1,8 @@
+# Single source of truth for the Go versions used across the CI workflows.
+#
+# Both values are bumped manually with each Go release:
+#   GO_VERSION_CURRENT - the current Go minor version.
+#   GO_VERSION_PREV    - the deliberate N-1 version (one minor behind CURRENT)
+#                        kept for backwards-compatibility coverage.
+GO_VERSION_CURRENT=1.26.x
+GO_VERSION_PREV=1.25.x

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,13 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - name: Resolve Go versions
+        id: go_versions
+        uses: ./.github/actions/go-versions
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.26.x
+          go-version: ${{ steps.go_versions.outputs.current }}
           check-latest: true
       - name: Check dependencies
         run: |

--- a/.github/workflows/tc39.yml
+++ b/.github/workflows/tc39.yml
@@ -27,10 +27,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+      - name: Resolve Go versions
+        id: go_versions
+        uses: ./.github/actions/go-versions
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.26.x
+          go-version: ${{ steps.go_versions.outputs.current }}
           check-latest: true
       - name: Run tests
         run: |

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -13,12 +13,27 @@ permissions:
   contents: read
 
 jobs:
+  configure:
+    runs-on: ubuntu-latest
+    outputs:
+      go_current: ${{ steps.go_versions.outputs.current }}
+      go_prev: ${{ steps.go_versions.outputs.prev }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Resolve Go versions
+        id: go_versions
+        uses: ./.github/actions/go-versions
+
   test-prev:
+    needs: configure
     if: ${{ github.ref == 'refs/heads/master' }}
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.25.x]
+        go-version: ["${{ needs.configure.outputs.go_prev }}"]
         platform:
           [ubuntu-24.04, ubuntu-arm64-large, github-hosted-windows-x64-large]
     runs-on: ${{ matrix.platform }}
@@ -71,10 +86,11 @@ jobs:
           use_gotip: "true"
 
   test-latest:
+    needs: configure
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.26.x]
+        go-version: ["${{ needs.configure.outputs.go_current }}"]
         platform:
           [ubuntu-24.04, ubuntu-arm64-large, github-hosted-windows-x64-large]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,12 +13,27 @@ permissions:
   contents: read
 
 jobs:
+  configure:
+    runs-on: ubuntu-latest
+    outputs:
+      go_current: ${{ steps.go_versions.outputs.current }}
+      go_prev: ${{ steps.go_versions.outputs.prev }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - name: Resolve Go versions
+        id: go_versions
+        uses: ./.github/actions/go-versions
+
   test-prev:
+    needs: configure
     if: ${{ github.ref == 'refs/heads/master' }}
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.25.x]
+        go-version: ["${{ needs.configure.outputs.go_prev }}"]
         platform: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -67,10 +82,11 @@ jobs:
           platform: ${{ matrix.platform }}
 
   test-latest:
+    needs: configure
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.26.x]
+        go-version: ["${{ needs.configure.outputs.go_current }}"]
         platform: [ubuntu-24.04, ubuntu-24.04-arm, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -18,10 +18,13 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+      - name: Resolve Go versions
+        id: go_versions
+        uses: ./.github/actions/go-versions
       - name: Install Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.26.x
+          go-version: ${{ steps.go_versions.outputs.current }}
           check-latest: true
       # TODO: combine WebPlatform tests checkout & patch into the single step
       - name: Run Streams Tests

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -27,11 +27,15 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
+      - name: Resolve Go versions
+        id: go_versions
+        if: matrix.go != 'tip'
+        uses: ./.github/actions/go-versions
       - name: Install Go
         if: matrix.go != 'tip'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.26.x
+          go-version: ${{ steps.go_versions.outputs.current }}
           check-latest: true
       - name: Download Go tip
         if: matrix.go == 'tip'

--- a/renovate.json
+++ b/renovate.json
@@ -8,21 +8,6 @@
     "**/vendor/**",
     ".github/workflows/xk6-tests/**"
   ],
-  "customManagers": [
-    {
-      "customType": "regex",
-      "description": "Track Go minor version in setup-go go-version: 1.X.x lines",
-      "managerFilePatterns": ["/^\\.github/workflows/[^/]+\\.ya?ml$/"],
-      "matchStrings": [
-        "go-version:\\s+(?<currentValue>\\d+\\.\\d+)\\.x",
-        "go-version:\\s+\\[(?<currentValue>\\d+\\.\\d+)\\.x\\]"
-      ],
-      "depNameTemplate": "golang/go",
-      "datasourceTemplate": "golang-version",
-      "extractVersionTemplate": "^(?<version>\\d+\\.\\d+)",
-      "versioningTemplate": "loose"
-    }
-  ],
   "baseBranchPatterns": [
     "master",
     "v1.x"


### PR DESCRIPTION
## What?

Adds `.github/go-versions.env` as the single source of truth for the Go versions used across CI:

```
GO_VERSION_CURRENT=1.26.x
GO_VERSION_PREV=1.25.x
```

A new `.github/actions/go-versions` composite action reads it and exposes `current` / `prev` outputs. All workflows now resolve their Go version from there instead of hardcoding it:

- `lint`, `tc39`, `wpt`, `xk6` and the `lint` composite action resolve the version in a step before `setup-go`.
- `test` and `test-browser` gain a small `configure` job (mirroring the existing pattern in `build.yml`) that feeds `current`/`prev` into the `test-latest`/`test-prev` matrices.

The Renovate custom manager that auto-bumped the Go version is removed; both `CURRENT` and `PREV` are now bumped manually with each Go release.

## Why?

The Go versions were duplicated across ~8 lines in 6 workflow files. The Renovate manager from #5981 matched the deliberate N-1 matrix entry the same as the current one, so it proposed bumping the N-1 entry to latest (#6085) — collapsing the "current + previous" coverage into testing the same version twice. There is no native "latest minus one" in Renovate, so the N-1 pin can only be managed by hand. Centralizing into one file makes the per-release update a single two-line edit and removes the ambiguity that triggered #6085.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _n/a_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Follows up on #5981
- Resolves the problem behind #6085

🤖 Generated with [Claude Code](https://claude.com/claude-code)
