### PR TITLE
test: add mouse options unit tests

### DIFF
--- a/internal/js/modules/k6/browser/common/mouse_options_test.go
+++ b/internal/js/modules/k6/browser/common/mouse_options_test.go
@@ -1,0 +1,70 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewMouseClickOptions(t *testing.T) {
+	t.Parallel()
+
+	opts := NewMouseClickOptions()
+
+	assert.Equal(t, "left", opts.Button)
+	assert.Equal(t, int64(1), opts.ClickCount)
+	assert.Equal(t, int64(0), opts.Delay)
+}
+
+func TestNewMouseDblClickOptions(t *testing.T) {
+	t.Parallel()
+
+	opts := NewMouseDblClickOptions()
+
+	assert.Equal(t, "left", opts.Button)
+	assert.Equal(t, int64(0), opts.Delay)
+}
+
+func TestNewMouseDownUpOptions(t *testing.T) {
+	t.Parallel()
+
+	opts := NewMouseDownUpOptions()
+
+	assert.Equal(t, "left", opts.Button)
+	assert.Equal(t, int64(1), opts.ClickCount)
+}
+
+func TestNewMouseMoveOptions(t *testing.T) {
+	t.Parallel()
+
+	opts := NewMouseMoveOptions()
+
+	assert.Equal(t, int64(1), opts.Steps)
+}
+
+func TestMouseClickOptionsToMouseDownUpOptions(t *testing.T) {
+	t.Parallel()
+
+	src := &MouseClickOptions{Button: "right", ClickCount: 3, Delay: 50}
+
+	got := src.ToMouseDownUpOptions()
+
+	// Button and ClickCount are carried over. MouseDownUpOptions has no Delay
+	// field, so Delay is intentionally dropped.
+	assert.Equal(t, "right", got.Button)
+	assert.Equal(t, int64(3), got.ClickCount)
+}
+
+func TestMouseDblClickOptionsToMouseClickOptions(t *testing.T) {
+	t.Parallel()
+
+	src := &MouseDblClickOptions{Button: "right", Delay: 50}
+
+	got := src.ToMouseClickOptions()
+
+	// Button and Delay are copied, while ClickCount is always forced to 2
+	// because this represents a double click.
+	assert.Equal(t, "right", got.Button)
+	assert.Equal(t, int64(50), got.Delay)
+	assert.Equal(t, int64(2), got.ClickCount)
+}


### PR DESCRIPTION
## What?
Adds unit tests for the previously-untested `common/mouse_options.go`  (constructor defaults and the two option converters).

## Why?

Part of #4467. 
These helpers had no unit tests despite carrying real behaviour — e.g. `ToMouseClickOptions` forces ClickCount` to 2, which is what makes `Mouse.DblClick` a double click. The tests lock that invariant so regressions are caught at the unit level, not only via browser tests.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
