### PR TITLE
Add extension usage telemetry

### DIFF
--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -44,6 +44,11 @@ const (
 	// to keep the command tree construction off the real network.
 	ProvisionCatalogURL = "K6_PROVISION_CATALOG_URL"
 
+	// UsageReportURL overrides the endpoint the anonymous usage report is sent
+	// to. It defaults to the production endpoint and lets tests point it at an
+	// httptest server to observe the report.
+	UsageReportURL = "K6_USAGE_REPORT_URL"
+
 	// defaultBuildServiceURL defines the URL to the default (grafana hosted) build service
 	defaultBuildServiceURL = "https://ingest.k6.io/builder/api/v1"
 

--- a/internal/cmd/outputs.go
+++ b/internal/cmd/outputs.go
@@ -152,6 +152,15 @@ func createOutputs(
 			}
 		}
 
+		// An output is an extension by membership in the output registry, not by
+		// its name, so built-in outputs stay out of the "extensions" bucket that
+		// the usage report filters against the catalog.
+		if e, isExt := ext.Get(ext.OutputExtension)[outputType]; isExt {
+			if err := test.preInitState.Usage.Values("extensions", e); err != nil {
+				gs.Logger.WithError(err).Warnf("Couldn't report usage for output extension %q", outputType)
+			}
+		}
+
 		params := baseParams
 		params.OutputType = outputType
 		params.ConfigArgument = outputArg

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 
+	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/internal/build"
 	"go.k6.io/k6/v2/internal/execution"
 	"go.k6.io/k6/v2/internal/usage"
@@ -33,6 +34,10 @@ func createReport(u *usage.Usage, execScheduler *execution.Scheduler) map[string
 	return m
 }
 
+// defaultUsageReportURL is the production endpoint the anonymous usage report
+// is sent to when K6_USAGE_REPORT_URL is not set.
+const defaultUsageReportURL = "https://stats.grafana.org/k6-usage-report"
+
 func reportUsage(ctx context.Context, execScheduler *execution.Scheduler, test *loadedAndConfiguredTest) error {
 	m := createReport(test.preInitState.Usage, execScheduler)
 	body, err := json.Marshal(m)
@@ -40,7 +45,10 @@ func reportUsage(ctx context.Context, execScheduler *execution.Scheduler, test *
 		return err
 	}
 
-	const usageStatsURL = "https://stats.grafana.org/k6-usage-report"
+	usageStatsURL := defaultUsageReportURL
+	if url, ok := test.preInitState.LookupEnv(state.UsageReportURL); ok && url != "" {
+		usageStatsURL = url
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, usageStatsURL, bytes.NewBuffer(body))
 	if err != nil {
 		return err

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"runtime"
 	"strconv"
+	"time"
 
 	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/ext"
@@ -32,14 +33,35 @@ func newExtensionEntry(e *ext.Extension) extensionEntry {
 	}
 }
 
+// envLookup adapts an environment map to the lookup-function shape the report
+// helpers share with the run path's LookupEnv.
+func envLookup(env map[string]string) func(string) (string, bool) {
+	return func(key string) (string, bool) {
+		val, ok := env[key]
+		return val, ok
+	}
+}
+
+// addEnvironmentInfo stamps the fields identifying this k6 binary and where it
+// runs. Both the run report and the subcommand report carry them.
+func addEnvironmentInfo(m map[string]any, lookupEnv func(string) (string, bool)) {
+	m["k6_version"] = build.Version
+	m["goos"] = runtime.GOOS
+	m["goarch"] = runtime.GOARCH
+	m["is_ci"] = isCI(lookupEnv)
+}
+
+// createReport assembles the anonymous usage report for a run from its
+// scheduler and recorded usage, keeping only the used extensions advertised in
+// the public catalog. It is the run report k6 has always sent, with the
+// extensions field added.
 func createReport(u *usage.Usage, execScheduler *execution.Scheduler, catalog map[string]struct{}) map[string]any {
 	execState := execScheduler.GetState()
 	m := u.Map()
 
-	m["k6_version"] = build.Version
+	addEnvironmentInfo(m, execState.Test.LookupEnv)
+
 	m["duration"] = execState.GetCurrentTestRunDuration().String()
-	m["goos"] = runtime.GOOS
-	m["goarch"] = runtime.GOARCH
 	m["vus_max"] = uint64(execState.GetInitializedVUsCount()) //nolint:gosec
 	m["iterations"] = execState.GetFullIterationCount()
 	executors := make(map[string]int)
@@ -47,9 +69,21 @@ func createReport(u *usage.Usage, execScheduler *execution.Scheduler, catalog ma
 		executors[ec.GetType()]++
 	}
 	m["executors"] = executors
-	m["is_ci"] = isCI(execState.Test.LookupEnv)
 
 	resolveExtensions(m, catalog)
+
+	return m
+}
+
+// createSubcommandReport builds the usage report for an invoked subcommand
+// extension. A subcommand is not a load test, so it reports the identity fields
+// and the used extension without the run summary that createReport derives from
+// a scheduler.
+func createSubcommandReport(ctx context.Context, gs *state.GlobalState, extension *ext.Extension) map[string]any {
+	m := make(map[string]any)
+	addEnvironmentInfo(m, envLookup(gs.Env))
+	m["extensions"] = []any{extension}
+	resolveExtensions(m, catalogModulePaths(ctx, gs))
 
 	return m
 }
@@ -94,19 +128,33 @@ func filterExtensions(used []any, public map[string]struct{}) []extensionEntry {
 	return entries
 }
 
+// reportUsage sends the report built by create, logging the attempt and outcome
+// at debug, all bounded by a timeout. Both k6 run and k6 x call it; whether to
+// run it in the background is the caller's concern, not the pipeline's.
+func reportUsage(ctx context.Context, gs *state.GlobalState, create func(ctx context.Context) map[string]any) {
+	reportCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	gs.Logger.Debug("Sending usage report...")
+	if err := postUsageReport(reportCtx, envLookup(gs.Env), create(reportCtx)); err != nil {
+		gs.Logger.WithError(err).Debug("Error sending usage report")
+	} else {
+		gs.Logger.Debug("Usage report sent successfully")
+	}
+}
+
 // defaultUsageReportURL is the production endpoint the anonymous usage report
 // is sent to when K6_USAGE_REPORT_URL is not set.
 const defaultUsageReportURL = "https://stats.grafana.org/k6-usage-report"
 
-func reportUsage(ctx context.Context, gs *state.GlobalState, execScheduler *execution.Scheduler, test *loadedAndConfiguredTest) error {
-	m := createReport(test.preInitState.Usage, execScheduler, catalogModulePaths(ctx, gs))
+func postUsageReport(ctx context.Context, lookupEnv func(string) (string, bool), m map[string]any) error {
 	body, err := json.Marshal(m)
 	if err != nil {
 		return err
 	}
 
 	usageStatsURL := defaultUsageReportURL
-	if url, ok := test.preInitState.LookupEnv(state.UsageReportURL); ok && url != "" {
+	if url, ok := lookupEnv(state.UsageReportURL); ok && url != "" {
 		usageStatsURL = url
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, usageStatsURL, bytes.NewBuffer(body))

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -9,12 +9,30 @@ import (
 	"strconv"
 
 	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/ext"
 	"go.k6.io/k6/v2/internal/build"
 	"go.k6.io/k6/v2/internal/execution"
 	"go.k6.io/k6/v2/internal/usage"
 )
 
-func createReport(u *usage.Usage, execScheduler *execution.Scheduler) map[string]any {
+// extensionEntry identifies a used extension in the usage report by its Go
+// module path, along with its version and kind.
+type extensionEntry struct {
+	Module  string `json:"module"`
+	Version string `json:"version"`
+	Kind    string `json:"kind"`
+}
+
+// newExtensionEntry builds the usage-report entry for a registered extension.
+func newExtensionEntry(e *ext.Extension) extensionEntry {
+	return extensionEntry{
+		Module:  e.Path,
+		Version: e.Version,
+		Kind:    e.Type.String(),
+	}
+}
+
+func createReport(u *usage.Usage, execScheduler *execution.Scheduler, catalog map[string]struct{}) map[string]any {
 	execState := execScheduler.GetState()
 	m := u.Map()
 
@@ -31,15 +49,57 @@ func createReport(u *usage.Usage, execScheduler *execution.Scheduler) map[string
 	m["executors"] = executors
 	m["is_ci"] = isCI(execState.Test.LookupEnv)
 
+	resolveExtensions(m, catalog)
+
 	return m
+}
+
+// resolveExtensions replaces the used extensions recorded under "extensions" in
+// usage with report entries, keeping only those advertised in the public
+// catalog. Fail closed: dropping the raw list first means an empty catalog
+// reports no extensions rather than leaking it, and the key stays omitted when
+// nothing survives instead of sending [].
+func resolveExtensions(m map[string]any, catalog map[string]struct{}) {
+	used, ok := m["extensions"].([]any)
+	if !ok {
+		return
+	}
+	delete(m, "extensions")
+	if entries := filterExtensions(used, catalog); len(entries) > 0 {
+		m["extensions"] = entries
+	}
+}
+
+// filterExtensions turns the recorded used extensions into report entries,
+// keeping only those whose module path is advertised in the public catalog and
+// de-duplicating per (module, kind).
+func filterExtensions(used []any, public map[string]struct{}) []extensionEntry {
+	seen := make(map[[2]string]struct{}, len(used))
+	entries := make([]extensionEntry, 0, len(used))
+	for _, v := range used {
+		e, ok := v.(*ext.Extension)
+		if !ok {
+			continue
+		}
+		if _, ok := public[e.Path]; !ok {
+			continue
+		}
+		key := [2]string{e.Path, e.Type.String()}
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		entries = append(entries, newExtensionEntry(e))
+	}
+	return entries
 }
 
 // defaultUsageReportURL is the production endpoint the anonymous usage report
 // is sent to when K6_USAGE_REPORT_URL is not set.
 const defaultUsageReportURL = "https://stats.grafana.org/k6-usage-report"
 
-func reportUsage(ctx context.Context, execScheduler *execution.Scheduler, test *loadedAndConfiguredTest) error {
-	m := createReport(test.preInitState.Usage, execScheduler)
+func reportUsage(ctx context.Context, gs *state.GlobalState, execScheduler *execution.Scheduler, test *loadedAndConfiguredTest) error {
+	m := createReport(test.preInitState.Usage, execScheduler, catalogModulePaths(ctx, gs))
 	body, err := json.Marshal(m)
 	if err != nil {
 		return err

--- a/internal/cmd/report_test.go
+++ b/internal/cmd/report_test.go
@@ -50,8 +50,7 @@ func TestCreateReport(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		s.GetState().MarkEnded()
 
-		m := createReport(usage.New(), s)
-		require.NoError(t, err)
+		m := createReport(usage.New(), s, nil)
 
 		assert.Equal(t, build.Version, m["k6_version"])
 		assert.EqualValues(t, map[string]int{"shared-iterations": 1}, m["executors"])
@@ -72,8 +71,7 @@ func TestCreateReport(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		m := createReport(usage.New(), s)
-		require.NoError(t, err)
+		m := createReport(usage.New(), s, nil)
 
 		assert.Equal(t, build.Version, m["k6_version"])
 		assert.EqualValues(t, map[string]int{"shared-iterations": 1}, m["executors"])
@@ -94,8 +92,7 @@ func TestCreateReport(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		m := createReport(usage.New(), s)
-		require.NoError(t, err)
+		m := createReport(usage.New(), s, nil)
 
 		assert.Equal(t, build.Version, m["k6_version"])
 		assert.EqualValues(t, map[string]int{"shared-iterations": 1}, m["executors"])

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -197,7 +197,11 @@ func (c *rootCommand) execute() {
 	if ext, ok := detectExtensionCompletion(c.cmd, c.globalState); ok {
 		err = completeExtension(c.globalState, ext, newCacheProvisioner(c.globalState))
 	} else {
-		err = c.cmd.Execute()
+		var executed *cobra.Command
+		executed, err = c.cmd.ExecuteC()
+		// Report subcommand usage after the command runs, regardless of its exit
+		// error, so a failed subcommand is still counted.
+		reportSubcommandUsage(c.globalState, executed)
 	}
 	if err == nil {
 		exitCode = 0

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -460,15 +460,9 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 	// usage report after the context is done.
 	if !conf.NoUsageReport.Bool {
 		backgroundProcesses.Go(func() {
-			reportCtx, reportCancel := context.WithTimeout(globalCtx, 3*time.Second)
-			defer reportCancel()
-			logger.Debug("Sending usage report...")
-
-			if rerr := reportUsage(reportCtx, c.gs, execScheduler, test); rerr != nil {
-				logger.WithError(rerr).Debug("Error sending usage report")
-			} else {
-				logger.Debug("Usage report sent successfully")
-			}
+			reportUsage(globalCtx, c.gs, func(ctx context.Context) map[string]any {
+				return createReport(test.preInitState.Usage, execScheduler, catalogModulePaths(ctx, c.gs))
+			})
 		})
 	}
 

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -464,7 +464,7 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 			defer reportCancel()
 			logger.Debug("Sending usage report...")
 
-			if rerr := reportUsage(reportCtx, execScheduler, test); rerr != nil {
+			if rerr := reportUsage(reportCtx, c.gs, execScheduler, test); rerr != nil {
 				logger.WithError(rerr).Debug("Error sending usage report")
 			} else {
 				logger.Debug("Usage report sent successfully")

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -80,6 +81,27 @@ Run "k6 x explore" to see the full list of official and community-provided subco
 	cmd.AddCommand(registryStubs(gs, baked)...)
 
 	return cmd
+}
+
+// reportSubcommandUsage reports usage for a subcommand extension after it runs.
+// It is called with the command cobra actually executed, whether that command
+// succeeded or failed, so a subcommand that exits non-zero is still counted. It
+// reports only for a name backed by a registered subcommand extension, so the
+// catch-all `x` help, `k6 run`, completions, and provisioning stubs are ignored.
+func reportSubcommandUsage(gs *state.GlobalState, executed *cobra.Command) {
+	if executed == nil {
+		return
+	}
+	extension, ok := ext.Get(ext.SubcommandExtension)[executed.Name()]
+	if !ok {
+		return
+	}
+	if conf, err := readEnvConfig(gs.Env); err != nil || conf.NoUsageReport.Bool {
+		return
+	}
+	reportUsage(gs.Ctx, gs, func(ctx context.Context) map[string]any {
+		return createSubcommandReport(ctx, gs, extension)
+	})
 }
 
 // registryStubs returns cobra stubs for registry-advertised subcommands not

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"cmp"
 	"fmt"
 	"slices"
 	"strings"
@@ -107,7 +106,7 @@ func registryStubs(gs *state.GlobalState, baked []*cobra.Command) []*cobra.Comma
 		gs.Logger.WithError(err).Debug("k6 extension catalog")
 	}
 	if subs == nil && first == 0 { // first == 0: not TAB completion, network allowed
-		url := cmp.Or(gs.Env[state.ProvisionCatalogURL], defaultCatalogURL())
+		url := catalogURL(gs)
 		_, _ = fmt.Fprint(gs.Stderr, "Loading the subcommand list...")
 		tail := "\n\n"
 		if gs.Stderr.IsTTY {

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -15,6 +15,7 @@ import (
 	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/ext"
 	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/internal/cmd/tests/testfork"
 	"go.k6.io/k6/v2/internal/cmd/tests/testimport2"
 	"go.k6.io/k6/v2/js/modules"
 )
@@ -52,6 +53,7 @@ func registerRunReportTestExtensions(t *testing.T) {
 	registerRunReportTestExtensionsOnce.Do(func() {
 		modules.Register("k6/x/testimport", &runReportTestModule{})
 		modules.Register("k6/x/testimport2", &testimport2.Module{})
+		modules.Register("k6/x/testfork", &testfork.Module{})
 	})
 }
 
@@ -131,6 +133,15 @@ func TestRunReportsExtensions(t *testing.T) {
 					"kind":    "js",
 				},
 			},
+		},
+		{
+			// The catalog lists the real extension's module path for this import
+			// name, but the imported fork resolves to its own path, so matching
+			// by module path drops it.
+			name:                "private fork reusing a public import name is dropped",
+			script:              `import "k6/x/testfork"; export default function() {};`,
+			catalog:             `{"k6/x/testfork": {"module":"` + testImportModule + `"}}`,
+			wantNoExtensionsKey: true,
 		},
 	}
 

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -97,6 +97,23 @@ func TestRunReportsExtensions(t *testing.T) {
 			},
 		},
 		{
+			name:    "distinct imported extensions are each reported",
+			script:  `import "k6/x/testimport"; import "k6/x/testimport2"; export default function() {};`,
+			catalog: `{"k6/x/testimport": {"module":"` + testImportModule + `"},"k6/x/testimport2": {"module":"` + testImportModule2 + `"}}`,
+			wantExtensions: []map[string]any{
+				{
+					"module":  testImportModule,
+					"version": ext.Get(ext.JSExtension)["k6/x/testimport"].Version,
+					"kind":    "js",
+				},
+				{
+					"module":  testImportModule2,
+					"version": ext.Get(ext.JSExtension)["k6/x/testimport2"].Version,
+					"kind":    "js",
+				},
+			},
+		},
+		{
 			name:    "extension not in the catalog is filtered out",
 			script:  `import "k6/x/testimport"; import "k6/x/testimport2"; export default function() {};`,
 			catalog: `{"k6/x/testimport2": {"module":"` + testImportModule2 + `"}}`,

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -67,6 +67,7 @@ func TestRunReportsExtensions(t *testing.T) {
 		args                []string
 		script              string
 		catalog             string
+		unreachableCatalog  bool
 		wantExtensions      []map[string]any
 		wantNoExtensionsKey bool
 	}{
@@ -143,6 +144,15 @@ func TestRunReportsExtensions(t *testing.T) {
 			catalog:             `{"k6/x/testfork": {"module":"` + testImportModule + `"}}`,
 			wantNoExtensionsKey: true,
 		},
+		{
+			// An unreachable catalog with no cache must fail closed: report no
+			// extensions rather than leak the unfiltered import, and never fail
+			// the run.
+			name:                "unreachable catalog reports nothing",
+			script:              `import "k6/x/testimport"; export default function() {};`,
+			unreachableCatalog:  true,
+			wantNoExtensionsKey: true,
+		},
 	}
 
 	for _, tc := range tt {
@@ -170,6 +180,12 @@ func TestRunReportsExtensions(t *testing.T) {
 					_, _ = w.Write([]byte(tc.catalog))
 				}))
 				t.Cleanup(catalogServer.Close)
+				ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
+			}
+			if tc.unreachableCatalog {
+				// Close the server immediately so its URL refuses connections.
+				catalogServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+				catalogServer.Close()
 				ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
 			}
 			ts.CmdArgs = append([]string{"k6", "run"}, tc.args...)

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -68,6 +68,7 @@ func TestRunReportsExtensions(t *testing.T) {
 		script              string
 		catalog             string
 		unreachableCatalog  bool
+		optOut              bool
 		wantExtensions      []map[string]any
 		wantNoExtensionsKey bool
 	}{
@@ -153,6 +154,14 @@ func TestRunReportsExtensions(t *testing.T) {
 			unreachableCatalog:  true,
 			wantNoExtensionsKey: true,
 		},
+		{
+			// The existing opt-out gates the whole report, so neither the report
+			// endpoint nor the catalog is consulted.
+			name:    "opt-out suppresses the report and catalog fetch",
+			script:  `import "k6/x/testimport"; export default function() {};`,
+			catalog: `{"k6/x/testimport": {"module":"` + testImportModule + `"}}`,
+			optOut:  true,
+		},
 	}
 
 	for _, tc := range tt {
@@ -171,11 +180,18 @@ func TestRunReportsExtensions(t *testing.T) {
 			}))
 			t.Cleanup(reportServer.Close)
 
+			var catalogHit atomic.Bool
+
 			ts := NewGlobalTestState(t)
-			ts.Env["K6_NO_USAGE_REPORT"] = "false"
+			if tc.optOut {
+				ts.Env["K6_NO_USAGE_REPORT"] = "true"
+			} else {
+				ts.Env["K6_NO_USAGE_REPORT"] = "false"
+			}
 			ts.Env[state.UsageReportURL] = reportServer.URL
 			if tc.catalog != "" {
 				catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					catalogHit.Store(true)
 					w.Header().Set("Content-Type", "application/json")
 					_, _ = w.Write([]byte(tc.catalog))
 				}))
@@ -193,6 +209,12 @@ func TestRunReportsExtensions(t *testing.T) {
 			ts.Stdin = bytes.NewBufferString(tc.script)
 
 			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			if tc.optOut {
+				require.False(t, reported.Load(), "expected the opt-out to suppress the usage report")
+				require.False(t, catalogHit.Load(), "expected the opt-out to suppress the catalog fetch")
+				return
+			}
 
 			require.True(t, reported.Load(), "expected the usage report to reach the configured endpoint")
 

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -1,0 +1,49 @@
+package tests
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/internal/cmd"
+)
+
+func TestRunReportsExtensions(t *testing.T) {
+	t.Parallel()
+
+	tt := []struct {
+		name string
+	}{
+		{name: "sends the usage report to the configured endpoint"},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var reported atomic.Bool
+			reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					reported.Store(true)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(reportServer.Close)
+
+			ts := NewGlobalTestState(t)
+			ts.Env["K6_NO_USAGE_REPORT"] = "false"
+			ts.Env[state.UsageReportURL] = reportServer.URL
+			ts.CmdArgs = []string{"k6", "run", "-"}
+			ts.Stdin = bytes.NewBufferString(`export default function() {};`)
+
+			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			require.True(t, reported.Load(), "expected the usage report to reach the configured endpoint")
+		})
+	}
+}

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -88,6 +88,7 @@ func TestRunReportsExtensions(t *testing.T) {
 		optOut              bool
 		wantExtensions      []map[string]any
 		wantNoExtensionsKey bool
+		wantOutputs         []any
 	}{
 		{
 			name:   "sends the usage report to the configured endpoint",
@@ -153,6 +154,16 @@ func TestRunReportsExtensions(t *testing.T) {
 					"kind":    "output",
 				},
 			},
+		},
+		{
+			// A built-in output is classified by the built-in output enum and never
+			// enters the extensions bucket, so it is absent from "extensions" yet
+			// still listed under "outputs".
+			name:                "built-in output is not an extension",
+			args:                []string{"--out", "json"},
+			script:              `export default function() {};`,
+			wantNoExtensionsKey: true,
+			wantOutputs:         []any{"json"},
 		},
 		{
 			// The output extension is used but its module path is absent from the
@@ -256,6 +267,20 @@ func TestRunReportsExtensions(t *testing.T) {
 			}
 
 			require.True(t, reported.Load(), "expected the usage report to reach the configured endpoint")
+
+			if tc.wantOutputs != nil {
+				raw, ok := gotBody.Load().([]byte)
+				require.True(t, ok, "expected a report body")
+				var report struct {
+					Outputs    []any            `json:"outputs"`
+					Extensions []map[string]any `json:"extensions"`
+				}
+				require.NoError(t, json.Unmarshal(raw, &report))
+				require.Equal(t, tc.wantOutputs, report.Outputs, "expected the built-in output to stay listed under outputs")
+				for _, e := range report.Extensions {
+					require.NotEqual(t, "output", e["kind"], "expected no output-kind extension entry for a built-in output")
+				}
+			}
 
 			if tc.wantNoExtensionsKey {
 				raw, ok := gotBody.Load().([]byte)

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -61,15 +61,22 @@ func TestRunReportsExtensions(t *testing.T) {
 	registerRunReportTestExtensions(t)
 
 	tt := []struct {
-		name           string
-		args           []string
-		script         string
-		catalog        string
-		wantExtensions []map[string]any
+		name                string
+		args                []string
+		script              string
+		catalog             string
+		wantExtensions      []map[string]any
+		wantNoExtensionsKey bool
 	}{
 		{
 			name:   "sends the usage report to the configured endpoint",
 			script: `export default function() {};`,
+		},
+		{
+			name:                "compiled but unused extension omits the extensions key",
+			script:              `export default function() {};`,
+			catalog:             `{"k6/x/testimport": {"module":"` + testImportModule + `"}}`,
+			wantNoExtensionsKey: true,
 		},
 		{
 			name:    "used public import is reported",
@@ -161,6 +168,16 @@ func TestRunReportsExtensions(t *testing.T) {
 			cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 			require.True(t, reported.Load(), "expected the usage report to reach the configured endpoint")
+
+			if tc.wantNoExtensionsKey {
+				raw, ok := gotBody.Load().([]byte)
+				require.True(t, ok, "expected a report body")
+				var report map[string]json.RawMessage
+				require.NoError(t, json.Unmarshal(raw, &report))
+				_, present := report["extensions"]
+				require.False(t, present, "expected no extensions key when nothing catalogued was used")
+				return
+			}
 
 			if tc.wantExtensions == nil {
 				return

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -18,6 +18,8 @@ import (
 	"go.k6.io/k6/v2/internal/cmd/tests/testfork"
 	"go.k6.io/k6/v2/internal/cmd/tests/testimport2"
 	"go.k6.io/k6/v2/js/modules"
+	"go.k6.io/k6/v2/metrics"
+	"go.k6.io/k6/v2/output"
 )
 
 // testImportModule is the resolved module path of the in-tree k6/x/testimport
@@ -30,6 +32,20 @@ const testImportModule = "go.k6.io/k6/v2/internal/cmd/tests"
 // extension. Its module type lives in its own Go package, so it resolves to a
 // distinct path from testImportModule.
 const testImportModule2 = "go.k6.io/k6/v2/internal/cmd/tests/testimport2"
+
+// newReportTestOutput is the output extension constructor registered under the
+// "testoutput" name. Its resolved module path is the runtime name of this
+// function, read back via ext.Get(ext.OutputExtension)["testoutput"].Path.
+func newReportTestOutput(output.Params) (output.Output, error) {
+	return reportTestOutput{}, nil
+}
+
+type reportTestOutput struct{}
+
+func (reportTestOutput) Description() string                        { return "testoutput" }
+func (reportTestOutput) Start() error                               { return nil }
+func (reportTestOutput) AddMetricSamples([]metrics.SampleContainer) {}
+func (reportTestOutput) Stop() error                                { return nil }
 
 type runReportTestModule struct{}
 
@@ -54,6 +70,7 @@ func registerRunReportTestExtensions(t *testing.T) {
 		modules.Register("k6/x/testimport", &runReportTestModule{})
 		modules.Register("k6/x/testimport2", &testimport2.Module{})
 		modules.Register("k6/x/testfork", &testfork.Module{})
+		output.RegisterExtension("testoutput", newReportTestOutput)
 	})
 }
 
@@ -121,6 +138,19 @@ func TestRunReportsExtensions(t *testing.T) {
 					"module":  testImportModule2,
 					"version": ext.Get(ext.JSExtension)["k6/x/testimport2"].Version,
 					"kind":    "js",
+				},
+			},
+		},
+		{
+			name:    "selected output extension is reported",
+			args:    []string{"--out", "testoutput"},
+			script:  `export default function() {};`,
+			catalog: `{"testoutput": {"module":"` + ext.Get(ext.OutputExtension)["testoutput"].Path + `"}}`,
+			wantExtensions: []map[string]any{
+				{
+					"module":  ext.Get(ext.OutputExtension)["testoutput"].Path,
+					"version": ext.Get(ext.OutputExtension)["testoutput"].Version,
+					"kind":    "output",
 				},
 			},
 		},

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -155,6 +155,15 @@ func TestRunReportsExtensions(t *testing.T) {
 			},
 		},
 		{
+			// The output extension is used but its module path is absent from the
+			// catalog, so the shared filter must drop it just like a JS import.
+			name:                "output extension not in the catalog is dropped",
+			args:                []string{"--out", "testoutput"},
+			script:              `export default function() {};`,
+			catalog:             `{"k6/x/testimport": {"module":"` + testImportModule + `"}}`,
+			wantNoExtensionsKey: true,
+		},
+		{
 			name:    "extension not in the catalog is filtered out",
 			script:  `import "k6/x/testimport"; import "k6/x/testimport2"; export default function() {};`,
 			catalog: `{"k6/x/testimport2": {"module":"` + testImportModule2 + `"}}`,

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -2,24 +2,98 @@ package tests
 
 import (
 	"bytes"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/ext"
 	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/internal/cmd/tests/testimport2"
+	"go.k6.io/k6/v2/js/modules"
 )
+
+// testImportModule is the resolved module path of the in-tree k6/x/testimport
+// extension registered by registerRunReportTestExtensions. It is whatever
+// ext.Get(ext.JSExtension)["k6/x/testimport"].Path returns for an in-tree
+// registration, i.e. this test package's own Go package path.
+const testImportModule = "go.k6.io/k6/v2/internal/cmd/tests"
+
+// testImportModule2 is the resolved module path of the in-tree k6/x/testimport2
+// extension. Its module type lives in its own Go package, so it resolves to a
+// distinct path from testImportModule.
+const testImportModule2 = "go.k6.io/k6/v2/internal/cmd/tests/testimport2"
+
+type runReportTestModule struct{}
+
+func (*runReportTestModule) NewModuleInstance(_ modules.VU) modules.Instance {
+	return &runReportTestModuleInstance{}
+}
+
+type runReportTestModuleInstance struct{}
+
+func (*runReportTestModuleInstance) Exports() modules.Exports {
+	return modules.Exports{Named: map[string]any{}}
+}
+
+// registerRunReportTestExtensionsOnce guards process-global ext.Register, which
+// panics on a duplicate name/type.
+var registerRunReportTestExtensionsOnce sync.Once //nolint:gochecknoglobals
+
+func registerRunReportTestExtensions(t *testing.T) {
+	t.Helper()
+
+	registerRunReportTestExtensionsOnce.Do(func() {
+		modules.Register("k6/x/testimport", &runReportTestModule{})
+		modules.Register("k6/x/testimport2", &testimport2.Module{})
+	})
+}
 
 func TestRunReportsExtensions(t *testing.T) {
 	t.Parallel()
 
+	registerRunReportTestExtensions(t)
+
 	tt := []struct {
-		name string
+		name           string
+		script         string
+		catalog        string
+		wantExtensions []map[string]any
 	}{
-		{name: "sends the usage report to the configured endpoint"},
+		{
+			name:   "sends the usage report to the configured endpoint",
+			script: `export default function() {};`,
+		},
+		{
+			name:    "used public import is reported",
+			script:  `import "k6/x/testimport"; export default function() {};`,
+			catalog: `{"k6/x/testimport": {"module":"` + testImportModule + `"}}`,
+			wantExtensions: []map[string]any{
+				{
+					"module":  testImportModule,
+					"version": ext.Get(ext.JSExtension)["k6/x/testimport"].Version,
+					"kind":    "js",
+				},
+			},
+		},
+		{
+			name:    "extension not in the catalog is filtered out",
+			script:  `import "k6/x/testimport"; import "k6/x/testimport2"; export default function() {};`,
+			catalog: `{"k6/x/testimport2": {"module":"` + testImportModule2 + `"}}`,
+			wantExtensions: []map[string]any{
+				{
+					"module":  testImportModule2,
+					"version": ext.Get(ext.JSExtension)["k6/x/testimport2"].Version,
+					"kind":    "js",
+				},
+			},
+		},
 	}
 
 	for _, tc := range tt {
@@ -27,8 +101,11 @@ func TestRunReportsExtensions(t *testing.T) {
 			t.Parallel()
 
 			var reported atomic.Bool
+			var gotBody atomic.Value
 			reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method == http.MethodPost {
+					body, _ := io.ReadAll(r.Body)
+					gotBody.Store(body)
 					reported.Store(true)
 				}
 				w.WriteHeader(http.StatusOK)
@@ -38,12 +115,32 @@ func TestRunReportsExtensions(t *testing.T) {
 			ts := NewGlobalTestState(t)
 			ts.Env["K6_NO_USAGE_REPORT"] = "false"
 			ts.Env[state.UsageReportURL] = reportServer.URL
+			if tc.catalog != "" {
+				catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(tc.catalog))
+				}))
+				t.Cleanup(catalogServer.Close)
+				ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
+			}
 			ts.CmdArgs = []string{"k6", "run", "-"}
-			ts.Stdin = bytes.NewBufferString(`export default function() {};`)
+			ts.Stdin = bytes.NewBufferString(tc.script)
 
 			cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 			require.True(t, reported.Load(), "expected the usage report to reach the configured endpoint")
+
+			if tc.wantExtensions == nil {
+				return
+			}
+
+			raw, ok := gotBody.Load().([]byte)
+			require.True(t, ok, "expected a report body")
+			var report struct {
+				Extensions []map[string]any `json:"extensions"`
+			}
+			require.NoError(t, json.Unmarshal(raw, &report))
+			require.ElementsMatch(t, tc.wantExtensions, report.Extensions)
 		})
 	}
 }

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -62,6 +62,7 @@ func TestRunReportsExtensions(t *testing.T) {
 
 	tt := []struct {
 		name           string
+		args           []string
 		script         string
 		catalog        string
 		wantExtensions []map[string]any
@@ -72,6 +73,19 @@ func TestRunReportsExtensions(t *testing.T) {
 		},
 		{
 			name:    "used public import is reported",
+			script:  `import "k6/x/testimport"; export default function() {};`,
+			catalog: `{"k6/x/testimport": {"module":"` + testImportModule + `"}}`,
+			wantExtensions: []map[string]any{
+				{
+					"module":  testImportModule,
+					"version": ext.Get(ext.JSExtension)["k6/x/testimport"].Version,
+					"kind":    "js",
+				},
+			},
+		},
+		{
+			name:    "module imported by many VUs is reported once",
+			args:    []string{"--vus", "5", "--iterations", "5"},
 			script:  `import "k6/x/testimport"; export default function() {};`,
 			catalog: `{"k6/x/testimport": {"module":"` + testImportModule + `"}}`,
 			wantExtensions: []map[string]any{
@@ -123,7 +137,8 @@ func TestRunReportsExtensions(t *testing.T) {
 				t.Cleanup(catalogServer.Close)
 				ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
 			}
-			ts.CmdArgs = []string{"k6", "run", "-"}
+			ts.CmdArgs = append([]string{"k6", "run"}, tc.args...)
+			ts.CmdArgs = append(ts.CmdArgs, "-")
 			ts.Stdin = bytes.NewBufferString(tc.script)
 
 			cmd.ExecuteWithGlobalState(ts.GlobalState)

--- a/internal/cmd/tests/cmd_subcommand_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_report_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/errext/exitcodes"
 	"go.k6.io/k6/v2/ext"
 	"go.k6.io/k6/v2/internal/cmd"
 	"go.k6.io/k6/v2/subcommand"
@@ -45,10 +46,13 @@ func TestSubcommandReportsUsage(t *testing.T) {
 	testSubModule := ext.Get(ext.SubcommandExtension)["testsub"].Path
 
 	tt := []struct {
-		name           string
-		args           []string
-		catalog        string
-		wantExtensions []map[string]any
+		name               string
+		args               []string
+		catalog            string
+		unreachableCatalog bool
+		wantNoReport       bool
+		wantExitCode       int
+		wantExtensions     []map[string]any
 	}{
 		{
 			name:    "catalogued subcommand run is reported",
@@ -68,6 +72,16 @@ func TestSubcommandReportsUsage(t *testing.T) {
 			catalog:        `{"other": {"subcommands":["other"],"module":"example.com/x-other"}}`,
 			wantExtensions: nil,
 		},
+		{
+			// An unregistered name cannot be provisioned from an unreachable
+			// catalog, so the host builds no command for it and the wrapped hook
+			// never runs. Neither the report endpoint nor the catalog is consulted.
+			name:               "unknown subcommand is not reported",
+			args:               []string{"x", "not-a-catalog-name"},
+			unreachableCatalog: true,
+			wantNoReport:       true,
+			wantExitCode:       int(exitcodes.ScriptException),
+		},
 	}
 
 	for _, tc := range tt {
@@ -86,21 +100,41 @@ func TestSubcommandReportsUsage(t *testing.T) {
 			}))
 			t.Cleanup(reportServer.Close)
 
+			var catalogHit atomic.Bool
+
 			ts := NewGlobalTestState(t)
 			ts.Env["K6_NO_USAGE_REPORT"] = "false"
 			ts.Env[state.UsageReportURL] = reportServer.URL
 			if tc.catalog != "" {
 				catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					catalogHit.Store(true)
 					w.Header().Set("Content-Type", "application/json")
 					_, _ = w.Write([]byte(tc.catalog))
 				}))
 				t.Cleanup(catalogServer.Close)
 				ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
 			}
+			if tc.unreachableCatalog {
+				// Close the server immediately so its URL refuses connections.
+				catalogServer := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+					catalogHit.Store(true)
+				}))
+				catalogServer.Close()
+				ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
+				// Keep the provisioning attempt off the real build service.
+				ts.Env["K6_BUILD_SERVICE_URL"] = "http://127.0.0.1:1/unreachable"
+			}
+			ts.ExpectedExitCode = tc.wantExitCode
 			ts.CmdArgs = append([]string{"k6"}, tc.args...)
 			ts.ReparseFlags()
 
 			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			if tc.wantNoReport {
+				require.Equal(t, int32(0), reportCount.Load(), "expected no usage report for an unknown subcommand")
+				require.False(t, catalogHit.Load(), "expected no catalog request for an unknown subcommand")
+				return
+			}
 
 			require.Equal(t, int32(1), reportCount.Load(), "expected exactly one usage report")
 

--- a/internal/cmd/tests/cmd_subcommand_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_report_test.go
@@ -1,0 +1,110 @@
+package tests
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/ext"
+	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/subcommand"
+)
+
+// registerReportTestSubcommandOnce guards process-global ext.Register, which
+// panics on a duplicate name/type.
+var registerReportTestSubcommandOnce sync.Once //nolint:gochecknoglobals
+
+func registerReportTestSubcommand(t *testing.T) {
+	t.Helper()
+
+	registerReportTestSubcommandOnce.Do(func() {
+		subcommand.RegisterExtension("testsub", func(*state.GlobalState) *cobra.Command {
+			return &cobra.Command{
+				Use: "testsub",
+				Run: func(*cobra.Command, []string) {},
+			}
+		})
+	})
+}
+
+func TestSubcommandReportsUsage(t *testing.T) {
+	t.Parallel()
+
+	registerReportTestSubcommand(t)
+
+	// The subcommand constructor is an in-tree func, so its resolved module path
+	// is the constructor's runtime name in this test package.
+	testSubModule := ext.Get(ext.SubcommandExtension)["testsub"].Path
+
+	tt := []struct {
+		name           string
+		args           []string
+		catalog        string
+		wantExtensions []map[string]any
+	}{
+		{
+			name:    "catalogued subcommand run is reported",
+			args:    []string{"x", "testsub"},
+			catalog: `{"testsub": {"subcommands":["testsub"],"module":"` + testSubModule + `"}}`,
+			wantExtensions: []map[string]any{
+				{
+					"module":  testSubModule,
+					"version": ext.Get(ext.SubcommandExtension)["testsub"].Version,
+					"kind":    "subcommand",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var reportCount atomic.Int32
+			var gotBody atomic.Value
+			reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					body, _ := io.ReadAll(r.Body)
+					gotBody.Store(body)
+					reportCount.Add(1)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(reportServer.Close)
+
+			ts := NewGlobalTestState(t)
+			ts.Env["K6_NO_USAGE_REPORT"] = "false"
+			ts.Env[state.UsageReportURL] = reportServer.URL
+			if tc.catalog != "" {
+				catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = w.Write([]byte(tc.catalog))
+				}))
+				t.Cleanup(catalogServer.Close)
+				ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
+			}
+			ts.CmdArgs = append([]string{"k6"}, tc.args...)
+			ts.ReparseFlags()
+
+			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			require.Equal(t, int32(1), reportCount.Load(), "expected exactly one usage report")
+
+			raw, ok := gotBody.Load().([]byte)
+			require.True(t, ok, "expected a report body")
+			var report struct {
+				Extensions []map[string]any `json:"extensions"`
+			}
+			require.NoError(t, json.Unmarshal(raw, &report))
+			require.ElementsMatch(t, tc.wantExtensions, report.Extensions)
+		})
+	}
+}

--- a/internal/cmd/tests/cmd_subcommand_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_report_test.go
@@ -62,6 +62,12 @@ func TestSubcommandReportsUsage(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:           "subcommand absent from catalog is dropped",
+			args:           []string{"x", "testsub"},
+			catalog:        `{"other": {"subcommands":["other"],"module":"example.com/x-other"}}`,
+			wantExtensions: nil,
+		},
 	}
 
 	for _, tc := range tt {

--- a/internal/cmd/tests/cmd_subcommand_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_report_test.go
@@ -8,7 +8,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
@@ -16,6 +18,7 @@ import (
 	"go.k6.io/k6/v2/errext/exitcodes"
 	"go.k6.io/k6/v2/ext"
 	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/internal/lib/testutils"
 	"go.k6.io/k6/v2/subcommand"
 )
 
@@ -50,6 +53,7 @@ func TestSubcommandReportsUsage(t *testing.T) {
 		args               []string
 		catalog            string
 		unreachableCatalog bool
+		slowReport         bool
 		wantNoReport       bool
 		wantExitCode       int
 		wantExtensions     []map[string]any
@@ -82,6 +86,15 @@ func TestSubcommandReportsUsage(t *testing.T) {
 			wantNoReport:       true,
 			wantExitCode:       int(exitcodes.ScriptException),
 		},
+		{
+			// A slow report endpoint must not delay or fail the command: the send
+			// is abandoned within the bounded timeout, the command still exits 0,
+			// and only a debug-level log records the failure.
+			name:       "slow endpoint does not delay or fail the command",
+			args:       []string{"x", "testsub", "-v"},
+			catalog:    `{"testsub": {"subcommands":["testsub"],"module":"` + testSubModule + `"}}`,
+			slowReport: true,
+		},
 	}
 
 	for _, tc := range tt {
@@ -90,7 +103,17 @@ func TestSubcommandReportsUsage(t *testing.T) {
 
 			var reportCount atomic.Int32
 			var gotBody atomic.Value
+			released := make(chan struct{})
 			reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if tc.slowReport {
+					// Hang past the bounded timeout so the client abandons the send;
+					// release only at cleanup to avoid leaking the handler goroutine.
+					select {
+					case <-r.Context().Done():
+					case <-released:
+					}
+					return
+				}
 				if r.Method == http.MethodPost {
 					body, _ := io.ReadAll(r.Body)
 					gotBody.Store(body)
@@ -98,7 +121,9 @@ func TestSubcommandReportsUsage(t *testing.T) {
 				}
 				w.WriteHeader(http.StatusOK)
 			}))
+			// Release the hung handler before Close waits on it (cleanups run LIFO).
 			t.Cleanup(reportServer.Close)
+			t.Cleanup(func() { close(released) })
 
 			var catalogHit atomic.Bool
 
@@ -128,7 +153,30 @@ func TestSubcommandReportsUsage(t *testing.T) {
 			ts.CmdArgs = append([]string{"k6"}, tc.args...)
 			ts.ReparseFlags()
 
+			start := time.Now()
 			cmd.ExecuteWithGlobalState(ts.GlobalState)
+			elapsed := time.Since(start)
+
+			if tc.slowReport {
+				// Exit 0 (default, asserted by the harness) with the send abandoned
+				// within the bounded run-report timeout, surfacing the failure only
+				// at debug level.
+				require.Equal(t, int32(0), reportCount.Load(), "expected the slow send to be abandoned")
+				require.Less(t, elapsed, 10*time.Second, "expected the slow send to be abandoned within the bounded timeout")
+
+				entries := ts.LoggerHook.Drain()
+				require.True(t,
+					testutils.LogContains(entries, logrus.DebugLevel, "Error sending usage report"),
+					"expected a debug-level log for the failed usage report",
+				)
+				for _, e := range entries {
+					if e.Level < logrus.DebugLevel {
+						require.NotContains(t, e.Message, "usage report",
+							"expected the report failure to surface only at debug level")
+					}
+				}
+				return
+			}
 
 			if tc.wantNoReport {
 				require.Equal(t, int32(0), reportCount.Load(), "expected no usage report for an unknown subcommand")

--- a/internal/cmd/tests/cmd_subcommand_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_report_test.go
@@ -54,6 +54,8 @@ func TestSubcommandReportsUsage(t *testing.T) {
 		catalog            string
 		unreachableCatalog bool
 		slowReport         bool
+		optOut             bool
+		autoOff            bool
 		wantNoReport       bool
 		wantExitCode       int
 		wantExtensions     []map[string]any
@@ -95,6 +97,18 @@ func TestSubcommandReportsUsage(t *testing.T) {
 			catalog:    `{"testsub": {"subcommands":["testsub"],"module":"` + testSubModule + `"}}`,
 			slowReport: true,
 		},
+		{
+			// The existing opt-out gates the subcommand report too, so neither the
+			// report endpoint nor the catalog is consulted by the telemetry path
+			// even though the wrapped subcommand body still runs. Auto-resolution is
+			// off so the unrelated `k6 x` stub listing never touches the catalog,
+			// leaving the report as the only possible catalog consumer.
+			name:    "opt-out suppresses the subcommand report",
+			args:    []string{"x", "testsub"},
+			catalog: `{"testsub": {"subcommands":["testsub"],"module":"` + testSubModule + `"}}`,
+			optOut:  true,
+			autoOff: true,
+		},
 	}
 
 	for _, tc := range tt {
@@ -128,7 +142,14 @@ func TestSubcommandReportsUsage(t *testing.T) {
 			var catalogHit atomic.Bool
 
 			ts := NewGlobalTestState(t)
-			ts.Env["K6_NO_USAGE_REPORT"] = "false"
+			if tc.optOut {
+				ts.Env["K6_NO_USAGE_REPORT"] = "true"
+			} else {
+				ts.Env["K6_NO_USAGE_REPORT"] = "false"
+			}
+			if tc.autoOff {
+				ts.Env[state.AutoExtensionResolution] = "false"
+			}
 			ts.Env[state.UsageReportURL] = reportServer.URL
 			if tc.catalog != "" {
 				catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -175,6 +196,12 @@ func TestSubcommandReportsUsage(t *testing.T) {
 							"expected the report failure to surface only at debug level")
 					}
 				}
+				return
+			}
+
+			if tc.optOut {
+				require.Equal(t, int32(0), reportCount.Load(), "expected the opt-out to suppress the usage report")
+				require.False(t, catalogHit.Load(), "expected the opt-out to suppress the catalog fetch")
 				return
 			}
 

--- a/internal/cmd/tests/testfork/testfork.go
+++ b/internal/cmd/tests/testfork/testfork.go
@@ -1,0 +1,23 @@
+// Package testfork hosts an in-tree JS module type in its own Go package so it
+// resolves to a distinct module path from the k6/x/testimport extension. It
+// stands in for a private fork registered under a public import name: the
+// catalog advertises the real extension's module path for that name, while this
+// fork resolves to its own path, so matching by module path drops it.
+package testfork
+
+import "go.k6.io/k6/v2/js/modules"
+
+// Module is a no-op JS module used only to register a fork extension whose
+// module path differs from the catalogued one.
+type Module struct{}
+
+// NewModuleInstance implements modules.Module.
+func (*Module) NewModuleInstance(_ modules.VU) modules.Instance {
+	return &instance{}
+}
+
+type instance struct{}
+
+func (*instance) Exports() modules.Exports {
+	return modules.Exports{Named: map[string]any{}}
+}

--- a/internal/cmd/tests/testimport2/testimport2.go
+++ b/internal/cmd/tests/testimport2/testimport2.go
@@ -1,0 +1,21 @@
+// Package testimport2 hosts a second in-tree JS module type in its own Go
+// package so it resolves to a distinct module path from the k6/x/testimport
+// extension. Two module types in the same package would share one path and get
+// de-duplicated, which would hide slot-overwrite or over-dedup bugs.
+package testimport2
+
+import "go.k6.io/k6/v2/js/modules"
+
+// Module is a no-op JS module used only to register a second distinct extension.
+type Module struct{}
+
+// NewModuleInstance implements modules.Module.
+func (*Module) NewModuleInstance(_ modules.VU) modules.Instance {
+	return &instance{}
+}
+
+type instance struct{}
+
+func (*instance) Exports() modules.Exports {
+	return modules.Exports{Named: map[string]any{}}
+}

--- a/internal/cmd/x_registry.go
+++ b/internal/cmd/x_registry.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -69,6 +70,12 @@ func catalogMajorVersion() string {
 	return v
 }
 
+// catalogURL returns the extension registry catalog URL, honouring the
+// K6_PROVISION_CATALOG_URL override.
+func catalogURL(gs *state.GlobalState) string {
+	return cmp.Or(gs.Env[state.ProvisionCatalogURL], defaultCatalogURL())
+}
+
 // catalogCachePath returns the on-disk location of the k6 extension registry
 // catalog cache, alongside the build cache so both share the user cache dir.
 func catalogCachePath(gs *state.GlobalState) string {
@@ -79,23 +86,9 @@ func catalogCachePath(gs *state.GlobalState) string {
 // cache. A missing or stale cache returns (nil, nil); real I/O or parse
 // failures return an error so the caller can surface them at debug.
 func readCachedCatalog(gs *state.GlobalState, cachePath string) (registrySubcommands, error) {
-	maxAge := 24 * time.Hour
-	if d, err := time.ParseDuration(gs.Env[state.ProvisionCatalogTTL]); err == nil {
-		maxAge = d
-	}
-	info, err := gs.FS.Stat(cachePath)
-	if errors.Is(err, fs.ErrNotExist) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("checking extensions cache: %w", err)
-	}
-	if time.Since(info.ModTime()) > maxAge {
-		return nil, nil
-	}
-	raw, err := fsext.ReadFile(gs.FS, cachePath)
-	if err != nil {
-		return nil, fmt.Errorf("reading extensions cache: %w", err)
+	raw, err := readCachedCatalogBytes(gs, cachePath)
+	if raw == nil || err != nil {
+		return nil, err
 	}
 	var subs registrySubcommands
 	if err := json.Unmarshal(raw, &subs); err != nil {
@@ -134,6 +127,86 @@ func fetchCatalog(ctx context.Context, url string) (registrySubcommands, []byte,
 		return nil, nil, fmt.Errorf("parsing extensions catalog: %w", err)
 	}
 	return subs, raw, nil
+}
+
+// catalogModulePaths returns the set of Go module paths advertised in the k6
+// extension registry catalog. It shares the same cache file, TTL, and
+// K6_PROVISION_CATALOG_URL override as `k6 x`: it reads the on-disk cache and,
+// on a miss, fetches the catalog and writes the fresh bytes back. The caller
+// bounds ctx so the fetch stays non-fatal and off the run's hot path; any
+// failure yields an empty set.
+func catalogModulePaths(ctx context.Context, gs *state.GlobalState) map[string]struct{} {
+	cachePath := catalogCachePath(gs)
+	raw, err := readCachedCatalogBytes(gs, cachePath)
+	if err != nil {
+		gs.Logger.WithError(err).Debug("k6 extension catalog")
+	}
+	if raw == nil {
+		raw, err = fetchCatalogBytes(ctx, gs, cachePath)
+		if err != nil {
+			gs.Logger.WithError(err).Debug("k6 extension catalog")
+			return nil
+		}
+	}
+	return parseCatalogModulePaths(raw)
+}
+
+// readCachedCatalogBytes returns the raw catalog cache bytes when the cache
+// exists and is fresh, honouring the K6_PROVISION_CATALOG_TTL override. A miss
+// (absent or stale cache) returns (nil, nil); real I/O failures return an
+// error so the caller can surface them at debug.
+func readCachedCatalogBytes(gs *state.GlobalState, cachePath string) ([]byte, error) {
+	maxAge := 24 * time.Hour
+	if d, err := time.ParseDuration(gs.Env[state.ProvisionCatalogTTL]); err == nil {
+		maxAge = d
+	}
+	info, err := gs.FS.Stat(cachePath)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("checking extensions cache: %w", err)
+	}
+	if time.Since(info.ModTime()) > maxAge {
+		return nil, nil
+	}
+	raw, err := fsext.ReadFile(gs.FS, cachePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading extensions cache: %w", err)
+	}
+	return raw, nil
+}
+
+// fetchCatalogBytes downloads the catalog exactly as `k6 x` does, honouring the
+// K6_PROVISION_CATALOG_URL override, and writes the fresh bytes to the cache.
+func fetchCatalogBytes(ctx context.Context, gs *state.GlobalState, cachePath string) ([]byte, error) {
+	_, raw, err := fetchCatalog(ctx, catalogURL(gs))
+	if err != nil {
+		return nil, err
+	}
+	if err := writeCachedCatalog(gs, cachePath, raw); err != nil {
+		gs.Logger.WithError(err).Debug("k6 extension catalog")
+	}
+	return raw, nil
+}
+
+// parseCatalogModulePaths reads the per-entry "module" field the
+// registrySubcommands decoder drops, collecting each catalog entry's Go module
+// path into a set. Entries without a module path are skipped.
+func parseCatalogModulePaths(raw []byte) map[string]struct{} {
+	var catalog map[string]struct {
+		Module string `json:"module"`
+	}
+	if err := json.Unmarshal(raw, &catalog); err != nil {
+		return nil
+	}
+	paths := make(map[string]struct{}, len(catalog))
+	for _, e := range catalog {
+		if e.Module != "" {
+			paths[e.Module] = struct{}{}
+		}
+	}
+	return paths
 }
 
 // writeCachedCatalog persists raw catalog bytes under cachePath, creating any

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -45,6 +45,30 @@ func (u *Usage) Strings(originalKey, value string) error {
 	return nil
 }
 
+// Values appends the provided value to a slice of values that is the value,
+// like Strings but for arbitrary values, so callers can record structured usage
+// without Usage knowing their types. It also works out level of keys.
+func (u *Usage) Values(originalKey string, value any) error {
+	u.l.Lock()
+	defer u.l.Unlock()
+	m, newKey, err := u.createLevel(originalKey)
+	if err != nil {
+		return err
+	}
+	oldV, ok := m[newKey]
+	if !ok {
+		m[newKey] = []any{value}
+		return nil
+	}
+	switch oldValue := oldV.(type) {
+	case []any:
+		m[newKey] = append(oldValue, value)
+	default:
+		return fmt.Errorf("value of key %s is not []any as expected but %T", originalKey, oldValue)
+	}
+	return nil
+}
+
 // Uint64 adds the provided value to a given key. Creating the key if needed and working out levels of keys
 func (u *Usage) Uint64(originalKey string, value uint64) error {
 	u.l.Lock()

--- a/js/modules/resolution.go
+++ b/js/modules/resolution.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/sobek/ast"
 	"github.com/sirupsen/logrus"
 
+	"go.k6.io/k6/v2/ext"
 	"go.k6.io/k6/v2/internal/js/compiler"
 	"go.k6.io/k6/v2/internal/loader"
 	"go.k6.io/k6/v2/internal/usage"
@@ -78,12 +79,17 @@ func (mr *ModuleResolver) initializeGoModule(name string) (sobek.ModuleRecord, e
 		mr.unknownModules = append(mr.unknownModules, name)
 		return &unknownModule{name: name, requested: make(map[string]struct{})}, nil
 	}
-	// we don't want to report extensions and we would have hit cache if this isn't the first time
-	if !strings.HasPrefix(name, "k6/x/") {
-		err := mr.usage.Strings("modules", name)
-		if err != nil {
-			mr.logger.WithError(err).Warnf("Error while reporting usage of module %q", name)
+	// We would have hit the cache if this isn't the first time, so each distinct
+	// module is recorded once. An extension is identified by membership in the
+	// extension registry, not by its k6/x/ name: its resolved registry entry is
+	// recorded under "extensions" so the report needs no re-resolution, while
+	// built-in modules stay in the "modules" bucket.
+	if e, ok := ext.Get(ext.JSExtension)[name]; ok {
+		if err := mr.usage.Values("extensions", e); err != nil {
+			mr.logger.WithError(err).Warnf("Error while reporting usage of extension %q", name)
 		}
+	} else if err := mr.usage.Strings("modules", name); err != nil {
+		mr.logger.WithError(err).Warnf("Error while reporting usage of module %q", name)
 	}
 	k6m, ok := mod.(Module)
 	if !ok {


### PR DESCRIPTION
## What?

Adds anonymous extension usage to the k6 usage report, covering the three user-facing surfaces:

- An extension (a `k6/x/` module) is reported when a run resolves it, not when it is merely compiled into the binary.
- An output extension is reported when a run selects it with `--out`; built-in outputs are unaffected.
- A subcommand extension is reported when invoked via `k6 x`, whether it exits zero or non-zero.

Each entry carries the extension's Go module path, version, and kind. Only extensions listed in the public registry catalog are reported: matching is by module path, so a private fork reusing a public import name is dropped, and an unreachable catalog reports nothing rather than falling back to unfiltered data. When no cataloged extension was used, the report omits the field entirely. The existing `--no-usage-report` / `K6_NO_USAGE_REPORT` opt-out gates all of it; no new opt-out, no new endpoint, and the send stays bounded and non-fatal: it never fails a command, and a hanging endpoint delays exit by at most 3 seconds, the same bound the `k6 run` report has always had.

## Why?

Extension adoption is a blind spot: the usage report tracks built-in modules but deliberately drops every extension, so decisions about which extensions to promote, maintain, or retire run on guesswork. Cloud-executed runs are partly tracked, while local execution, most OSS usage, stays invisible. Reporting catalog extensions through the same anonymous report k6 already sends closes that gap without a new data category: private and unlisted extensions never appear, xk6-built and provisioned binaries report identically, and a newly cataloged extension becomes reportable as soon as the catalog cache refreshes, with no new k6 release.

## Note

- #6110 holds the requirements, edge cases, and test vectors.
- The output surface ships now but reports nothing in production until the catalog lists output extensions.
- Distinguishing [xk6 builds](https://github.com/grafana/k6/pull/6111) from provisioned binaries is out of scope.
- One new env var, `K6_USAGE_REPORT_URL`, makes the report endpoint overridable so the integration tests can assert on the actually-sent report; catalog membership reuses the existing `K6_PROVISION_CATALOG_URL` override.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Closes #6109
