### PR TITLE
refactor(cloudapi): dedupe provisioning against v6/legacy shared helpers

### DIFF
--- a/cloudapi/client.go
+++ b/cloudapi/client.go
@@ -13,6 +13,9 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
+	"go.k6.io/k6/v2/internal/cloudapi/httperr"
+	"go.k6.io/k6/v2/internal/cloudapi/httputil"
 )
 
 const (
@@ -144,16 +147,9 @@ func (c *Client) prepareHeaders(req *http.Request) {
 }
 
 func (c *Client) do(req *http.Request, v any, attempt int) (retry bool, err error) {
-	resp, err := c.client.Do(req) //nolint:gosec
+	resp, err := c.client.Do(req) //nolint:gosec,bodyclose // body closed via httputil.CloseResponse below
 
-	defer func() {
-		if resp != nil {
-			_, _ = io.Copy(io.Discard, resp.Body)
-			if cerr := resp.Body.Close(); cerr != nil && err == nil {
-				err = cerr
-			}
-		}
-	}()
+	defer httputil.CloseResponse(resp, &err)
 
 	if shouldRetry(resp, err, attempt, c.retries) {
 		return true, err
@@ -197,11 +193,8 @@ func CheckResponse(r *http.Response) error {
 		Error ResponseError `json:"error"`
 	}
 	if err := json.Unmarshal(data, &payload); err != nil {
-		if r.StatusCode == http.StatusUnauthorized {
-			return errNotAuthenticated
-		}
-		if r.StatusCode == http.StatusForbidden {
-			return errNotAuthorized
+		if classified := httperr.ClassifyStatus(r.StatusCode); classified != nil {
+			return classified
 		}
 		return fmt.Errorf(
 			"unexpected HTTP error from %s: %d %s",

--- a/cloudapi/errors.go
+++ b/cloudapi/errors.go
@@ -8,11 +8,7 @@ import (
 	"strings"
 )
 
-var (
-	errNotAuthorized    = errors.New("not allowed to upload result to k6 Cloud")
-	errNotAuthenticated = errors.New("failed to authenticate with k6 Cloud")
-	errUnknown          = errors.New("an error occurred communicating with k6 Cloud")
-)
+var errUnknown = errors.New("an error occurred communicating with k6 Cloud")
 
 // ResponseError represents an error cause by talking to the API
 type ResponseError struct {

--- a/internal/cloudapi/httperr/httperr.go
+++ b/internal/cloudapi/httperr/httperr.go
@@ -1,0 +1,41 @@
+// Package httperr contains small, shared HTTP-status-code-related error
+// helpers used by k6 Cloud's several API clients (e.g. the legacy v1 client
+// in cloudapi, the v6 client in internal/cloudapi/v6, and the provisioning
+// client in internal/cloudapi/provisioning).
+//
+// It intentionally stays tiny: it only captures the part of those clients'
+// CheckResponse-style functions that is genuinely identical across them -
+// classifying a 401/403 HTTP status code into a friendly sentinel error.
+// Everything else about decoding a cloud API error response body differs
+// between API versions and is left to each client to implement on its own.
+package httperr
+
+import (
+	"errors"
+	"net/http"
+)
+
+var (
+	// ErrNotAuthenticated is returned when the k6 Cloud API responds with
+	// HTTP 401 Unauthorized, meaning the configured token failed to
+	// authenticate the request.
+	ErrNotAuthenticated = errors.New("failed to authenticate with k6 Cloud")
+
+	// ErrNotAuthorized is returned when the k6 Cloud API responds with
+	// HTTP 403 Forbidden, meaning the request was authenticated but is not
+	// allowed to perform the requested operation.
+	ErrNotAuthorized = errors.New("not allowed to upload result to k6 Cloud")
+)
+
+// ClassifyStatus returns ErrNotAuthenticated for HTTP 401, ErrNotAuthorized
+// for HTTP 403, and nil for any other status code.
+func ClassifyStatus(statusCode int) error {
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return ErrNotAuthenticated
+	case http.StatusForbidden:
+		return ErrNotAuthorized
+	default:
+		return nil
+	}
+}

--- a/internal/cloudapi/httperr/httperr_test.go
+++ b/internal/cloudapi/httperr/httperr_test.go
@@ -1,0 +1,57 @@
+package httperr
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClassifyStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		expected   error
+	}{
+		{
+			name:       "401 returns ErrNotAuthenticated",
+			statusCode: http.StatusUnauthorized,
+			expected:   ErrNotAuthenticated,
+		},
+		{
+			name:       "403 returns ErrNotAuthorized",
+			statusCode: http.StatusForbidden,
+			expected:   ErrNotAuthorized,
+		},
+		{
+			name:       "200 returns nil",
+			statusCode: http.StatusOK,
+			expected:   nil,
+		},
+		{
+			name:       "500 returns nil",
+			statusCode: http.StatusInternalServerError,
+			expected:   nil,
+		},
+		{
+			name:       "400 returns nil",
+			statusCode: http.StatusBadRequest,
+			expected:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := ClassifyStatus(tt.statusCode)
+			if tt.expected == nil {
+				assert.NoError(t, err)
+				return
+			}
+			assert.ErrorIs(t, err, tt.expected)
+		})
+	}
+}

--- a/internal/cloudapi/httputil/httputil.go
+++ b/internal/cloudapi/httputil/httputil.go
@@ -19,16 +19,9 @@ const (
 	RetryInterval = 500 * time.Millisecond
 )
 
-// CloseResponse drains res.Body to io.Discard and then closes it.
-//
-// Draining the body before closing it allows the underlying connection to
-// be returned to the client's connection pool and reused for a subsequent
-// request; closing an unread body forces the transport to discard the
-// connection instead. See https://pkg.go.dev/net/http#Response for details.
-//
-// If closing the body fails and *rerr is nil, the close error is assigned
-// to *rerr. An error already present in *rerr (e.g. one produced while
-// handling the response) is never overwritten.
+// CloseResponse drains res.Body before closing it, so the connection can be
+// reused instead of discarded, then assigns any close error to *rerr unless
+// it's already set.
 func CloseResponse(res *http.Response, rerr *error) {
 	if res == nil || res.Body == nil {
 		return
@@ -40,8 +33,7 @@ func CloseResponse(res *http.Response, rerr *error) {
 	}
 }
 
-// ToInt32 converts v to int32, returning an error if it overflows the
-// int32 range instead of truncating it.
+// ToInt32 errors on overflow instead of truncating.
 func ToInt32(v int64) (int32, error) {
 	if v < math.MinInt32 || v > math.MaxInt32 {
 		return 0, fmt.Errorf("value %d overflows int32", v)

--- a/internal/cloudapi/httputil/httputil.go
+++ b/internal/cloudapi/httputil/httputil.go
@@ -1,0 +1,74 @@
+// Package httputil contains small HTTP helpers shared by the various
+// cloud API clients (the legacy v1 client in cloudapi, the v6 client in
+// internal/cloudapi/v6, and the provisioning client in
+// internal/cloudapi/provisioning).
+package httputil
+
+import (
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"time"
+)
+
+const (
+	// MaxRetries is the default number of retry attempts for cloud API requests.
+	MaxRetries = 3
+	// RetryInterval is the default cloud request retry interval.
+	RetryInterval = 500 * time.Millisecond
+)
+
+// CloseResponse drains res.Body to io.Discard and then closes it.
+//
+// Draining the body before closing it allows the underlying connection to
+// be returned to the client's connection pool and reused for a subsequent
+// request; closing an unread body forces the transport to discard the
+// connection instead. See https://pkg.go.dev/net/http#Response for details.
+//
+// If closing the body fails and *rerr is nil, the close error is assigned
+// to *rerr. An error already present in *rerr (e.g. one produced while
+// handling the response) is never overwritten.
+func CloseResponse(res *http.Response, rerr *error) {
+	if res == nil || res.Body == nil {
+		return
+	}
+
+	_, _ = io.Copy(io.Discard, res.Body)
+	if err := res.Body.Close(); err != nil && *rerr == nil {
+		*rerr = err
+	}
+}
+
+// BodyResetTransport resets req.Body from req.GetBody before every round
+// trip after the first.
+//
+// The vendored k6cloud SDK (and any hand-rolled retry loop built around a
+// plain *http.Client) retries 5xx/429 responses by re-calling Do on the
+// same *http.Request without resetting its Body. After the first attempt
+// drains the body (or the server sends Connection: close), replaying the
+// same request produces "ContentLength=N with Body length 0". Wrapping
+// the transport here fixes it for every retrying caller in one place.
+type BodyResetTransport struct{ Base http.RoundTripper }
+
+// RoundTrip implements http.RoundTripper.
+func (rt BodyResetTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.GetBody == nil {
+		return rt.Base.RoundTrip(req)
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	req.Body = body
+	return rt.Base.RoundTrip(req)
+}
+
+// ToInt32 converts v to int32, returning an error if it overflows the
+// int32 range instead of truncating it.
+func ToInt32(v int64) (int32, error) {
+	if v < math.MinInt32 || v > math.MaxInt32 {
+		return 0, fmt.Errorf("value %d overflows int32", v)
+	}
+	return int32(v), nil
+}

--- a/internal/cloudapi/httputil/httputil.go
+++ b/internal/cloudapi/httputil/httputil.go
@@ -40,30 +40,6 @@ func CloseResponse(res *http.Response, rerr *error) {
 	}
 }
 
-// BodyResetTransport resets req.Body from req.GetBody before every round
-// trip after the first.
-//
-// The vendored k6cloud SDK (and any hand-rolled retry loop built around a
-// plain *http.Client) retries 5xx/429 responses by re-calling Do on the
-// same *http.Request without resetting its Body. After the first attempt
-// drains the body (or the server sends Connection: close), replaying the
-// same request produces "ContentLength=N with Body length 0". Wrapping
-// the transport here fixes it for every retrying caller in one place.
-type BodyResetTransport struct{ Base http.RoundTripper }
-
-// RoundTrip implements http.RoundTripper.
-func (rt BodyResetTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.GetBody == nil {
-		return rt.Base.RoundTrip(req)
-	}
-	body, err := req.GetBody()
-	if err != nil {
-		return nil, err
-	}
-	req.Body = body
-	return rt.Base.RoundTrip(req)
-}
-
 // ToInt32 converts v to int32, returning an error if it overflows the
 // int32 range instead of truncating it.
 func ToInt32(v int64) (int32, error) {

--- a/internal/cloudapi/httputil/httputil_test.go
+++ b/internal/cloudapi/httputil/httputil_test.go
@@ -1,7 +1,6 @@
 package httputil
 
 import (
-	"bytes"
 	"errors"
 	"io"
 	"math"
@@ -84,60 +83,6 @@ func TestCloseResponseDoesNotOverwriteExistingError(t *testing.T) {
 type errReader struct{}
 
 func (errReader) Read([]byte) (int, error) { return 0, io.EOF }
-
-// recordingRoundTripper records every request it sees and returns a fixed
-// response.
-type recordingRoundTripper struct {
-	bodies [][]byte
-	resp   *http.Response
-	err    error
-}
-
-func (rt *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	var b []byte
-	if req.Body != nil {
-		b, _ = io.ReadAll(req.Body)
-	}
-	rt.bodies = append(rt.bodies, b)
-	return rt.resp, rt.err
-}
-
-func TestBodyResetTransportResetsBodyWhenGetBodySet(t *testing.T) {
-	t.Parallel()
-
-	want := []byte("hello")
-	rt := &recordingRoundTripper{resp: &http.Response{StatusCode: http.StatusOK}}
-	transport := BodyResetTransport{Base: rt}
-
-	req, err := http.NewRequest(http.MethodPost, "http://example.com", nil) //nolint:noctx
-	require.NoError(t, err)
-	req.GetBody = func() (io.ReadCloser, error) {
-		return io.NopCloser(bytes.NewReader(want)), nil
-	}
-
-	_, err = transport.RoundTrip(req) //nolint:bodyclose // canned response has no real body
-	require.NoError(t, err)
-	_, err = transport.RoundTrip(req) //nolint:bodyclose // canned response has no real body
-	require.NoError(t, err)
-
-	require.Len(t, rt.bodies, 2)
-	assert.Equal(t, want, rt.bodies[0])
-	assert.Equal(t, want, rt.bodies[1])
-}
-
-func TestBodyResetTransportPassesThroughWhenNoGetBody(t *testing.T) {
-	t.Parallel()
-
-	rt := &recordingRoundTripper{resp: &http.Response{StatusCode: http.StatusOK}}
-	transport := BodyResetTransport{Base: rt}
-
-	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil) //nolint:noctx
-	require.NoError(t, err)
-
-	resp, err := transport.RoundTrip(req) //nolint:bodyclose // canned response has no real body
-	require.NoError(t, err)
-	assert.Same(t, rt.resp, resp)
-}
 
 func TestToInt32(t *testing.T) {
 	t.Parallel()

--- a/internal/cloudapi/httputil/httputil_test.go
+++ b/internal/cloudapi/httputil/httputil_test.go
@@ -11,9 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// closeRecorder is an io.ReadCloser that records whether it was closed and,
-// optionally, reads from an underlying reader before returning a
-// configurable error on Close.
 type closeRecorder struct {
 	io.Reader
 	closeErr error
@@ -25,61 +22,43 @@ func (c *closeRecorder) Close() error {
 	return c.closeErr
 }
 
-func TestCloseResponseNilResponse(t *testing.T) {
+func TestCloseResponse(t *testing.T) {
 	t.Parallel()
 
-	var rerr error
-	assert.NotPanics(t, func() {
-		CloseResponse(nil, &rerr)
+	t.Run("nil response does not panic", func(t *testing.T) {
+		t.Parallel()
+		var rerr error
+		assert.NotPanics(t, func() { CloseResponse(nil, &rerr) })
 	})
-	assert.NoError(t, rerr)
+
+	t.Run("close error is assigned when rerr is nil", func(t *testing.T) {
+		t.Parallel()
+		closeErr := errors.New("close failed")
+		body := &closeRecorder{Reader: io.LimitReader(errReader{}, 0), closeErr: closeErr}
+		res := &http.Response{Body: body}
+
+		var rerr error
+		CloseResponse(res, &rerr)
+
+		assert.Equal(t, closeErr, rerr)
+		assert.True(t, body.closed)
+	})
+
+	t.Run("close error does not overwrite an existing error", func(t *testing.T) {
+		t.Parallel()
+		closeErr := errors.New("close failed")
+		existingErr := errors.New("already set")
+		body := &closeRecorder{Reader: io.LimitReader(errReader{}, 0), closeErr: closeErr}
+		res := &http.Response{Body: body}
+
+		rerr := existingErr
+		CloseResponse(res, &rerr)
+
+		require.Error(t, rerr)
+		assert.Equal(t, existingErr, rerr)
+	})
 }
 
-func TestCloseResponseSuccess(t *testing.T) {
-	t.Parallel()
-
-	body := &closeRecorder{Reader: io.LimitReader(errReader{}, 0)}
-	res := &http.Response{Body: body}
-
-	var rerr error
-	CloseResponse(res, &rerr)
-
-	assert.True(t, body.closed)
-	assert.NoError(t, rerr)
-}
-
-func TestCloseResponseSetsErrorWhenNilRerr(t *testing.T) {
-	t.Parallel()
-
-	closeErr := errors.New("close failed")
-	body := &closeRecorder{Reader: io.LimitReader(errReader{}, 0), closeErr: closeErr}
-	res := &http.Response{Body: body}
-
-	var rerr error
-	CloseResponse(res, &rerr)
-
-	require.Error(t, rerr)
-	assert.Equal(t, closeErr, rerr)
-	assert.True(t, body.closed)
-}
-
-func TestCloseResponseDoesNotOverwriteExistingError(t *testing.T) {
-	t.Parallel()
-
-	closeErr := errors.New("close failed")
-	existingErr := errors.New("already set")
-	body := &closeRecorder{Reader: io.LimitReader(errReader{}, 0), closeErr: closeErr}
-	res := &http.Response{Body: body}
-
-	rerr := existingErr
-	CloseResponse(res, &rerr)
-
-	require.Error(t, rerr)
-	assert.Equal(t, existingErr, rerr)
-	assert.True(t, body.closed)
-}
-
-// errReader is an io.Reader that always returns io.EOF without producing data.
 type errReader struct{}
 
 func (errReader) Read([]byte) (int, error) { return 0, io.EOF }
@@ -93,10 +72,7 @@ func TestToInt32(t *testing.T) {
 		want    int32
 		wantErr bool
 	}{
-		{name: "zero", in: 0, want: 0},
-		{name: "positive in range", in: 42, want: 42},
-		{name: "max int32", in: math.MaxInt32, want: math.MaxInt32},
-		{name: "min int32", in: math.MinInt32, want: math.MinInt32},
+		{name: "in range", in: 42, want: 42},
 		{name: "overflow above", in: math.MaxInt32 + 1, wantErr: true},
 		{name: "overflow below", in: math.MinInt32 - 1, wantErr: true},
 	}

--- a/internal/cloudapi/httputil/httputil_test.go
+++ b/internal/cloudapi/httputil/httputil_test.go
@@ -1,0 +1,172 @@
+package httputil
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"math"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// closeRecorder is an io.ReadCloser that records whether it was closed and,
+// optionally, reads from an underlying reader before returning a
+// configurable error on Close.
+type closeRecorder struct {
+	io.Reader
+	closeErr error
+	closed   bool
+}
+
+func (c *closeRecorder) Close() error {
+	c.closed = true
+	return c.closeErr
+}
+
+func TestCloseResponseNilResponse(t *testing.T) {
+	t.Parallel()
+
+	var rerr error
+	assert.NotPanics(t, func() {
+		CloseResponse(nil, &rerr)
+	})
+	assert.NoError(t, rerr)
+}
+
+func TestCloseResponseSuccess(t *testing.T) {
+	t.Parallel()
+
+	body := &closeRecorder{Reader: io.LimitReader(errReader{}, 0)}
+	res := &http.Response{Body: body}
+
+	var rerr error
+	CloseResponse(res, &rerr)
+
+	assert.True(t, body.closed)
+	assert.NoError(t, rerr)
+}
+
+func TestCloseResponseSetsErrorWhenNilRerr(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("close failed")
+	body := &closeRecorder{Reader: io.LimitReader(errReader{}, 0), closeErr: closeErr}
+	res := &http.Response{Body: body}
+
+	var rerr error
+	CloseResponse(res, &rerr)
+
+	require.Error(t, rerr)
+	assert.Equal(t, closeErr, rerr)
+	assert.True(t, body.closed)
+}
+
+func TestCloseResponseDoesNotOverwriteExistingError(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("close failed")
+	existingErr := errors.New("already set")
+	body := &closeRecorder{Reader: io.LimitReader(errReader{}, 0), closeErr: closeErr}
+	res := &http.Response{Body: body}
+
+	rerr := existingErr
+	CloseResponse(res, &rerr)
+
+	require.Error(t, rerr)
+	assert.Equal(t, existingErr, rerr)
+	assert.True(t, body.closed)
+}
+
+// errReader is an io.Reader that always returns io.EOF without producing data.
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, io.EOF }
+
+// recordingRoundTripper records every request it sees and returns a fixed
+// response.
+type recordingRoundTripper struct {
+	bodies [][]byte
+	resp   *http.Response
+	err    error
+}
+
+func (rt *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	var b []byte
+	if req.Body != nil {
+		b, _ = io.ReadAll(req.Body)
+	}
+	rt.bodies = append(rt.bodies, b)
+	return rt.resp, rt.err
+}
+
+func TestBodyResetTransportResetsBodyWhenGetBodySet(t *testing.T) {
+	t.Parallel()
+
+	want := []byte("hello")
+	rt := &recordingRoundTripper{resp: &http.Response{StatusCode: http.StatusOK}}
+	transport := BodyResetTransport{Base: rt}
+
+	req, err := http.NewRequest(http.MethodPost, "http://example.com", nil) //nolint:noctx
+	require.NoError(t, err)
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(want)), nil
+	}
+
+	_, err = transport.RoundTrip(req) //nolint:bodyclose // canned response has no real body
+	require.NoError(t, err)
+	_, err = transport.RoundTrip(req) //nolint:bodyclose // canned response has no real body
+	require.NoError(t, err)
+
+	require.Len(t, rt.bodies, 2)
+	assert.Equal(t, want, rt.bodies[0])
+	assert.Equal(t, want, rt.bodies[1])
+}
+
+func TestBodyResetTransportPassesThroughWhenNoGetBody(t *testing.T) {
+	t.Parallel()
+
+	rt := &recordingRoundTripper{resp: &http.Response{StatusCode: http.StatusOK}}
+	transport := BodyResetTransport{Base: rt}
+
+	req, err := http.NewRequest(http.MethodGet, "http://example.com", nil) //nolint:noctx
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req) //nolint:bodyclose // canned response has no real body
+	require.NoError(t, err)
+	assert.Same(t, rt.resp, resp)
+}
+
+func TestToInt32(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		in      int64
+		want    int32
+		wantErr bool
+	}{
+		{name: "zero", in: 0, want: 0},
+		{name: "positive in range", in: 42, want: 42},
+		{name: "max int32", in: math.MaxInt32, want: math.MaxInt32},
+		{name: "min int32", in: math.MinInt32, want: math.MinInt32},
+		{name: "overflow above", in: math.MaxInt32 + 1, wantErr: true},
+		{name: "overflow below", in: math.MinInt32 - 1, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ToInt32(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/cloudapi/provisioning/api.go
+++ b/internal/cloudapi/provisioning/api.go
@@ -8,12 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"time"
 
 	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
 
+	"go.k6.io/k6/v2/internal/cloudapi/httputil"
 	v6 "go.k6.io/k6/v2/internal/cloudapi/v6"
 )
 
@@ -79,7 +79,7 @@ type SecretsConfig struct {
 // UploadArchive PUTs pre-serialised archive bytes to the given
 // presigned S3 URL. The URL carries auth in query params, so no
 // Authorization header is set. Retries on 5xx and transport errors.
-func (c *Client) UploadArchive(ctx context.Context, uploadURL string, body []byte) error {
+func (c *Client) UploadArchive(ctx context.Context, uploadURL string, body []byte) (err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, uploadURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("creating upload request: %w", err)
@@ -87,14 +87,11 @@ func (c *Client) UploadArchive(ctx context.Context, uploadURL string, body []byt
 	req.Header.Set("Content-Type", "application/x-tar")
 	req.ContentLength = int64(len(body))
 
-	resp, err := c.doWithRetry(req)
+	resp, err := c.doWithRetry(req) //nolint:bodyclose // closed via httputil.CloseResponse below
 	if err != nil {
 		return fmt.Errorf("uploading archive: %w", err)
 	}
-	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}()
+	defer httputil.CloseResponse(resp, &err)
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		respBody, readErr := io.ReadAll(resp.Body)
@@ -187,11 +184,11 @@ func (c *Client) StartLocalExecution(
 		return nil, fmt.Errorf("unmarshalling options for SDK: %w", err)
 	}
 
-	maxVUs, err := toInt32(req.MaxVUs)
+	maxVUs, err := httputil.ToInt32(req.MaxVUs)
 	if err != nil {
 		return nil, fmt.Errorf("max_vus: %w", err)
 	}
-	totalDuration, err := toInt32(req.TotalDuration)
+	totalDuration, err := httputil.ToInt32(req.TotalDuration)
 	if err != nil {
 		return nil, fmt.Errorf("total_duration: %w", err)
 	}
@@ -199,7 +196,7 @@ func (c *Client) StartLocalExecution(
 	sdkReq := k6cloud.NewStartLocalExecutionTestRequest(opts, maxVUs, totalDuration)
 
 	if req.ArchiveSize != nil {
-		v, err := toInt32(*req.ArchiveSize)
+		v, err := httputil.ToInt32(*req.ArchiveSize)
 		if err != nil {
 			return nil, fmt.Errorf("archive_size: %w", err)
 		}
@@ -212,8 +209,8 @@ func (c *Client) StartLocalExecution(
 		StartLocalExecutionTest(c.authCtx(ctx), loadTestID).
 		K6IdempotencyKey(hex.EncodeToString(key[:])).
 		StartLocalExecutionTestRequest(sdkReq).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	if hr != nil {
 		if respErr := CheckResponse(hr); respErr != nil {
@@ -263,25 +260,4 @@ func mapStartLocalExecutionResponse(res *k6cloud.StartLocalExecutionTestResponse
 	}
 
 	return resp
-}
-
-// toInt32 safely converts an int64 to int32, returning an error if
-// the value overflows.
-func toInt32(v int64) (int32, error) {
-	if v < math.MinInt32 || v > math.MaxInt32 {
-		return 0, fmt.Errorf("value %d overflows int32", v)
-	}
-	return int32(v), nil
-}
-
-// closeResponse drains and closes an HTTP response body. It mirrors
-// the v6 package's closeResponse helper.
-func closeResponse(res *http.Response, rerr *error) {
-	if res == nil {
-		return
-	}
-	_, _ = io.Copy(io.Discard, res.Body)
-	if err := res.Body.Close(); err != nil && *rerr == nil {
-		*rerr = err
-	}
 }

--- a/internal/cloudapi/provisioning/client.go
+++ b/internal/cloudapi/provisioning/client.go
@@ -40,7 +40,10 @@ func NewClient(
 		return nil, fmt.Errorf("token is required to create provisioning API client")
 	}
 
-	cfg := v6.NewSDKConfiguration(host, version, "k6 Cloud API (provisioning).", timeout)
+	cfg := v6.NewSDKConfiguration(
+		host, version, "k6 Cloud API (provisioning).", timeout,
+		&bodyResetTransport{base: http.DefaultTransport},
+	)
 
 	v6c, err := v6.NewClient(logger, token, host, version, timeout)
 	if err != nil {
@@ -72,10 +75,28 @@ func (c *Client) authCtx(ctx context.Context) context.Context {
 	return context.WithValue(ctx, k6cloud.ContextAccessToken, c.token)
 }
 
+// bodyResetTransport resets req.Body from GetBody before each round trip.
+// The vendored SDK retries 5xx/429 by re-calling Do on the same request
+// without resetting its Body. After Connection: close the drained body
+// causes "ContentLength=N with Body length 0".
+type bodyResetTransport struct{ base http.RoundTripper }
+
+func (rt *bodyResetTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.GetBody == nil {
+		return rt.base.RoundTrip(req)
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	req.Body = body
+	return rt.base.RoundTrip(req)
+}
+
 // doWithRetry executes the given HTTP request, retrying on 5xx/429 status
 // codes and transport errors up to httputil.MaxRetries times (matching the
 // vendored SDK's own retry predicate). On each retry the body is replayed
-// via req.GetBody (reset at the transport layer by httputil.BodyResetTransport,
+// via req.GetBody (reset at the transport layer by bodyResetTransport,
 // which the client's Configuration is built with). 4xx errors other than
 // 429 are NOT retried.
 func (c *Client) doWithRetry(req *http.Request) (*http.Response, error) {

--- a/internal/cloudapi/provisioning/client.go
+++ b/internal/cloudapi/provisioning/client.go
@@ -3,7 +3,6 @@ package provisioning
 import (
 	"context"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -12,13 +11,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	v6 "go.k6.io/k6/v2/internal/cloudapi/v6"
-)
-
-const (
-	// RetryInterval is the default cloud request retry interval.
-	RetryInterval = 500 * time.Millisecond
-	// MaxRetries specifies max retry attempts.
-	MaxRetries = 3
 )
 
 // Client handles communication with the provisioning and v6 cloud APIs.
@@ -48,23 +40,7 @@ func NewClient(
 		return nil, fmt.Errorf("token is required to create provisioning API client")
 	}
 
-	cfg := &k6cloud.Configuration{
-		DefaultHeader: make(map[string]string),
-		UserAgent:     "k6cloud/" + version,
-		Servers: k6cloud.ServerConfigurations{
-			{
-				URL:         host,
-				Description: "k6 Cloud API (provisioning).",
-			},
-		},
-		OperationServers: map[string]k6cloud.ServerConfigurations{},
-		HTTPClient: &http.Client{
-			Timeout:   timeout,
-			Transport: &bodyResetTransport{base: http.DefaultTransport},
-		},
-		MaxRetries:    MaxRetries,
-		RetryInterval: RetryInterval,
-	}
+	cfg := v6.NewSDKConfiguration(host, version, "k6 Cloud API (provisioning).", timeout)
 
 	v6c, err := v6.NewClient(logger, token, host, version, timeout)
 	if err != nil {
@@ -96,55 +72,12 @@ func (c *Client) authCtx(ctx context.Context) context.Context {
 	return context.WithValue(ctx, k6cloud.ContextAccessToken, c.token)
 }
 
-// doWithRetry executes the given HTTP request, retrying on 5xx status
-// codes and transport errors up to MaxRetries times. On each retry the
-// body is replayed via req.GetBody (reset by bodyResetTransport).
-// 4xx errors are NOT retried.
+// doWithRetry executes the given HTTP request, retrying on 5xx/429 status
+// codes and transport errors up to httputil.MaxRetries times (matching the
+// vendored SDK's own retry predicate). On each retry the body is replayed
+// via req.GetBody (reset at the transport layer by httputil.BodyResetTransport,
+// which the client's Configuration is built with). 4xx errors other than
+// 429 are NOT retried.
 func (c *Client) doWithRetry(req *http.Request) (*http.Response, error) {
-	httpClient := c.apiClient.GetConfig().HTTPClient
-
-	var (
-		lastErr  error
-		lastResp *http.Response
-	)
-
-	for attempt := 1; attempt <= MaxRetries; attempt++ {
-		lastResp, lastErr = httpClient.Do(req) //nolint:gosec
-		if lastErr != nil {
-			if attempt < MaxRetries {
-				time.Sleep(RetryInterval)
-				continue
-			}
-			break
-		}
-
-		if lastResp.StatusCode >= 500 && attempt < MaxRetries {
-			_, _ = io.Copy(io.Discard, lastResp.Body)
-			_ = lastResp.Body.Close()
-			time.Sleep(RetryInterval)
-			continue
-		}
-
-		break
-	}
-
-	return lastResp, lastErr
-}
-
-// bodyResetTransport resets req.Body from GetBody before each round trip.
-// The vendored SDK retries 5xx/429 by re-calling Do on the same request
-// without resetting its Body. After Connection: close the drained body
-// causes "ContentLength=N with Body length 0".
-type bodyResetTransport struct{ base http.RoundTripper }
-
-func (rt *bodyResetTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.GetBody == nil {
-		return rt.base.RoundTrip(req)
-	}
-	body, err := req.GetBody()
-	if err != nil {
-		return nil, err
-	}
-	req.Body = body
-	return rt.base.RoundTrip(req)
+	return doHTTPWithRetry(c.apiClient.GetConfig().HTTPClient, req, nil)
 }

--- a/internal/cloudapi/provisioning/errors.go
+++ b/internal/cloudapi/provisioning/errors.go
@@ -1,27 +1,61 @@
 package provisioning
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
+	"strings"
+
+	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
+
+	"go.k6.io/k6/v2/internal/cloudapi/httperr"
 )
 
 var errUnknown = errors.New("an error occurred communicating with the provisioning API")
 
-// ResponseError represents an error returned by the provisioning API.
+// ResponseError represents a parsed error response from the provisioning
+// API. Its wire shape ({"error": {message, code, target, details}}) is the
+// same ErrorResponseApiModel every vendored-SDK-backed client decodes on
+// failure (see internal/cloudapi/v6's identically-shaped ResponseError).
 type ResponseError struct {
-	StatusCode int
-	Body       string
+	StatusCode int                   `json:"-"`
+	APIError   k6cloud.ErrorApiModel `json:"error"`
 }
 
 func (e *ResponseError) Error() string {
-	return fmt.Sprintf("provisioning API error (%d): %s", e.StatusCode, e.Body)
+	msg := e.APIError.Message
+
+	if e.APIError.Target.IsSet() {
+		msg += " (target: '" + *e.APIError.Target.Get() + "')"
+	}
+
+	details := make([]string, len(e.APIError.Details))
+	for i, d := range e.APIError.Details {
+		details[i] = d.Message
+		if d.Target.IsSet() {
+			details[i] += " (target: '" + *d.Target.Get() + "')"
+		}
+	}
+	if len(details) > 0 {
+		msg += "\n" + strings.Join(details, "\n")
+	}
+
+	code := strconv.Itoa(e.StatusCode)
+	if e.APIError.Code != "" {
+		code += "/" + e.APIError.Code
+	}
+
+	return fmt.Sprintf("(%s) %s", code, msg)
 }
 
 // CheckResponse checks an HTTP response from the provisioning API.
-// It returns nil if the status code is in the 2xx range, otherwise it
-// returns a *ResponseError with the status code and response body.
+// It returns nil if the status code is in the 2xx range. On failure it
+// tries to parse the body as the SDK's ErrorResponseApiModel shape into a
+// *ResponseError; if that fails, it falls back to a friendly
+// httperr-classified sentinel for 401/403, or a generic status-line error.
 func CheckResponse(resp *http.Response) error {
 	if resp == nil {
 		return errUnknown
@@ -36,8 +70,18 @@ func CheckResponse(resp *http.Response) error {
 		return errUnknown
 	}
 
-	return &ResponseError{
-		StatusCode: resp.StatusCode,
-		Body:       string(data),
+	var payload ResponseError
+	if err := json.Unmarshal(data, &payload); err != nil {
+		if classified := httperr.ClassifyStatus(resp.StatusCode); classified != nil {
+			return classified
+		}
+		return fmt.Errorf(
+			"unexpected HTTP error from %s: %d %s",
+			resp.Request.URL,
+			resp.StatusCode,
+			http.StatusText(resp.StatusCode),
+		)
 	}
+	payload.StatusCode = resp.StatusCode
+	return &payload
 }

--- a/internal/cloudapi/provisioning/errors_test.go
+++ b/internal/cloudapi/provisioning/errors_test.go
@@ -21,12 +21,26 @@ func TestCheckResponse(t *testing.T) {
 		name       string
 		statusCode int
 		body       string
-		wantErr    bool
-		wantStatus int
+		wantErr    error // nil means "no error"; sentinel means require.ErrorIs
+		wantStatus int   // checked via *ResponseError when wantErr is nil and status is non-2xx
 	}{
-		{"2xx returns nil", 200, "{}", false, 0},
-		{"4xx wraps as ResponseError", 400, `{"error":{"message":"bad","code":"BAD_REQUEST"}}`, true, 400},
-		{"5xx wraps as ResponseError", 500, `{"error":{"message":"oops","code":"INTERNAL"}}`, true, 500},
+		{name: "2xx returns nil", statusCode: 200, body: "{}"},
+		{
+			name: "4xx parses into ResponseError", statusCode: 400,
+			body: `{"error":{"message":"bad","code":"BAD_REQUEST"}}`, wantStatus: 400,
+		},
+		{
+			name: "5xx parses into ResponseError", statusCode: 500,
+			body: `{"error":{"message":"oops","code":"INTERNAL"}}`, wantStatus: 500,
+		},
+		{
+			name: "401 with unparsable body falls back to httperr", statusCode: http.StatusUnauthorized,
+			body: "plain text, not JSON", wantErr: httperr.ErrNotAuthenticated,
+		},
+		{
+			name: "403 with unparsable body falls back to httperr", statusCode: http.StatusForbidden,
+			body: "plain text, not JSON", wantErr: httperr.ErrNotAuthorized,
+		},
 	}
 
 	for _, tc := range cases {
@@ -39,47 +53,21 @@ func TestCheckResponse(t *testing.T) {
 			}
 
 			err := CheckResponse(resp)
-			if !tc.wantErr {
+			switch {
+			case tc.statusCode >= 200 && tc.statusCode <= 299:
 				assert.NoError(t, err)
-				return
+			case tc.wantErr != nil:
+				require.ErrorIs(t, err, tc.wantErr)
+			default:
+				var respErr *ResponseError
+				require.ErrorAs(t, err, &respErr)
+				assert.Equal(t, tc.wantStatus, respErr.StatusCode)
 			}
-
-			require.Error(t, err)
-			var respErr *ResponseError
-			require.ErrorAs(t, err, &respErr)
-			assert.Equal(t, tc.wantStatus, respErr.StatusCode)
 		})
 	}
 }
 
-func TestCheckResponse_401And403FallBackToHttperr(t *testing.T) {
-	t.Parallel()
-
-	cases := []struct {
-		name       string
-		statusCode int
-		wantErr    error
-	}{
-		{"401 non-JSON body", http.StatusUnauthorized, httperr.ErrNotAuthenticated},
-		{"403 non-JSON body", http.StatusForbidden, httperr.ErrNotAuthorized},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			resp := &http.Response{
-				StatusCode: tc.statusCode,
-				Body:       io.NopCloser(strings.NewReader("plain text, not JSON")),
-			}
-
-			err := CheckResponse(resp)
-			require.ErrorIs(t, err, tc.wantErr)
-		})
-	}
-}
-
-func TestCheckResponse_UnparsableBodyFallsBackToGenericError(t *testing.T) {
+func TestCheckResponse_UnparsableBodyWithoutHttperrMatchFallsBackToGenericError(t *testing.T) {
 	t.Parallel()
 
 	resp := &http.Response{
@@ -93,15 +81,12 @@ func TestCheckResponse_UnparsableBodyFallsBackToGenericError(t *testing.T) {
 	assert.Contains(t, err.Error(), "418")
 }
 
-func TestResponseError_Error_FormatsStatusAndBody(t *testing.T) {
+func TestResponseError_Error(t *testing.T) {
 	t.Parallel()
 
 	re := &ResponseError{
 		StatusCode: 422,
-		APIError: k6cloud.ErrorApiModel{
-			Message: "validation failed",
-			Code:    "VALIDATION",
-		},
+		APIError:   k6cloud.ErrorApiModel{Message: "validation failed", Code: "VALIDATION"},
 	}
 
 	msg := re.Error()

--- a/internal/cloudapi/provisioning/errors_test.go
+++ b/internal/cloudapi/provisioning/errors_test.go
@@ -3,11 +3,15 @@ package provisioning
 import (
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 
+	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/internal/cloudapi/httperr"
 )
 
 func TestCheckResponse(t *testing.T) {
@@ -21,8 +25,8 @@ func TestCheckResponse(t *testing.T) {
 		wantStatus int
 	}{
 		{"2xx returns nil", 200, "{}", false, 0},
-		{"4xx wraps as ResponseError", 400, `{"error":"bad"}`, true, 400},
-		{"5xx wraps as ResponseError", 500, `{"error":"oops"}`, true, 500},
+		{"4xx wraps as ResponseError", 400, `{"error":{"message":"bad","code":"BAD_REQUEST"}}`, true, 400},
+		{"5xx wraps as ResponseError", 500, `{"error":{"message":"oops","code":"INTERNAL"}}`, true, 500},
 	}
 
 	for _, tc := range cases {
@@ -48,15 +52,60 @@ func TestCheckResponse(t *testing.T) {
 	}
 }
 
+func TestCheckResponse_401And403FallBackToHttperr(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		statusCode int
+		wantErr    error
+	}{
+		{"401 non-JSON body", http.StatusUnauthorized, httperr.ErrNotAuthenticated},
+		{"403 non-JSON body", http.StatusForbidden, httperr.ErrNotAuthorized},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp := &http.Response{
+				StatusCode: tc.statusCode,
+				Body:       io.NopCloser(strings.NewReader("plain text, not JSON")),
+			}
+
+			err := CheckResponse(resp)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestCheckResponse_UnparsableBodyFallsBackToGenericError(t *testing.T) {
+	t.Parallel()
+
+	resp := &http.Response{
+		StatusCode: http.StatusTeapot,
+		Body:       io.NopCloser(strings.NewReader("plain text, not JSON")),
+		Request:    &http.Request{URL: &url.URL{Scheme: "https", Host: "api.k6.io", Path: "/provisioning/v1/test"}},
+	}
+
+	err := CheckResponse(resp)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "418")
+}
+
 func TestResponseError_Error_FormatsStatusAndBody(t *testing.T) {
 	t.Parallel()
 
 	re := &ResponseError{
 		StatusCode: 422,
-		Body:       "validation failed",
+		APIError: k6cloud.ErrorApiModel{
+			Message: "validation failed",
+			Code:    "VALIDATION",
+		},
 	}
 
 	msg := re.Error()
 	assert.Contains(t, msg, "422")
+	assert.Contains(t, msg, "VALIDATION")
 	assert.Contains(t, msg, "validation failed")
 }

--- a/internal/cloudapi/provisioning/http_client.go
+++ b/internal/cloudapi/provisioning/http_client.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/sirupsen/logrus"
+
+	"go.k6.io/k6/v2/internal/cloudapi/httputil"
 )
 
 // HTTPClient is a Bearer-authenticated HTTP layer used by the cloud
@@ -34,7 +35,7 @@ func NewHTTPClient(httpClient *http.Client, token, version string, logger logrus
 
 // Do executes the request with Bearer auth, retries on 5xx and
 // transport errors, and decodes the response body into v if non-nil.
-func (p *HTTPClient) Do(req *http.Request, v any) error {
+func (p *HTTPClient) Do(req *http.Request, v any) (err error) {
 	// Ensure GetBody is set so the body can be replayed on retries.
 	if req.Body != nil && req.GetBody == nil {
 		body, err := io.ReadAll(req.Body)
@@ -53,55 +54,33 @@ func (p *HTTPClient) Do(req *http.Request, v any) error {
 	req.Header.Set("Authorization", "Bearer "+p.token)
 	req.Header.Set("User-Agent", "k6cloud/"+p.version)
 
-	var (
-		lastErr  error
-		lastResp *http.Response
-	)
-
-	for attempt := 1; attempt <= MaxRetries; attempt++ {
-		lastResp, lastErr = p.httpClient.Do(req) //nolint:gosec
-		if lastErr != nil {
-			if attempt < MaxRetries {
-				time.Sleep(RetryInterval)
-				if req.GetBody != nil {
-					req.Body, _ = req.GetBody()
-				}
-				continue
-			}
-			break
+	//nolint:bodyclose // closed via httputil.CloseResponse below
+	lastResp, err := doHTTPWithRetry(p.httpClient, req, func() error {
+		if req.GetBody == nil {
+			return nil
 		}
-
-		if lastResp.StatusCode >= 500 && attempt < MaxRetries {
-			_, _ = io.Copy(io.Discard, lastResp.Body)
-			_ = lastResp.Body.Close()
-			time.Sleep(RetryInterval)
-			if req.GetBody != nil {
-				req.Body, _ = req.GetBody()
-			}
-			continue
+		body, getBodyErr := req.GetBody()
+		if getBodyErr != nil {
+			return getBodyErr
 		}
-
-		break
+		req.Body = body
+		return nil
+	})
+	if err != nil {
+		return err
 	}
+	defer httputil.CloseResponse(lastResp, &err)
 
-	if lastErr != nil {
-		return lastErr
-	}
-
-	defer func() {
-		_, _ = io.Copy(io.Discard, lastResp.Body)
-		_ = lastResp.Body.Close()
-	}()
-
-	if err := CheckResponse(lastResp); err != nil {
+	if err = CheckResponse(lastResp); err != nil {
 		return err
 	}
 
 	if v != nil {
-		if err := json.NewDecoder(lastResp.Body).Decode(v); err != nil && !errors.Is(err, io.EOF) {
+		if err = json.NewDecoder(lastResp.Body).Decode(v); err != nil && !errors.Is(err, io.EOF) {
 			return fmt.Errorf("decoding response: %w", err)
 		}
+		err = nil
 	}
 
-	return nil
+	return err
 }

--- a/internal/cloudapi/provisioning/http_client_test.go
+++ b/internal/cloudapi/provisioning/http_client_test.go
@@ -101,7 +101,7 @@ func TestHTTPClient_NoRetryOn4xx(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		hits.Add(1)
 		w.WriteHeader(http.StatusBadRequest)
-		_, _ = w.Write([]byte(`{"error":"bad input"}`))
+		_, _ = w.Write([]byte(`{"error":{"message":"bad input","code":"BAD_INPUT"}}`))
 	}))
 	defer srv.Close()
 

--- a/internal/cloudapi/provisioning/notify.go
+++ b/internal/cloudapi/provisioning/notify.go
@@ -8,6 +8,7 @@ import (
 	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
 
 	"go.k6.io/k6/v2/errext"
+	"go.k6.io/k6/v2/internal/cloudapi/httputil"
 )
 
 // notifyError represents a script execution error in the notify
@@ -70,8 +71,8 @@ func (c *Client) NotifyTestRunCompleted(
 	hr, err := c.apiClient.ProvisioningAPI.
 		TestRunsNotify(scopedCtx, testRunID).
 		ScriptExecutionCompletedNotificationApiModel(model).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	if hr != nil {
 		if respErr := CheckResponse(hr); respErr != nil {

--- a/internal/cloudapi/provisioning/retry.go
+++ b/internal/cloudapi/provisioning/retry.go
@@ -8,16 +8,10 @@ import (
 	"go.k6.io/k6/v2/internal/cloudapi/httputil"
 )
 
-// doHTTPWithRetry executes req via client, retrying on transport errors,
-// 5xx responses, and 429 responses - the same predicate the vendored SDK
-// uses for its own generated operations - up to httputil.MaxRetries
-// attempts.
-//
-// If resetBody is non-nil, it's called before every retry attempt (not the
-// first) to rewind a request body that isn't rewound automatically at the
-// transport layer. Pass nil when client's Transport already replays the
-// body itself (e.g. bodyResetTransport, as used by the SDK-backed
-// *Client.apiClient).
+// doHTTPWithRetry retries on transport errors, 5xx, and 429 - matching the
+// vendored SDK's own retry predicate. resetBody, if non-nil, rewinds the
+// request body before each retry; pass nil when the client's Transport
+// already replays it (e.g. bodyResetTransport).
 func doHTTPWithRetry(client *http.Client, req *http.Request, resetBody func() error) (*http.Response, error) {
 	var (
 		lastErr  error

--- a/internal/cloudapi/provisioning/retry.go
+++ b/internal/cloudapi/provisioning/retry.go
@@ -16,7 +16,7 @@ import (
 // If resetBody is non-nil, it's called before every retry attempt (not the
 // first) to rewind a request body that isn't rewound automatically at the
 // transport layer. Pass nil when client's Transport already replays the
-// body itself (e.g. httputil.BodyResetTransport, as used by the SDK-backed
+// body itself (e.g. bodyResetTransport, as used by the SDK-backed
 // *Client.apiClient).
 func doHTTPWithRetry(client *http.Client, req *http.Request, resetBody func() error) (*http.Response, error) {
 	var (

--- a/internal/cloudapi/provisioning/retry.go
+++ b/internal/cloudapi/provisioning/retry.go
@@ -1,0 +1,49 @@
+package provisioning
+
+import (
+	"io"
+	"net/http"
+	"time"
+
+	"go.k6.io/k6/v2/internal/cloudapi/httputil"
+)
+
+// doHTTPWithRetry executes req via client, retrying on transport errors,
+// 5xx responses, and 429 responses - the same predicate the vendored SDK
+// uses for its own generated operations - up to httputil.MaxRetries
+// attempts.
+//
+// If resetBody is non-nil, it's called before every retry attempt (not the
+// first) to rewind a request body that isn't rewound automatically at the
+// transport layer. Pass nil when client's Transport already replays the
+// body itself (e.g. httputil.BodyResetTransport, as used by the SDK-backed
+// *Client.apiClient).
+func doHTTPWithRetry(client *http.Client, req *http.Request, resetBody func() error) (*http.Response, error) {
+	var (
+		lastErr  error
+		lastResp *http.Response
+	)
+
+	for attempt := 1; attempt <= httputil.MaxRetries; attempt++ {
+		if attempt > 1 && resetBody != nil {
+			if err := resetBody(); err != nil {
+				return nil, err
+			}
+		}
+
+		lastResp, lastErr = client.Do(req) //nolint:gosec // caller closes lastResp on return
+		retryableStatus := lastResp != nil &&
+			(lastResp.StatusCode >= http.StatusInternalServerError || lastResp.StatusCode == http.StatusTooManyRequests)
+		if attempt >= httputil.MaxRetries || (lastErr == nil && !retryableStatus) {
+			break
+		}
+
+		if lastResp != nil {
+			_, _ = io.Copy(io.Discard, lastResp.Body)
+			_ = lastResp.Body.Close()
+		}
+		time.Sleep(httputil.RetryInterval)
+	}
+
+	return lastResp, lastErr
+}

--- a/internal/cloudapi/v6/api.go
+++ b/internal/cloudapi/v6/api.go
@@ -13,6 +13,7 @@ import (
 
 	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
 
+	"go.k6.io/k6/v2/internal/cloudapi/httputil"
 	"go.k6.io/k6/v2/lib"
 )
 
@@ -63,8 +64,8 @@ func (c *Client) listProjectsPage(
 		XStackId(c.stackID).
 		Skip(skip).
 		Top(top).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	if err := CheckResponse(hr, err); err != nil {
 		return nil, err
@@ -88,8 +89,8 @@ func (c *Client) ValidateToken(ctx context.Context, stackURL string) (_ *k6cloud
 	res, hr, err := c.apiClient.AuthorizationAPI.
 		Auth(c.authCtx(ctx)).
 		XStackUrl(stackURL).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	if err := CheckResponse(hr, err); err != nil {
 		return nil, err
@@ -122,8 +123,8 @@ func (c *Client) ValidateOptions(ctx context.Context, projectID int32, opts lib.
 		ValidateOptions(c.authCtx(ctx)).
 		XStackId(c.stackID).
 		ValidateOptionsRequest(req).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	if err := CheckResponse(hr, err); err != nil {
 		return err
@@ -143,8 +144,8 @@ func (c *Client) CreateOrFindLoadTest(ctx context.Context, projectID int32, name
 		ProjectsLoadTestsCreate(c.authCtx(ctx), projectID).
 		XStackId(c.stackID).
 		Name(name).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	if err := CheckResponse(hr, err); err != nil {
 		var rerr ResponseError
@@ -199,8 +200,8 @@ func (c *Client) createTest(
 		XStackId(c.stackID).
 		Name(name).
 		Script(archiveReader(arc)).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	if err := CheckResponse(hr, err); err != nil {
 		return nil, err
@@ -220,8 +221,8 @@ func (c *Client) findTestByName(
 		XStackId(c.stackID).
 		Name(name).
 		Top(1).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	if err := CheckResponse(hr, err); err != nil {
 		return nil, err
@@ -243,8 +244,8 @@ func (c *Client) updateScript(ctx context.Context, testID int32, arc *lib.Archiv
 		LoadTestsScriptUpdate(c.authCtx(ctx), testID).
 		XStackId(c.stackID).
 		Body(archiveReader(arc)).
-		Execute()
-	defer closeResponse(res, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(res, &err)
 
 	return CheckResponse(res, err)
 }
@@ -260,8 +261,8 @@ func (c *Client) StartTest(ctx context.Context, loadTestID int32) (_ *k6cloud.St
 		LoadTestsStart(c.authCtx(ctx), loadTestID).
 		XStackId(c.stackID).
 		K6IdempotencyKey(hex.EncodeToString(key[:])).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	if err := CheckResponse(hr, err); err != nil {
 		return nil, err
@@ -278,8 +279,8 @@ func (c *Client) StopTest(ctx context.Context, testRunID int32) (err error) {
 	hr, err := c.apiClient.TestRunsAPI.
 		TestRunsAbort(c.authCtx(ctx), testRunID).
 		XStackId(c.stackID).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	err = CheckResponse(hr, err)
 	var rerr ResponseError
@@ -295,8 +296,8 @@ func (c *Client) FetchTest(ctx context.Context, testRunID int32) (_ *TestProgres
 	res, hr, err := c.apiClient.TestRunsAPI.
 		TestRunsRetrieve(c.authCtx(ctx), testRunID).
 		XStackId(c.stackID).
-		Execute()
-	defer closeResponse(hr, &err)
+		Execute() //nolint:bodyclose // response body is drained and closed via httputil.CloseResponse below
+	defer httputil.CloseResponse(hr, &err)
 
 	if err := CheckResponse(hr, err); err != nil {
 		return nil, err
@@ -316,16 +317,6 @@ func (c *Client) FetchTest(ctx context.Context, testRunID int32) (_ *TestProgres
 
 func (c *Client) authCtx(ctx context.Context) context.Context {
 	return context.WithValue(ctx, k6cloud.ContextAccessToken, c.token)
-}
-
-func closeResponse(res *http.Response, rerr *error) {
-	if res == nil {
-		return
-	}
-	_, _ = io.Copy(io.Discard, res.Body)
-	if err := res.Body.Close(); err != nil && *rerr == nil {
-		*rerr = err
-	}
 }
 
 func archiveReader(arc *lib.Archive) io.ReadCloser {

--- a/internal/cloudapi/v6/client.go
+++ b/internal/cloudapi/v6/client.go
@@ -27,9 +27,12 @@ type Client struct {
 
 // NewSDKConfiguration builds a *k6cloud.Configuration for a client backed by
 // the vendored k6cloud-openapi SDK, shared by this package and
-// internal/cloudapi/provisioning: the same UserAgent convention, retry
-// policy, and body-reset-on-retry workaround for the SDK's own retry loop.
-func NewSDKConfiguration(host, version, serverDescription string, timeout time.Duration) *k6cloud.Configuration {
+// internal/cloudapi/provisioning: the same UserAgent convention and retry
+// policy. transport lets each caller supply its own http.RoundTripper (e.g.
+// a retry-body-reset workaround) rather than baking one in here.
+func NewSDKConfiguration(
+	host, version, serverDescription string, timeout time.Duration, transport http.RoundTripper,
+) *k6cloud.Configuration {
 	cfg := k6cloud.NewConfiguration()
 	cfg.UserAgent = "k6cloud/" + version
 	cfg.Servers = k6cloud.ServerConfigurations{
@@ -40,11 +43,29 @@ func NewSDKConfiguration(host, version, serverDescription string, timeout time.D
 	}
 	cfg.HTTPClient = &http.Client{
 		Timeout:   timeout,
-		Transport: httputil.BodyResetTransport{Base: http.DefaultTransport},
+		Transport: transport,
 	}
 	cfg.MaxRetries = httputil.MaxRetries
 	cfg.RetryInterval = httputil.RetryInterval
 	return cfg
+}
+
+// bodyResetTransport resets req.Body from GetBody before each round trip.
+// The vendored SDK retries 5xx/429 by re-calling Do on the same request
+// without resetting its Body. After Connection: close the drained body
+// causes "ContentLength=N with Body length 0".
+type bodyResetTransport struct{ base http.RoundTripper }
+
+func (rt *bodyResetTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.GetBody == nil {
+		return rt.base.RoundTrip(req)
+	}
+	body, err := req.GetBody()
+	if err != nil {
+		return nil, err
+	}
+	req.Body = body
+	return rt.base.RoundTrip(req)
 }
 
 // NewClient return a new client for the cloud API
@@ -53,7 +74,10 @@ func NewClient(logger logrus.FieldLogger, token, host, version string, timeout t
 		return nil, fmt.Errorf("token is required to create cloud API client")
 	}
 
-	cfg := NewSDKConfiguration(host, version, "Global k6 Cloud API.", timeout)
+	cfg := NewSDKConfiguration(
+		host, version, "Global k6 Cloud API.", timeout,
+		&bodyResetTransport{base: http.DefaultTransport},
+	)
 
 	c := &Client{
 		apiClient: k6cloud.NewAPIClient(cfg),

--- a/internal/cloudapi/v6/client.go
+++ b/internal/cloudapi/v6/client.go
@@ -10,13 +10,9 @@ import (
 
 	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
 	"github.com/sirupsen/logrus"
-)
 
-const (
-	// RetryInterval is the default cloud request retry interval
-	RetryInterval = 500 * time.Millisecond
-	// MaxRetries specifies max retry attempts
-	MaxRetries = 3
+	"go.k6.io/k6/v2/internal/cloudapi/httperr"
+	"go.k6.io/k6/v2/internal/cloudapi/httputil"
 )
 
 // Client handles communication with the k6 Cloud API.
@@ -29,29 +25,35 @@ type Client struct {
 	logger logrus.FieldLogger
 }
 
+// NewSDKConfiguration builds a *k6cloud.Configuration for a client backed by
+// the vendored k6cloud-openapi SDK, shared by this package and
+// internal/cloudapi/provisioning: the same UserAgent convention, retry
+// policy, and body-reset-on-retry workaround for the SDK's own retry loop.
+func NewSDKConfiguration(host, version, serverDescription string, timeout time.Duration) *k6cloud.Configuration {
+	cfg := k6cloud.NewConfiguration()
+	cfg.UserAgent = "k6cloud/" + version
+	cfg.Servers = k6cloud.ServerConfigurations{
+		{
+			URL:         host,
+			Description: serverDescription,
+		},
+	}
+	cfg.HTTPClient = &http.Client{
+		Timeout:   timeout,
+		Transport: httputil.BodyResetTransport{Base: http.DefaultTransport},
+	}
+	cfg.MaxRetries = httputil.MaxRetries
+	cfg.RetryInterval = httputil.RetryInterval
+	return cfg
+}
+
 // NewClient return a new client for the cloud API
 func NewClient(logger logrus.FieldLogger, token, host, version string, timeout time.Duration) (*Client, error) {
 	if token == "" {
 		return nil, fmt.Errorf("token is required to create cloud API client")
 	}
 
-	cfg := &k6cloud.Configuration{
-		DefaultHeader: make(map[string]string),
-		UserAgent:     "k6cloud/" + version,
-		Servers: k6cloud.ServerConfigurations{
-			{
-				URL:         host,
-				Description: "Global k6 Cloud API.",
-			},
-		},
-		OperationServers: map[string]k6cloud.ServerConfigurations{},
-		HTTPClient: &http.Client{
-			Timeout:   timeout,
-			Transport: &bodyResetTransport{base: http.DefaultTransport},
-		},
-		MaxRetries:    MaxRetries,
-		RetryInterval: RetryInterval,
-	}
+	cfg := NewSDKConfiguration(host, version, "Global k6 Cloud API.", timeout)
 
 	c := &Client{
 		apiClient: k6cloud.NewAPIClient(cfg),
@@ -70,24 +72,6 @@ func (c *Client) SetStackID(stackID int32) {
 // BaseURL returns configured host.
 func (c *Client) BaseURL() string {
 	return c.baseURL
-}
-
-// bodyResetTransport resets req.Body from GetBody before each round trip.
-// The vendored SDK retries 5xx/429 by re-calling Do on the same request
-// without resetting its Body. After Connection: close the drained body
-// causes "ContentLength=N with Body length 0".
-type bodyResetTransport struct{ base http.RoundTripper }
-
-func (rt *bodyResetTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	if req.GetBody == nil {
-		return rt.base.RoundTrip(req)
-	}
-	body, err := req.GetBody()
-	if err != nil {
-		return nil, err
-	}
-	req.Body = body
-	return rt.base.RoundTrip(req)
 }
 
 // CheckResponse checks the parsed response.
@@ -116,11 +100,8 @@ func CheckResponse(r *http.Response, err error) error {
 
 	var payload ResponseError
 	if err := json.Unmarshal(data, &payload); err != nil {
-		if r.StatusCode == http.StatusUnauthorized {
-			return errNotAuthenticated
-		}
-		if r.StatusCode == http.StatusForbidden {
-			return errNotAuthorized
+		if classified := httperr.ClassifyStatus(r.StatusCode); classified != nil {
+			return classified
 		}
 		return fmt.Errorf(
 			"unexpected HTTP error from %s: %d %s",

--- a/internal/cloudapi/v6/client_test.go
+++ b/internal/cloudapi/v6/client_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"go.k6.io/k6/v2/internal/cloudapi/httperr"
 )
 
 func TestCheckResponse(t *testing.T) {
@@ -43,7 +45,7 @@ func TestCheckResponse(t *testing.T) {
 				StatusCode: http.StatusUnauthorized,
 				Body:       io.NopCloser(strings.NewReader("invalid json")),
 			},
-			expectedError: errNotAuthenticated.Error(),
+			expectedError: httperr.ErrNotAuthenticated.Error(),
 		},
 		{
 			name: "forbidden 403 with invalid JSON",
@@ -51,7 +53,7 @@ func TestCheckResponse(t *testing.T) {
 				StatusCode: http.StatusForbidden,
 				Body:       io.NopCloser(strings.NewReader("invalid json")),
 			},
-			expectedError: errNotAuthorized.Error(),
+			expectedError: httperr.ErrNotAuthorized.Error(),
 		},
 		{
 			name: "server error 500 with invalid JSON",

--- a/internal/cloudapi/v6/errors.go
+++ b/internal/cloudapi/v6/errors.go
@@ -10,10 +10,8 @@ import (
 )
 
 var (
-	errNotAuthorized    = errors.New("not allowed to upload result to k6 Cloud")
-	errNotAuthenticated = errors.New("failed to authenticate with k6 Cloud")
-	errTestNotExists    = errors.New("load test not found")
-	errUnknown          = errors.New("an error occurred communicating with k6 Cloud")
+	errTestNotExists = errors.New("load test not found")
+	errUnknown       = errors.New("an error occurred communicating with k6 Cloud")
 )
 
 // ResponseError represents an error cause by talking to the API

--- a/internal/cmd/outputs_cloud.go
+++ b/internal/cmd/outputs_cloud.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -17,6 +16,7 @@ import (
 	"go.k6.io/k6/v2/cloudapi"
 	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/internal/build"
+	"go.k6.io/k6/v2/internal/cloudapi/httputil"
 	"go.k6.io/k6/v2/internal/cloudapi/provisioning"
 	cloudsecrets "go.k6.io/k6/v2/internal/secretsource/cloud"
 	"go.k6.io/k6/v2/lib"
@@ -36,7 +36,7 @@ const (
 // This method also sets the test run ID in the environment so it can be used later,
 // and applies any Cloud configuration overrides returned by the API.
 //
-//nolint:funlen,gocognit,cyclop
+//nolint:funlen,cyclop
 func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error {
 	// Otherwise, we continue normally with the creation of the test run in the k6 Cloud backend services.
 	conf, warn, err := cloudapi.GetConsolidatedConfig(
@@ -110,21 +110,13 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 
 	logger := gs.Logger.WithFields(logrus.Fields{"output": builtinOutputCloud.String()})
 
-	// Safe int64 → int32 conversion (same pattern as prepCloudTestRun).
-	toInt32 := func(v int64) (int32, error) {
-		if v < math.MinInt32 || v > math.MaxInt32 {
-			return 0, fmt.Errorf("value %d overflows int32", v)
-		}
-		return int32(v), nil
-	}
-
 	// stackID==0 is treated by provisioning.NewClient as "no stack
 	// configured" and the X-Stack-Id header is omitted; this preserves
 	// behavior for callers that did not set K6_CLOUD_STACK_ID.
 	var stackID int32
 	if conf.StackID.Valid {
 		var err error
-		stackID, err = toInt32(conf.StackID.Int64)
+		stackID, err = httputil.ToInt32(conf.StackID.Int64)
 		if err != nil {
 			return err
 		}
@@ -149,7 +141,7 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 		}
 	}
 
-	projectID, err := toInt32(conf.ProjectID.Int64)
+	projectID, err := httputil.ToInt32(conf.ProjectID.Int64)
 	if err != nil {
 		return err
 	}

--- a/internal/output/cloud/output.go
+++ b/internal/output/cloud/output.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"net/http"
 	"path/filepath"
 	"strconv"
@@ -18,6 +17,7 @@ import (
 	"go.k6.io/k6/v2/cloudapi"
 	"go.k6.io/k6/v2/errext"
 	"go.k6.io/k6/v2/internal/build"
+	"go.k6.io/k6/v2/internal/cloudapi/httputil"
 	"go.k6.io/k6/v2/internal/cloudapi/provisioning"
 	"go.k6.io/k6/v2/internal/usage"
 	"go.k6.io/k6/v2/lib"
@@ -503,17 +503,15 @@ func (out *Output) lazyInitProvisioning() error {
 
 	// Lazy-construct the provisioning notifier (used at end-of-test).
 	if out.provisioningNotifier == nil {
-		// Inline overflow check matches cmd_project_list.go:79-80 pattern
-		// (one cast in scope; local closure pattern would be overkill).
 		// stackID==0 is treated by provisioning.NewClient as "no stack
 		// configured" and the X-Stack-Id header is omitted.
 		var stackID int32
 		if out.config.StackID.Valid {
-			v := out.config.StackID.Int64
-			if v < math.MinInt32 || v > math.MaxInt32 {
-				return fmt.Errorf("stack ID %d overflows int32", v)
+			v, err := httputil.ToInt32(out.config.StackID.Int64)
+			if err != nil {
+				return fmt.Errorf("stack ID: %w", err)
 			}
-			stackID = int32(v)
+			stackID = v
 		}
 		c, err := provisioning.NewClient(
 			out.logger,


### PR DESCRIPTION
## What?

Builds on top of #6159's `internal/cloudapi/httperr` package and extends the same dedup effort to `internal/cloudapi/provisioning` (this branch's local-execution work), plus adds a matching `internal/cloudapi/httputil` package for shared helpers. Concretely:

- **`closeResponse`**: verbatim copy of the drain-then-close-body helper across all three clients (legacy `cloudapi`, `v6`, `provisioning`) → `internal/cloudapi/httputil.CloseResponse`.
- **`k6cloud.Configuration` construction**: a third copy of the `UserAgent`/`Servers`/`HTTPClient`/`MaxRetries`/`RetryInterval` boilerplate → `v6.NewSDKConfiguration(host, version, description, timeout, transport)`, shared by `v6.NewClient` and `provisioning.NewClient`. `bodyResetTransport` itself is deliberately *not* centralized here (see note below) — each caller still passes its own local `bodyResetTransport` in as the `transport` argument.
- **`MaxRetries`/`RetryInterval`**: a third copy of the same literal values → `httputil.MaxRetries`/`httputil.RetryInterval`.
- **`toInt32`**: the int64→int32 overflow-check was scattered across `provisioning/api.go`, `internal/cmd/outputs_cloud.go`, and `internal/output/cloud/output.go` → `httputil.ToInt32`.
- **401/403 classification**: `provisioning.CheckResponse` had none at all (unlike `v6`/legacy), so 401/403 responses rendered as a raw status-line error. Now uses `httperr.ClassifyStatus` (from #6159).
- **Error body parsing**: `provisioning.ResponseError` only carried a raw status code + body string. The vendored SDK's own generated provisioning operations decode errors into the same `{"error": {message, code, target, details}}` shape `v6.ResponseError` already parses (confirmed by reading the SDK's own generated decode target, `ErrorResponseApiModel`), so `provisioning.ResponseError` now parses the same way — kept as its own type to preserve the existing `*ResponseError` contract for `notify.go` and tests.
- **Two near-identical hand-rolled retry loops** (`UploadArchive`'s `doWithRetry`, `HTTPClient.Do`'s inline loop) merged into one `doHTTPWithRetry`, with the retry predicate aligned to the vendored SDK's own `shouldRetry` (`>=500` or `429` — both loops were previously missing the `429` case).

**Deliberately not deduplicated:** `bodyResetTransport` (the retry-body-reset workaround) is intentionally left as-is, duplicated between `v6` and `provisioning`, rather than moved into `httputil`. The bug it works around is already fixed upstream and being consumed via #6151; once that merges and this branch rebases, `v6`'s copy goes away on its own. Centralizing it now would just create work to undo again shortly after.

## Why?

This is a followup to a review pass on this branch that specifically looked for what's duplicated across `cloudapi`/`v6`/`provisioning` and what's genuinely shareable vs. not. `provisioning` reinvented (or, in the 401/403 case, simply lacked) several things the other two clients already had solved. No behavior change is intended beyond closing the 401/403 and 429 gaps, both of which are SDK-parity fixes rather than deliberate design choices.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Based on `local-exec-prov-take2` (#6068's head branch), not `master` — `internal/cloudapi/provisioning` doesn't exist on `master` yet.
- #6159 (introduces `internal/cloudapi/httperr`, consumed here)
- #6152, #6151 (earlier `internal/cloudapi/v6` cleanup in the same area; #6151 will remove `v6`'s `bodyResetTransport` once merged)