### PR TITLE
Fix web-vital trace-span correlation

### DIFF
--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -57,7 +57,6 @@ type webVitalKey struct {
 type webVitalSample struct {
 	sample k6metrics.Sample
 	name   string
-	spanID string
 	rating string
 }
 
@@ -389,7 +388,6 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 		NumEntries     json.Number
 		NavigationType string
 		URL            string
-		SpanID         string
 	}{}
 
 	if err := json.Unmarshal([]byte(object), &wv); err != nil {
@@ -425,7 +423,6 @@ func (fs *FrameSession) parseAndEmitWebVitalMetric(object string) error {
 			Time:       time.Now(),
 		},
 		name:   wv.Name,
-		spanID: wv.SpanID,
 		rating: wv.Rating,
 	}
 	fs.bufferedWebVitalsMu.Unlock()
@@ -447,7 +444,7 @@ func (fs *FrameSession) flushWebVitals() {
 		})
 
 		_, span := TraceEvent(
-			fs.ctx, fs.targetID.String(), "web_vital", wv.spanID, trace.WithAttributes(
+			fs.ctx, fs.targetID.String(), "web_vital", trace.WithAttributes(
 				attribute.String("web_vital.name", wv.name),
 				attribute.Float64("web_vital.value", wv.sample.Value),
 				attribute.String("web_vital.rating", wv.rating),
@@ -906,34 +903,12 @@ func (fs *FrameSession) processNavigationSpan(id cdp.FrameID) {
 		fs.mainFrameSpan.End()
 	}
 
+	// The web_vital events for this page are correlated to this navigation span
+	// on the Go side when the per-page buffer is flushed (see flushWebVitals),
+	// so there is no need to inject a span id into the page.
 	_, fs.mainFrameSpan = TraceNavigation(
 		fs.ctx, fs.targetID.String(),
 	)
-
-	spanID := fs.mainFrameSpan.SpanContext().SpanID().String()
-
-	// Set k6SpanId property in the page so it can be retrieved when pushing
-	// the Web Vitals events from the page execution context and used to
-	// correlate them with the navigation span to which they belong to.
-	setSpanIDProp := func() {
-		js := fmt.Sprintf("window.k6SpanId = '%s';", spanID)
-		err := newFrame.EvaluateGlobal(fs.ctx, js)
-		if err != nil {
-			fs.logger.Debugf(
-				"FrameSession:onFrameNavigated", "error on evaluating window.k6SpanId: %v", err,
-			)
-		}
-	}
-
-	// Executing a CDP command in the event parsing goroutine might deadlock in some cases.
-	// For example a deadlock happens if the content loaded in the frame that has navigated
-	// includes a JavaScript initiated dialog which we have to explicitly accept or dismiss
-	// (see onEventJavascriptDialogOpening). In that case our EvaluateGlobal call can't be
-	// executed, as the browser is waiting for us to accept/dismiss the JS dialog, but we
-	// can't act on that because the event parsing goroutine is stuck in onFrameNavigated.
-	// Because in this case the action is to set an attribute to the global object (window)
-	// it should be safe to just execute this in a separate goroutine.
-	go setSpanIDProp()
 }
 
 func (fs *FrameSession) onFrameRequestedNavigation(event *cdppage.EventFrameRequestedNavigation) {

--- a/internal/js/modules/k6/browser/common/js/web_vital_init.js
+++ b/internal/js/modules/k6/browser/common/js/web_vital_init.js
@@ -8,12 +8,6 @@ function print(metric) {
     numEntries: metric.entries.length,
     navigationType: metric.navigationType,
     url: window.location.href,
-    // To be able to associate a Web Vital measurement to the PageNavigation
-    // span, we need to collect the span ID that was previously set in the
-    // page after the navigation, and pass it back to k6 browser included in
-    // the WV event so the measurement can be correctly linked to the page
-    // navigation span
-    spanID: window.k6SpanId,
   }
   window.k6browserSendWebVitalMetric(JSON.stringify(m))
 }

--- a/internal/js/modules/k6/browser/common/trace.go
+++ b/internal/js/modules/k6/browser/common/trace.go
@@ -19,7 +19,7 @@ type Tracer interface {
 		ctx context.Context, targetID string, opts ...trace.SpanStartOption,
 	) (context.Context, trace.Span)
 	TraceEvent(
-		ctx context.Context, targetID string, eventName string, spanID string, opts ...trace.SpanStartOption,
+		ctx context.Context, targetID string, eventName string, opts ...trace.SpanStartOption,
 	) (context.Context, trace.Span)
 }
 
@@ -51,10 +51,10 @@ func TraceNavigation(
 // calls its TraceEvent implementation. If the Tracer is not present in the given
 // ctx, it returns a noopSpan and the given context.
 func TraceEvent(
-	ctx context.Context, targetID string, eventName string, spanID string, options ...trace.SpanStartOption,
+	ctx context.Context, targetID string, eventName string, options ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
 	if tracer := GetTracer(ctx); tracer != nil {
-		return tracer.TraceEvent(ctx, targetID, eventName, spanID, options...)
+		return tracer.TraceEvent(ctx, targetID, eventName, options...)
 	}
 	return ctx, browsertrace.NoopSpan{}
 }

--- a/internal/js/modules/k6/browser/trace/trace.go
+++ b/internal/js/modules/k6/browser/trace/trace.go
@@ -91,9 +91,6 @@ func (t *Tracer) TraceNavigation(
 	t.liveSpansMu.Lock()
 	defer t.liveSpansMu.Unlock()
 
-	// TODO: Should we keep track of all spans, even ones that are closed, to
-	// ensure we associate web vitals to the spans in the current iteration?
-
 	ls := t.liveSpans[targetID]
 	if ls != nil {
 		// If there is a previous live span
@@ -112,34 +109,22 @@ func (t *Tracer) TraceNavigation(
 }
 
 // TraceEvent creates a new span representing the specified event and associates it with the current
-// liveSpan for the given targetID only if the spanID matches with the liveSpan.
-// It is the caller's responsibility to close the generated span.
+// liveSpan for the given targetID. It is the caller's responsibility to close the generated span.
 //
-// If no liveSpan is found for the given targetID, the action is ignored and a noopSpan is returned.
-// If the given spanID does not match the one for the current liveSpan associated with the targetID,
-// it means the specified target has navigated, generating a new span for that navigation, therefore
-// the event is not associated with that span, and instead a noopSpan is returned.
+// The event is attached to the target's current live navigation span. Callers buffer per-page
+// events (e.g. Web Vitals) and flush them at the navigation boundary while the owning navigation
+// span is still live, so the live span is the one the event belongs to.
+//
+// If no liveSpan is found for the given targetID, the action is ignored and a noopSpan is returned,
+// to avoid associating the event with an unrelated root span possibly wrapped in ctx.
 func (t *Tracer) TraceEvent(
-	ctx context.Context, targetID string, eventName string, spanID string, opts ...trace.SpanStartOption,
+	ctx context.Context, targetID string, eventName string, opts ...trace.SpanStartOption,
 ) (context.Context, trace.Span) {
 	t.liveSpansMu.Lock()
 	defer t.liveSpansMu.Unlock()
 
 	ls := t.liveSpans[targetID]
 	if ls == nil {
-		// If there is not a liveSpan for the given targetID,
-		// avoid associating the event with the root span possibly
-		// wrapped in ctx, and instead return a noopSpan
-		return ctx, NoopSpan{}
-	}
-
-	sid := ls.span.SpanContext().SpanID().String()
-	if sid != spanID {
-		// If the given spanID does not match the current liveSpan for
-		// targetID, it means the target has navigated to a different
-		// page than the one the event should be associated with.
-		// Therefore avoid associating the event with the current span,
-		// and return a noopSpan instead
 		return ctx, NoopSpan{}
 	}
 

--- a/internal/js/modules/k6/browser/trace/trace_test.go
+++ b/internal/js/modules/k6/browser/trace/trace_test.go
@@ -1,0 +1,98 @@
+package trace
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/embedded"
+)
+
+// recordingTracer is a minimal trace.Tracer that records started spans and the
+// parent each was created under, so tests can assert parent/child linkage
+// without pulling in the OTEL SDK (which is not vendored).
+type recordingTracer struct {
+	embedded.Tracer
+
+	mu      sync.Mutex
+	started []recordedSpan
+	next    byte
+}
+
+type recordedSpan struct {
+	name   string
+	parent trace.SpanID
+}
+
+func (rt *recordingTracer) Start(
+	ctx context.Context, name string, _ ...trace.SpanStartOption,
+) (context.Context, trace.Span) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+
+	parent := trace.SpanContextFromContext(ctx).SpanID()
+	rt.next++
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1},
+		SpanID:  trace.SpanID{rt.next},
+	})
+	rt.started = append(rt.started, recordedSpan{name: name, parent: parent})
+
+	return trace.ContextWithSpanContext(ctx, sc), recordingSpan{sc: sc}
+}
+
+func (rt *recordingTracer) parentOf(name string) (trace.SpanID, bool) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for _, s := range rt.started {
+		if s.name == name {
+			return s.parent, true
+		}
+	}
+	return trace.SpanID{}, false
+}
+
+type recordingSpan struct {
+	trace.Span
+	sc trace.SpanContext
+}
+
+func (s recordingSpan) SpanContext() trace.SpanContext { return s.sc }
+func (s recordingSpan) IsRecording() bool              { return true }
+func (s recordingSpan) End(...trace.SpanEndOption)     {}
+
+type fakeTracerProvider struct{ tr trace.Tracer }
+
+func (f fakeTracerProvider) Tracer(string, ...trace.TracerOption) trace.Tracer { return f.tr }
+
+// TestTracerWebVitalAttachesToLiveNavigationSpan asserts that a web_vital event
+// attaches to the target's current live navigation span, even when it arrives
+// after the span has rotated (as late web vitals do). On the current code the
+// event is dropped because its injected span ID no longer matches the live
+// span; after the fix it attaches to the live span.
+func TestTracerWebVitalAttachesToLiveNavigationSpan(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingTracer{}
+	tracer := NewTracer(fakeTracerProvider{tr: rec}, map[string]string{})
+	ctx := context.Background()
+
+	tracer.TraceNavigation(ctx, "target")
+
+	// A second navigation rotates the live span; the first is ended.
+	_, nav2 := tracer.TraceNavigation(ctx, "target")
+	liveID := nav2.SpanContext().SpanID()
+
+	// A late web vital (delivered after the span rotated) must attach to the
+	// target's live navigation span rather than being silently dropped.
+	_, ev := tracer.TraceEvent(ctx, "target", "web_vital")
+	ev.End()
+
+	require.True(t, ev.SpanContext().IsValid(), "web_vital span was dropped (noop)")
+	parent, ok := rec.parentOf("web_vital")
+	require.True(t, ok, "web_vital span was never started")
+	assert.Equal(t, liveID, parent, "web_vital should be a child of the live navigation span")
+}


### PR DESCRIPTION
## What?

Correlate browser web-vital trace spans to their navigation span on the Go side instead of via an injected `window.k6SpanId`. `TraceEvent` now attaches the `web_vital` span to the target's live navigation span, and the fire-and-forget `window.k6SpanId` injection plus the `spanID` plumbing (JS payload field, buffered-sample field, `TraceEvent` parameter and interface) are removed. Net −46 lines.

## Why?

Web-vital spans were linked to their navigation span by injecting `window.k6SpanId` into the page from a goroutine and matching it against the live span in `TraceEvent`. The injection is racy and could leave a stale/undefined id that silently dropped the `web_vital` span.

Since #6163 buffers web vitals per page and flushes them at the navigation boundary and page close — while the owning navigation span is still live — the live span is the correct parent, so the injected id is unnecessary. Attaching directly makes correlation deterministic and resolves the long-standing "track closed spans to associate web vitals" TODO in `trace.go`.

Trade-off: a web vital that arrives after its page's navigation boundary attaches to the then-current live span rather than being dropped; with continuous reporting (`reportAllChanges`, from #6163) the latest value is buffered during the page's life and flushed at the boundary, so post-boundary arrivals are rare, matching how the metric sample is already attributed at the same flush.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Based on: #6163 (per-page web vitals buffering/flush)
- Stacked on: #6167 (phantom navigation spans) — this PR targets its branch