### PR TITLE
fix(httpext): classify HTTP/2 errors and negotiate h2 correctly under Go 1.27

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -39,15 +39,4 @@ runs:
             unset args[2]
           fi
         fi
-        if [[ ${USE_GOTIP} == 'true' ]]; then
-          # Under Go 1.27+, golang.org/x/net/http2 switches to a "wrapping
-          # implementation" that delegates to net/http. With it, ConfigureTransport
-          # no longer forces HTTP/2 over custom dialers, and HTTP/2 errors surface as
-          # unexported net/http/internal/http2 types that lib/netext/httpext can no
-          # longer classify (only StreamError has an upstream errors.As bridge;
-          # ConnectionError and GoAwayError do not). Force the legacy x/net
-          # implementation until k6 adapts. See Dependencies.md / the http2 error
-          # handling in lib/netext/httpext/error_codes.go.
-          args+=("-tags" "http2legacy")
-        fi
         go test "${args[@]}" -timeout 1600s `go list ./... | grep -v browser/tests`

--- a/internal/js/runner.go
+++ b/internal/js/runner.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/grafana/sobek"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/http2"
 	"golang.org/x/time/rate"
 
 	"go.k6.io/k6/v2/errext"
@@ -206,14 +205,11 @@ func (r *Runner) newVU(
 	}
 
 	if r.forceHTTP1() {
-		transport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper) // send over h1 protocol
+		transport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
 	} else {
-		// Go 1.27+: golang.org/x/net/http2.ConfigureTransport is a no-op (its wrapping
-		// implementation defers to net/http), and net/http does not negotiate HTTP/2
-		// over a Transport that has a custom DialContext/TLSClientConfig unless
-		// ForceAttemptHTTP2 is set. Without this, VUs would silently drop to HTTP/1.1.
+		// net/http negotiates HTTP/2 over a Transport with a custom DialContext or
+		// TLSClientConfig only when ForceAttemptHTTP2 is set (see Go issue #14275).
 		transport.ForceAttemptHTTP2 = true
-		_ = http2.ConfigureTransport(transport) // send over h2 protocol
 	}
 
 	cookieJar, err := cookiejar.New(nil)

--- a/internal/js/runner.go
+++ b/internal/js/runner.go
@@ -208,6 +208,11 @@ func (r *Runner) newVU(
 	if r.forceHTTP1() {
 		transport.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper) // send over h1 protocol
 	} else {
+		// Go 1.27+: golang.org/x/net/http2.ConfigureTransport is a no-op (its wrapping
+		// implementation defers to net/http), and net/http does not negotiate HTTP/2
+		// over a Transport that has a custom DialContext/TLSClientConfig unless
+		// ForceAttemptHTTP2 is set. Without this, VUs would silently drop to HTTP/1.1.
+		transport.ForceAttemptHTTP2 = true
 		_ = http2.ConfigureTransport(transport) // send over h2 protocol
 	}
 

--- a/internal/lib/testutils/httpmultibin/httpmultibin.go
+++ b/internal/lib/testutils/httpmultibin/httpmultibin.go
@@ -359,10 +359,18 @@ func NewHTTPMultiBin(t testing.TB) *HTTPMultiBin {
 	})
 	require.NoError(t, err)
 
-	// Pre-configure the HTTP client transport with the dialer and TLS config (incl. HTTP2 support)
+	// Pre-configure the HTTP client transport with the dialer and TLS config (incl. HTTP2 support).
+	//
+	// Advertise both h2 and http/1.1 so the client can reach both the HTTP/2 server and the
+	// http/1.1-only HTTPS server: the h2 server setup above left tlsConfig.NextProtos as ["h2"],
+	// and since Go 1.27 http2.ConfigureTransport no longer appends "http/1.1". ForceAttemptHTTP2
+	// is also required on Go 1.27+, where ConfigureTransport is a no-op and net/http won't
+	// negotiate HTTP/2 over a Transport with a custom dialer/TLS config without it.
+	tlsConfig.NextProtos = []string{http2.NextProtoTLS, "http/1.1"}
 	transport := &http.Transport{
-		DialContext:     dialer.DialContext,
-		TLSClientConfig: tlsConfig,
+		DialContext:       dialer.DialContext,
+		TLSClientConfig:   tlsConfig,
+		ForceAttemptHTTP2: true,
 	}
 	require.NoError(t, http2.ConfigureTransport(transport))
 

--- a/internal/lib/testutils/httpmultibin/httpmultibin.go
+++ b/internal/lib/testutils/httpmultibin/httpmultibin.go
@@ -359,20 +359,22 @@ func NewHTTPMultiBin(t testing.TB) *HTTPMultiBin {
 	})
 	require.NoError(t, err)
 
-	// Pre-configure the HTTP client transport with the dialer and TLS config (incl. HTTP2 support).
+	// Pre-configure the HTTP client transport with the dialer and TLS config.
 	//
 	// Advertise both h2 and http/1.1 so the client can reach both the HTTP/2 server and the
-	// http/1.1-only HTTPS server: the h2 server setup above left tlsConfig.NextProtos as ["h2"],
-	// and since Go 1.27 http2.ConfigureTransport no longer appends "http/1.1". ForceAttemptHTTP2
-	// is also required on Go 1.27+, where ConfigureTransport is a no-op and net/http won't
-	// negotiate HTTP/2 over a Transport with a custom dialer/TLS config without it.
-	tlsConfig.NextProtos = []string{http2.NextProtoTLS, "http/1.1"}
+	// http/1.1-only HTTPS server. ForceAttemptHTTP2 tells net/http to negotiate HTTP/2 even
+	// when a custom DialContext/TLSClientConfig is set (see Go issue #14275).
+	//
+	// Clone the server TLS config before widening NextProtos: http2Srv.TLS and tlsConfig are
+	// the same pointer (assigned above), so mutating it in place would change the server's
+	// advertised protocols after StartTLS() has already been called.
+	clientTLSConfig := tlsConfig.Clone()
+	clientTLSConfig.NextProtos = []string{http2.NextProtoTLS, "http/1.1"}
 	transport := &http.Transport{
 		DialContext:       dialer.DialContext,
-		TLSClientConfig:   tlsConfig,
+		TLSClientConfig:   clientTLSConfig,
 		ForceAttemptHTTP2: true,
 	}
-	require.NoError(t, http2.ConfigureTransport(transport))
 
 	ctx, ctxCancel := context.WithCancel(context.Background())
 

--- a/lib/netext/httpext/error_codes.go
+++ b/lib/netext/httpext/error_codes.go
@@ -105,20 +105,25 @@ func http2ErrCodeByName(name string) (http2.ErrCode, bool) {
 	return 0, false
 }
 
-// errorCodeForHTTP2Message classifies an HTTP/2 connection or GOAWAY error by
-// the text of its Error() method, as a fallback to the type switch in
-// errorCodeForError.
-//
-// Since Go 1.27, golang.org/x/net/http2 compiles a "wrapping implementation"
-// (build tag `go1.27 && !http2legacy`) that delegates to net/http. HTTP/2
-// errors then surface as values of the unexported net/http/internal/http2
-// connection- and GOAWAY-error types, which the http2.{ConnectionError,
-// GoAwayError} cases in errorCodeForError cannot match and which - unlike
-// http2.StreamError - have no errors.As bridge to the x/net types. Their
-// Error() text is identical to x/net's, so we match on that instead. Only
-// spec-defined error codes are recognized; an unknown code falls through.
+// errorCodeForHTTP2Message classifies an HTTP/2 error by the text of its
+// Error() method. All HTTP/2 error types from both golang.org/x/net/http2 and
+// Go's stdlib net/http/internal/http2 produce the same Error() strings, so
+// this single path handles every Go version uniformly. Only spec-defined error
+// codes are recognized; an unknown code falls through.
 func errorCodeForHTTP2Message(msg string) (errCode, string, bool) {
 	switch {
+	case strings.HasPrefix(msg, "stream error: "):
+		// Format: "stream error: stream ID N; ERRCODE[; cause]"
+		// Cause is omitted when StreamError.Cause == nil, so the trailing "; cause"
+		// segment may be absent. Skip "stream error: stream ID N; " then take the
+		// ERRCODE up to the next ";" (with cause) or end of string (without cause).
+		if _, rest, ok := strings.Cut(msg, "; "); ok {
+			name, _, _ := strings.Cut(rest, ";")
+			if code, ok := http2ErrCodeByName(strings.TrimSpace(name)); ok {
+				return unknownHTTP2StreamErrorCode + http2ErrCodeOffset(code),
+					fmt.Sprintf(http2StreamErrorCodeMsg, code), true
+			}
+		}
 	case strings.HasPrefix(msg, "connection error: "):
 		name := strings.TrimPrefix(msg, "connection error: ")
 		if code, ok := http2ErrCodeByName(name); ok {
@@ -231,15 +236,6 @@ func errorCodeForError(err error) (errCode, string) {
 		return blackListedIPErrorCode, blackListedIPErrorCodeMsg
 	case netext.BlockedHostError:
 		return blockedHostnameErrorCode, blockedHostnameErrorMsg
-	case http2.GoAwayError:
-		return unknownHTTP2GoAwayErrorCode + http2ErrCodeOffset(e.ErrCode),
-			fmt.Sprintf(http2GoAwayErrorCodeMsg, e.ErrCode)
-	case http2.StreamError:
-		return unknownHTTP2StreamErrorCode + http2ErrCodeOffset(e.Code),
-			fmt.Sprintf(http2StreamErrorCodeMsg, e.Code)
-	case http2.ConnectionError:
-		return unknownHTTP2ConnectionErrorCode + http2ErrCodeOffset(http2.ErrCode(e)),
-			fmt.Sprintf(http2ConnectionErrorCodeMsg, http2.ErrCode(e))
 	case *net.OpError:
 		return errorCodeForNetOpError(e)
 	case x509.UnknownAuthorityError:
@@ -251,22 +247,15 @@ func errorCodeForError(err error) (errCode, string) {
 	case *url.Error:
 		return errorCodeForError(e.Err)
 	default:
-		// Go 1.27+ fallback: x/net/http2's wrapping implementation surfaces HTTP/2
-		// errors as unexported net/http/internal/http2 values that don't match the
-		// http2.* cases above. StreamError can still be recovered via errors.As (the
-		// standard-library type implements an As bridge to x/net's StreamError);
-		// ConnectionError and GoAwayError have no such bridge and are matched by
-		// their (implementation-independent) Error() text instead.
-		var streamErr http2.StreamError
-		if errors.As(err, &streamErr) {
-			return unknownHTTP2StreamErrorCode + http2ErrCodeOffset(streamErr.Code),
-				fmt.Sprintf(http2StreamErrorCodeMsg, streamErr.Code)
+		// Unwrap first: a wrapped error may have a concrete inner type that one of
+		// the cases above can match. String matching runs only on errors that have
+		// no unwrappable inner type, reducing the chance of a false positive from
+		// a non-HTTP/2 error whose message happens to start with an HTTP/2 prefix.
+		if wrappedErr := errors.Unwrap(err); wrappedErr != nil {
+			return errorCodeForError(wrappedErr)
 		}
 		if code, msg, ok := errorCodeForHTTP2Message(err.Error()); ok {
 			return code, msg
-		}
-		if wrappedErr := errors.Unwrap(err); wrappedErr != nil {
-			return errorCodeForError(wrappedErr)
 		}
 
 		return defaultErrorCode, err.Error()

--- a/lib/netext/httpext/error_codes.go
+++ b/lib/netext/httpext/error_codes.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strings"
 	"syscall"
 
 	"golang.org/x/net/http2"
@@ -90,6 +91,63 @@ func http2ErrCodeOffset(code http2.ErrCode) errCode {
 		return 0
 	}
 	return 1 + errCode(code)
+}
+
+// http2ErrCodeByName maps the textual form produced by http2.ErrCode.String()
+// (e.g. "PROTOCOL_ERROR") back to its code. Only the spec-defined codes are
+// recognized; anything else returns false.
+func http2ErrCodeByName(name string) (http2.ErrCode, bool) {
+	for code := http2.ErrCodeNo; code <= http2.ErrCodeHTTP11Required; code++ {
+		if code.String() == name {
+			return code, true
+		}
+	}
+	return 0, false
+}
+
+// errorCodeForHTTP2Message classifies an HTTP/2 connection or GOAWAY error by
+// the text of its Error() method, as a fallback to the type switch in
+// errorCodeForError.
+//
+// Since Go 1.27, golang.org/x/net/http2 compiles a "wrapping implementation"
+// (build tag `go1.27 && !http2legacy`) that delegates to net/http. HTTP/2
+// errors then surface as values of the unexported net/http/internal/http2
+// connection- and GOAWAY-error types, which the http2.{ConnectionError,
+// GoAwayError} cases in errorCodeForError cannot match and which - unlike
+// http2.StreamError - have no errors.As bridge to the x/net types. Their
+// Error() text is identical to x/net's, so we match on that instead. Only
+// spec-defined error codes are recognized; an unknown code falls through.
+func errorCodeForHTTP2Message(msg string) (errCode, string, bool) {
+	switch {
+	case strings.HasPrefix(msg, "connection error: "):
+		name := strings.TrimPrefix(msg, "connection error: ")
+		if code, ok := http2ErrCodeByName(name); ok {
+			return unknownHTTP2ConnectionErrorCode + http2ErrCodeOffset(code),
+				fmt.Sprintf(http2ConnectionErrorCodeMsg, code), true
+		}
+	case strings.HasPrefix(msg, "http2: server sent GOAWAY"):
+		if name, ok := stringBetween(msg, "ErrCode=", ","); ok {
+			if code, ok := http2ErrCodeByName(name); ok {
+				return unknownHTTP2GoAwayErrorCode + http2ErrCodeOffset(code),
+					fmt.Sprintf(http2GoAwayErrorCodeMsg, code), true
+			}
+		}
+	}
+	return 0, "", false
+}
+
+// stringBetween returns the substring of s found between the first occurrence
+// of prefix and the next occurrence of sep that follows it.
+func stringBetween(s, prefix, sep string) (string, bool) {
+	_, after, found := strings.Cut(s, prefix)
+	if !found {
+		return "", false
+	}
+	mid, _, found := strings.Cut(after, sep)
+	if !found {
+		return "", false
+	}
+	return mid, true
 }
 
 //nolint:errorlint
@@ -193,6 +251,20 @@ func errorCodeForError(err error) (errCode, string) {
 	case *url.Error:
 		return errorCodeForError(e.Err)
 	default:
+		// Go 1.27+ fallback: x/net/http2's wrapping implementation surfaces HTTP/2
+		// errors as unexported net/http/internal/http2 values that don't match the
+		// http2.* cases above. StreamError can still be recovered via errors.As (the
+		// standard-library type implements an As bridge to x/net's StreamError);
+		// ConnectionError and GoAwayError have no such bridge and are matched by
+		// their (implementation-independent) Error() text instead.
+		var streamErr http2.StreamError
+		if errors.As(err, &streamErr) {
+			return unknownHTTP2StreamErrorCode + http2ErrCodeOffset(streamErr.Code),
+				fmt.Sprintf(http2StreamErrorCodeMsg, streamErr.Code)
+		}
+		if code, msg, ok := errorCodeForHTTP2Message(err.Error()); ok {
+			return code, msg
+		}
 		if wrappedErr := errors.Unwrap(err); wrappedErr != nil {
 			return errorCodeForError(wrappedErr)
 		}

--- a/lib/netext/httpext/error_codes_test.go
+++ b/lib/netext/httpext/error_codes_test.go
@@ -192,9 +192,18 @@ func TestHTTP2StreamError(t *testing.T) {
 		time.Sleep(time.Millisecond * 2)
 		panic("expected internal error")
 	})
+	// ForceAttemptHTTP2 is required on Go 1.27+: there http2.ConfigureTransport is a
+	// no-op and the standard library won't negotiate HTTP/2 over a Transport that has a
+	// custom dialer/TLS config unless explicitly asked to.
+	transport := &http.Transport{
+		DialContext:       tb.Dialer.DialContext,
+		TLSClientConfig:   tb.TLSClientConfig,
+		ForceAttemptHTTP2: true,
+	}
+	require.NoError(t, http2.ConfigureTransport(transport))
 	client := http.Client{
 		Timeout:   time.Second * 3,
-		Transport: tb.HTTPTransport,
+		Transport: transport,
 	}
 
 	res, err := client.Get(tb.Replacer.Replace("HTTP2BIN_URL/tsr")) //nolint:noctx
@@ -213,9 +222,18 @@ func TestX509HostnameError(t *testing.T) {
 	t.Parallel()
 	tb := httpmultibin.NewHTTPMultiBin(t)
 
+	// On Go 1.27+ the shared client TLS config advertises only "h2" (ConfigureTransport
+	// no longer appends "http/1.1"), so a request to the http/1.1-only HTTPSBIN server
+	// fails ALPN with "no application protocol" before the x509 check can run. Offer
+	// http/1.1 explicitly so the handshake proceeds to certificate verification.
+	tlsCfg := tb.TLSClientConfig.Clone()
+	tlsCfg.NextProtos = []string{"http/1.1"}
 	client := http.Client{
-		Timeout:   time.Second * 3,
-		Transport: tb.HTTPTransport,
+		Timeout: time.Second * 3,
+		Transport: &http.Transport{
+			DialContext:     tb.Dialer.DialContext,
+			TLSClientConfig: tlsCfg,
+		},
 	}
 	var err error
 	badHostname := "somewhere.else"
@@ -428,8 +446,9 @@ func getHTTP2ServerWithCustomConnContext(t *testing.T) *httpmultibin.HTTPMultiBi
 	require.NoError(t, err)
 
 	transport := &http.Transport{
-		DialContext:     dialer.DialContext,
-		TLSClientConfig: tlsConfig,
+		DialContext:       dialer.DialContext,
+		TLSClientConfig:   tlsConfig,
+		ForceAttemptHTTP2: true, // required on Go 1.27+, where ConfigureTransport no longer forces h2 over a custom dialer
 	}
 	require.NoError(t, http2.ConfigureTransport(transport))
 	return &httpmultibin.HTTPMultiBin{

--- a/lib/netext/httpext/error_codes_test.go
+++ b/lib/netext/httpext/error_codes_test.go
@@ -192,18 +192,9 @@ func TestHTTP2StreamError(t *testing.T) {
 		time.Sleep(time.Millisecond * 2)
 		panic("expected internal error")
 	})
-	// ForceAttemptHTTP2 is required on Go 1.27+: there http2.ConfigureTransport is a
-	// no-op and the standard library won't negotiate HTTP/2 over a Transport that has a
-	// custom dialer/TLS config unless explicitly asked to.
-	transport := &http.Transport{
-		DialContext:       tb.Dialer.DialContext,
-		TLSClientConfig:   tb.TLSClientConfig,
-		ForceAttemptHTTP2: true,
-	}
-	require.NoError(t, http2.ConfigureTransport(transport))
 	client := http.Client{
 		Timeout:   time.Second * 3,
-		Transport: transport,
+		Transport: tb.HTTPTransport,
 	}
 
 	res, err := client.Get(tb.Replacer.Replace("HTTP2BIN_URL/tsr")) //nolint:noctx
@@ -222,18 +213,9 @@ func TestX509HostnameError(t *testing.T) {
 	t.Parallel()
 	tb := httpmultibin.NewHTTPMultiBin(t)
 
-	// On Go 1.27+ the shared client TLS config advertises only "h2" (ConfigureTransport
-	// no longer appends "http/1.1"), so a request to the http/1.1-only HTTPSBIN server
-	// fails ALPN with "no application protocol" before the x509 check can run. Offer
-	// http/1.1 explicitly so the handshake proceeds to certificate verification.
-	tlsCfg := tb.TLSClientConfig.Clone()
-	tlsCfg.NextProtos = []string{"http/1.1"}
 	client := http.Client{
-		Timeout: time.Second * 3,
-		Transport: &http.Transport{
-			DialContext:     tb.Dialer.DialContext,
-			TLSClientConfig: tlsCfg,
-		},
+		Timeout:   time.Second * 3,
+		Transport: tb.HTTPTransport,
 	}
 	var err error
 	badHostname := "somewhere.else"

--- a/lib/netext/httpext/error_codes_test.go
+++ b/lib/netext/httpext/error_codes_test.go
@@ -338,6 +338,62 @@ func TestHTTP2GoAwayError(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf(http2GoAwayErrorCodeMsg, http2.ErrCodeInadequateSecurity), msg)
 }
 
+// TestHTTP2MessageFallback covers the message-based classification of HTTP/2
+// connection and GOAWAY errors. Since Go 1.27, golang.org/x/net/http2's wrapping
+// implementation surfaces these as unexported net/http/internal/http2 types that
+// errorCodeForError cannot match by type and that, unlike StreamError, have no
+// errors.As bridge. The error strings below are exactly what those types' Error()
+// methods produce (identical to x/net's), so the fallback must classify them.
+// This feeds the messages directly, so it runs on every Go version.
+func TestHTTP2MessageFallback(t *testing.T) {
+	t.Parallel()
+
+	connErr := errors.New("connection error: " + http2.ErrCodeProtocol.String())
+	goAwayErr := fmt.Errorf(
+		"http2: server sent GOAWAY and closed the connection; LastStreamID=4, ErrCode=%v, debug=%q",
+		http2.ErrCodeInadequateSecurity, "whatever")
+
+	testCases := []struct {
+		name     string
+		err      error
+		wantCode errCode
+		wantMsg  string
+	}{
+		{
+			"connection error",
+			connErr,
+			unknownHTTP2ConnectionErrorCode + http2ErrCodeOffset(http2.ErrCodeProtocol),
+			fmt.Sprintf(http2ConnectionErrorCodeMsg, http2.ErrCodeProtocol),
+		},
+		{
+			"connection error wrapped in url.Error",
+			&url.Error{Op: "Get", URL: "https://example.com", Err: connErr},
+			unknownHTTP2ConnectionErrorCode + http2ErrCodeOffset(http2.ErrCodeProtocol),
+			fmt.Sprintf(http2ConnectionErrorCodeMsg, http2.ErrCodeProtocol),
+		},
+		{
+			"goaway error",
+			goAwayErr,
+			unknownHTTP2GoAwayErrorCode + http2ErrCodeOffset(http2.ErrCodeInadequateSecurity),
+			fmt.Sprintf(http2GoAwayErrorCodeMsg, http2.ErrCodeInadequateSecurity),
+		},
+		{
+			"goaway error wrapped",
+			fmt.Errorf("read tcp: %w", goAwayErr),
+			unknownHTTP2GoAwayErrorCode + http2ErrCodeOffset(http2.ErrCodeInadequateSecurity),
+			fmt.Sprintf(http2GoAwayErrorCodeMsg, http2.ErrCodeInadequateSecurity),
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			code, msg := errorCodeForError(tc.err)
+			assert.Equal(t, tc.wantCode, code)
+			assert.Equal(t, tc.wantMsg, msg)
+		})
+	}
+}
+
 type connKeyT int32
 
 const connKey connKeyT = 2

--- a/lib/netext/httpext/error_codes_test.go
+++ b/lib/netext/httpext/error_codes_test.go
@@ -338,16 +338,16 @@ func TestHTTP2GoAwayError(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf(http2GoAwayErrorCodeMsg, http2.ErrCodeInadequateSecurity), msg)
 }
 
-// TestHTTP2MessageFallback covers the message-based classification of HTTP/2
-// connection and GOAWAY errors. Since Go 1.27, golang.org/x/net/http2's wrapping
-// implementation surfaces these as unexported net/http/internal/http2 types that
-// errorCodeForError cannot match by type and that, unlike StreamError, have no
-// errors.As bridge. The error strings below are exactly what those types' Error()
-// methods produce (identical to x/net's), so the fallback must classify them.
-// This feeds the messages directly, so it runs on every Go version.
+// TestHTTP2MessageFallback covers message-based classification of HTTP/2 errors.
+// Both golang.org/x/net/http2 and Go's stdlib net/http/internal/http2 produce
+// identical Error() strings, so a single message-based path handles every Go
+// version uniformly. This feeds exact error strings directly, so it runs on
+// every Go version without a live server.
 func TestHTTP2MessageFallback(t *testing.T) {
 	t.Parallel()
 
+	streamErr := fmt.Errorf("stream error: stream ID 1; %v; EOF", http2.ErrCodeInternal)
+	streamErrNoCause := fmt.Errorf("stream error: stream ID 1; %v", http2.ErrCodeInternal)
 	connErr := errors.New("connection error: " + http2.ErrCodeProtocol.String())
 	goAwayErr := fmt.Errorf(
 		"http2: server sent GOAWAY and closed the connection; LastStreamID=4, ErrCode=%v, debug=%q",
@@ -359,6 +359,24 @@ func TestHTTP2MessageFallback(t *testing.T) {
 		wantCode errCode
 		wantMsg  string
 	}{
+		{
+			"stream error",
+			streamErr,
+			unknownHTTP2StreamErrorCode + http2ErrCodeOffset(http2.ErrCodeInternal),
+			fmt.Sprintf(http2StreamErrorCodeMsg, http2.ErrCodeInternal),
+		},
+		{
+			"stream error wrapped",
+			fmt.Errorf("read: %w", streamErr),
+			unknownHTTP2StreamErrorCode + http2ErrCodeOffset(http2.ErrCodeInternal),
+			fmt.Sprintf(http2StreamErrorCodeMsg, http2.ErrCodeInternal),
+		},
+		{
+			"stream error no cause",
+			streamErrNoCause,
+			unknownHTTP2StreamErrorCode + http2ErrCodeOffset(http2.ErrCodeInternal),
+			fmt.Sprintf(http2StreamErrorCodeMsg, http2.ErrCodeInternal),
+		},
 		{
 			"connection error",
 			connErr,
@@ -430,9 +448,8 @@ func getHTTP2ServerWithCustomConnContext(t *testing.T) *httpmultibin.HTTPMultiBi
 	transport := &http.Transport{
 		DialContext:       dialer.DialContext,
 		TLSClientConfig:   tlsConfig,
-		ForceAttemptHTTP2: true, // required on Go 1.27+, where ConfigureTransport no longer forces h2 over a custom dialer
+		ForceAttemptHTTP2: true,
 	}
-	require.NoError(t, http2.ConfigureTransport(transport))
 	return &httpmultibin.HTTPMultiBin{
 		Mux:         mux,
 		ServerHTTP2: http2Srv,


### PR DESCRIPTION
## What?

`golang.org/x/net/http2` v0.55.0 ships two implementations selected by
build tag:

- `!(go1.27 && !http2legacy)` — the original transport (used on Go ≤ 1.26)
- `go1.27 && !http2legacy` — a wrapping implementation (`transport_wrap.go`)
  that delegates to `net/http`'s internal HTTP/2 stack

When the wrapping implementation is active (Go 1.27), two things break:

1. **Error classification silently degrades.** HTTP/2 errors surface as
   unexported `net/http/internal/http2` types instead of the exported
   `golang.org/x/net/http2` types. The existing type-switch on
   `http2.GoAwayError`, `http2.StreamError`, and `http2.ConnectionError`
   never matches, so every HTTP/2 error collapses to `defaultErrorCode`
   (1000). Only `StreamError` has an `errors.As` bridge to the x/net type;
   `GoAwayError` and `ConnectionError` have none.

2. **VUs and test transports stop negotiating HTTP/2.** With a custom
   `DialContext` or `TLSClientConfig`, `net/http` skips automatic h2
   setup unless `ForceAttemptHTTP2` is set (Go issue #14275).
   The wrapping implementation in the x/net release available then did not enable h2 for those transports through `http2.ConfigureTransport`; this was fixed upstream in a newer x/net release that master has since picked up.

## Why?

The test-tip CI job was failing on all three error-classification tests and
the `TestForceHTTP1Feature` h2-negotiation test. The error-classification
problem remains with the current dependency; the transport-negotiation issue
was subsequently fixed upstream. This PR keeps HTTP/2 negotiation explicit
while making error classification independent of the implementation stack.

## Changes

**`lib/netext/httpext/error_codes.go`**
- Add `http2ErrCodeByName` (name → `http2.ErrCode`) and
  `errorCodeForHTTP2Message` (classify all three HTTP/2 error types by
  their `Error()` string, which is identical across x/net and stdlib).
- Remove the now-dead x/net type-switch cases for `GoAwayError`,
  `StreamError`, and `ConnectionError`.
- In the default branch: unwrap first, then fall back to string matching,
  so a wrapped error's inner type can reach the concrete cases before
  string matching fires.

**`internal/js/runner.go`**
- Replace `http2.ConfigureTransport(transport)` with
  `transport.ForceAttemptHTTP2 = true` so VU transports negotiate h2 on
  all Go versions.

**`internal/lib/testutils/httpmultibin/httpmultibin.go`**
- Same transport change. Clone the TLS config before widening `NextProtos`
  so the HTTP/2 test server's TLS config is not mutated after `StartTLS()`.

**`lib/netext/httpext/error_codes_test.go`**
- Add `TestHTTP2MessageFallback` covering connection, GoAway, stream (with
  and without `Cause`), and wrapped variants — no live server required.
- Update the h2 test helper transport to use `ForceAttemptHTTP2`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

Fixes the `test-tip` CI failures visible in https://github.com/grafana/k6/pull/6040

**Upstream issue** filed against `golang.org/x/net`: `GoAwayError` and
`ConnectionError` have no `errors.As` bridge from the stdlib
`net/http/internal/http2` types to the exported x/net types (unlike
`StreamError`, which does). See the PR description thread for a minimal
reproduction and suggested upstream fixes.
