### PR TITLE
fix: prevent OpenTelemetry output panic with basic auth and no headers

### DIFF
--- a/internal/output/opentelemetry/exporter.go
+++ b/internal/output/opentelemetry/exporter.go
@@ -31,7 +31,7 @@ func getExporter(cfg Config) (metric.Exporter, error) {
 		return nil, err
 	}
 
-	var headers map[string]string
+	headers := make(map[string]string)
 	if cfg.Headers.Valid {
 		headers, err = parseHeaders(cfg.Headers.String)
 		if err != nil {

--- a/internal/output/opentelemetry/exporter_test.go
+++ b/internal/output/opentelemetry/exporter_test.go
@@ -1,0 +1,82 @@
+package opentelemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v3"
+)
+
+// TestGetExporterBasicAuth verifies that configuring HTTP Basic Auth via
+// K6_OTEL_HTTP_EXPORTER_USERNAME/PASSWORD does not panic when no headers are
+// configured through K6_OTEL_HEADERS. Previously the headers map was nil and
+// assigning the Authorization header caused a "assignment to entry in nil map"
+// panic.
+func TestGetExporterBasicAuth(t *testing.T) {
+	t.Parallel()
+
+	httpBase := func() Config {
+		return Config{
+			ExporterProtocol:     null.StringFrom(httpExporterProtocol),
+			HTTPExporterEndpoint: null.StringFrom("localhost:4318"),
+			HTTPExporterURLPath:  null.StringFrom("/v1/metrics"),
+		}
+	}
+
+	grpcBase := func() Config {
+		return Config{
+			ExporterProtocol:     null.StringFrom(grpcExporterProtocol),
+			GRPCExporterEndpoint: null.StringFrom("localhost:4317"),
+		}
+	}
+
+	testCases := map[string]struct {
+		cfg func() Config
+	}{
+		"http basic auth without headers": {
+			cfg: func() Config {
+				cfg := httpBase()
+				cfg.HTTPUsername = null.StringFrom("user")
+				cfg.HTTPPassword = null.StringFrom("pass")
+				return cfg
+			},
+		},
+		"http basic auth with headers": {
+			cfg: func() Config {
+				cfg := httpBase()
+				cfg.HTTPUsername = null.StringFrom("user")
+				cfg.HTTPPassword = null.StringFrom("pass")
+				cfg.Headers = null.StringFrom("X-Scope-OrgID=test")
+				return cfg
+			},
+		},
+		"http headers only": {
+			cfg: func() Config {
+				cfg := httpBase()
+				cfg.Headers = null.StringFrom("X-Scope-OrgID=test")
+				return cfg
+			},
+		},
+		"http no auth no headers": {
+			cfg: httpBase,
+		},
+		"grpc basic auth without headers": {
+			cfg: func() Config {
+				cfg := grpcBase()
+				cfg.HTTPUsername = null.StringFrom("user")
+				cfg.HTTPPassword = null.StringFrom("pass")
+				return cfg
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			exporter, err := getExporter(tc.cfg())
+			require.NoError(t, err)
+			require.NotNil(t, exporter)
+		})
+	}
+}


### PR DESCRIPTION
getExporter declared the headers map with 'var headers map[string]string', leaving it nil unless K6_OTEL_HEADERS was set. When basic auth was configured via K6_OTEL_HTTP_EXPORTER_USERNAME/PASSWORD but no headers were provided, assigning the Authorization header panicked with 'assignment to entry in nil map'.

Initialize the map so basic auth works independently of K6_OTEL_HEADERS. Adds a regression test covering basic auth with/without headers for both the HTTP and gRPC exporters.

<img width="1098" height="488" alt="image" src="https://github.com/user-attachments/assets/e9798854-5976-4baf-aa3d-a855bb66ea97" />

As a workaround one could add variable, for example:

```
K6_OTEL_HEADERS=X-Scope-OrgID=prod
```

## What?
Initialize the OpenTelemetry HTTP exporter headers map so configuring basic
auth (K6_OTEL_HTTP_EXPORTER_USERNAME/PASSWORD) without K6_OTEL_HEADERS no
longer panics.

## Why?
getExporter declared `var headers map[string]string` (nil unless
K6_OTEL_HEADERS was set). With basic auth but no headers, assigning the
Authorization header panicked: `assignment to entry in nil map`, crashing k6
at output start.

## Checklist
- [x] Regression test added (HTTP + gRPC, with/without headers)
- [x] go test ./internal/output/opentelemetry/ passes
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
