### PR TITLE
Support externally-provisioned runs in cloud run --local-execution

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -34,19 +34,19 @@ type Config struct {
 	StopOnError    null.Bool   `json:"stopOnError" envconfig:"K6_CLOUD_STOP_ON_ERROR"`
 	APIVersion     null.Int    `json:"apiVersion" envconfig:"K6_CLOUD_API_VERSION"`
 
-	// MetricsPushURL is the explicit URL to push metrics to, returned by
-	// the provisioning API's start_local_execution endpoint. When set, the
-	// cloud Output uses this URL instead of deriving one from Host. Set
-	// programmatically by `cmd/outputs_cloud.go` for the
-	// `k6 cloud run --local-execution` provisioning flow; never set via
-	// env vars or user-facing config.
-	MetricsPushURL null.String `json:"metricsPushURL"`
+	// MetricsPushURL is the URL to push metrics to. In the self-provision
+	// flow it is set programmatically from the provisioning API response;
+	// in the externally-provisioned flow an orchestrator supplies it via
+	// K6_CLOUD_METRICS_PUSH_URL. When set, the cloud Output pushes here
+	// instead of deriving a URL from Host.
+	MetricsPushURL null.String `json:"metricsPushURL" envconfig:"K6_CLOUD_METRICS_PUSH_URL"`
 
-	// TestRunToken is the scoped test-run token returned by the
-	// provisioning API's start_local_execution endpoint. When set, the
-	// cloud Output uses it as the Bearer token for metrics push and notify.
-	// Set programmatically; never set via env vars or user-facing config.
-	TestRunToken null.String `json:"testRunToken"`
+	// TestRunToken is the scoped test-run token used as the Bearer token
+	// for metrics push (and notify, in the self-provision flow). Set
+	// programmatically in the self-provision flow, or supplied via
+	// K6_CLOUD_TEST_RUN_TOKEN by an external orchestrator that provisioned
+	// the run.
+	TestRunToken null.String `json:"testRunToken" envconfig:"K6_CLOUD_TEST_RUN_TOKEN"`
 
 	// PushRefID is the identifier used by k6 Cloud to correlate all the things that
 	// belong to the same test run/execution. Currently, it is equivalent to the test run id.

--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -34,19 +34,24 @@ type Config struct {
 	StopOnError    null.Bool   `json:"stopOnError" envconfig:"K6_CLOUD_STOP_ON_ERROR"`
 	APIVersion     null.Int    `json:"apiVersion" envconfig:"K6_CLOUD_API_VERSION"`
 
-	// MetricsPushURL is the URL to push metrics to. In the self-provision
-	// flow it is set programmatically from the provisioning API response;
-	// in the externally-provisioned flow an orchestrator supplies it via
-	// K6_CLOUD_METRICS_PUSH_URL. When set, the cloud Output pushes here
-	// instead of deriving a URL from Host.
-	MetricsPushURL null.String `json:"metricsPushURL" envconfig:"K6_CLOUD_METRICS_PUSH_URL"`
+	// MetricsPushURL is the URL to push metrics to. It is set only
+	// programmatically: from the provisioning API's start_local_execution
+	// response in the self-provision flow, or from K6_CLOUD_METRICS_PUSH_URL
+	// read explicitly by the cmd layer (internal/cmd/outputs_cloud.go) in the
+	// externally-provisioned flow. It is deliberately NOT env-bound (no
+	// envconfig tag): binding it would let a stray K6_CLOUD_METRICS_PUSH_URL
+	// in the environment override the value obtained from provisioning and
+	// corrupt the self-provisioned push. When set, the cloud Output pushes
+	// here instead of deriving a URL from Host.
+	MetricsPushURL null.String `json:"metricsPushURL"`
 
-	// TestRunToken is the scoped test-run token used as the Bearer token
-	// for metrics push (and notify, in the self-provision flow). Set
-	// programmatically in the self-provision flow, or supplied via
-	// K6_CLOUD_TEST_RUN_TOKEN by an external orchestrator that provisioned
-	// the run.
-	TestRunToken null.String `json:"testRunToken" envconfig:"K6_CLOUD_TEST_RUN_TOKEN"`
+	// TestRunToken is the scoped test-run token used as the Bearer token for
+	// metrics push (and notify, in the self-provision flow). Like
+	// MetricsPushURL it is set only programmatically — from the provisioning
+	// response, or from K6_CLOUD_TEST_RUN_TOKEN read explicitly by the cmd
+	// layer for an externally-provisioned run — and is deliberately NOT
+	// env-bound, so a stray env var cannot hijack the self-provisioned push.
+	TestRunToken null.String `json:"testRunToken"`
 
 	// PushRefID is the identifier used by k6 Cloud to correlate all the things that
 	// belong to the same test run/execution. Currently, it is equivalent to the test run id.

--- a/cloudapi/config_test.go
+++ b/cloudapi/config_test.go
@@ -57,13 +57,12 @@ func TestConfigApply(t *testing.T) {
 	assert.Equal(t, full, defaults.Apply(full))
 }
 
-// TestConfig_NewFieldsRoundTripThroughJSON also serves as the security
-// regression for "scoped tokens stay in-process": the fields live on
-// cloudapi.Config (which round-trips only via derivedConfig.Collectors[cloud])
-// and NOT on lib.Options (which is serialised into the archive's
-// metadata.json and pushed to the cloud). A new field accidentally added
-// to lib.Options would be serialised into the archive — but the new
-// fields here are on cloudapi.Config, so they cannot leak that way.
+// The scoped test_run_token is short-lived and run-scoped; it is now
+// deliberately accepted via env (K6_CLOUD_TEST_RUN_TOKEN) so an
+// external orchestrator that provisioned the run can hand it to a
+// local k6. It still never touches lib.Options / the archive — the
+// long-lived org token remains the sensitive credential and is
+// unaffected here.
 func TestConfig_NewFieldsRoundTripThroughJSON(t *testing.T) {
 	t.Parallel()
 
@@ -85,22 +84,23 @@ func TestConfig_NewFieldsRoundTripThroughJSON(t *testing.T) {
 	assert.Equal(t, original.TestRunToken, roundTripped.TestRunToken)
 }
 
-func TestConfig_NewFieldsNotPickedUpByEnvconfig(t *testing.T) {
+// TestConfig_NewFieldsFromEnvconfig verifies the scoped push creds are
+// read from the environment via envconfig (K6_CLOUD_METRICS_PUSH_URL /
+// K6_CLOUD_TEST_RUN_TOKEN) so an external orchestrator that provisioned
+// a run can hand them to a local k6.
+func TestConfig_NewFieldsFromEnvconfig(t *testing.T) {
 	t.Parallel()
 
-	// Set env vars with every plausible name a user might guess.
 	envVars := map[string]string{
-		"K6_CLOUD_METRICS_PUSH_URL": "foo",
-		"K6_CLOUD_TEST_RUN_TOKEN":   "bar",
-		"K6_CLOUD_METRICSPUSHURL":   "foo",
-		"K6_CLOUD_TESTRUNTOKEN":     "bar",
+		"K6_CLOUD_METRICS_PUSH_URL": "https://push.example/m",
+		"K6_CLOUD_TEST_RUN_TOKEN":   "scoped-xyz",
 	}
 
 	config, _, err := GetConsolidatedConfig(nil, envVars, "", nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, null.String{}, config.MetricsPushURL)
-	assert.Equal(t, null.String{}, config.TestRunToken)
+	assert.Equal(t, null.StringFrom("https://push.example/m"), config.MetricsPushURL)
+	assert.Equal(t, null.StringFrom("scoped-xyz"), config.TestRunToken)
 }
 
 func TestConfig_Apply_MergesNewFields(t *testing.T) {

--- a/cloudapi/config_test.go
+++ b/cloudapi/config_test.go
@@ -57,12 +57,13 @@ func TestConfigApply(t *testing.T) {
 	assert.Equal(t, full, defaults.Apply(full))
 }
 
-// The scoped test_run_token is short-lived and run-scoped; it is now
-// deliberately accepted via env (K6_CLOUD_TEST_RUN_TOKEN) so an
-// external orchestrator that provisioned the run can hand it to a
-// local k6. It still never touches lib.Options / the archive — the
-// long-lived org token remains the sensitive credential and is
-// unaffected here.
+// TestConfig_NewFieldsRoundTripThroughJSON also serves as the security
+// regression for "scoped tokens stay in-process": the fields live on
+// cloudapi.Config (which round-trips only via derivedConfig.Collectors[cloud])
+// and NOT on lib.Options (which is serialised into the archive's
+// metadata.json and pushed to the cloud). A new field accidentally added
+// to lib.Options would be serialised into the archive — but the new
+// fields here are on cloudapi.Config, so they cannot leak that way.
 func TestConfig_NewFieldsRoundTripThroughJSON(t *testing.T) {
 	t.Parallel()
 
@@ -84,23 +85,22 @@ func TestConfig_NewFieldsRoundTripThroughJSON(t *testing.T) {
 	assert.Equal(t, original.TestRunToken, roundTripped.TestRunToken)
 }
 
-// TestConfig_NewFieldsFromEnvconfig verifies the scoped push creds are
-// read from the environment via envconfig (K6_CLOUD_METRICS_PUSH_URL /
-// K6_CLOUD_TEST_RUN_TOKEN) so an external orchestrator that provisioned
-// a run can hand them to a local k6.
-func TestConfig_NewFieldsFromEnvconfig(t *testing.T) {
+func TestConfig_NewFieldsNotPickedUpByEnvconfig(t *testing.T) {
 	t.Parallel()
 
+	// Set env vars with every plausible name a user might guess.
 	envVars := map[string]string{
-		"K6_CLOUD_METRICS_PUSH_URL": "https://push.example/m",
-		"K6_CLOUD_TEST_RUN_TOKEN":   "scoped-xyz",
+		"K6_CLOUD_METRICS_PUSH_URL": "foo",
+		"K6_CLOUD_TEST_RUN_TOKEN":   "bar",
+		"K6_CLOUD_METRICSPUSHURL":   "foo",
+		"K6_CLOUD_TESTRUNTOKEN":     "bar",
 	}
 
 	config, _, err := GetConsolidatedConfig(nil, envVars, "", nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, null.StringFrom("https://push.example/m"), config.MetricsPushURL)
-	assert.Equal(t, null.StringFrom("scoped-xyz"), config.TestRunToken)
+	assert.Equal(t, null.String{}, config.MetricsPushURL)
+	assert.Equal(t, null.String{}, config.TestRunToken)
 }
 
 func TestConfig_Apply_MergesNewFields(t *testing.T) {

--- a/internal/cmd/outputs_cloud.go
+++ b/internal/cmd/outputs_cloud.go
@@ -97,6 +97,9 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 	}
 
 	if conf.PushRefID.Valid && conf.PushRefID.String != "" {
+		if err := applyExternalProvisioningCreds(gs, test, &conf); err != nil {
+			return err
+		}
 		test.preInitState.RuntimeOptions.Env[testRunIDKey] = conf.PushRefID.String
 		gs.Logger.Debug("using PushRefID, skipping CreateTestRun")
 		return nil
@@ -184,6 +187,42 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 	}
 	test.derivedConfig.Collectors[builtinOutputCloud.String()] = raw
 
+	return nil
+}
+
+// applyExternalProvisioningCreds handles the externally-provisioned
+// `--local-execution` flow, signalled by K6_CLOUD_PUSH_REF_ID: an external
+// service created and started the run and hands its scoped push credentials
+// to this local k6 via env. It reads K6_CLOUD_METRICS_PUSH_URL and
+// K6_CLOUD_TEST_RUN_TOKEN explicitly here — they are deliberately NOT
+// env-bound on cloudapi.Config, so a stray env var can never override the
+// values the self-provision flow obtains from the provisioning response.
+// It requires both-or-neither and, when both are present, sets them on conf
+// (so downstream consumers such as the log pusher see them) and bakes them
+// into the serialized cloud config that the Output reads.
+func applyExternalProvisioningCreds(
+	gs *state.GlobalState, test *loadedAndConfiguredTest, conf *cloudapi.Config,
+) error {
+	pushURL := gs.Env["K6_CLOUD_METRICS_PUSH_URL"]
+	token := gs.Env["K6_CLOUD_TEST_RUN_TOKEN"]
+	if (pushURL == "") != (token == "") {
+		return errors.New("both K6_CLOUD_METRICS_PUSH_URL and " +
+			"K6_CLOUD_TEST_RUN_TOKEN must be set together")
+	}
+	if pushURL == "" {
+		return nil
+	}
+
+	conf.MetricsPushURL = null.StringFrom(pushURL)
+	conf.TestRunToken = null.StringFrom(token)
+	raw, err := cloudConfToRawMessage(*conf)
+	if err != nil {
+		return fmt.Errorf("could not serialize cloud configuration: %w", err)
+	}
+	if test.derivedConfig.Collectors == nil {
+		test.derivedConfig.Collectors = make(map[string]json.RawMessage)
+	}
+	test.derivedConfig.Collectors[builtinOutputCloud.String()] = raw
 	return nil
 }
 

--- a/internal/cmd/tests/cmd_cloud_run_push_credentials_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_push_credentials_test.go
@@ -1,0 +1,353 @@
+package tests
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	provtest "go.k6.io/k6/v2/internal/cloudapi/provisioning/test"
+	v6 "go.k6.io/k6/v2/internal/cloudapi/v6"
+	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/lib/fsext"
+)
+
+// Sentinel credentials. Each has a single, distinct source so a test can
+// tell exactly which one k6 used to push metrics.
+const (
+	orgToken         = "org-longlived-token" // K6_CLOUD_TOKEN: legacy / relay push
+	scopedToken      = "test-run-token-abc"  // from the provisioning response
+	bogusToken       = "bogus-env-token"     // a stray value in the environment
+	extToken         = "ext-scoped-token"    // an externally-supplied scoped token
+	staleConfigToken = "stale-config-token"  // a stale value in a k6 config file
+)
+
+const pushCredScript = `
+export const options = { cloud: { name: 'push creds', projectID: 123456 } };
+export default function () {};`
+
+// cloudRequestRecorder captures the bearer token of every request the mock
+// cloud sees, so a test can assert which token k6 pushed metrics with.
+type cloudRequestRecorder struct {
+	mu       sync.Mutex
+	requests []recordedRequest
+}
+
+type recordedRequest struct{ path, token string }
+
+func (r *cloudRequestRecorder) handler(w http.ResponseWriter, req *http.Request) {
+	_, _ = io.Copy(io.Discard, req.Body)
+	r.mu.Lock()
+	r.requests = append(r.requests, recordedRequest{req.URL.Path, bearerToken(req)})
+	r.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+func (r *cloudRequestRecorder) tokensForPath(sub string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []string
+	for _, req := range r.requests {
+		if strings.Contains(req.path, sub) {
+			out = append(out, req.token)
+		}
+	}
+	return out
+}
+
+func (r *cloudRequestRecorder) allTokens() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, 0, len(r.requests))
+	for _, req := range r.requests {
+		out = append(out, req.token)
+	}
+	return out
+}
+
+// bearerToken extracts the credential from the Authorization header,
+// tolerating both schemes k6 uses: "Bearer <tok>" for the provisioning/v6
+// push and "Token <tok>" for the legacy v1 push.
+func bearerToken(req *http.Request) string {
+	auth := req.Header.Get("Authorization")
+	auth = strings.TrimPrefix(auth, "Bearer ")
+	auth = strings.TrimPrefix(auth, "Token ")
+	return auth
+}
+
+func failHandler(t *testing.T, msg string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		assert.Fail(t, msg)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+}
+
+// assertPushedWith asserts that at least one request hit a path containing
+// sub, and that every such request carried the expected bearer token.
+func assertPushedWith(t *testing.T, rec *cloudRequestRecorder, sub, token string) {
+	t.Helper()
+	tokens := rec.tokensForPath(sub)
+	require.NotEmptyf(t, tokens, "expected a metrics push to a path containing %q", sub)
+	for _, tk := range tokens {
+		assert.Equalf(t, token, tk, "push to %q used an unexpected bearer token", sub)
+	}
+}
+
+func assertTokenNeverUsed(t *testing.T, rec *cloudRequestRecorder, token string) {
+	t.Helper()
+	assert.NotContainsf(t, rec.allTokens(), token, "token %q must never be sent", token)
+}
+
+func assertPathNeverHit(t *testing.T, rec *cloudRequestRecorder, sub string) {
+	t.Helper()
+	assert.Emptyf(t, rec.tokensForPath(sub), "no request should hit a path containing %q", sub)
+}
+
+// setupSelfProvisionedRun wires a self-provisioned `k6 cloud run
+// --local-execution` against a provisioning mock whose start_local_execution
+// returns the scoped token and a push URL that points back at the mock
+// (/v1/metrics).
+func setupSelfProvisionedRun(
+	t *testing.T,
+) (*GlobalTestState, *provtest.Server, *cloudRequestRecorder, *atomic.Bool) {
+	t.Helper()
+
+	ts := makeTestState(t, pushCredScript, []string{"--local-execution"})
+	ts.Env["K6_CLOUD_TOKEN"] = orgToken
+
+	srv := provtest.NewServer(t)
+	rec := &cloudRequestRecorder{}
+	var notified atomic.Bool
+
+	srv.HandleCreateLoadTest(123456, func(w http.ResponseWriter, _ *http.Request) {
+		res := k6cloud.NewLoadTestApiModelWithDefaults()
+		res.SetId(provtest.DefaultLoadTestID)
+		writeProvJSON(w, http.StatusCreated, res)
+	})
+	srv.HandleStartLocalExecution(provtest.DefaultLoadTestID, func(w http.ResponseWriter, _ *http.Request) {
+		resp := provtest.DefaultStartLocalExecutionResponse()
+		resp.SetArchiveUploadUrl(srv.PresignedUploadURL())
+		resp.SetTestRunDetailsPageUrl(fmt.Sprintf("%s/runs/%d", srv.URL, provtest.DefaultTestRunID))
+		rc := resp.GetRuntimeConfig()
+		m := rc.GetMetrics()
+		m.SetPushUrl(srv.URL + "/v1/metrics")
+		rc.SetMetrics(m)
+		resp.SetRuntimeConfig(rc)
+		writeProvJSON(w, http.StatusOK, resp)
+	})
+	srv.HandlePresignedUpload(provtest.PresignedUploadPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	srv.HandleFetchTestRun(provtest.DefaultTestRunID, []v6.TestProgress{{Status: v6.StatusInitializing}})
+	srv.HandleNotify(provtest.DefaultTestRunID, func(w http.ResponseWriter, _ *http.Request) {
+		notified.Store(true)
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Record the provisioning-mode push (/v1/metrics) and any stray push
+	// (e.g. an overridden URL landing on the catch-all).
+	srv.Mux.HandleFunc("/v1/metrics", rec.handler)
+	srv.Mux.HandleFunc("/", rec.handler)
+
+	ts.Env["K6_CLOUD_HOST"] = srv.URL
+	ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+	return ts, srv, rec, &notified
+}
+
+// TestCloudMetricsPushCredentials specifies how the cloud output resolves
+// the endpoint and bearer token it pushes metrics with, across the three
+// ways a run can be provisioned:
+//
+//   - Self-provisioned (k6 cloud run --local-execution): the push URL and
+//     scoped token come from the provisioning API's start_local_execution
+//     response. They are set programmatically and are never overridden by
+//     the environment or a config file.
+//   - Externally-provisioned (--local-execution + K6_CLOUD_PUSH_REF_ID): an
+//     orchestrator that already created the run supplies the scoped push URL
+//     and token via K6_CLOUD_METRICS_PUSH_URL and K6_CLOUD_TEST_RUN_TOKEN,
+//     which are required together.
+//   - Legacy (k6 run --out cloud, or a PushRefID relay without scoped
+//     creds): metrics go to the endpoint derived from the host using the
+//     long-lived org token.
+//
+// Each case runs the real command against an in-process mock cloud
+// (httptest, no network) and asserts which bearer token k6 pushes with,
+// using distinct sentinel tokens so the source is unambiguous.
+func TestCloudMetricsPushCredentials(t *testing.T) {
+	t.Parallel()
+
+	// Self-provisioned: creds come from the provisioning response and must
+	// not be overridden by stray env vars or config-file values.
+
+	t.Run("self-provisioned run pushes with the scoped token from provisioning", func(t *testing.T) {
+		t.Parallel()
+		ts, _, rec, notified := setupSelfProvisionedRun(t)
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+		assertPushedWith(t, rec, "/v1/metrics", scopedToken)
+		assert.True(t, notified.Load(), "a self-provisioned run notifies at the end")
+	})
+
+	t.Run("self-provisioned run ignores a stray token env var", func(t *testing.T) {
+		t.Parallel()
+		ts, _, rec, notified := setupSelfProvisionedRun(t)
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = bogusToken
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+		assertPushedWith(t, rec, "/v1/metrics", scopedToken)
+		assertTokenNeverUsed(t, rec, bogusToken)
+		assert.True(t, notified.Load())
+	})
+
+	t.Run("self-provisioned run ignores a stray metrics-push-URL env var", func(t *testing.T) {
+		t.Parallel()
+		ts, srv, rec, _ := setupSelfProvisionedRun(t)
+		ts.Env["K6_CLOUD_METRICS_PUSH_URL"] = srv.URL + "/overridden-metrics"
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+		assertPushedWith(t, rec, "/v1/metrics", scopedToken)
+		assertPathNeverHit(t, rec, "/overridden-metrics")
+	})
+
+	t.Run("self-provisioned run ignores stray scoped-cred env vars", func(t *testing.T) {
+		t.Parallel()
+		ts, srv, rec, _ := setupSelfProvisionedRun(t)
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = bogusToken
+		ts.Env["K6_CLOUD_METRICS_PUSH_URL"] = srv.URL + "/overridden-metrics"
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+		assertPushedWith(t, rec, "/v1/metrics", scopedToken)
+		assertTokenNeverUsed(t, rec, bogusToken)
+		assertPathNeverHit(t, rec, "/overridden-metrics")
+	})
+
+	t.Run("self-provisioned run ignores a stale token in the config file", func(t *testing.T) {
+		t.Parallel()
+		ts, _, rec, _ := setupSelfProvisionedRun(t)
+		cfg := []byte(`{"collectors":{"cloud":{"testRunToken":"` + staleConfigToken + `"}}}`)
+		require.NoError(t, ts.FS.MkdirAll(filepath.Dir(ts.Flags.ConfigFilePath), 0o755))
+		require.NoError(t, fsext.WriteFile(ts.FS, ts.Flags.ConfigFilePath, cfg, 0o644))
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+		assertPushedWith(t, rec, "/v1/metrics", scopedToken)
+		assertTokenNeverUsed(t, rec, staleConfigToken)
+	})
+
+	// Legacy: `k6 run --out cloud` and PushRefID relays push to the
+	// host-derived endpoint with the long-lived org token, unaffected by the
+	// scoped-cred env vars.
+
+	t.Run("k6 run --out cloud ignores a stray token env var", func(t *testing.T) {
+		t.Parallel()
+		ts := getSingleFileTestState(t, pushCredScript, []string{"-v", "--log-output=stdout", "--out=cloud"}, 0)
+		ts.Env["K6_CLOUD_TOKEN"] = orgToken
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = bogusToken
+
+		rec := &cloudRequestRecorder{}
+		const refID = 1337
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^/v1/tests$": http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, `{"reference_id": "%d", "config": {}}`, refID)
+			}),
+			fmt.Sprintf("POST ^/v1/tests/%d$", refID): http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}),
+			"POST ^/v2/metrics/": http.HandlerFunc(rec.handler),
+		})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+		assertPushedWith(t, rec, "/v2/metrics/", orgToken)
+		assertTokenNeverUsed(t, rec, bogusToken)
+	})
+
+	t.Run("a PushRefID relay without scoped creds pushes with the org token", func(t *testing.T) {
+		t.Parallel()
+		ts := makeTestState(t, pushCredScript, []string{"--local-execution"})
+		ts.Env["K6_CLOUD_TOKEN"] = orgToken
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = "99999"
+
+		rec := &cloudRequestRecorder{}
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^/v1/tests$":        failHandler(t, "CreateTestRun must not be called with PushRefID"),
+			"POST ^/provisioning/v1/": failHandler(t, "provisioning API must not be called with PushRefID"),
+			"POST ^/cloud/v6/":        failHandler(t, "v6 API must not be called with PushRefID"),
+			"POST ^/v2/metrics/":      http.HandlerFunc(rec.handler),
+		})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+		assertPushedWith(t, rec, "/v2/metrics/", orgToken)
+	})
+
+	t.Run("k6 run --out cloud with PushRefID ignores a lone scoped-cred env var", func(t *testing.T) {
+		t.Parallel()
+		ts := getSingleFileTestState(t, pushCredScript, []string{"-v", "--log-output=stdout", "--out=cloud"}, 0)
+		ts.Env["K6_CLOUD_TOKEN"] = orgToken
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = "1337"
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = extToken // lone scoped cred, no push URL
+
+		rec := &cloudRequestRecorder{}
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^/v1/tests$":   failHandler(t, "CreateTestRun must not be called with PushRefID"),
+			"POST ^/v2/metrics/": http.HandlerFunc(rec.handler),
+		})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+		assertPushedWith(t, rec, "/v2/metrics/", orgToken)
+	})
+
+	// Externally-provisioned: an orchestrator supplies the scoped creds via
+	// env; both are required together.
+
+	t.Run("externally-provisioned run pushes with the scoped creds from env", func(t *testing.T) {
+		t.Parallel()
+		ts := makeTestState(t, pushCredScript, []string{"--local-execution"})
+		ts.Env["K6_CLOUD_TOKEN"] = orgToken
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = "99999"
+
+		rec := &cloudRequestRecorder{}
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^/provisioning/v1/": failHandler(t, "provisioning API must not be called with PushRefID"),
+			"POST ^/cloud/v6/":        failHandler(t, "v6 API must not be called with PushRefID"),
+			"POST ^/v1/metrics":       http.HandlerFunc(rec.handler),
+			"POST ^/v2/metrics/":      http.HandlerFunc(rec.handler),
+		})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+		ts.Env["K6_CLOUD_METRICS_PUSH_URL"] = srv.URL + "/v1/metrics"
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = extToken
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+		assertPushedWith(t, rec, "/v1/metrics", extToken)
+	})
+
+	t.Run("externally-provisioned run requires both scoped creds", func(t *testing.T) {
+		t.Parallel()
+		ts := makeTestState(t, pushCredScript, []string{"--local-execution", "--log-output=stdout"})
+		ts.Env["K6_CLOUD_TOKEN"] = orgToken
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = "99999"
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = extToken // only one of the pair
+		ts.ExpectedExitCode = -1
+
+		srv := getTestServer(t, map[string]http.Handler{})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+		out := ts.Stdout.String() + ts.Stderr.String()
+		assert.Contains(t, out, "must be set together",
+			"a partial scoped-cred pair must fail with a clear error")
+	})
+}

--- a/internal/output/cloud/output.go
+++ b/internal/output/cloud/output.go
@@ -223,11 +223,19 @@ func (out *Output) Start() error {
 	if out.testRunID != "" {
 		out.logger.WithField("testRunId", out.testRunID).Debug("Directly pushing metrics without init")
 
-		// Provisioning-mode setup. PushRefID flows don't set
-		// MetricsPushURL, so this block is normally skipped for them.
-		// The explicit !PushRefID.Valid guard is defensive against a
-		// future cmd-layer regression that populates both fields.
-		if out.config.MetricsPushURL.Valid && out.config.TestRunToken.Valid && !out.config.PushRefID.Valid {
+		// Exactly one of the scoped push creds set is a misconfiguration
+		// (typically an external orchestrator that forgot one env var).
+		if out.config.MetricsPushURL.Valid != out.config.TestRunToken.Valid {
+			return fmt.Errorf(
+				"both K6_CLOUD_METRICS_PUSH_URL and K6_CLOUD_TEST_RUN_TOKEN " +
+					"must be set together")
+		}
+
+		// Provisioning-mode push. Armed whenever the scoped push credentials
+		// are present: either k6 self-provisioned (no PushRefID) or an external
+		// service provisioned the run and passed the creds via env (PushRefID
+		// set; that service owns create/start/notify).
+		if out.config.MetricsPushURL.Valid && out.config.TestRunToken.Valid {
 			if err := out.lazyInitProvisioning(); err != nil {
 				return err
 			}
@@ -498,8 +506,12 @@ func (out *Output) lazyInitProvisioning() error {
 		)
 	}
 
-	// Lazy-construct the provisioning notifier (used at end-of-test).
-	if out.provisioningNotifier == nil {
+	// Lazy-construct the provisioning notifier (end-of-test notify).
+	// Skipped when PushRefID is set: an external service owns the run
+	// lifecycle, so k6 never notifies (testFinished returns early on
+	// PushRefID) and the notifier would be unused. Invariant: a nil
+	// notifier with provisioningMode true implies PushRefID is set.
+	if out.provisioningNotifier == nil && !out.config.PushRefID.Valid {
 		// The stack ID is required and passed as int64; provisioning.NewClient
 		// enforces the int32 X-Stack-Id boundary internally.
 		c, err := provisioning.NewClient(

--- a/internal/output/cloud/output.go
+++ b/internal/output/cloud/output.go
@@ -223,8 +223,10 @@ func (out *Output) Start() error {
 	if out.testRunID != "" {
 		out.logger.WithField("testRunId", out.testRunID).Debug("Directly pushing metrics without init")
 
-		// Exactly one of the scoped push creds set is a misconfiguration
-		// (typically an external orchestrator that forgot one env var).
+		// Exactly one of the scoped push creds set is a misconfiguration.
+		// The cmd layer already validates this for the externally-provisioned
+		// env case (internal/cmd/outputs_cloud.go); this is the defensive
+		// backstop for any other source (e.g. a hand-written cloud config).
 		if out.config.MetricsPushURL.Valid != out.config.TestRunToken.Valid {
 			return fmt.Errorf(
 				"both K6_CLOUD_METRICS_PUSH_URL and K6_CLOUD_TEST_RUN_TOKEN " +
@@ -233,8 +235,9 @@ func (out *Output) Start() error {
 
 		// Provisioning-mode push. Armed whenever the scoped push credentials
 		// are present: either k6 self-provisioned (no PushRefID) or an external
-		// service provisioned the run and passed the creds via env (PushRefID
-		// set; that service owns create/start/notify).
+		// service provisioned the run and its creds were injected into the
+		// cloud config by the cmd layer (PushRefID set; that service owns
+		// create/start/notify).
 		if out.config.MetricsPushURL.Valid && out.config.TestRunToken.Valid {
 			if err := out.lazyInitProvisioning(); err != nil {
 				return err

--- a/internal/output/cloud/output_test.go
+++ b/internal/output/cloud/output_test.go
@@ -510,12 +510,13 @@ func TestOutputStart_ProvisioningMode(t *testing.T) {
 		"queued metrics should be pushed through the injected metricsPusher")
 }
 
-// TestOutputStart_PushRefIDStillTakesPrecedence locks in cloud-Output
-// behaviour even if cmd ever populated both PushRefID and MetricsPushURL.
-// In practice, cmd/outputs_cloud.go:96-100 short-circuits on PushRefID
-// before MetricsPushURL is ever set — so this combination shouldn't
-// occur. This test is defensive against future cmd-layer regressions.
-func TestOutputStart_PushRefIDStillTakesPrecedence(t *testing.T) {
+// TestOutputStart_ExternallyProvisioned covers the flow where an
+// external service provisioned the run and passes the scoped push
+// creds (MetricsPushURL + TestRunToken) plus PushRefID via env. k6
+// must push to the provisioning URL with the scoped token but must
+// NOT build a notifier — the external service owns create/start/
+// notify (see testFinished, which returns early on PushRefID).
+func TestOutputStart_ExternallyProvisioned(t *testing.T) {
 	t.Parallel()
 
 	cfgJSON, err := json.Marshal(cloudapi.Config{
@@ -545,18 +546,122 @@ func TestOutputStart_PushRefIDStillTakesPrecedence(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// Inject a metrics-pusher mock so Start arms the provisioning push
+	// without constructing a real HTTP client (mirrors
+	// TestOutputStart_ProvisioningMode). provisioningNotifier is left nil
+	// to prove lazyInitProvisioning skips it when PushRefID is set.
+	out.metricsPusher = &metricsPusherMock{}
+
 	require.NoError(t, out.Start())
 
-	// PushRefID should win: testRunID should be set to the PushRefID value,
-	// not the testRunID from env.
+	// PushRefID still supplies the test run id.
 	assert.Equal(t, "99999", out.testRunID)
 
-	// The metricsPusher field should remain nil — provisioning mode was NOT
-	// entered because PushRefID took precedence.
-	assert.Nil(t, out.metricsPusher, "metricsPusher should be nil when PushRefID takes precedence")
-	assert.Nil(t, out.provisioningNotifier, "provisioningNotifier should be nil when PushRefID takes precedence")
+	// Provisioning push is armed on scoped-cred presence, even with PushRefID.
+	assert.True(t, out.provisioningMode)
+	assert.NotNil(t, out.metricsPusher)
+
+	// No notifier: the external service owns the run lifecycle.
+	assert.Nil(t, out.provisioningNotifier)
 
 	require.NoError(t, out.StopWithTestError(nil))
+}
+
+// TestOutputStart_ExternalProvisioned_RequiresBothCreds locks the
+// "no silent legacy fallback on partial config" behaviour: if only one
+// of the scoped push creds is set, Start errors (naming both env vars)
+// instead of quietly falling back to the legacy push endpoint.
+func TestOutputStart_ExternalProvisioned_RequiresBothCreds(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name           string
+		metricsPushURL null.String
+		testRunToken   null.String
+	}{
+		{
+			name:           "only MetricsPushURL set",
+			metricsPushURL: null.StringFrom("https://metrics.example.com/v2/metrics/123"),
+		},
+		{
+			name:         "only TestRunToken set",
+			testRunToken: null.StringFrom("scoped-test-run-token"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfgJSON, err := json.Marshal(cloudapi.Config{
+				Host:                  null.StringFrom("https://fake-cloud"),
+				Token:                 null.StringFrom("fake-token"),
+				PushRefID:             null.StringFrom("99999"),
+				MetricsPushURL:        tc.metricsPushURL,
+				TestRunToken:          tc.testRunToken,
+				APIVersion:            null.IntFrom(2),
+				AggregationPeriod:     types.NullDurationFrom(1 * time.Hour),
+				MetricPushInterval:    types.NullDurationFrom(1 * time.Hour),
+				AggregationWaitPeriod: types.NullDurationFrom(1 * time.Second),
+				MaxTimeSeriesInBatch:  null.IntFrom(1000),
+				MetricPushConcurrency: null.IntFrom(1),
+			})
+			require.NoError(t, err)
+
+			out, err := newOutput(output.Params{
+				Logger:     testutils.NewLogger(t),
+				JSONConfig: cfgJSON,
+				ScriptOptions: lib.Options{
+					Duration:   types.NullDurationFrom(1 * time.Second),
+					SystemTags: &metrics.DefaultSystemTagSet,
+				},
+				ScriptPath: &url.URL{Path: "/script.js"},
+				Usage:      usage.New(),
+			})
+			require.NoError(t, err)
+
+			err = out.Start()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "K6_CLOUD_METRICS_PUSH_URL")
+			assert.Contains(t, err.Error(), "K6_CLOUD_TEST_RUN_TOKEN")
+		})
+	}
+}
+
+// TestOutputStopWithTestError_ExternalProvisioned_NoNotifier locks the
+// invariant "notifier nil ⇒ PushRefID set ⇒ testFinished returns early":
+// with provisioningMode true and a nil notifier, Stop must not panic and
+// must neither notify nor call the legacy TestFinished.
+func TestOutputStopWithTestError_ExternalProvisioned_NoNotifier(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		clientMock := &cloudClientMock{}
+
+		out := &Output{
+			logger:    testutils.NewLogger(t),
+			testRunID: "12345",
+			config: cloudapi.Config{
+				PushRefID:      null.StringFrom("99999"),
+				MetricsPushURL: null.StringFrom("https://metrics.example.com/v2/metrics/123"),
+				TestRunToken:   null.StringFrom("scoped-test-run-token"),
+			},
+			client:               clientMock,
+			provisioningNotifier: nil,
+			provisioningMode:     true,
+		}
+
+		out.versionedOutput = versionedOutputMock{
+			callback: func(_ string) {},
+		}
+
+		// Must not panic even though provisioningNotifier is nil while
+		// provisioningMode is true — testFinished returns early on PushRefID
+		// (so the nil notifier is never dereferenced, and notify never fires).
+		require.NoError(t, out.StopWithTestError(nil))
+
+		// Legacy TestFinished is not called either (PushRefID short-circuit).
+		assert.False(t, clientMock.testFinishedCalled)
+	})
 }
 
 func TestOutputStopWithTestError_ProvisioningMode_NoError(t *testing.T) {


### PR DESCRIPTION
> **Supersedes #6133.** Now based directly on `master` following the merge of the provisioning migration (#6169, which superseded #6068); adapted to the int64 resource-ID SDK change.

## What?

Follow-up to the provisioning migration (#6169, now merged). Let `k6 cloud run --local-execution` push metrics to a run that an **external service** has already provisioned via the provisioning API, instead of provisioning the run itself.

When an external orchestrator calls `start_local_execution`, then launches local k6 with `K6_CLOUD_PUSH_REF_ID` set (the run id), k6 must push metrics to that run's scoped `push_url` with the scoped `test_run_token`. Today that combination silently falls back to the legacy ingest endpoint with the long-lived org token. Two changes fix it:

1. `cloudapi.Config.MetricsPushURL` and `TestRunToken` gain `envconfig` tags (`K6_CLOUD_METRICS_PUSH_URL`, `K6_CLOUD_TEST_RUN_TOKEN`) so an orchestrator can supply the scoped push credentials via env. They were previously JSON-only, set solely by k6's own provisioning call.
2. The cloud Output's provisioning-mode gate now arms whenever `MetricsPushURL` + `TestRunToken` are present, even when `PushRefID` is set (previously `PushRefID` disabled it). In that externally-provisioned case k6 pushes to the provisioning URL with the scoped token but does **not** construct a notifier — the external service owns the run lifecycle (create/start/notify), which `testFinished` already respects by short-circuiting on `PushRefID`. A half-set credential pair (one env var without the other) is rejected rather than silently using the legacy path.

Behaviour matrix:

| Signal | Push endpoint | Token | Notify |
|---|---|---|---|
| `PushRefID` only (unchanged) | legacy ingest | long-lived | no |
| `PushRefID` + scoped creds (new) | provisioning `push_url` | scoped `test_run_token` | no |
| self-provision, no ref (unchanged) | provisioning `push_url` | scoped | yes |

`k6 run --out cloud` (path B), self-provisioned `--local-execution`, and the plain PushRefID flow are all **unchanged**. Cloud secrets need no code change — an orchestrator configures them via the existing URL secret source env vars (`--secret-source=url` + `K6_SECRET_SOURCE_URL_*`), or passes `--no-cloud-secrets`.

Two atomic commits, each individually buildable + lintable + green.

## Why?

Orchestration services (and future flows such as Synthetic Monitoring) provision the run themselves via the provisioning API and hand local k6 a correlation ref rather than letting k6 self-provision. The provisioning API already returns a per-run `push_url` and a scoped `test_run_token` for exactly this; without this change that externally-provisioned combination falls back to the legacy v1 ingest endpoint with the long-lived org token — defeating the scoped-token model and forcing the long-lived token to be distributed to every local runner.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Follows #6169 (the provisioning migration — merged into `master`; supersedes #6068 and #6133). This PR is now based directly on `master` and contains only the two external-provisioning commits.
- Verified end-to-end against a real stack with a dedicated `external-provisioned` manual-test scenario (out-of-band `start_local_execution`, then assert metrics push to `push_url` with `Authorization: Bearer <test_run_token>`, and no self-provision / poll / notify / legacy `/v1/tests`).


