### PR TITLE
Fix phantom browser navigation spans on client redirects

### DIFF
--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -107,6 +107,16 @@ type FrameSession struct {
 	// mainframe never again create a navigation span.
 	initialNavDone bool
 
+	// mainFrameLoadingRotated is true once a main-frame frameStartedLoading has
+	// rotated the navigation span and neither a document commit
+	// (onFrameNavigated) nor a within-document navigation
+	// (onPageNavigatedWithinDocument) has happened since. Chrome emits multiple
+	// consecutive frameStartedLoading events for a single main-frame navigation
+	// (e.g. client-initiated redirects fire two); rotating on each would create
+	// a spurious phantom navigation span. Only touched on the FrameSession
+	// event-loop goroutine, so it needs no synchronization.
+	mainFrameLoadingRotated bool
+
 	// Web vital metrics are buffered per (url, metric name) and flushed once
 	// per page: at each main-frame navigation boundary and at page close. This
 	// keeps a single sample per page and metric even when a page reports a
@@ -852,6 +862,12 @@ func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
 			frame.URL+frame.URLFragment, err)
 	}
 
+	// A main-frame document commit ends the current loading episode, so the
+	// next frameStartedLoading rotates a fresh navigation span.
+	if fs.isMainFrameID(frame.ID) {
+		fs.mainFrameLoadingRotated = false
+	}
+
 	// Only create a navigation span once from here, since a new page navigating
 	// to about:blank doesn't call onFrameStartedLoading. All subsequent
 	// navigations call onFrameStartedLoading.
@@ -933,12 +949,31 @@ func (fs *FrameSession) onFrameRequestedNavigation(event *cdppage.EventFrameRequ
 	}
 }
 
+// isMainFrameID reports whether frameID identifies the page's main frame.
+func (fs *FrameSession) isMainFrameID(frameID cdp.FrameID) bool {
+	mf := fs.manager.MainFrame()
+	return mf != nil && mf.ID() == frameID.String()
+}
+
 func (fs *FrameSession) onFrameStartedLoading(frameID cdp.FrameID) {
 	fs.logger.Debugf("FrameSession:onFrameStartedLoading",
 		"sid:%v tid:%v fid:%v",
 		fs.session.ID(), fs.targetID, frameID)
 
-	fs.processNavigationSpan(frameID)
+	// Chrome can emit multiple consecutive frameStartedLoading events for a
+	// single main-frame navigation (e.g. client-initiated redirects fire two).
+	// Rotate the navigation span only on the first of an episode; the flag is
+	// reset on a document commit (onFrameNavigated) or a within-document
+	// navigation (onPageNavigatedWithinDocument). Non-main frames are
+	// unaffected: processNavigationSpan already ignores them.
+	isMain := fs.isMainFrameID(frameID)
+	suppressPhantom := isMain && fs.mainFrameLoadingRotated
+	if !suppressPhantom {
+		fs.processNavigationSpan(frameID)
+	}
+	if isMain {
+		fs.mainFrameLoadingRotated = true
+	}
 
 	fs.manager.frameLoadingStarted(frameID)
 }
@@ -992,6 +1027,12 @@ func (fs *FrameSession) onPageNavigatedWithinDocument(event *cdppage.EventNaviga
 	fs.logger.Debugf("FrameSession:onPageNavigatedWithinDocument",
 		"sid:%v tid:%v fid:%v",
 		fs.session.ID(), fs.targetID, event.FrameID)
+
+	// A within-document (same-page) navigation ends the current loading
+	// episode, so the next frameStartedLoading rotates a fresh span.
+	if fs.isMainFrameID(event.FrameID) {
+		fs.mainFrameLoadingRotated = false
+	}
 
 	fs.manager.frameNavigatedWithinDocument(event.FrameID, event.URL)
 }

--- a/internal/js/modules/k6/browser/tests/tracing_test.go
+++ b/internal/js/modules/k6/browser/tests/tracing_test.go
@@ -52,6 +52,23 @@ const html = `
 </html>
 `
 
+// clientRedirectHTML performs a single client-initiated redirect on load (JS
+// assigning location). The query-string guard prevents a redirect loop. Chrome
+// emits two consecutive main-frame frameStartedLoading events for the resulting
+// document, which used to create a spurious phantom navigation span.
+const clientRedirectHTML = `<!DOCTYPE html>
+<html>
+<head><title>redirect</title></head>
+<body>landing
+<script>
+  if (!location.search) {
+    location.replace(location.pathname + '?var=B');
+  }
+</script>
+</body>
+</html>
+`
+
 // TestTracing verifies that all methods instrumented to generate
 // traces behave correctly.
 func TestTracing(t *testing.T) {
@@ -324,6 +341,58 @@ func TestNavigationSpanCreation(t *testing.T) {
 			assert.ElementsMatch(t, tc.expected, got, fmt.Sprintf("%s failed", tc.name))
 		})
 	}
+}
+
+// TestNavigationSpanPhantomOnClientRedirect asserts that a client-initiated
+// redirect does not create a spurious phantom navigation span. Navigating to a
+// page that redirects itself once should yield exactly one navigation span per
+// committed main-frame document plus the initial about:blank: about:blank, the
+// landing document, and the redirect target (3), not 4.
+func TestNavigationSpanPhantomOnClientRedirect(t *testing.T) {
+	t.Parallel()
+
+	tracer := &mockTracer{spans: make(map[string]struct{})}
+	tp := &mockTracerProvider{tracer: tracer}
+
+	ts := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			_, err := fmt.Fprint(w, clientRedirectHTML)
+			require.NoError(t, err)
+		},
+	))
+	t.Cleanup(ts.Close)
+
+	vu := k6test.NewVU(t, k6test.WithTracerProvider(tp))
+	rt := vu.Runtime()
+	root := browser.New()
+	mod := root.NewModuleInstance(vu)
+	jsMod, ok := mod.Exports().Default.(*browser.JSModule)
+	require.Truef(t, ok, "unexpected default mod export type %T", mod.Exports().Default)
+	require.NoError(t, rt.Set("browser", jsMod.Browser))
+	vu.ActivateVU()
+	vu.StartIteration(t)
+	defer vu.EndIteration(t)
+
+	js := fmt.Sprintf(`
+		page = await browser.newPage();
+		await page.goto('%s', {waitUntil:'load'});
+		await page.waitForTimeout(1500);
+		await page.close();
+		`, ts.URL)
+	assertJSInEventLoop(t, vu, js)
+
+	got := tracer.cloneOrderedSpans()
+	navs := 0
+	for _, s := range got {
+		if s == "navigation" {
+			navs++
+		}
+	}
+	// about:blank + landing document + redirect target = 3. A phantom
+	// rotation on the redirect's duplicate frameStartedLoading would make 4.
+	assert.Equalf(t, 3, navs,
+		"expected 3 navigation spans (no phantom), got %d; spans: %v", navs, got)
 }
 
 func setupTestTracing(t *testing.T, rt *sobek.Runtime) {


### PR DESCRIPTION
## What?

Stop the browser tracer from emitting a spurious phantom `navigation` span on client-initiated redirects. A `frameStartedLoading`-driven span rotation is now suppressed when it directly follows another with no intervening document commit (`onFrameNavigated`) or within-document navigation (`onPageNavigatedWithinDocument`), so each main-frame loading episode produces exactly one navigation span.

## Why?

Chrome emits two consecutive main-frame `frameStartedLoading` events for a single document produced by a client-initiated redirect (a page assigning `location` — A/B-testing tools, consent gates, marketing redirects). The tracer rotated the navigation span on every `frameStartedLoading`, so the first rotation's span was ended empty and discarded as a phantom, and its span ID was invalidated mid-flight.

Reproduced deterministically against `grafana.com/products/cloud/` (an Adobe Target redirect) and a local fixture across `location.replace`/`.assign`/`.href`/`.search`. `about:blank` and same-page (fragment / SPA `pushState`) navigation behaviour is deliberately unchanged: those pair a `frameStartedLoading` with a within-document navigation, which resets the guard.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Based on (target branch): #6163 (per-page web vitals buffering/flush)
- Stacked follow-up: web-vital trace-span correlation (removes the `window.k6SpanId` injection)