### PR TITLE
fsext: serialize first-fill in CacheOnReadFs to fix concurrent-open race

### DIFF
--- a/lib/fsext/cacheonread.go
+++ b/lib/fsext/cacheonread.go
@@ -21,6 +21,21 @@ type CacheOnReadFs struct {
 	lock       *sync.Mutex
 	cachedOnly bool
 	cached     map[string]bool
+
+	// populated marks paths whose first copyToLayer has finished; subsequent
+	// Opens can then run concurrently through afero's cacheHit branch.
+	//
+	// Entries are never invalidated. k6 uses this wrapper read-only (see
+	// internal/loader/filesystems.go), so Remove/RemoveAll/Rename/Chtimes/
+	// Chmod - anything that triggers a fresh copyToLayer - would need to
+	// clear the marker to avoid re-exposing the copyToLayer race.
+	populated map[string]bool
+
+	// fills holds a per-path mutex serializing the first
+	// cacheMiss -> copyToLayer -> layer.Open in afero. Without it a second
+	// reader can be classified as cacheHit on the still-being-copied layer
+	// file and read empty/partial bytes.
+	fills map[string]*sync.Mutex
 }
 
 // OnlyCachedEnabler enables the mode of FS that allows to open
@@ -43,6 +58,8 @@ func NewCacheOnReadFs(base, layer afero.Fs, cacheTime time.Duration) afero.Fs {
 		lock:       &sync.Mutex{},
 		cachedOnly: false,
 		cached:     make(map[string]bool),
+		populated:  make(map[string]bool),
+		fills:      make(map[string]*sync.Mutex),
 	}
 }
 
@@ -66,13 +83,78 @@ func (c *CacheOnReadFs) Open(name string) (afero.File, error) {
 		return nil, err
 	}
 
-	return c.Fs.Open(name)
+	return c.openSerialized(name, func() (afero.File, error) {
+		return c.Fs.Open(name)
+	})
+}
+
+// OpenFile shares openSerialized with Open so a first cacheMiss can't race
+// with a concurrent reader. Read-only flags only: a write/truncate flag
+// mutates the layer while populated stays true, letting concurrent fast-path
+// Opens read torn or empty data (see the populated field comment).
+func (c *CacheOnReadFs) OpenFile(name string, flag int, perm fs.FileMode) (afero.File, error) {
+	if err := c.checkOrRemember(name); err != nil {
+		return nil, err
+	}
+
+	return c.openSerialized(name, func() (afero.File, error) {
+		return c.Fs.OpenFile(name, flag, perm)
+	})
+}
+
+// openSerialized invokes openFn while ensuring that, for a given name, the
+// first successful open completes before any other goroutine is allowed into
+// the same open path. Once a name is marked populated, openFn is invoked with
+// no extra locking.
+func (c *CacheOnReadFs) openSerialized(name string, openFn func() (afero.File, error)) (afero.File, error) {
+	c.lock.Lock()
+	if c.populated[name] {
+		c.lock.Unlock()
+		return openFn()
+	}
+	fl, ok := c.fills[name]
+	if !ok {
+		fl = &sync.Mutex{}
+		c.fills[name] = fl
+	}
+	c.lock.Unlock()
+
+	fl.Lock()
+
+	// Filler already finished: drop fl so queued waiters fan out in parallel
+	// through afero's cacheHit branch, and skip the redundant bookkeeping.
+	c.lock.Lock()
+	alreadyPopulated := c.populated[name]
+	c.lock.Unlock()
+	if alreadyPopulated {
+		fl.Unlock()
+		return openFn()
+	}
+
+	defer fl.Unlock()
+
+	f, err := openFn()
+	if err != nil {
+		return nil, err
+	}
+
+	c.lock.Lock()
+	c.populated[name] = true
+	delete(c.fills, name)
+	c.lock.Unlock()
+
+	return f, nil
 }
 
 // Stat returns a FileInfo describing the named file, or an error, if any
 // happens.
 // if CacheOnReadFs is in the opened only mode it should return
 // an error if path wasn't open before
+//
+// Not routed through openSerialized: a concurrent Stat during another
+// goroutine's first Open can see the layer file mid copyToLayer and report
+// Size=0. Safe today because k6's Stat callers only read presence/IsDir.
+// Route through openSerialized if a caller starts consuming Size/ModTime/Mode.
 func (c *CacheOnReadFs) Stat(path string) (fs.FileInfo, error) {
 	if err := c.checkOrRemember(path); err != nil {
 		return nil, err

--- a/lib/fsext/cacheonread_test.go
+++ b/lib/fsext/cacheonread_test.go
@@ -1,0 +1,82 @@
+package fsext
+
+import (
+	"io"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCacheOnReadFsConcurrentFirstOpen exercises the race where two goroutines
+// open the same not-yet-cached file at the same time. Without per-path
+// serialization in CacheOnReadFs the underlying afero CacheOnReadFs can be
+// caught mid copyToLayer by a second reader, which then opens the layer file
+// while it is still being filled and reads zero or partial bytes.
+func TestCacheOnReadFsConcurrentFirstOpen(t *testing.T) {
+	t.Parallel()
+	assertConcurrentFirstOpenReadsFullContent(t, func(fs afero.Fs, path string) (afero.File, error) {
+		return fs.Open(path)
+	})
+}
+
+// TestCacheOnReadFsConcurrentFirstOpenFile mirrors the plain Open test but
+// exercises the OpenFile entry point, which shares openSerialized. Guards
+// against a future refactor reintroducing the race on that path.
+func TestCacheOnReadFsConcurrentFirstOpenFile(t *testing.T) {
+	t.Parallel()
+	assertConcurrentFirstOpenReadsFullContent(t, func(fs afero.Fs, path string) (afero.File, error) {
+		return fs.OpenFile(path, syscall.O_RDONLY, 0)
+	})
+}
+
+// assertConcurrentFirstOpenReadsFullContent releases N goroutines simultaneously
+// at the first-open of a not-yet-cached path and asserts every goroutine reads
+// the full file content. The opener parameter picks the entry point under test
+// (Open vs OpenFile).
+func assertConcurrentFirstOpenReadsFullContent(t *testing.T, opener func(afero.Fs, string) (afero.File, error)) {
+	t.Helper()
+
+	const (
+		path        = "/data.csv"
+		concurrency = 32
+	)
+	content := []byte("col1,col2\na,b\nc,d\n")
+
+	base := NewMemMapFs()
+	require.NoError(t, WriteFile(base, path, content, 0o644))
+
+	fs := NewCacheOnReadFs(base, NewMemMapFs(), 0)
+
+	var (
+		wg    sync.WaitGroup
+		start = make(chan struct{})
+	)
+	results := make([][]byte, concurrency)
+	errs := make([]error, concurrency)
+
+	for i := range concurrency {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			<-start
+			f, err := opener(fs, path)
+			if err != nil {
+				errs[idx] = err
+				return
+			}
+			defer f.Close() //nolint:errcheck
+			results[idx], errs[idx] = io.ReadAll(f)
+		}(i)
+	}
+
+	close(start)
+	wg.Wait()
+
+	for i, got := range results {
+		require.NoError(t, errs[i], "goroutine %d", i)
+		require.Equal(t, content, got, "goroutine %d read truncated data", i)
+	}
+}


### PR DESCRIPTION
## What?

Serialize the first `cacheMiss -> copyToLayer -> layer.Open` sequence in
`fsext.CacheOnReadFs` per path via a fill mutex, and remember paths whose
first open has completed so subsequent opens take a fast path with no
extra locking. `OpenFile` shares the same code path since it has the same
shape in afero. Queued waiters that wake after the first filler finished
release the fill mutex before running the underlying open so they can fan
out through afero's cacheHit branch in parallel.

## Why?

`afero.CacheOnReadFs.Open` on a `cacheMiss` runs `base.Stat +
copyToLayer + layer.Open`. A second goroutine entering `Open` during
that `copyToLayer` classifies the still-being-copied layer file as
`cacheHit` and returns `layer.Open(name)` on a partially written file,
reading zero or truncated bytes.

First observed as a flake in `TestRunCSVParseConcurrentFromMultipleModules`
in `internal/cmd/tests`: three top-level-await modules each call
`fs.open("data.csv") + csv.parse(file)`, one ends up reading 0 bytes, the
run exits with code 107. After this change the test passes
`-race -count=500` cleanly; before it produced multiple failures at the
same count.

The fix lives in the k6 wrapper (`lib/fsext/cacheonread.go`) — no changes
to vendored afero. A regression test in `lib/fsext/cacheonread_test.go`
exercises both the `Open` and `OpenFile` entry points via a shared
harness that races N goroutines through a first open and asserts every
one reads the full content.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

None.