### PR TITLE
Fix browser web vitals lost on intermediate pages

### DIFF
--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -42,6 +42,25 @@ type CPUProfile struct {
 	Rate float64
 }
 
+// webVitalKey identifies a buffered web vital by the URL of the page it was
+// measured on and the metric name. Keying by URL keeps distinct pages (and
+// subframes) as separate series, while repeated reports for the same page and
+// metric collapse onto a single buffered entry.
+type webVitalKey struct {
+	url  string
+	name string
+}
+
+// webVitalSample is a buffered web vital metric sample together with the
+// attributes needed to emit its web_vital trace span when the buffer is
+// flushed.
+type webVitalSample struct {
+	sample k6metrics.Sample
+	name   string
+	spanID string
+	rating string
+}
+
 /*
 FrameSession is used for managing a frame's life-cycle, or in other words its full session.
 It manages all the event listening while deferring the state storage to the Frame and FrameManager
@@ -87,6 +106,15 @@ type FrameSession struct {
 	// onFrameNavigated, but subsequent calls to onFrameNavigated in the same
 	// mainframe never again create a navigation span.
 	initialNavDone bool
+
+	// Web vital metrics are buffered per (url, metric name) and flushed once
+	// per page: at each main-frame navigation boundary and at page close. This
+	// keeps a single sample per page and metric even when a page reports a
+	// vital more than once. The mutex guards against the initial navigation's
+	// flush, which runs on the page-construction goroutine rather than the
+	// event-loop goroutine.
+	bufferedWebVitalsMu sync.Mutex
+	bufferedWebVitals   map[webVitalKey]webVitalSample
 }
 
 // NewFrameSession initializes and returns a new FrameSession.
@@ -119,6 +147,7 @@ func NewFrameSession(
 		isolatedWorlds:       make(map[string]bool),
 		eventCh:              make(chan Event),
 		childSessions:        make(map[cdp.FrameID]*FrameSession),
+		bufferedWebVitals:    make(map[webVitalKey]webVitalSample),
 		vu:                   k6ext.GetVU(ctx),
 		k6Metrics:            k6Metrics,
 		logger:               l,
@@ -235,7 +264,7 @@ func (fs *FrameSession) initDomains() error {
 	return nil
 }
 
-//nolint:cyclop
+//nolint:cyclop,funlen
 func (fs *FrameSession) initEvents() {
 	fs.logger.Debugf("NewFrameSession:initEvents",
 		"sid:%v tid:%v", fs.session.ID(), fs.targetID)
@@ -255,6 +284,8 @@ func (fs *FrameSession) initEvents() {
 			// If there is an active span for main frame,
 			// end it before exiting so it can be flushed
 			if fs.mainFrameSpan != nil {
+				// Flush the last page's buffered web vitals while its span is live.
+				fs.flushWebVitals()
 				// The url needs to be added here instead of at the start of the span
 				// because at the start of the span we don't know the correct url for
 				// the page we're navigating to. At the end of the span we do have this
@@ -373,26 +404,48 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 
 	tags = tags.With("rating", wv.Rating)
 
-	now := time.Now()
-	pushIfNotDone(fs.vu.Context(), fs.logger, state.Samples, k6metrics.ConnectedSamples{
-		Samples: []k6metrics.Sample{
-			{
-				TimeSeries: k6metrics.TimeSeries{Metric: metric, Tags: tags},
-				Value:      value,
-				Time:       now,
-			},
+	// Buffer the latest value for this page and metric instead of emitting it
+	// immediately. The buffer is flushed once per page so each page contributes
+	// a single sample per metric.
+	fs.bufferedWebVitalsMu.Lock()
+	fs.bufferedWebVitals[webVitalKey{url: wv.URL, name: wv.Name}] = webVitalSample{
+		sample: k6metrics.Sample{
+			TimeSeries: k6metrics.TimeSeries{Metric: metric, Tags: tags},
+			Value:      value,
+			Time:       time.Now(),
 		},
-	})
-
-	_, span := TraceEvent(
-		fs.ctx, fs.targetID.String(), "web_vital", wv.SpanID, trace.WithAttributes(
-			attribute.String("web_vital.name", wv.Name),
-			attribute.Float64("web_vital.value", value),
-			attribute.String("web_vital.rating", wv.Rating),
-		))
-	defer span.End()
+		name:   wv.Name,
+		spanID: wv.SpanID,
+		rating: wv.Rating,
+	}
+	fs.bufferedWebVitalsMu.Unlock()
 
 	return nil
+}
+
+// flushWebVitals emits every buffered web vital metric sample and its
+// web_vital trace span, then clears the buffer. Clearing makes the flush
+// idempotent, so a page is emitted exactly once even when flushed at both a
+// navigation boundary and at teardown.
+func (fs *FrameSession) flushWebVitals() {
+	fs.bufferedWebVitalsMu.Lock()
+	defer fs.bufferedWebVitalsMu.Unlock()
+
+	for key, wv := range fs.bufferedWebVitals {
+		pushIfNotDone(fs.vu.Context(), fs.logger, fs.vu.State().Samples, k6metrics.ConnectedSamples{
+			Samples: []k6metrics.Sample{wv.sample},
+		})
+
+		_, span := TraceEvent(
+			fs.ctx, fs.targetID.String(), "web_vital", wv.spanID, trace.WithAttributes(
+				attribute.String("web_vital.name", wv.name),
+				attribute.Float64("web_vital.value", wv.sample.Value),
+				attribute.String("web_vital.rating", wv.rating),
+			))
+		span.End()
+
+		delete(fs.bufferedWebVitals, key)
+	}
 }
 
 func (fs *FrameSession) onEventJavascriptDialogOpening(event *cdppage.EventJavascriptDialogOpening) {
@@ -821,6 +874,11 @@ func (fs *FrameSession) processNavigationSpan(id cdp.FrameID) {
 	if newFrame.page.frameManager.MainFrame() != newFrame {
 		return
 	}
+
+	// Flush the outgoing page's buffered web vitals while its navigation span
+	// is still live. This must run after the main-frame guard above so that a
+	// subframe load does not drain the main page's buffer.
+	fs.flushWebVitals()
 
 	// End the navigation span if it is non-nil
 	if fs.mainFrameSpan != nil {

--- a/internal/js/modules/k6/browser/common/js/web_vital_init.js
+++ b/internal/js/modules/k6/browser/common/js/web_vital_init.js
@@ -19,12 +19,12 @@ function print(metric) {
 }
 
 function load() {
-  webVitals.onCLS(print);
-  webVitals.onLCP(print);
+  webVitals.onCLS(print, {reportAllChanges: true});
+  webVitals.onLCP(print, {reportAllChanges: true});
 
-  webVitals.onFCP(print);
-  webVitals.onINP(print);
-  webVitals.onTTFB(print);
+  webVitals.onFCP(print, {reportAllChanges: true});
+  webVitals.onINP(print, {reportAllChanges: true});
+  webVitals.onTTFB(print, {reportAllChanges: true});
 }
 
 load();

--- a/internal/js/modules/k6/browser/tests/webvital_test.go
+++ b/internal/js/modules/k6/browser/tests/webvital_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,6 +101,87 @@ func TestWebVitalMetricNoInteraction(t *testing.T) {
 
 	for k, v := range expected {
 		assert.True(t, v, "expected %s to have been measured and emitted", k)
+	}
+}
+
+// TestWebVitalMetricPerPage asserts that web vitals are recorded for every
+// page in a single-tab navigation flow, not just the last one. It navigates
+// one page across two distinct URLs and, without interacting with the first
+// page, checks that the now-intermediate page still reports its LCP (as well
+// as FCP and TTFB), with exactly one sample per (url, metric).
+func TestWebVitalMetricPerPage(t *testing.T) {
+	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("timeouts on windows")
+	}
+
+	var (
+		samples = make(chan k6metrics.SampleContainer, 1000)
+		browser = newTestBrowser(t, withFileServer(), withSamples(samples))
+		page    = browser.NewPage(nil)
+	)
+
+	opts := &common.FrameGotoOptions{
+		Timeout: common.DefaultTimeout,
+	}
+
+	// Navigate to the first page and dwell so its web vitals settle and are
+	// reported before navigating away. The page is not interacted with, so
+	// without continuous reporting its LCP is never finalized.
+	resp, err := page.Goto(browser.staticURL("/web_vitals.html"), opts)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	page.WaitForTimeout(1000)
+
+	// Navigate to a second, distinct page. This makes web_vitals.html an
+	// intermediate page whose web vitals would be lost without continuous
+	// reporting.
+	resp, err = page.Goto(browser.staticURL("/usual.html"), opts)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.NoError(t, page.Close())
+	close(samples)
+
+	// Count web vital samples per (url, metric).
+	type urlMetric struct{ url, metric string }
+	counts := make(map[urlMetric]int)
+	for sc := range samples {
+		for _, s := range sc.GetSamples() {
+			if !strings.HasPrefix(s.Metric.Name, "browser_web_vital_") {
+				continue
+			}
+			url, ok := s.Tags.Get("url")
+			require.Truef(t, ok, "web vital sample %s is missing a url tag", s.Metric.Name)
+			counts[urlMetric{url: url, metric: s.Metric.Name}]++
+		}
+	}
+
+	// The intermediate page must have recorded LCP, the key differentiator:
+	// without continuous reporting it finalizes only on visibilitychange,
+	// which does not fire on a hard navigation. FCP and TTFB are asserted as
+	// a sanity check (they finalize early during load).
+	intermediateHas := func(metric string) bool {
+		for k := range counts {
+			if k.metric == metric && strings.Contains(k.url, "web_vitals.html") {
+				return true
+			}
+		}
+		return false
+	}
+	assert.True(t, intermediateHas("browser_web_vital_lcp"),
+		"expected intermediate page web_vitals.html to record LCP")
+	assert.True(t, intermediateHas("browser_web_vital_fcp"),
+		"expected intermediate page web_vitals.html to record FCP")
+	assert.True(t, intermediateHas("browser_web_vital_ttfb"),
+		"expected intermediate page web_vitals.html to record TTFB")
+
+	// Continuous reporting must not duplicate samples: each (url, metric)
+	// pair must be emitted exactly once.
+	for k, n := range counts {
+		assert.Equalf(t, 1, n,
+			"expected exactly one %s sample for %s, got %d", k.metric, k.url, n)
 	}
 }
 


### PR DESCRIPTION
## What?

Two commits:

1. Refactor how the browser module emits web vital metrics (`browser_web_vital_ttfb/lcp/cls/inp/fcp`). Instead of pushing a sample immediately on every measurement, buffer the latest value per `(url, metric)` on the `FrameSession` and flush it once per page — at each main-frame navigation boundary and at page close. Behaviour is unchanged by this commit.
2. Pass `{reportAllChanges: true}` to the web-vitals callbacks so LCP/CLS/INP are reported during each page's lifetime. Together with the buffer, this records web vitals for **every** page in a single-tab navigation flow (not just the last one), while still emitting a single sample per page.

## Why?

Web vital finalization is forced only at `page.close()` (introduced in #5661). LCP/CLS/INP finalize on `visibilitychange` -> hidden, which headless Chrome does not fire on a hard navigation. So in a script that navigates several times within one page/tab and closes once at the end — the typical Synthetic Monitoring browser-check flow (load -> auth -> app -> detail) — every page except the last silently loses its CLS/INP (and usually LCP). Only TTFB/FCP survived, because they finalize early during load.

Reporting all changes lets each page's values arrive while it is still alive (no teardown race), and the per-page buffer collapses the now-frequent reports back to one sample per page so the `Trend` aggregates are not polluted. This was verified against an isolated single-page measurement of the same URLs (the recovered intermediate-page values matched) and cross-checked against Lighthouse for LCP/FCP. Note that the web vital aggregates now legitimately include the intermediate-page values that were previously dropped.

The change is scoped to per-page web vital capture; page ordering labels, trace-span identity, and SPA soft-navigation are intentionally out of scope.

Trade-off: TTFB/FCP were previously pushed to the metrics engine the moment they were measured; with this change they sit in the per-page buffer until the next navigation or page close. If the test ends abruptly (abort, ^C) and the push context is already cancelled when the teardown flush runs, the buffered samples are dropped with a warning. LCP/CLS/INP already had exactly this exposure (they only finalized at page.close()), so this widens an existing narrow window to two more metrics rather than introducing a new class of loss. Normal iteration ends and explicit page.close() flush cleanly. If this window ever matters, an eager flush of each metric's first report (TTFB/FCP only report once per page) would close it.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Web vitals v5 finalization this builds on: #5661