### PR TITLE
ci: force legacy x/net/http2 implementation on the gotip test job (backport to v1.x)

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -39,4 +39,15 @@ runs:
             unset args[2]
           fi
         fi
+        if [[ ${USE_GOTIP} == 'true' ]]; then
+          # Under Go 1.27+, golang.org/x/net/http2 switches to a "wrapping
+          # implementation" that delegates to net/http. With it, ConfigureTransport
+          # no longer forces HTTP/2 over custom dialers, and HTTP/2 errors surface as
+          # unexported net/http/internal/http2 types that lib/netext/httpext can no
+          # longer classify (only StreamError has an upstream errors.As bridge;
+          # ConnectionError and GoAwayError do not). Force the legacy x/net
+          # implementation until k6 adapts. See Dependencies.md / the http2 error
+          # handling in lib/netext/httpext/error_codes.go.
+          args+=("-tags" "http2legacy")
+        fi
         go test "${args[@]}" -timeout 1600s `go list ./... | grep -v browser/tests`


### PR DESCRIPTION
## What?

Backport of #6067 to `v1.x`.

Adds `-tags http2legacy` to the `test-tip` CI job so the gotip test run uses the original `golang.org/x/net/http2` implementation rather than the new Go 1.27 wrapping implementation.

## Why?

Under Go 1.27+, `golang.org/x/net/http2` v0.55.0+ activates a "wrapping implementation" (build tag `go1.27 && !http2legacy`) that delegates to `net/http`. This causes two silent breakages:

- `http2.ConfigureTransport` becomes a no-op, so HTTP/2 is not negotiated over transports with a custom `DialContext`/`TLSClientConfig`.
- HTTP/2 errors surface as unexported `net/http/internal/http2` types; the `golang.org/x/net/http2` type-switch in `errorCodeForError` no longer matches them.

The proper fix (reworking error classification and transport setup) is tracked in #6138 for `master`. This backport keeps the `test-tip` job green on `v1.x` in the interim.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Backport of #6067
- Proper fix tracked in #6138 (master only)