### PR TITLE
Support HTTPS proxy for gRPC

### DIFF
--- a/internal/lib/netext/grpcext/conn.go
+++ b/internal/lib/netext/grpcext/conn.go
@@ -2,10 +2,16 @@
 package grpcext
 
 import (
+	"bufio"
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -31,6 +37,8 @@ import (
 	"google.golang.org/protobuf/types/dynamicpb"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
+
+type proxyFromEnvironmentFunc func(*http.Request) (*url.URL, error)
 
 // InvokeRequest represents a unary gRPC request.
 type InvokeRequest struct {
@@ -82,7 +90,7 @@ type Conn struct {
 // with common options for requests from a VU.
 func DefaultOptions(getState func() *lib.State) []grpc.DialOption {
 	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
-		return getState().Dialer.DialContext(ctx, "tcp", addr)
+		return dialGRPCContext(ctx, getState(), addr)
 	}
 
 	return []grpc.DialOption{
@@ -92,6 +100,137 @@ func DefaultOptions(getState func() *lib.State) []grpc.DialOption {
 		grpc.WithStatsHandler(statsHandler{getState: getState}),
 		grpc.WithContextDialer(dialer),
 	}
+}
+
+func dialGRPCContext(ctx context.Context, state *lib.State, addr string) (net.Conn, error) {
+	return dialGRPCContextWithProxy(ctx, state, addr, http.ProxyFromEnvironment)
+}
+
+func dialGRPCContextWithProxy(
+	ctx context.Context, state *lib.State, addr string, proxyFromEnvironment proxyFromEnvironmentFunc,
+) (net.Conn, error) {
+	proxyURL, err := proxyURLForGRPCTarget(addr, proxyFromEnvironment)
+	if err != nil {
+		return nil, err
+	}
+	if proxyURL == nil {
+		return state.Dialer.DialContext(ctx, "tcp", addr)
+	}
+
+	return dialGRPCContextViaProxy(ctx, state, addr, proxyURL)
+}
+
+func proxyURLForGRPCTarget(addr string, proxyFromEnvironment proxyFromEnvironmentFunc) (*url.URL, error) {
+	req := &http.Request{URL: &url.URL{
+		Scheme: "https",
+		Host:   addr,
+	}}
+	return proxyFromEnvironment(req)
+}
+
+func dialGRPCContextViaProxy(
+	ctx context.Context, state *lib.State, addr string, proxyURL *url.URL,
+) (_ net.Conn, err error) {
+	proxyAddr, err := proxyDialAddress(proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := state.Dialer.DialContext(ctx, "tcp", proxyAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	return doHTTPConnectHandshake(ctx, conn, addr, proxyURL.User)
+}
+
+func proxyDialAddress(proxyURL *url.URL) (string, error) {
+	scheme := proxyURL.Scheme
+	if scheme == "" {
+		scheme = "http"
+	}
+	if scheme != "http" {
+		return "", fmt.Errorf("unsupported grpc proxy scheme %q", scheme)
+	}
+
+	host := proxyURL.Hostname()
+	if host == "" {
+		return "", errors.New("proxy URL has no host")
+	}
+
+	port := proxyURL.Port()
+	if port == "" {
+		port = "80"
+	}
+
+	return net.JoinHostPort(host, port), nil
+}
+
+type proxyBufferConn struct {
+	net.Conn
+	r io.Reader
+}
+
+func (c *proxyBufferConn) Read(b []byte) (int, error) {
+	return c.r.Read(b)
+}
+
+func doHTTPConnectHandshake(
+	ctx context.Context, conn net.Conn, addr string, user *url.Userinfo,
+) (_ net.Conn, err error) {
+	cancelHandshake := context.AfterFunc(ctx, func() {
+		_ = conn.Close()
+	})
+
+	defer func() {
+		if err != nil {
+			_ = conn.Close()
+		}
+		cancelHandshake()
+	}()
+
+	req := (&http.Request{
+		Method: http.MethodConnect,
+		URL:    &url.URL{Host: addr},
+		Host:   addr,
+		Header: make(http.Header),
+	}).WithContext(ctx)
+	if user != nil {
+		username := user.Username()
+		password, _ := user.Password()
+		auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
+		req.Header.Set("Proxy-Authorization", "Basic "+auth)
+	}
+
+	if err := req.Write(conn); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("failed to write proxy CONNECT request: %w", err)
+	}
+
+	reader := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(reader, req) //nolint:bodyclose // CONNECT success returns the tunnel stream.
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("failed to read proxy CONNECT response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("proxy CONNECT failed: %s", resp.Status)
+	}
+	if reader.Buffered() > 0 {
+		if !cancelHandshake() && ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return &proxyBufferConn{Conn: conn, r: reader}, nil
+	}
+
+	if !cancelHandshake() && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
+	return conn, nil
 }
 
 // Dial establish a gRPC connection.

--- a/internal/lib/netext/grpcext/conn.go
+++ b/internal/lib/netext/grpcext/conn.go
@@ -145,12 +145,8 @@ func dialGRPCContextViaProxy(
 }
 
 func proxyDialAddress(proxyURL *url.URL) (string, error) {
-	scheme := proxyURL.Scheme
-	if scheme == "" {
-		scheme = "http"
-	}
-	if scheme != "http" {
-		return "", fmt.Errorf("unsupported grpc proxy scheme %q", scheme)
+	if proxyURL.Scheme != "" && proxyURL.Scheme != "http" {
+		return "", fmt.Errorf("unsupported grpc proxy scheme %q", proxyURL.Scheme)
 	}
 
 	host := proxyURL.Hostname()

--- a/internal/lib/netext/grpcext/conn_test.go
+++ b/internal/lib/netext/grpcext/conn_test.go
@@ -55,7 +55,7 @@ func (healthcheckmock) NewStream(_ context.Context, _ *grpc.StreamDesc, _ string
 	panic("not implemented")
 }
 
-func TestDefaultOptionsUsesHTTPSProxy(t *testing.T) { //nolint:paralleltest // t.Setenv cannot be used in parallel tests.
+func TestDefaultOptionsUsesHTTPSProxy(t *testing.T) {
 	proxyAddr := "proxy.example:3128"
 
 	t.Setenv("HTTPS_PROXY", "http://"+proxyAddr)
@@ -403,6 +403,7 @@ func TestDialGRPCContextUsesHTTPSProxy(t *testing.T) {
 	proxyAddr := "proxy.example:80"
 	proxyURL, err := url.Parse("http://user:pass@proxy.example")
 	require.NoError(t, err)
+	var noProxyURL *url.URL
 
 	proxyFromEnvironment := func(req *http.Request) (*url.URL, error) {
 		assert.Equal(t, "https", req.URL.Scheme)
@@ -411,7 +412,7 @@ func TestDialGRPCContextUsesHTTPSProxy(t *testing.T) {
 		case grpcProxyTargetAddr:
 			return proxyURL, nil
 		case directAddr:
-			return nil, nil
+			return noProxyURL, nil
 		default:
 			return nil, fmt.Errorf("unexpected proxy lookup for %q", req.URL.Host)
 		}

--- a/internal/lib/netext/grpcext/conn_test.go
+++ b/internal/lib/netext/grpcext/conn_test.go
@@ -1,24 +1,37 @@
 package grpcext
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/bufbuild/protocompile"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/v2/lib"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
 	"google.golang.org/protobuf/types/dynamicpb"
 
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
+
+const grpcProxyTargetAddr = "grpc.example:443"
 
 type healthcheckmock func(in *healthpb.HealthCheckRequest, out *healthpb.HealthCheckResponse, opts ...grpc.CallOption) error
 
@@ -40,6 +53,56 @@ func (healthcheckmock) Close() error {
 
 func (healthcheckmock) NewStream(_ context.Context, _ *grpc.StreamDesc, _ string, _ ...grpc.CallOption) (grpc.ClientStream, error) {
 	panic("not implemented")
+}
+
+func TestDefaultOptionsUsesHTTPSProxy(t *testing.T) { //nolint:paralleltest // t.Setenv cannot be used in parallel tests.
+	proxyAddr := "proxy.example:3128"
+
+	t.Setenv("HTTPS_PROXY", "http://"+proxyAddr)
+	t.Setenv("https_proxy", "")
+	t.Setenv("HTTP_PROXY", "")
+	t.Setenv("http_proxy", "")
+	t.Setenv("NO_PROXY", "")
+	t.Setenv("no_proxy", "")
+
+	proxyReqCh := make(chan proxyRequestResult, 100)
+	dialer := &recordingDialer{
+		dial: func(_ context.Context, network, addr string) (net.Conn, error) {
+			if network != "tcp" {
+				return nil, fmt.Errorf("unexpected network %q", network)
+			}
+			if addr != proxyAddr {
+				return nil, fmt.Errorf("unexpected dial to %q", addr)
+			}
+			return acceptProxyConnect(proxyReqCh), nil
+		},
+	}
+	state := &lib.State{Dialer: dialer}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	opts := append(
+		DefaultOptions(func() *lib.State { return state }),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	conn, err := Dial(ctx, grpcProxyTargetAddr, new(protoregistry.Types), opts...)
+	if conn != nil {
+		require.NoError(t, conn.Close())
+	}
+	require.Error(t, err)
+
+	select {
+	case proxyReq := <-proxyReqCh:
+		require.NoError(t, proxyReq.err)
+		assert.Equal(t, http.MethodConnect, proxyReq.req.Method)
+		assert.Equal(t, grpcProxyTargetAddr, proxyReq.req.Host)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for proxy CONNECT request")
+	}
+
+	require.NotEmpty(t, dialer.calls())
+	assert.Equal(t, proxyAddr, dialer.calls()[0].addr)
 }
 
 func TestHealthCheck(t *testing.T) {
@@ -331,4 +394,230 @@ func (invokemock) NewStream(_ context.Context, _ *grpc.StreamDesc, _ string, _ .
 
 func (invokemock) Close() error {
 	return nil
+}
+
+func TestDialGRPCContextUsesHTTPSProxy(t *testing.T) {
+	t.Parallel()
+
+	directAddr := "direct.example:443"
+	proxyAddr := "proxy.example:80"
+	proxyURL, err := url.Parse("http://user:pass@proxy.example")
+	require.NoError(t, err)
+
+	proxyFromEnvironment := func(req *http.Request) (*url.URL, error) {
+		assert.Equal(t, "https", req.URL.Scheme)
+
+		switch req.URL.Host {
+		case grpcProxyTargetAddr:
+			return proxyURL, nil
+		case directAddr:
+			return nil, nil
+		default:
+			return nil, fmt.Errorf("unexpected proxy lookup for %q", req.URL.Host)
+		}
+	}
+
+	proxyReqCh := make(chan proxyRequestResult, 1)
+	dialer := &recordingDialer{
+		dial: func(_ context.Context, network, addr string) (net.Conn, error) {
+			if network != "tcp" {
+				return nil, fmt.Errorf("unexpected network %q", network)
+			}
+			switch addr {
+			case proxyAddr:
+				return acceptProxyConnect(proxyReqCh), nil
+			case directAddr:
+				clientConn, serverConn := net.Pipe()
+				_ = serverConn.Close()
+				return clientConn, nil
+			default:
+				return nil, fmt.Errorf("unexpected dial to %q", addr)
+			}
+		},
+	}
+	state := &lib.State{Dialer: dialer}
+
+	proxyConn, err := dialGRPCContextWithProxy(context.Background(), state, grpcProxyTargetAddr, proxyFromEnvironment)
+	require.NoError(t, err)
+	require.NoError(t, proxyConn.Close())
+
+	proxyReq := <-proxyReqCh
+	require.NoError(t, proxyReq.err)
+	assert.Equal(t, http.MethodConnect, proxyReq.req.Method)
+	assert.Equal(t, grpcProxyTargetAddr, proxyReq.req.Host)
+	assert.Equal(t, grpcProxyTargetAddr, proxyReq.req.URL.Host)
+	assert.Equal(t, "Basic "+base64.StdEncoding.EncodeToString([]byte("user:pass")),
+		proxyReq.req.Header.Get("Proxy-Authorization"))
+
+	directConn, err := dialGRPCContextWithProxy(context.Background(), state, directAddr, proxyFromEnvironment)
+	require.NoError(t, err)
+	require.NoError(t, directConn.Close())
+
+	assert.Equal(t, []dialCall{
+		{network: "tcp", addr: proxyAddr},
+		{network: "tcp", addr: directAddr},
+	}, dialer.calls())
+}
+
+func TestDialGRPCContextRejectsUnsupportedProxyScheme(t *testing.T) {
+	t.Parallel()
+
+	proxyURL, err := url.Parse("https://token:secret@proxy.example:443")
+	require.NoError(t, err)
+
+	proxyFromEnvironment := func(*http.Request) (*url.URL, error) {
+		return proxyURL, nil
+	}
+
+	dialer := &recordingDialer{
+		dial: func(context.Context, string, string) (net.Conn, error) {
+			return nil, errors.New("dial should not be called")
+		},
+	}
+	state := &lib.State{Dialer: dialer}
+
+	conn, err := dialGRPCContextWithProxy(context.Background(), state, grpcProxyTargetAddr, proxyFromEnvironment)
+	require.Error(t, err)
+	require.Nil(t, conn)
+	assert.Contains(t, err.Error(), `unsupported grpc proxy scheme "https"`)
+	assert.NotContains(t, err.Error(), "token")
+	assert.NotContains(t, err.Error(), "secret")
+	assert.Empty(t, dialer.calls())
+}
+
+func TestHTTPConnectHandshakeStopsOnContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	proxyReqCh := make(chan proxyRequestResult, 1)
+	releaseProxy := make(chan struct{})
+	defer close(releaseProxy)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	conn, err := doHTTPConnectHandshake(
+		ctx,
+		acceptStalledProxyConnect(proxyReqCh, releaseProxy),
+		grpcProxyTargetAddr,
+		nil,
+	)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Nil(t, conn)
+	assert.Less(t, time.Since(start), time.Second)
+
+	proxyReq := <-proxyReqCh
+	require.NoError(t, proxyReq.err)
+	assert.Equal(t, http.MethodConnect, proxyReq.req.Method)
+}
+
+func TestHTTPConnectHandshakeDoesNotDrainSuccessfulTunnel(t *testing.T) {
+	t.Parallel()
+
+	proxyReqCh := make(chan proxyRequestResult, 1)
+	releaseProxy := make(chan struct{})
+	defer close(releaseProxy)
+
+	type handshakeResult struct {
+		conn net.Conn
+		err  error
+	}
+	resultCh := make(chan handshakeResult, 1)
+	go func() {
+		conn, err := doHTTPConnectHandshake(
+			context.Background(),
+			acceptProxyConnectWithBodyHeader(proxyReqCh, releaseProxy),
+			grpcProxyTargetAddr,
+			nil,
+		)
+		resultCh <- handshakeResult{conn: conn, err: err}
+	}()
+
+	var result handshakeResult
+	select {
+	case result = <-resultCh:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timed out waiting for CONNECT handshake to return")
+	}
+	require.NoError(t, result.err)
+	require.NotNil(t, result.conn)
+	require.NoError(t, result.conn.Close())
+
+	proxyReq := <-proxyReqCh
+	require.NoError(t, proxyReq.err)
+	assert.Equal(t, http.MethodConnect, proxyReq.req.Method)
+}
+
+type proxyRequestResult struct {
+	req *http.Request
+	err error
+}
+
+func acceptProxyConnect(proxyReqCh chan<- proxyRequestResult) net.Conn {
+	clientConn, serverConn := net.Pipe()
+	go func() {
+		defer func() { _ = serverConn.Close() }()
+
+		req, err := http.ReadRequest(bufio.NewReader(serverConn))
+		if err == nil {
+			_, err = serverConn.Write([]byte("HTTP/1.1 200 OK\r\n\r\n"))
+		}
+		proxyReqCh <- proxyRequestResult{req: req, err: err}
+	}()
+	return clientConn
+}
+
+func acceptProxyConnectWithBodyHeader(proxyReqCh chan<- proxyRequestResult, release <-chan struct{}) net.Conn {
+	clientConn, serverConn := net.Pipe()
+	go func() {
+		defer func() { _ = serverConn.Close() }()
+
+		req, err := http.ReadRequest(bufio.NewReader(serverConn))
+		if err == nil {
+			_, err = serverConn.Write([]byte("HTTP/1.1 200 OK\r\nContent-Length: 1\r\n\r\n"))
+		}
+		proxyReqCh <- proxyRequestResult{req: req, err: err}
+		<-release
+	}()
+	return clientConn
+}
+
+func acceptStalledProxyConnect(proxyReqCh chan<- proxyRequestResult, release <-chan struct{}) net.Conn {
+	clientConn, serverConn := net.Pipe()
+	go func() {
+		defer func() { _ = serverConn.Close() }()
+
+		req, err := http.ReadRequest(bufio.NewReader(serverConn))
+		proxyReqCh <- proxyRequestResult{req: req, err: err}
+		<-release
+	}()
+	return clientConn
+}
+
+type dialCall struct {
+	network string
+	addr    string
+}
+
+type recordingDialer struct {
+	mu    sync.Mutex
+	dials []dialCall
+	dial  func(context.Context, string, string) (net.Conn, error)
+}
+
+func (d *recordingDialer) DialContext(ctx context.Context, network, addr string) (net.Conn, error) {
+	d.mu.Lock()
+	d.dials = append(d.dials, dialCall{network: network, addr: addr})
+	d.mu.Unlock()
+
+	return d.dial(ctx, network, addr)
+}
+
+func (d *recordingDialer) calls() []dialCall {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	calls := make([]dialCall, len(d.dials))
+	copy(calls, d.dials)
+	return calls
 }


### PR DESCRIPTION
## What?

Adds `HTTPS_PROXY` support for k6 gRPC connections when using the custom gRPC dialer.

The gRPC dial path now:
- checks proxy settings with Go’s `http.ProxyFromEnvironment`
- establishes an HTTP `CONNECT` tunnel through supported HTTP proxies
- preserves k6’s existing dialer behavior for DNS, hosts, blacklist, blocked hostnames, and byte accounting
- rejects unsupported proxy schemes before sending credentials
- respects context cancellation during the CONNECT handshake
- preserves successful CONNECT tunnel bytes without draining the stream

## Why?

k6 gRPC currently uses `grpc.WithContextDialer`, which bypasses grpc-go’s built-in proxy handling. As a result, gRPC requests do not honor `HTTPS_PROXY`.

This fixes that behavior while keeping k6-specific networking behavior intact.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.
  - `make check` was not run because `golangci-lint` is not installed locally.
  - Ran:
    - `go test ./internal/lib/netext/grpcext -count=1`
    - `go test ./internal/js/modules/k6/grpc -count=1`
    - `go test ./internal/lib/netext/... -count=1`
    - `go test -race ./internal/lib/netext/grpcext -count=1`
    - `go vet ./internal/lib/netext/grpcext`
    - `git diff --check`

## Checklist: Documentation (only for k6 maintainers and if relevant)

Not applicable for this contributor PR; this does not change public JavaScript APIs or documentation-facing behavior.

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

Closes #3175