### PR TITLE
Support externally-provisioned runs in cloud run --local-execution

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -34,19 +34,19 @@ type Config struct {
 	StopOnError    null.Bool   `json:"stopOnError" envconfig:"K6_CLOUD_STOP_ON_ERROR"`
 	APIVersion     null.Int    `json:"apiVersion" envconfig:"K6_CLOUD_API_VERSION"`
 
-	// MetricsPushURL is the explicit URL to push metrics to, returned by
-	// the provisioning API's start_local_execution endpoint. When set, the
-	// cloud Output uses this URL instead of deriving one from Host. Set
-	// programmatically by `cmd/outputs_cloud.go` for the
-	// `k6 cloud run --local-execution` provisioning flow; never set via
-	// env vars or user-facing config.
-	MetricsPushURL null.String `json:"metricsPushURL"`
+	// MetricsPushURL is the URL to push metrics to. In the self-provision
+	// flow it is set programmatically from the provisioning API response;
+	// in the externally-provisioned flow an orchestrator supplies it via
+	// K6_CLOUD_METRICS_PUSH_URL. When set, the cloud Output pushes here
+	// instead of deriving a URL from Host.
+	MetricsPushURL null.String `json:"metricsPushURL" envconfig:"K6_CLOUD_METRICS_PUSH_URL"`
 
-	// TestRunToken is the scoped test-run token returned by the
-	// provisioning API's start_local_execution endpoint. When set, the
-	// cloud Output uses it as the Bearer token for metrics push and notify.
-	// Set programmatically; never set via env vars or user-facing config.
-	TestRunToken null.String `json:"testRunToken"`
+	// TestRunToken is the scoped test-run token used as the Bearer token
+	// for metrics push (and notify, in the self-provision flow). Set
+	// programmatically in the self-provision flow, or supplied via
+	// K6_CLOUD_TEST_RUN_TOKEN by an external orchestrator that provisioned
+	// the run.
+	TestRunToken null.String `json:"testRunToken" envconfig:"K6_CLOUD_TEST_RUN_TOKEN"`
 
 	// PushRefID is the identifier used by k6 Cloud to correlate all the things that
 	// belong to the same test run/execution. Currently, it is equivalent to the test run id.

--- a/cloudapi/config_test.go
+++ b/cloudapi/config_test.go
@@ -57,13 +57,12 @@ func TestConfigApply(t *testing.T) {
 	assert.Equal(t, full, defaults.Apply(full))
 }
 
-// TestConfig_NewFieldsRoundTripThroughJSON also serves as the security
-// regression for "scoped tokens stay in-process": the fields live on
-// cloudapi.Config (which round-trips only via derivedConfig.Collectors[cloud])
-// and NOT on lib.Options (which is serialised into the archive's
-// metadata.json and pushed to the cloud). A new field accidentally added
-// to lib.Options would be serialised into the archive — but the new
-// fields here are on cloudapi.Config, so they cannot leak that way.
+// The scoped test_run_token is short-lived and run-scoped; it is now
+// deliberately accepted via env (K6_CLOUD_TEST_RUN_TOKEN) so an
+// external orchestrator that provisioned the run can hand it to a
+// local k6. It still never touches lib.Options / the archive — the
+// long-lived org token remains the sensitive credential and is
+// unaffected here.
 func TestConfig_NewFieldsRoundTripThroughJSON(t *testing.T) {
 	t.Parallel()
 
@@ -85,22 +84,23 @@ func TestConfig_NewFieldsRoundTripThroughJSON(t *testing.T) {
 	assert.Equal(t, original.TestRunToken, roundTripped.TestRunToken)
 }
 
-func TestConfig_NewFieldsNotPickedUpByEnvconfig(t *testing.T) {
+// TestConfig_NewFieldsFromEnvconfig verifies the scoped push creds are
+// read from the environment via envconfig (K6_CLOUD_METRICS_PUSH_URL /
+// K6_CLOUD_TEST_RUN_TOKEN) so an external orchestrator that provisioned
+// a run can hand them to a local k6.
+func TestConfig_NewFieldsFromEnvconfig(t *testing.T) {
 	t.Parallel()
 
-	// Set env vars with every plausible name a user might guess.
 	envVars := map[string]string{
-		"K6_CLOUD_METRICS_PUSH_URL": "foo",
-		"K6_CLOUD_TEST_RUN_TOKEN":   "bar",
-		"K6_CLOUD_METRICSPUSHURL":   "foo",
-		"K6_CLOUD_TESTRUNTOKEN":     "bar",
+		"K6_CLOUD_METRICS_PUSH_URL": "https://push.example/m",
+		"K6_CLOUD_TEST_RUN_TOKEN":   "scoped-xyz",
 	}
 
 	config, _, err := GetConsolidatedConfig(nil, envVars, "", nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, null.String{}, config.MetricsPushURL)
-	assert.Equal(t, null.String{}, config.TestRunToken)
+	assert.Equal(t, null.StringFrom("https://push.example/m"), config.MetricsPushURL)
+	assert.Equal(t, null.StringFrom("scoped-xyz"), config.TestRunToken)
 }
 
 func TestConfig_Apply_MergesNewFields(t *testing.T) {

--- a/internal/output/cloud/output.go
+++ b/internal/output/cloud/output.go
@@ -224,11 +224,19 @@ func (out *Output) Start() error {
 	if out.testRunID != "" {
 		out.logger.WithField("testRunId", out.testRunID).Debug("Directly pushing metrics without init")
 
-		// Provisioning-mode setup. PushRefID flows don't set
-		// MetricsPushURL, so this block is normally skipped for them.
-		// The explicit !PushRefID.Valid guard is defensive against a
-		// future cmd-layer regression that populates both fields.
-		if out.config.MetricsPushURL.Valid && out.config.TestRunToken.Valid && !out.config.PushRefID.Valid {
+		// Exactly one of the scoped push creds set is a misconfiguration
+		// (typically an external orchestrator that forgot one env var).
+		if out.config.MetricsPushURL.Valid != out.config.TestRunToken.Valid {
+			return fmt.Errorf(
+				"both K6_CLOUD_METRICS_PUSH_URL and K6_CLOUD_TEST_RUN_TOKEN " +
+					"must be set together")
+		}
+
+		// Provisioning-mode push. Armed whenever the scoped push credentials
+		// are present: either k6 self-provisioned (no PushRefID) or an external
+		// service provisioned the run and passed the creds via env (PushRefID
+		// set; that service owns create/start/notify).
+		if out.config.MetricsPushURL.Valid && out.config.TestRunToken.Valid {
 			if err := out.lazyInitProvisioning(); err != nil {
 				return err
 			}
@@ -501,8 +509,12 @@ func (out *Output) lazyInitProvisioning() error {
 		)
 	}
 
-	// Lazy-construct the provisioning notifier (used at end-of-test).
-	if out.provisioningNotifier == nil {
+	// Lazy-construct the provisioning notifier (end-of-test notify).
+	// Skipped when PushRefID is set: an external service owns the run
+	// lifecycle, so k6 never notifies (testFinished returns early on
+	// PushRefID) and the notifier would be unused. Invariant: a nil
+	// notifier with provisioningMode true implies PushRefID is set.
+	if out.provisioningNotifier == nil && !out.config.PushRefID.Valid {
 		// Inline overflow check matches cmd_project_list.go:79-80 pattern
 		// (one cast in scope; local closure pattern would be overkill).
 		// stackID==0 is treated by provisioning.NewClient as "no stack

--- a/internal/output/cloud/output_test.go
+++ b/internal/output/cloud/output_test.go
@@ -494,12 +494,13 @@ func TestOutputStart_ProvisioningMode(t *testing.T) {
 	require.NoError(t, out.StopWithTestError(nil))
 }
 
-// TestOutputStart_PushRefIDStillTakesPrecedence locks in cloud-Output
-// behaviour even if cmd ever populated both PushRefID and MetricsPushURL.
-// In practice, cmd/outputs_cloud.go:96-100 short-circuits on PushRefID
-// before MetricsPushURL is ever set — so this combination shouldn't
-// occur. This test is defensive against future cmd-layer regressions.
-func TestOutputStart_PushRefIDStillTakesPrecedence(t *testing.T) {
+// TestOutputStart_ExternallyProvisioned covers the flow where an
+// external service provisioned the run and passes the scoped push
+// creds (MetricsPushURL + TestRunToken) plus PushRefID via env. k6
+// must push to the provisioning URL with the scoped token but must
+// NOT build a notifier — the external service owns create/start/
+// notify (see testFinished, which returns early on PushRefID).
+func TestOutputStart_ExternallyProvisioned(t *testing.T) {
 	t.Parallel()
 
 	cfgJSON, err := json.Marshal(cloudapi.Config{
@@ -529,18 +530,122 @@ func TestOutputStart_PushRefIDStillTakesPrecedence(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Inject a metrics-pusher mock so Start arms the provisioning push
+	// without constructing a real HTTP client (mirrors
+	// TestOutputStart_ProvisioningMode). provisioningNotifier is left nil
+	// to prove lazyInitProvisioning skips it when PushRefID is set.
+	out.metricsPusher = &metricsPusherMock{}
+
 	require.NoError(t, out.Start())
 
-	// PushRefID should win: testRunID should be set to the PushRefID value,
-	// not the testRunID from env.
+	// PushRefID still supplies the test run id.
 	assert.Equal(t, "99999", out.testRunID)
 
-	// The metricsPusher field should remain nil — provisioning mode was NOT
-	// entered because PushRefID took precedence.
-	assert.Nil(t, out.metricsPusher, "metricsPusher should be nil when PushRefID takes precedence")
-	assert.Nil(t, out.provisioningNotifier, "provisioningNotifier should be nil when PushRefID takes precedence")
+	// Provisioning push is armed on scoped-cred presence, even with PushRefID.
+	assert.True(t, out.provisioningMode)
+	assert.NotNil(t, out.metricsPusher)
+
+	// No notifier: the external service owns the run lifecycle.
+	assert.Nil(t, out.provisioningNotifier)
 
 	require.NoError(t, out.StopWithTestError(nil))
+}
+
+// TestOutputStart_ExternalProvisioned_RequiresBothCreds locks the
+// "no silent legacy fallback on partial config" behaviour: if only one
+// of the scoped push creds is set, Start errors (naming both env vars)
+// instead of quietly falling back to the legacy push endpoint.
+func TestOutputStart_ExternalProvisioned_RequiresBothCreds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		metricsPushURL null.String
+		testRunToken   null.String
+	}{
+		{
+			name:           "only MetricsPushURL set",
+			metricsPushURL: null.StringFrom("https://metrics.example.com/v2/metrics/123"),
+		},
+		{
+			name:         "only TestRunToken set",
+			testRunToken: null.StringFrom("scoped-test-run-token"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfgJSON, err := json.Marshal(cloudapi.Config{
+				Host:                  null.StringFrom("https://fake-cloud"),
+				Token:                 null.StringFrom("fake-token"),
+				PushRefID:             null.StringFrom("99999"),
+				MetricsPushURL:        tc.metricsPushURL,
+				TestRunToken:          tc.testRunToken,
+				APIVersion:            null.IntFrom(2),
+				AggregationPeriod:     types.NullDurationFrom(1 * time.Hour),
+				MetricPushInterval:    types.NullDurationFrom(1 * time.Hour),
+				AggregationWaitPeriod: types.NullDurationFrom(1 * time.Second),
+				MaxTimeSeriesInBatch:  null.IntFrom(1000),
+				MetricPushConcurrency: null.IntFrom(1),
+			})
+			require.NoError(t, err)
+
+			out, err := newOutput(output.Params{
+				Logger:     testutils.NewLogger(t),
+				JSONConfig: cfgJSON,
+				ScriptOptions: lib.Options{
+					Duration:   types.NullDurationFrom(1 * time.Second),
+					SystemTags: &metrics.DefaultSystemTagSet,
+				},
+				ScriptPath: &url.URL{Path: "/script.js"},
+				Usage:      usage.New(),
+			})
+			require.NoError(t, err)
+
+			err = out.Start()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "K6_CLOUD_METRICS_PUSH_URL")
+			assert.Contains(t, err.Error(), "K6_CLOUD_TEST_RUN_TOKEN")
+		})
+	}
+}
+
+// TestOutputStopWithTestError_ExternalProvisioned_NoNotifier locks the
+// invariant "notifier nil ⇒ PushRefID set ⇒ testFinished returns early":
+// with provisioningMode true and a nil notifier, Stop must not panic and
+// must neither notify nor call the legacy TestFinished.
+func TestOutputStopWithTestError_ExternalProvisioned_NoNotifier(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		clientMock := &cloudClientMock{}
+
+		out := &Output{
+			logger:    testutils.NewLogger(t),
+			testRunID: "12345",
+			config: cloudapi.Config{
+				PushRefID:      null.StringFrom("99999"),
+				MetricsPushURL: null.StringFrom("https://metrics.example.com/v2/metrics/123"),
+				TestRunToken:   null.StringFrom("scoped-test-run-token"),
+			},
+			client:               clientMock,
+			provisioningNotifier: nil,
+			provisioningMode:     true,
+		}
+
+		out.versionedOutput = versionedOutputMock{
+			callback: func(_ string) {},
+		}
+
+		// Must not panic even though provisioningNotifier is nil while
+		// provisioningMode is true — testFinished returns early on PushRefID
+		// (so the nil notifier is never dereferenced, and notify never fires).
+		require.NoError(t, out.StopWithTestError(nil))
+
+		// Legacy TestFinished is not called either (PushRefID short-circuit).
+		assert.False(t, clientMock.testFinishedCalled)
+	})
 }
 
 func TestOutputStopWithTestError_ProvisioningMode_NoError(t *testing.T) {


### PR DESCRIPTION
## What?

Follow-up to #6068 (stacked on its branch). Let `k6 cloud run --local-execution` push metrics to a run that an **external service** has already provisioned via the provisioning API, instead of provisioning the run itself.

When an external orchestrator calls `start_local_execution`, then launches local k6 with `K6_CLOUD_PUSH_REF_ID` set (the run id), k6 must push metrics to that run's scoped `push_url` with the scoped `test_run_token`. Today that combination silently falls back to the legacy ingest endpoint with the long-lived org token. Two changes fix it:

1. `cloudapi.Config.MetricsPushURL` and `TestRunToken` gain `envconfig` tags (`K6_CLOUD_METRICS_PUSH_URL`, `K6_CLOUD_TEST_RUN_TOKEN`) so an orchestrator can supply the scoped push credentials via env. They were previously JSON-only, set solely by k6's own provisioning call.
2. The cloud Output's provisioning-mode gate now arms whenever `MetricsPushURL` + `TestRunToken` are present, even when `PushRefID` is set (previously `PushRefID` disabled it). In that externally-provisioned case k6 pushes to the provisioning URL with the scoped token but does **not** construct a notifier — the external service owns the run lifecycle (create/start/notify), which `testFinished` already respects by short-circuiting on `PushRefID`. A half-set credential pair (one env var without the other) is rejected rather than silently using the legacy path.

Behaviour matrix:

| Signal | Push endpoint | Token | Notify |
|---|---|---|---|
| `PushRefID` only (unchanged) | legacy ingest | long-lived | no |
| `PushRefID` + scoped creds (new) | provisioning `push_url` | scoped `test_run_token` | no |
| self-provision, no ref (unchanged) | provisioning `push_url` | scoped | yes |

`k6 run --out cloud` (path B), self-provisioned `--local-execution`, and the plain PushRefID flow are all **unchanged**. Cloud secrets need no code change — an orchestrator configures them via the existing URL secret source env vars (`--secret-source=url` + `K6_SECRET_SOURCE_URL_*`), or passes `--no-cloud-secrets`.

Two atomic commits, each individually buildable + lintable + green.

## Why?

Orchestration services (and future flows such as Synthetic Monitoring) provision the run themselves via the provisioning API and hand local k6 a correlation ref rather than letting k6 self-provision. The provisioning API already returns a per-run `push_url` and a scoped `test_run_token` for exactly this; without this change that externally-provisioned combination falls back to the legacy v1 ingest endpoint with the long-lived org token — defeating the scoped-token model and forcing the long-lived token to be distributed to every local runner.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Stacked on #6068 — base branch is `local-exec-prov-take2`, so this PR's diff is only the incremental change. Review #6068 first; retarget this PR to `master` once #6068 merges.
- Verified end-to-end against a real stack with a dedicated `external-provisioned` manual-test scenario (out-of-band `start_local_execution`, then assert metrics push to `push_url` with `Authorization: Bearer <test_run_token>`, and no self-provision / poll / notify / legacy `/v1/tests`).
