### PR TITLE
Fix potential data race and TOCTOU inconsistency in route operation

### DIFF
--- a/internal/js/modules/k6/browser/common/page.go
+++ b/internal/js/modules/k6/browser/common/page.go
@@ -1356,7 +1356,9 @@ func (p *Page) Referrer() string {
 func (p *Page) Route(path string, cb RouteHandlerCallback, rm RegExMatcher) error {
 	p.logger.Debugf("Page:Route", "sid:%v path:%s", p.sessionID(), path)
 
-	if !p.hasRoutes() {
+	p.routesMu.Lock()
+	defer p.routesMu.Unlock()
+	if len(p.routes) == 0 {
 		err := p.mainFrameSession.updateRequestInterception(true)
 		if err != nil {
 			return err
@@ -1369,8 +1371,6 @@ func (p *Page) Route(path string, cb RouteHandlerCallback, rm RegExMatcher) erro
 	}
 
 	routeHandler := NewRouteHandler(path, cb, matcher)
-	p.routesMu.Lock()
-	defer p.routesMu.Unlock()
 	// Append new route at the beginning of the slice as, when several routes match the given pattern,
 	// they will run in the opposite order to their registration.
 	p.routes = append([]*RouteHandler{routeHandler}, p.routes...)

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -4024,6 +4025,29 @@ func TestClickInNestedFramesCORS(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, expectedCount, countD)
 	})
+}
+
+func TestPageRouteConcurrentEnableDataRace(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t, withHTTPServer())
+	p := tb.NewPage(nil)
+
+	matcher := func(pattern, url string) (bool, error) {
+		return regexp.MatchString(fmt.Sprintf("http://[^/]*%s", pattern), url)
+	}
+	h := func(rt *common.Route) error { return rt.Continue(common.ContinueOptions{}) }
+
+	// Test checks for data race because : Each first-time registration sees routes empty, so each calls updateRequestInterception(true).
+	var wg sync.WaitGroup
+	for i := range 16 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = p.Route(fmt.Sprintf("/api/%d", i), h, matcher)
+		}(i)
+	}
+	wg.Wait()
 }
 
 func TestPageUnroute(t *testing.T) {

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -4038,16 +4038,22 @@ func TestPageRouteConcurrentEnableDataRace(t *testing.T) {
 	}
 	h := func(rt *common.Route) error { return rt.Continue(common.ContinueOptions{}) }
 
-	// Test checks for data race because : Each first-time registration sees routes empty, so each calls updateRequestInterception(true).
+	// This test is intended to surface a data race under `go test -race`: concurrent first-time registrations
+	// can each observe routes as empty and call updateRequestInterception(true).
 	var wg sync.WaitGroup
+	errCh := make(chan error, 16)
 	for i := range 16 {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			_ = p.Route(fmt.Sprintf("/api/%d", i), h, matcher)
+			errCh <- p.Route(fmt.Sprintf("/api/%d", i), h, matcher)
 		}(i)
 	}
 	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		require.NoError(t, err)
+	}
 }
 
 func TestPageUnroute(t *testing.T) {


### PR DESCRIPTION
## What?

Fixes issue : https://github.com/grafana/k6/issues/6148

The fix addresses a potential data race in https://github.com/grafana/k6/blob/master/internal/js/modules/k6/browser/common/page.go#L1356

## Why?

in internal/js/modules/k6/browser/common/page.go: Route method had an updateRequestInterception as true in its method body, however this was not protected under any locks. if more than 1 goroutine fires for the same api and calls route, there is an obvious data race on thestate update of updateRequestInterception. Additionally if a route and unroute is called by different goroutines , the interception mode on the api would be in an inconsistent state. it may be turned on or off.

Affected code links : https://github.com/grafana/k6/blob/master/internal/js/modules/k6/browser/common/page.go#L1356

There is a steps to reproduce unit test also provided in this pr as well as in the issue link https://github.com/grafana/k6/issues/6148


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

https://github.com/grafana/k6/issues/6148

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
