### PR TITLE
chore: bump k6 version to 2.1.0

### DIFF
--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -3,4 +3,4 @@ package build
 
 // Version contains the current version of k6
 // represented using Semantic Versioning expression.
-const Version = "2.0.0"
+const Version = "2.1.0"


### PR DESCRIPTION
## What?

Bumps k6 version to v2.1.0
