### PR TITLE
Stream --local-execution logs to Grafana Cloud

### DIFF
--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -59,6 +59,17 @@ type Config struct {
 	// no test run id, and we may still need an identifier to correlate all the things.
 	PushRefID null.String `json:"pushRefID" envconfig:"K6_CLOUD_PUSH_REF_ID"`
 
+	// Log-push configuration for `k6 cloud run --local-execution`. Supplied
+	// by the provisioning API's runtime_config.logs (self-provisioned) or
+	// by an external orchestrator via env (externally-provisioned). Consumed
+	// by cmd to configure the cloud log pusher; env-only, not serialised.
+	LogsPushURL        null.String        `json:"-" envconfig:"K6_CLOUD_LOGS_PUSH_URL"`
+	LogsLevel          null.String        `json:"-" envconfig:"K6_CLOUD_LOGS_LEVEL"`
+	LogsLimit          null.Int           `json:"-" envconfig:"K6_CLOUD_LOGS_LIMIT"`
+	LogsPushPeriod     types.NullDuration `json:"-" envconfig:"K6_CLOUD_LOGS_PUSH_PERIOD"`
+	LogsMessageMaxSize null.Int           `json:"-" envconfig:"K6_CLOUD_LOGS_MESSAGE_MAX_SIZE"`
+	LogsAllowedLabels  []string           `json:"-" envconfig:"K6_CLOUD_LOGS_ALLOWED_LABELS"`
+
 	// Defines the max allowed number of time series in a single batch.
 	MaxTimeSeriesInBatch null.Int `json:"maxTimeSeriesInBatch" envconfig:"K6_CLOUD_MAX_TIME_SERIES_IN_BATCH"`
 
@@ -160,6 +171,24 @@ func (c Config) Apply(cfg Config) Config {
 	}
 	if cfg.PushRefID.Valid {
 		c.PushRefID = cfg.PushRefID
+	}
+	if cfg.LogsPushURL.Valid {
+		c.LogsPushURL = cfg.LogsPushURL
+	}
+	if cfg.LogsLevel.Valid {
+		c.LogsLevel = cfg.LogsLevel
+	}
+	if cfg.LogsLimit.Valid {
+		c.LogsLimit = cfg.LogsLimit
+	}
+	if cfg.LogsPushPeriod.Valid {
+		c.LogsPushPeriod = cfg.LogsPushPeriod
+	}
+	if cfg.LogsMessageMaxSize.Valid {
+		c.LogsMessageMaxSize = cfg.LogsMessageMaxSize
+	}
+	if len(cfg.LogsAllowedLabels) > 0 {
+		c.LogsAllowedLabels = cfg.LogsAllowedLabels
 	}
 	if cfg.WebAppURL.Valid {
 		c.WebAppURL = cfg.WebAppURL

--- a/cloudapi/config.go
+++ b/cloudapi/config.go
@@ -59,16 +59,19 @@ type Config struct {
 	// no test run id, and we may still need an identifier to correlate all the things.
 	PushRefID null.String `json:"pushRefID" envconfig:"K6_CLOUD_PUSH_REF_ID"`
 
-	// Log-push configuration for `k6 cloud run --local-execution`. Supplied
-	// by the provisioning API's runtime_config.logs (self-provisioned) or
-	// by an external orchestrator via env (externally-provisioned). Consumed
-	// by cmd to configure the cloud log pusher; env-only, not serialised.
-	LogsPushURL        null.String        `json:"-" envconfig:"K6_CLOUD_LOGS_PUSH_URL"`
-	LogsLevel          null.String        `json:"-" envconfig:"K6_CLOUD_LOGS_LEVEL"`
-	LogsLimit          null.Int           `json:"-" envconfig:"K6_CLOUD_LOGS_LIMIT"`
-	LogsPushPeriod     types.NullDuration `json:"-" envconfig:"K6_CLOUD_LOGS_PUSH_PERIOD"`
-	LogsMessageMaxSize null.Int           `json:"-" envconfig:"K6_CLOUD_LOGS_MESSAGE_MAX_SIZE"`
-	LogsAllowedLabels  []string           `json:"-" envconfig:"K6_CLOUD_LOGS_ALLOWED_LABELS"`
+	// Log-push configuration for `k6 cloud run --local-execution`. Like the
+	// scoped push creds above, these are programmatic-only (no envconfig tag):
+	// the self-provisioned flow sets them from the provisioning API's
+	// runtime_config.logs, while the externally-provisioned flow reads the
+	// K6_CLOUD_LOGS_* env vars explicitly in cmd (applyExternalLogsConfig), so
+	// a stray env value can't override the run-scoped values. Consumed by cmd
+	// to configure the cloud log pusher; never serialised.
+	LogsPushURL        null.String        `json:"-"`
+	LogsLevel          null.String        `json:"-"`
+	LogsLimit          null.Int           `json:"-"`
+	LogsPushPeriod     types.NullDuration `json:"-"`
+	LogsMessageMaxSize null.Int           `json:"-"`
+	LogsAllowedLabels  []string           `json:"-"`
 
 	// Defines the max allowed number of time series in a single batch.
 	MaxTimeSeriesInBatch null.Int `json:"maxTimeSeriesInBatch" envconfig:"K6_CLOUD_MAX_TIME_SERIES_IN_BATCH"`

--- a/cloudapi/config_test.go
+++ b/cloudapi/config_test.go
@@ -146,6 +146,93 @@ func TestConfig_Apply_MergesNewFields(t *testing.T) {
 	}
 }
 
+// TestConfig_LogsFieldsFromEnvconfig verifies the log-push config
+// fields are read from the environment via envconfig (K6_CLOUD_LOGS_*)
+// so an external orchestrator that provisioned a run can hand the log
+// push settings to a local k6.
+func TestConfig_LogsFieldsFromEnvconfig(t *testing.T) {
+	t.Parallel()
+
+	envVars := map[string]string{
+		"K6_CLOUD_LOGS_PUSH_URL":         "https://api.k6.io/logs/v1/test_runs/42",
+		"K6_CLOUD_LOGS_LEVEL":            "info",
+		"K6_CLOUD_LOGS_LIMIT":            "900",
+		"K6_CLOUD_LOGS_PUSH_PERIOD":      "3s",
+		"K6_CLOUD_LOGS_MESSAGE_MAX_SIZE": "10000",
+		"K6_CLOUD_LOGS_ALLOWED_LABELS":   "lz,level,test_run_id",
+	}
+
+	config, _, err := GetConsolidatedConfig(nil, envVars, "", nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, null.StringFrom("https://api.k6.io/logs/v1/test_runs/42"), config.LogsPushURL)
+	assert.Equal(t, null.StringFrom("info"), config.LogsLevel)
+	assert.Equal(t, null.IntFrom(900), config.LogsLimit)
+	assert.Equal(t, types.NewNullDuration(3*time.Second, true), config.LogsPushPeriod)
+	assert.Equal(t, null.IntFrom(10000), config.LogsMessageMaxSize)
+	assert.Equal(t, []string{"lz", "level", "test_run_id"}, config.LogsAllowedLabels)
+}
+
+func TestConfig_Apply_MergesLogsFields(t *testing.T) {
+	t.Parallel()
+
+	baseCfg := Config{
+		LogsPushURL:        null.StringFrom("https://base.example/logs"),
+		LogsLevel:          null.StringFrom("warn"),
+		LogsLimit:          null.IntFrom(100),
+		LogsPushPeriod:     types.NewNullDuration(1*time.Second, true),
+		LogsMessageMaxSize: null.IntFrom(1024),
+		LogsAllowedLabels:  []string{"level"},
+	}
+	appliedCfg := Config{
+		LogsPushURL:        null.StringFrom("https://applied.example/logs"),
+		LogsLevel:          null.StringFrom("info"),
+		LogsLimit:          null.IntFrom(900),
+		LogsPushPeriod:     types.NewNullDuration(3*time.Second, true),
+		LogsMessageMaxSize: null.IntFrom(10000),
+		LogsAllowedLabels:  []string{"lz", "test_run_id"},
+	}
+
+	cases := []struct {
+		name    string
+		base    Config
+		applied Config
+		want    Config
+	}{
+		{
+			name:    "applied populated, base unset → uses applied",
+			base:    Config{},
+			applied: appliedCfg,
+			want:    appliedCfg,
+		},
+		{
+			name:    "applied unset, base populated → keeps base",
+			base:    baseCfg,
+			applied: Config{},
+			want:    baseCfg,
+		},
+		{
+			name:    "both populated → applied wins",
+			base:    baseCfg,
+			applied: appliedCfg,
+			want:    appliedCfg,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := tc.base.Apply(tc.applied)
+			assert.Equal(t, tc.want.LogsPushURL, got.LogsPushURL)
+			assert.Equal(t, tc.want.LogsLevel, got.LogsLevel)
+			assert.Equal(t, tc.want.LogsLimit, got.LogsLimit)
+			assert.Equal(t, tc.want.LogsPushPeriod, got.LogsPushPeriod)
+			assert.Equal(t, tc.want.LogsMessageMaxSize, got.LogsMessageMaxSize)
+			assert.Equal(t, tc.want.LogsAllowedLabels, got.LogsAllowedLabels)
+		})
+	}
+}
+
 func TestGetConsolidatedConfig(t *testing.T) {
 	t.Parallel()
 	config, warn, err := GetConsolidatedConfig(json.RawMessage(`{"token":"jsonraw"}`), nil, "", nil)

--- a/cloudapi/config_test.go
+++ b/cloudapi/config_test.go
@@ -90,17 +90,31 @@ func TestConfig_NewFieldsNotPickedUpByEnvconfig(t *testing.T) {
 
 	// Set env vars with every plausible name a user might guess.
 	envVars := map[string]string{
-		"K6_CLOUD_METRICS_PUSH_URL": "foo",
-		"K6_CLOUD_TEST_RUN_TOKEN":   "bar",
-		"K6_CLOUD_METRICSPUSHURL":   "foo",
-		"K6_CLOUD_TESTRUNTOKEN":     "bar",
+		"K6_CLOUD_METRICS_PUSH_URL":      "foo",
+		"K6_CLOUD_TEST_RUN_TOKEN":        "bar",
+		"K6_CLOUD_METRICSPUSHURL":        "foo",
+		"K6_CLOUD_TESTRUNTOKEN":          "bar",
+		"K6_CLOUD_LOGS_PUSH_URL":         "https://stray.example/logs",
+		"K6_CLOUD_LOGS_LEVEL":            "debug",
+		"K6_CLOUD_LOGS_LIMIT":            "5",
+		"K6_CLOUD_LOGS_PUSH_PERIOD":      "9s",
+		"K6_CLOUD_LOGS_MESSAGE_MAX_SIZE": "42",
+		"K6_CLOUD_LOGS_ALLOWED_LABELS":   "stray",
 	}
 
 	config, _, err := GetConsolidatedConfig(nil, envVars, "", nil)
 	require.NoError(t, err)
 
+	// The scoped push creds and the log-push config are all programmatic-only,
+	// so none of these env vars are picked up by envconfig.
 	assert.Equal(t, null.String{}, config.MetricsPushURL)
 	assert.Equal(t, null.String{}, config.TestRunToken)
+	assert.Equal(t, null.String{}, config.LogsPushURL)
+	assert.Equal(t, null.String{}, config.LogsLevel)
+	assert.Equal(t, null.Int{}, config.LogsLimit)
+	assert.Equal(t, types.NullDuration{}, config.LogsPushPeriod)
+	assert.Equal(t, null.Int{}, config.LogsMessageMaxSize)
+	assert.Empty(t, config.LogsAllowedLabels)
 }
 
 func TestConfig_Apply_MergesNewFields(t *testing.T) {
@@ -144,33 +158,6 @@ func TestConfig_Apply_MergesNewFields(t *testing.T) {
 			assert.Equal(t, tc.wantRunToken, got.TestRunToken)
 		})
 	}
-}
-
-// TestConfig_LogsFieldsFromEnvconfig verifies the log-push config
-// fields are read from the environment via envconfig (K6_CLOUD_LOGS_*)
-// so an external orchestrator that provisioned a run can hand the log
-// push settings to a local k6.
-func TestConfig_LogsFieldsFromEnvconfig(t *testing.T) {
-	t.Parallel()
-
-	envVars := map[string]string{
-		"K6_CLOUD_LOGS_PUSH_URL":         "https://api.k6.io/logs/v1/test_runs/42",
-		"K6_CLOUD_LOGS_LEVEL":            "info",
-		"K6_CLOUD_LOGS_LIMIT":            "900",
-		"K6_CLOUD_LOGS_PUSH_PERIOD":      "3s",
-		"K6_CLOUD_LOGS_MESSAGE_MAX_SIZE": "10000",
-		"K6_CLOUD_LOGS_ALLOWED_LABELS":   "lz,level,test_run_id",
-	}
-
-	config, _, err := GetConsolidatedConfig(nil, envVars, "", nil)
-	require.NoError(t, err)
-
-	assert.Equal(t, null.StringFrom("https://api.k6.io/logs/v1/test_runs/42"), config.LogsPushURL)
-	assert.Equal(t, null.StringFrom("info"), config.LogsLevel)
-	assert.Equal(t, null.IntFrom(900), config.LogsLimit)
-	assert.Equal(t, types.NewNullDuration(3*time.Second, true), config.LogsPushPeriod)
-	assert.Equal(t, null.IntFrom(10000), config.LogsMessageMaxSize)
-	assert.Equal(t, []string{"lz", "level", "test_run_id"}, config.LogsAllowedLabels)
 }
 
 func TestConfig_Apply_MergesLogsFields(t *testing.T) {

--- a/cmd/state/state.go
+++ b/cmd/state/state.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"go.k6.io/k6/v2/internal/event"
+	cloudlog "go.k6.io/k6/v2/internal/log/cloud"
 	cloudsecrets "go.k6.io/k6/v2/internal/secretsource/cloud"
 	"go.k6.io/k6/v2/internal/ui/console"
 	"go.k6.io/k6/v2/internal/usage"
@@ -95,6 +96,7 @@ type GlobalState struct {
 
 	SecretsManager    *secretsource.Manager
 	CloudSecretSource *cloudsecrets.SecretSource
+	CloudLogPusher    *cloudlog.Pusher
 	Usage             *usage.Usage
 	TestStatus        *lib.TestStatus
 }

--- a/internal/cloudapi/provisioning/api.go
+++ b/internal/cloudapi/provisioning/api.go
@@ -57,6 +57,7 @@ type RuntimeConfig struct {
 	Metrics      MetricsConfig
 	TestRunToken string
 	Secrets      SecretsConfig
+	Logs         LogsConfig
 }
 
 // MetricsConfig holds the metrics push configuration from the
@@ -76,6 +77,17 @@ type MetricsConfig struct {
 type SecretsConfig struct {
 	Endpoint     string
 	ResponsePath string
+}
+
+// LogsConfig holds the log-push configuration from the provisioning
+// API's runtime_config.logs object.
+type LogsConfig struct {
+	PushURL           string
+	Level             string
+	Limit             int32
+	PushPeriodSeconds string
+	MessageMaxSize    int32
+	AllowedLabels     []string
 }
 
 // UploadArchive PUTs pre-serialised archive bytes to the given
@@ -241,6 +253,7 @@ func mapStartLocalExecutionResponse(res *k6cloud.StartLocalExecutionTestResponse
 	rc := res.GetRuntimeConfig()
 	m := rc.GetMetrics()
 	s := rc.GetSecrets()
+	l := rc.GetLogs()
 
 	resp := &StartLocalExecutionResponse{
 		TestRunID:             res.GetTestRunId(),
@@ -259,6 +272,14 @@ func mapStartLocalExecutionResponse(res *k6cloud.StartLocalExecutionTestResponse
 			Secrets: SecretsConfig{
 				Endpoint:     s.GetEndpoint(),
 				ResponsePath: s.GetResponsePath(),
+			},
+			Logs: LogsConfig{
+				PushURL:           l.GetPushUrl(),
+				Level:             l.GetLevel(),
+				Limit:             l.GetLimit(),
+				PushPeriodSeconds: l.GetPushPeriodSeconds(),
+				MessageMaxSize:    l.GetMessageMaxSize(),
+				AllowedLabels:     l.GetAllowedLabels(),
 			},
 		},
 	}

--- a/internal/cloudapi/provisioning/api.go
+++ b/internal/cloudapi/provisioning/api.go
@@ -80,7 +80,8 @@ type SecretsConfig struct {
 }
 
 // LogsConfig holds the log-push configuration from the provisioning
-// API's runtime_config.logs object.
+// API's runtime_config.logs object. tail_url is intentionally omitted:
+// --local-execution pushes logs, it doesn't tail them.
 type LogsConfig struct {
 	PushURL           string
 	Level             string

--- a/internal/cloudapi/provisioning/api_test.go
+++ b/internal/cloudapi/provisioning/api_test.go
@@ -91,6 +91,14 @@ func TestStartLocalExecution(t *testing.T) {
 	require.NotNil(t, got.RuntimeConfig.Metrics.MaxSamplesPerPackage)
 	assert.Equal(t, int32(2000), *got.RuntimeConfig.Metrics.MaxSamplesPerPackage)
 
+	// Logs config.
+	assert.Equal(t, "https://logs.k6.io", got.RuntimeConfig.Logs.PushURL)
+	assert.Equal(t, "info", got.RuntimeConfig.Logs.Level)
+	assert.Equal(t, int32(900), got.RuntimeConfig.Logs.Limit)
+	assert.Equal(t, "3s", got.RuntimeConfig.Logs.PushPeriodSeconds)
+	assert.Equal(t, int32(10000), got.RuntimeConfig.Logs.MessageMaxSize)
+	assert.Equal(t, []string{"lz", "level"}, got.RuntimeConfig.Logs.AllowedLabels)
+
 	// --- Request assertions ---
 	assert.Equal(t, http.MethodPost, method)
 	assert.Equal(t, "/provisioning/v1/load_tests/456/start_local_execution", path)

--- a/internal/cmd/cloud_run.go
+++ b/internal/cmd/cloud_run.go
@@ -34,6 +34,9 @@ type cmdCloudRun struct {
 	// noCloudSecrets stores the state of the --no-cloud-secrets flag.
 	noCloudSecrets bool
 
+	// noCloudLogs stores the state of the --no-cloud-logs flag.
+	noCloudLogs bool
+
 	// runCmd holds an instance of the k6 run command that we store
 	// in order to be able to call its run method to support
 	// the --local-execution flag mode.
@@ -132,6 +135,13 @@ func (c *cmdCloudRun) preRun(cmd *cobra.Command, args []string) error {
 		)
 	}
 
+	if c.noCloudLogs {
+		return errext.WithExitCodeIfNone(
+			fmt.Errorf("the --no-cloud-logs flag can only be used in conjunction with the --local-execution flag"),
+			exitcodes.InvalidConfig,
+		)
+	}
+
 	return c.deprecatedCloudCmd.preRun(cmd, args)
 }
 
@@ -191,6 +201,12 @@ func (c *cmdCloudRun) flagSet() *pflag.FlagSet {
 		"no-cloud-secrets",
 		c.noCloudSecrets,
 		"only when using the local-execution mode, don't automatically configure the cloud secret source",
+	)
+	flags.BoolVar(
+		&c.noCloudLogs,
+		"no-cloud-logs",
+		c.noCloudLogs,
+		"only when using the local-execution mode, don't push logs to the cloud",
 	)
 	flags.StringArray("features", nil, "enable feature flags (comma-separated)")
 

--- a/internal/cmd/outputs.go
+++ b/internal/cmd/outputs.go
@@ -187,8 +187,20 @@ func createOutputs(
 			}
 		}
 
+		attachCloudLogDrainer(out, gs)
+
 		result = append(result, out)
 	}
 
 	return result, nil
+}
+
+// attachCloudLogDrainer gives the cloud output the local-execution log pusher
+// so it flushes buffered logs before the run is notified complete. The
+// concrete-nil guard avoids handing the output a typed-nil drainer once it is
+// wrapped in an interface.
+func attachCloudLogDrainer(out output.Output, gs *state.GlobalState) {
+	if co, ok := out.(*cloud.Output); ok && gs.CloudLogPusher != nil {
+		co.SetLogDrainer(gs.CloudLogPusher)
+	}
 }

--- a/internal/cmd/outputs_cloud.go
+++ b/internal/cmd/outputs_cloud.go
@@ -217,6 +217,11 @@ func applyExternalProvisioningCreds(
 		return errors.New("both K6_CLOUD_METRICS_PUSH_URL and " +
 			"K6_CLOUD_TEST_RUN_TOKEN must be set together")
 	}
+	// A logs push URL is authenticated with the same scoped token, so reject a
+	// logs URL supplied without it rather than silently streaming nothing.
+	if token == "" && conf.LogsPushURL.Valid && conf.LogsPushURL.String != "" {
+		return errors.New("K6_CLOUD_LOGS_PUSH_URL requires K6_CLOUD_TEST_RUN_TOKEN")
+	}
 	if pushURL == "" {
 		return nil
 	}

--- a/internal/cmd/outputs_cloud.go
+++ b/internal/cmd/outputs_cloud.go
@@ -17,6 +17,7 @@ import (
 	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/internal/build"
 	"go.k6.io/k6/v2/internal/cloudapi/provisioning"
+	cloudlog "go.k6.io/k6/v2/internal/log/cloud"
 	cloudsecrets "go.k6.io/k6/v2/internal/secretsource/cloud"
 	"go.k6.io/k6/v2/lib"
 	"go.k6.io/k6/v2/lib/types"
@@ -102,6 +103,9 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 		}
 		test.preInitState.RuntimeOptions.Env[testRunIDKey] = conf.PushRefID.String
 		gs.Logger.Debug("using PushRefID, skipping CreateTestRun")
+		// Externally-provisioned run: the logs config and token are already
+		// on conf from the environment. The run id is the PushRefID.
+		configureCloudLogPusher(gs, conf, conf.PushRefID.String)
 		return nil
 	}
 
@@ -176,6 +180,10 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 			ResponsePath: result.RuntimeConfig.Secrets.ResponsePath,
 		})
 	}
+
+	// Configure the log pusher for the self-provisioned run. The run id is
+	// the provisioning result's TestRunID.
+	configureCloudLogPusher(gs, conf, strconv.FormatInt(result.TestRunID, 10))
 
 	// Serialise overridden Config back into the collectors map (existing pattern).
 	raw, err := cloudConfToRawMessage(conf)
@@ -326,5 +334,62 @@ func buildConfigFromRuntimeConfig(
 	// expv2 has no min-samples aggregation knob; adding one would
 	// require changes to output/cloud/expv2/{collect.go, flush.go}.
 
+	// logs.push_url (string) → LogsPushURL
+	if v := rc.Logs.PushURL; v != "" {
+		cfg.LogsPushURL = null.StringFrom(v)
+	}
+	// logs.level (string) → LogsLevel
+	if v := rc.Logs.Level; v != "" {
+		cfg.LogsLevel = null.StringFrom(v)
+	}
+	// logs.limit (int32) → LogsLimit
+	if v := rc.Logs.Limit; v != 0 {
+		cfg.LogsLimit = null.IntFrom(int64(v))
+	}
+	// logs.push_period_seconds (string) → LogsPushPeriod (NullDuration)
+	if v := rc.Logs.PushPeriodSeconds; v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.LogsPushPeriod = types.NewNullDuration(d, true)
+		} else {
+			logger.WithError(err).WithField("field", "push_period_seconds").
+				Warn("invalid duration in runtime_config; using default")
+		}
+	}
+	// logs.message_max_size (int32) → LogsMessageMaxSize
+	if v := rc.Logs.MessageMaxSize; v != 0 {
+		cfg.LogsMessageMaxSize = null.IntFrom(int64(v))
+	}
+	// logs.allowed_labels ([]string) → LogsAllowedLabels
+	if v := rc.Logs.AllowedLabels; len(v) > 0 {
+		cfg.LogsAllowedLabels = v
+	}
+
 	return cfg
+}
+
+// configureCloudLogPusher points the registered cloud log pusher at the
+// run. It is a no-op unless the pusher was registered (i.e.
+// --local-execution without --no-cloud-logs).
+func configureCloudLogPusher(gs *state.GlobalState, conf cloudapi.Config, testRunID string) {
+	if gs.CloudLogPusher == nil {
+		return
+	}
+	gs.CloudLogPusher.SetConfig(logPusherConfig(conf, testRunID))
+}
+
+// logPusherConfig translates the resolved cloudapi.Config log-push fields
+// into the cloud log pusher's config. testRunID is the run identifier used
+// as the required test_run_id stream label: result.TestRunID in the
+// self-provisioned flow, PushRefID in the externally-provisioned flow.
+func logPusherConfig(conf cloudapi.Config, testRunID string) cloudlog.Config {
+	return cloudlog.Config{
+		PushURL:       conf.LogsPushURL.String,
+		Token:         conf.TestRunToken.String,
+		TestRunID:     testRunID,
+		Level:         conf.LogsLevel.String,
+		Limit:         int(conf.LogsLimit.Int64),
+		PushPeriod:    conf.LogsPushPeriod.TimeDuration(),
+		MsgMaxSize:    int(conf.LogsMessageMaxSize.Int64),
+		AllowedLabels: conf.LogsAllowedLabels,
+	}
 }

--- a/internal/cmd/outputs_cloud.go
+++ b/internal/cmd/outputs_cloud.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mstoykov/envconfig"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/guregu/null.v3"
 
@@ -103,8 +104,7 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 		}
 		test.preInitState.RuntimeOptions.Env[testRunIDKey] = conf.PushRefID.String
 		gs.Logger.Debug("using PushRefID, skipping CreateTestRun")
-		// Externally-provisioned run: the logs config and token are already
-		// on conf from the environment. The run id is the PushRefID.
+		// Externally-provisioned run: the run id is the PushRefID.
 		configureCloudLogPusher(gs, conf, conf.PushRefID.String)
 		return nil
 	}
@@ -207,10 +207,18 @@ func createCloudTest(gs *state.GlobalState, test *loadedAndConfiguredTest) error
 // values the self-provision flow obtains from the provisioning response.
 // It requires both-or-neither and, when both are present, sets them on conf
 // (so downstream consumers such as the log pusher see them) and bakes them
-// into the serialized cloud config that the Output reads.
+// into the serialized cloud config that the Output reads. It also reads the
+// K6_CLOUD_LOGS_* log-push config, which the external flow supplies the same
+// way.
 func applyExternalProvisioningCreds(
 	gs *state.GlobalState, test *loadedAndConfiguredTest, conf *cloudapi.Config,
 ) error {
+	// The log-push config is env-supplied for an external run and likewise not
+	// env-bound on the Config, so read it explicitly here (before the checks
+	// below, which require the token when a logs URL is set).
+	if err := applyExternalLogsConfig(gs, conf); err != nil {
+		return err
+	}
 	pushURL := gs.Env["K6_CLOUD_METRICS_PUSH_URL"]
 	token := gs.Env["K6_CLOUD_TEST_RUN_TOKEN"]
 	if (pushURL == "") != (token == "") {
@@ -236,6 +244,41 @@ func applyExternalProvisioningCreds(
 		test.derivedConfig.Collectors = make(map[string]json.RawMessage)
 	}
 	test.derivedConfig.Collectors[builtinOutputCloud.String()] = raw
+	return nil
+}
+
+// externalLogsConfig mirrors the K6_CLOUD_LOGS_* env vars an external
+// orchestrator uses to hand the log-push settings to a local k6. These are
+// read explicitly (the Logs* fields are not env-bound on cloudapi.Config) so a
+// stray env value can't override the run-scoped logs config in the
+// self-provisioned flow.
+type externalLogsConfig struct {
+	PushURL       null.String        `envconfig:"K6_CLOUD_LOGS_PUSH_URL"`
+	Level         null.String        `envconfig:"K6_CLOUD_LOGS_LEVEL"`
+	Limit         null.Int           `envconfig:"K6_CLOUD_LOGS_LIMIT"`
+	PushPeriod    types.NullDuration `envconfig:"K6_CLOUD_LOGS_PUSH_PERIOD"`
+	MsgMaxSize    null.Int           `envconfig:"K6_CLOUD_LOGS_MESSAGE_MAX_SIZE"`
+	AllowedLabels []string           `envconfig:"K6_CLOUD_LOGS_ALLOWED_LABELS"`
+}
+
+// applyExternalLogsConfig reads the K6_CLOUD_LOGS_* env vars into conf for the
+// externally-provisioned flow, where there is no provisioning response to
+// supply them. It uses the same envconfig parsing as GetConsolidatedConfig, so
+// malformed values fail the same way.
+func applyExternalLogsConfig(gs *state.GlobalState, conf *cloudapi.Config) error {
+	var elc externalLogsConfig
+	if err := envconfig.Process("", &elc, func(key string) (string, bool) {
+		v, ok := gs.Env[key]
+		return v, ok
+	}); err != nil {
+		return err
+	}
+	conf.LogsPushURL = elc.PushURL
+	conf.LogsLevel = elc.Level
+	conf.LogsLimit = elc.Limit
+	conf.LogsPushPeriod = elc.PushPeriod
+	conf.LogsMessageMaxSize = elc.MsgMaxSize
+	conf.LogsAllowedLabels = elc.AllowedLabels
 	return nil
 }
 

--- a/internal/cmd/outputs_cloud_test.go
+++ b/internal/cmd/outputs_cloud_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
 
+	"go.k6.io/k6/v2/cloudapi"
 	"go.k6.io/k6/v2/internal/cloudapi/provisioning"
 	"go.k6.io/k6/v2/internal/lib/testutils"
+	cloudlog "go.k6.io/k6/v2/internal/log/cloud"
 	"go.k6.io/k6/v2/lib/types"
 )
 
@@ -39,6 +41,14 @@ func TestBuildConfigFromRuntimeConfig(t *testing.T) {
 			Endpoint:     "https://secrets.example.com",
 			ResponsePath: "plaintext",
 		},
+		Logs: provisioning.LogsConfig{
+			PushURL:           "https://logs.example.com/push",
+			Level:             "info",
+			Limit:             900,
+			PushPeriodSeconds: "3s",
+			MessageMaxSize:    10000,
+			AllowedLabels:     []string{"lz", "level", "test_run_id"},
+		},
 	}
 
 	logger := testutils.NewLogger(t)
@@ -63,6 +73,24 @@ func TestBuildConfigFromRuntimeConfig(t *testing.T) {
 	// max_samples_per_package → MaxTimeSeriesInBatch
 	assert.True(t, cfg.MaxTimeSeriesInBatch.Valid)
 	assert.Equal(t, null.IntFrom(2000), cfg.MaxTimeSeriesInBatch)
+
+	// logs.push_url → LogsPushURL
+	assert.Equal(t, null.StringFrom("https://logs.example.com/push"), cfg.LogsPushURL)
+
+	// logs.level → LogsLevel
+	assert.Equal(t, null.StringFrom("info"), cfg.LogsLevel)
+
+	// logs.limit → LogsLimit
+	assert.Equal(t, null.IntFrom(900), cfg.LogsLimit)
+
+	// logs.push_period_seconds → LogsPushPeriod (parsed from "3s")
+	assert.Equal(t, types.NewNullDuration(3*time.Second, true), cfg.LogsPushPeriod)
+
+	// logs.message_max_size → LogsMessageMaxSize
+	assert.Equal(t, null.IntFrom(10000), cfg.LogsMessageMaxSize)
+
+	// logs.allowed_labels → LogsAllowedLabels
+	assert.Equal(t, []string{"lz", "level", "test_run_id"}, cfg.LogsAllowedLabels)
 }
 
 func TestBuildConfigFromRuntimeConfig_InvalidDurationLogsWarning(t *testing.T) {
@@ -97,6 +125,66 @@ func TestBuildConfigFromRuntimeConfig_InvalidDurationLogsWarning(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "expected a warning log entry for field push_interval")
+}
+
+func TestBuildConfigFromRuntimeConfig_InvalidLogsPushPeriodLogsWarning(t *testing.T) {
+	t.Parallel()
+
+	rc := provisioning.RuntimeConfig{
+		Logs: provisioning.LogsConfig{
+			PushPeriodSeconds: "not a duration",
+		},
+	}
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+	hook := testutils.NewLogHook()
+	logger.AddHook(hook)
+
+	cfg := buildConfigFromRuntimeConfig(logger, rc)
+
+	// LogsPushPeriod should be left unset (invalid) when parse fails.
+	assert.False(t, cfg.LogsPushPeriod.Valid, "expected LogsPushPeriod to remain unset for unparseable duration")
+
+	// A warning should have been logged (not an error).
+	entries := hook.Drain()
+	require.NotEmpty(t, entries, "expected at least one log entry for invalid duration")
+
+	found := false
+	for _, e := range entries {
+		assert.NotEqual(t, logrus.ErrorLevel, e.Level, "invalid duration must warn, not error")
+		if e.Level == logrus.WarnLevel && e.Data["field"] == "push_period_seconds" {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected a warning log entry for field push_period_seconds")
+}
+
+func TestLogPusherConfig(t *testing.T) {
+	t.Parallel()
+
+	conf := cloudapi.Config{
+		LogsPushURL:        null.StringFrom("https://logs.example.com/push"),
+		TestRunToken:       null.StringFrom("scoped-token"),
+		LogsLevel:          null.StringFrom("warn"),
+		LogsLimit:          null.IntFrom(500),
+		LogsPushPeriod:     types.NewNullDuration(2*time.Second, true),
+		LogsMessageMaxSize: null.IntFrom(2048),
+		LogsAllowedLabels:  []string{"lz", "test_run_id"},
+	}
+
+	got := logPusherConfig(conf, "42")
+
+	assert.Equal(t, cloudlog.Config{
+		PushURL:       "https://logs.example.com/push",
+		Token:         "scoped-token",
+		TestRunID:     "42",
+		Level:         "warn",
+		Limit:         500,
+		PushPeriod:    2 * time.Second,
+		MsgMaxSize:    2048,
+		AllowedLabels: []string{"lz", "test_run_id"},
+	}, got)
 }
 
 func TestBuildConfigFromRuntimeConfig_NilFieldsLeftUnset(t *testing.T) {

--- a/internal/cmd/outputs_cloud_test.go
+++ b/internal/cmd/outputs_cloud_test.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/v2/cloudapi"
+	"go.k6.io/k6/v2/cmd/state"
 	"go.k6.io/k6/v2/internal/cloudapi/provisioning"
 	"go.k6.io/k6/v2/internal/lib/testutils"
 	cloudlog "go.k6.io/k6/v2/internal/log/cloud"
@@ -205,6 +206,16 @@ func TestBuildConfigFromRuntimeConfig_NilFieldsLeftUnset(t *testing.T) {
 	assert.False(t, cfg.AggregationPeriod.Valid, "AggregationPeriod should be unset when input is nil")
 	assert.False(t, cfg.AggregationWaitPeriod.Valid, "AggregationWaitPeriod should be unset when input is nil")
 	assert.False(t, cfg.MaxTimeSeriesInBatch.Valid, "MaxTimeSeriesInBatch should be unset when input is nil")
+
+	// The logs fields must also stay unset when provisioning omits them, so a
+	// stray K6_CLOUD_LOGS_* env value cannot survive Apply in the
+	// self-provisioned flow (the fields are programmatic-only).
+	assert.False(t, cfg.LogsPushURL.Valid, "LogsPushURL should be unset when input is nil")
+	assert.False(t, cfg.LogsLevel.Valid, "LogsLevel should be unset when input is nil")
+	assert.False(t, cfg.LogsLimit.Valid, "LogsLimit should be unset when input is nil")
+	assert.False(t, cfg.LogsPushPeriod.Valid, "LogsPushPeriod should be unset when input is nil")
+	assert.False(t, cfg.LogsMessageMaxSize.Valid, "LogsMessageMaxSize should be unset when input is nil")
+	assert.Empty(t, cfg.LogsAllowedLabels, "LogsAllowedLabels should be unset when input is nil")
 }
 
 func TestBuildConfigFromRuntimeConfig_AggregationMinSamplesIgnored(t *testing.T) {
@@ -237,4 +248,30 @@ func TestBuildConfigFromRuntimeConfig_AggregationMinSamplesIgnored(t *testing.T)
 		assert.NotEqual(t, logrus.WarnLevel, e.Level, "unexpected warning logged for intentionally dropped field")
 		assert.NotEqual(t, logrus.ErrorLevel, e.Level, "unexpected error logged for intentionally dropped field")
 	}
+}
+
+// TestApplyExternalLogsConfig verifies the externally-provisioned flow reads
+// the log-push knobs from the K6_CLOUD_LOGS_* env vars into the config (the
+// fields are not env-bound on cloudapi.Config, so cmd reads them explicitly).
+func TestApplyExternalLogsConfig(t *testing.T) {
+	t.Parallel()
+
+	gs := &state.GlobalState{Env: map[string]string{
+		"K6_CLOUD_LOGS_PUSH_URL":         "https://api.k6.io/logs/v1/test_runs/42",
+		"K6_CLOUD_LOGS_LEVEL":            "info",
+		"K6_CLOUD_LOGS_LIMIT":            "900",
+		"K6_CLOUD_LOGS_PUSH_PERIOD":      "3s",
+		"K6_CLOUD_LOGS_MESSAGE_MAX_SIZE": "10000",
+		"K6_CLOUD_LOGS_ALLOWED_LABELS":   "lz,level,test_run_id",
+	}}
+
+	var conf cloudapi.Config
+	require.NoError(t, applyExternalLogsConfig(gs, &conf))
+
+	assert.Equal(t, null.StringFrom("https://api.k6.io/logs/v1/test_runs/42"), conf.LogsPushURL)
+	assert.Equal(t, null.StringFrom("info"), conf.LogsLevel)
+	assert.Equal(t, null.IntFrom(900), conf.LogsLimit)
+	assert.Equal(t, types.NewNullDuration(3*time.Second, true), conf.LogsPushPeriod)
+	assert.Equal(t, null.IntFrom(10000), conf.LogsMessageMaxSize)
+	assert.Equal(t, []string{"lz", "level", "test_run_id"}, conf.LogsAllowedLabels)
 }

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"go.k6.io/k6/v2/errext/exitcodes"
 	"go.k6.io/k6/v2/ext"
 	"go.k6.io/k6/v2/internal/log"
+	cloudlog "go.k6.io/k6/v2/internal/log/cloud"
 	"go.k6.io/k6/v2/secretsource"
 
 	_ "go.k6.io/k6/v2/internal/secretsource" // import it to register internal secret sources
@@ -84,10 +85,11 @@ func ExecuteWithGlobalState(gs *state.GlobalState) {
 type rootCommand struct {
 	globalState *state.GlobalState
 
-	cmd            *cobra.Command
-	stopLoggersCh  chan struct{}
-	loggersWg      sync.WaitGroup
-	loggerIsRemote bool
+	cmd                *cobra.Command
+	stopLoggersCh      chan struct{}
+	loggersWg          sync.WaitGroup
+	loggerIsRemote     bool
+	enableCloudLogPush bool
 }
 
 // newRootCommand creates a root command with a default launcher
@@ -156,6 +158,14 @@ func (c *rootCommand) persistentPreRunE(cmd *cobra.Command, _ []string) error {
 		if f == nil || f.Value.String() != "true" {
 			c.globalState.Flags.SecretSource = append(c.globalState.Flags.SecretSource, "cloud")
 		}
+	}
+
+	// For 'k6 cloud run --local-execution', push k6's own logs to the cloud unless
+	// --no-cloud-logs is set. The decision is made here and applied in setupLoggers,
+	// which registers the pusher on the logger.
+	if isCloudRunWithLocalExecution(cmd) {
+		f := cmd.Flag("no-cloud-logs")
+		c.enableCloudLogPush = f == nil || f.Value.String() != "true"
 	}
 
 	err := c.setupLoggers(c.stopLoggersCh)
@@ -417,6 +427,10 @@ func (c *rootCommand) setupLoggers(stop <-chan struct{}) error {
 		c.setLoggerHook(ctx, hook)
 	}
 
+	// Attach the cloud log pusher after the secrets-redaction hook so it only
+	// ever observes redacted entries (see setupCloudLogPusher).
+	c.setupCloudLogPusher(stop)
+
 	// Sometimes the Go runtime uses the standard log output to
 	// log some messages directly.
 	// It does when an invalid char is found in a Cookie.
@@ -437,6 +451,30 @@ func (c *rootCommand) setLoggerHook(ctx context.Context, h log.AsyncHook) {
 	})
 	c.globalState.Logger.AddHook(h)
 	c.globalState.Logger.SetOutput(io.Discard) // don't output to anywhere else
+}
+
+// setupCloudLogPusher registers the cloud log pusher on the logger and starts
+// its Listen goroutine under the logger goroutine group. It does nothing unless
+// cloud log push is enabled. It must be called after the secrets-redaction hook
+// is registered: logrus fires hooks in registration order and each hook mutates
+// the same entry in place, so a hook added later only observes redacted entries.
+// Unlike setLoggerHook, the hook is added directly and the primary log output is
+// left intact; the pusher only mirrors entries to the cloud. The pusher buffers
+// until it is configured and drains on shutdown when stop fires and its context
+// is cancelled.
+func (c *rootCommand) setupCloudLogPusher(stop <-chan struct{}) {
+	if !c.enableCloudLogPush {
+		return
+	}
+	p := cloudlog.New(c.globalState.FallbackLogger)
+	c.globalState.CloudLogPusher = p
+	c.globalState.Logger.AddHook(p)
+	pctx, pcancel := context.WithCancel(context.Background())
+	c.loggersWg.Go(func() { p.Listen(pctx) })
+	c.loggersWg.Go(func() {
+		<-stop
+		pcancel()
+	})
 }
 
 //nolint:gocognit

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -150,20 +150,18 @@ func (c *rootCommand) persistentPreRunE(cmd *cobra.Command, _ []string) error {
 		return errext.WithExitCodeIfNone(errAlreadyReported, exitcodes.InvalidConfig)
 	}
 
-	// For 'k6 cloud run --local-execution', automatically register the cloud secret source
-	// so scripts can call secrets.get() without any extra flags.
-	// This must happen before setupLoggers, which calls createSecretSources internally.
+	// For 'k6 cloud run --local-execution', wire up the cloud secret source and
+	// the cloud log push. Both must happen before setupLoggers, which calls
+	// createSecretSources and registers the log pusher on the logger.
 	if isCloudRunWithLocalExecution(cmd) {
-		f := cmd.Flag("no-cloud-secrets")
-		if f == nil || f.Value.String() != "true" {
+		// Register the cloud secret source so scripts can call secrets.get()
+		// without any extra flags.
+		if f := cmd.Flag("no-cloud-secrets"); f == nil || f.Value.String() != "true" {
 			c.globalState.Flags.SecretSource = append(c.globalState.Flags.SecretSource, "cloud")
 		}
-	}
 
-	// For 'k6 cloud run --local-execution', push k6's own logs to the cloud unless
-	// --no-cloud-logs is set. The decision is made here and applied in setupLoggers,
-	// which registers the pusher on the logger.
-	if isCloudRunWithLocalExecution(cmd) {
+		// Push k6's own logs to the cloud unless --no-cloud-logs is set; the
+		// decision is applied in setupLoggers.
 		f := cmd.Flag("no-cloud-logs")
 		c.enableCloudLogPush = f == nil || f.Value.String() != "true"
 	}

--- a/internal/cmd/tests/cmd_cloud_run_push_credentials_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_push_credentials_test.go
@@ -140,6 +140,12 @@ func setupSelfProvisionedRun(
 		m := rc.GetMetrics()
 		m.SetPushUrl(srv.URL + "/v1/metrics")
 		rc.SetMetrics(m)
+		// Point the logs push URL at the mock too: --local-execution activates
+		// the cloud log pusher, which would otherwise egress to the real logs
+		// host baked into DefaultStartLocalExecutionResponse.
+		l := rc.GetLogs()
+		l.SetPushUrl(srv.URL + logsPushPath)
+		rc.SetLogs(l)
 		resp.SetRuntimeConfig(rc)
 		writeProvJSON(w, http.StatusOK, resp)
 	})

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -234,6 +235,11 @@ export default function() {};`
 			m := rc.GetMetrics()
 			m.SetPushUrl(srv.URL + "/v1/metrics")
 			rc.SetMetrics(m)
+			// Point the logs push_url at the test server too, so the
+			// configured pusher never contacts the real logs host.
+			l := rc.GetLogs()
+			l.SetPushUrl(srv.URL + logsPushPath)
+			rc.SetLogs(l)
 			resp.SetRuntimeConfig(rc)
 			writeProvJSON(w, http.StatusOK, resp)
 		})
@@ -323,6 +329,11 @@ export default function() {};`
 			m := rc.GetMetrics()
 			m.SetPushUrl(srv.URL + "/v1/metrics")
 			rc.SetMetrics(m)
+			// Point the logs push_url at the test server too, so the
+			// configured pusher never contacts the real logs host.
+			l := rc.GetLogs()
+			l.SetPushUrl(srv.URL + logsPushPath)
+			rc.SetLogs(l)
 			resp.SetRuntimeConfig(rc)
 			writeProvJSON(w, http.StatusOK, resp)
 		})
@@ -392,6 +403,11 @@ export default function() {
 			m := rc.GetMetrics()
 			m.SetPushUrl(srv.URL + "/v1/metrics")
 			rc.SetMetrics(m)
+			// Point the logs push_url at the test server too, so the
+			// configured pusher never contacts the real logs host.
+			l := rc.GetLogs()
+			l.SetPushUrl(srv.URL + logsPushPath)
+			rc.SetLogs(l)
 			resp.SetRuntimeConfig(rc)
 			writeProvJSON(w, http.StatusOK, resp)
 		})
@@ -501,6 +517,11 @@ export default function() {};`
 		m := rc.GetMetrics()
 		m.SetPushUrl(srv.URL + "/v1/metrics")
 		rc.SetMetrics(m)
+		// Point the logs push_url at the test server too, so the
+		// configured pusher never contacts the real logs host.
+		l := rc.GetLogs()
+		l.SetPushUrl(srv.URL + logsPushPath)
+		rc.SetLogs(l)
 		resp.SetRuntimeConfig(rc)
 		writeProvJSON(w, http.StatusOK, resp)
 	})
@@ -533,6 +554,8 @@ export default function() {};`
 func TestCloudRunLocalExecutionCloudLogPusher(t *testing.T) {
 	t.Parallel()
 
+	// The VU logs one line so the pusher has a deterministic entry to push;
+	// console.log routes through the same logger the pusher hooks.
 	script := `
 export const options = {
   cloud: {
@@ -540,18 +563,68 @@ export const options = {
       projectID: 123456,
   },
 };
-export default function() {};`
+export default function() { console.log('hello from the vu'); };`
 
 	t.Run("registers the pusher for --local-execution", func(t *testing.T) {
 		t.Parallel()
 
 		ts := makeTestState(t, script, []string{"--local-execution"})
-		setupLocalExecutionProvMock(t, ts)
+		rec := setupLocalExecutionProvMock(t, ts)
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		assert.NotNil(t, ts.CloudLogPusher,
 			"cloud log pusher should be registered for k6 cloud run --local-execution")
+
+		// The self-provisioned flow must configure the pusher from the
+		// provisioning response: streams are pushed with the scoped token
+		// and the result's TestRunID as the test_run_id label.
+		auths, bodies := rec.snapshot()
+		require.NotEmpty(t, bodies, "expected at least one cloud log push")
+		assert.Equal(t, "Bearer test-run-token-abc", auths[0])
+		assert.Contains(t, bodies[0],
+			fmt.Sprintf(`"test_run_id":"%d"`, provtest.DefaultTestRunID))
+	})
+
+	t.Run("configures the pusher from env for an externally-provisioned run", func(t *testing.T) {
+		t.Parallel()
+
+		rec := &logPushRecorder{}
+		const pushRefID = "99999"
+
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^" + logsPushPath + "$": http.HandlerFunc(rec.handler),
+			"POST ^/v1/tests$": http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				require.Fail(t, "CreateTestRun must not be called when K6_CLOUD_PUSH_REF_ID is set")
+			}),
+			"POST ^/provisioning/v1/": http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+				require.Fail(t, "provisioning API must not be called when K6_CLOUD_PUSH_REF_ID is set")
+			}),
+		})
+		t.Cleanup(srv.Close)
+
+		ts := makeTestState(t, script, []string{"--local-execution"})
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = pushRefID
+		ts.Env["K6_CLOUD_LOGS_PUSH_URL"] = srv.URL + logsPushPath
+		// An external orchestrator supplies the scoped metrics push creds
+		// (PR #6133); they must be set together, and the same token is used
+		// as the Bearer for the logs push.
+		ts.Env["K6_CLOUD_METRICS_PUSH_URL"] = srv.URL + "/v1/metrics"
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = "ext-token"
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		require.NotNil(t, ts.CloudLogPusher,
+			"cloud log pusher should be registered for an externally-provisioned --local-execution run")
+
+		// The externally-provisioned flow reads the logs config and token
+		// from env; the run id is the PushRefID.
+		auths, bodies := rec.snapshot()
+		require.NotEmpty(t, bodies, "expected at least one cloud log push")
+		assert.Equal(t, "Bearer ext-token", auths[0])
+		assert.Contains(t, bodies[0], `"test_run_id":"`+pushRefID+`"`)
 	})
 
 	t.Run("does not register the pusher with --no-cloud-logs", func(t *testing.T) {
@@ -580,12 +653,43 @@ export default function() {};`
 	})
 }
 
+// logsPushPath is the path the local-execution mocks use for the cloud
+// logs push endpoint, overriding the real host baked into
+// DefaultStartLocalExecutionResponse so tests never contact it.
+const logsPushPath = "/logs/v1/push"
+
+// logPushRecorder captures cloud log pushes received by the mock server so
+// tests can assert on the pusher wiring (auth header + test_run_id label).
+type logPushRecorder struct {
+	mu     sync.Mutex
+	auths  []string
+	bodies []string
+}
+
+func (r *logPushRecorder) handler(w http.ResponseWriter, req *http.Request) {
+	body, _ := io.ReadAll(req.Body)
+	r.mu.Lock()
+	r.auths = append(r.auths, req.Header.Get("Authorization"))
+	r.bodies = append(r.bodies, string(body))
+	r.mu.Unlock()
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (r *logPushRecorder) snapshot() (auths, bodies []string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]string(nil), r.auths...), append([]string(nil), r.bodies...)
+}
+
 // setupLocalExecutionProvMock wires a provisioning mock server for a
 // k6 cloud run --local-execution flow and points ts at it. It mirrors the
-// handlers used by TestCloudRunLocalExecutionNoCloudSecrets.
-func setupLocalExecutionProvMock(t *testing.T, ts *GlobalTestState) {
+// handlers used by TestCloudRunLocalExecutionNoCloudSecrets. The returned
+// recorder captures any cloud log pushes; the logs push_url is overridden
+// onto the mock server so the real logs host is never contacted.
+func setupLocalExecutionProvMock(t *testing.T, ts *GlobalTestState) *logPushRecorder {
 	t.Helper()
 
+	rec := &logPushRecorder{}
 	srv := provtest.NewServer(t)
 
 	srv.HandleCreateLoadTest(123456, func(w http.ResponseWriter, _ *http.Request) {
@@ -603,6 +707,9 @@ func setupLocalExecutionProvMock(t *testing.T, ts *GlobalTestState) {
 		m := rc.GetMetrics()
 		m.SetPushUrl(srv.URL + "/v1/metrics")
 		rc.SetMetrics(m)
+		l := rc.GetLogs()
+		l.SetPushUrl(srv.URL + logsPushPath)
+		rc.SetLogs(l)
 		resp.SetRuntimeConfig(rc)
 		writeProvJSON(w, http.StatusOK, resp)
 	})
@@ -619,12 +726,16 @@ func setupLocalExecutionProvMock(t *testing.T, ts *GlobalTestState) {
 		w.WriteHeader(http.StatusOK)
 	})
 
+	srv.Mux.HandleFunc("POST "+logsPushPath, rec.handler)
+
 	srv.Mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
 	ts.Env["K6_CLOUD_HOST"] = srv.URL
 	ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+
+	return rec
 }
 
 func makeTestState(tb testing.TB, script string, cliFlags []string) *GlobalTestState {

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -155,6 +155,11 @@ func TestCloudRunCommandIncompatibleFlags(t *testing.T) {
 			cliArgs:            []string{"--no-cloud-secrets"},
 			wantStderrContains: "the --no-cloud-secrets flag can only be used in conjunction with the --local-execution flag",
 		},
+		{
+			name:               "using --no-cloud-logs without --local-execution should fail",
+			cliArgs:            []string{"--no-cloud-logs"},
+			wantStderrContains: "the --no-cloud-logs flag can only be used in conjunction with the --local-execution flag",
+		},
 	}
 
 	for _, tc := range testCases {
@@ -523,6 +528,103 @@ export default function() {};`
 
 	// --no-cloud-secrets must prevent the cloud source from being registered.
 	assert.Nil(t, ts.CloudSecretSource, "cloud secret source should not be registered when --no-cloud-secrets is set")
+}
+
+func TestCloudRunLocalExecutionCloudLogPusher(t *testing.T) {
+	t.Parallel()
+
+	script := `
+export const options = {
+  cloud: {
+      name: 'Test cloud logs',
+      projectID: 123456,
+  },
+};
+export default function() {};`
+
+	t.Run("registers the pusher for --local-execution", func(t *testing.T) {
+		t.Parallel()
+
+		ts := makeTestState(t, script, []string{"--local-execution"})
+		setupLocalExecutionProvMock(t, ts)
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		assert.NotNil(t, ts.CloudLogPusher,
+			"cloud log pusher should be registered for k6 cloud run --local-execution")
+	})
+
+	t.Run("does not register the pusher with --no-cloud-logs", func(t *testing.T) {
+		t.Parallel()
+
+		ts := makeTestState(t, script, []string{"--local-execution", "--no-cloud-logs"})
+		setupLocalExecutionProvMock(t, ts)
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		assert.Nil(t, ts.CloudLogPusher,
+			"cloud log pusher should not be registered when --no-cloud-logs is set")
+	})
+
+	t.Run("does not register the pusher for non-local-execution", func(t *testing.T) {
+		t.Parallel()
+
+		ts := NewGlobalTestState(t)
+		require.NoError(t, fsext.WriteFile(ts.FS, filepath.Join(ts.Cwd, "test.js"), []byte(script), 0o644))
+		ts.CmdArgs = []string{"k6", "run", "test.js"}
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		assert.Nil(t, ts.CloudLogPusher,
+			"cloud log pusher should not be registered for a non-local-execution run")
+	})
+}
+
+// setupLocalExecutionProvMock wires a provisioning mock server for a
+// k6 cloud run --local-execution flow and points ts at it. It mirrors the
+// handlers used by TestCloudRunLocalExecutionNoCloudSecrets.
+func setupLocalExecutionProvMock(t *testing.T, ts *GlobalTestState) {
+	t.Helper()
+
+	srv := provtest.NewServer(t)
+
+	srv.HandleCreateLoadTest(123456, func(w http.ResponseWriter, _ *http.Request) {
+		res := k6cloud.NewLoadTestApiModelWithDefaults()
+		res.SetId(provtest.DefaultLoadTestID)
+		writeProvJSON(w, http.StatusCreated, res)
+	})
+
+	srv.HandleStartLocalExecution(provtest.DefaultLoadTestID, func(w http.ResponseWriter, _ *http.Request) {
+		resp := provtest.DefaultStartLocalExecutionResponse()
+		uploadURL := srv.URL + provtest.PresignedUploadPath
+		resp.SetArchiveUploadUrl(uploadURL)
+		resp.SetTestRunDetailsPageUrl(fmt.Sprintf("%s/runs/%d", srv.URL, provtest.DefaultTestRunID))
+		rc := resp.GetRuntimeConfig()
+		m := rc.GetMetrics()
+		m.SetPushUrl(srv.URL + "/v1/metrics")
+		rc.SetMetrics(m)
+		resp.SetRuntimeConfig(rc)
+		writeProvJSON(w, http.StatusOK, resp)
+	})
+
+	srv.HandlePresignedUpload(provtest.PresignedUploadPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv.HandleFetchTestRun(provtest.DefaultTestRunID, []v6.TestProgress{
+		{Status: v6.StatusInitializing},
+	})
+
+	srv.HandleNotify(provtest.DefaultTestRunID, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv.Mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ts.Env["K6_CLOUD_HOST"] = srv.URL
+	ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
 }
 
 func makeTestState(tb testing.TB, script string, cliFlags []string) *GlobalTestState {

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -650,6 +651,198 @@ export default function() { console.log('hello from the vu'); };`
 
 		assert.Nil(t, ts.CloudLogPusher,
 			"cloud log pusher should not be registered for a non-local-execution run")
+	})
+
+	// The subtests below mirror TestCloudMetricsPushCredentials (which pins the metrics
+	// push-credential resolution) for the cloud *log* push: the observable
+	// is which bearer token / URL k6 streams logs with across the
+	// self-provisioned, externally-provisioned and legacy paths. The
+	// sentinel token consts (scopedToken, bogusToken, extToken,
+	// staleConfigToken, orgToken) are shared with
+	// cmd_cloud_run_push_credentials_test.go.
+
+	// A2 (log): a stray K6_CLOUD_TEST_RUN_TOKEN in the env must NOT override
+	// the run-scoped token the self-provisioned flow gets from provisioning.
+	// The token is programmatic-only (no envconfig), so the stray is inert.
+	t.Run("self-provisioned log push ignores a stray token env var", func(t *testing.T) {
+		t.Parallel()
+
+		ts := makeTestState(t, script, []string{"--local-execution"})
+		rec := setupLocalExecutionProvMock(t, ts)
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = bogusToken
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		auths, bodies := rec.snapshot()
+		require.NotEmpty(t, bodies, "expected at least one cloud log push")
+		for _, a := range auths {
+			assert.Equalf(t, "Bearer "+scopedToken, a,
+				"log push must use the run-scoped token, not the stray env token %q", bogusToken)
+		}
+	})
+
+	// A3 (log): a stray K6_CLOUD_LOGS_PUSH_URL must NOT override the
+	// provisioning-supplied logs URL. conf.Apply(runtime_config) overwrites
+	// the env value. If it leaked, the push would go to the unroutable host
+	// and the provisioning logs endpoint (rec) would record nothing.
+	t.Run("self-provisioned log push ignores a stray logs-push-URL env var", func(t *testing.T) {
+		t.Parallel()
+
+		ts := makeTestState(t, script, []string{"--local-execution"})
+		rec := setupLocalExecutionProvMock(t, ts)
+		ts.Env["K6_CLOUD_LOGS_PUSH_URL"] = "http://stray.invalid/logs/push"
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		auths, bodies := rec.snapshot()
+		require.NotEmpty(t, bodies,
+			"log push must hit the provisioning logs URL, not the stray env URL")
+		for _, a := range auths {
+			assert.Equal(t, "Bearer "+scopedToken, a)
+		}
+	})
+
+	// A4 (log): both stray env vars at once — scoped token + provisioning URL
+	// must still win.
+	t.Run("self-provisioned log push ignores both stray env vars", func(t *testing.T) {
+		t.Parallel()
+
+		ts := makeTestState(t, script, []string{"--local-execution"})
+		rec := setupLocalExecutionProvMock(t, ts)
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = bogusToken
+		ts.Env["K6_CLOUD_LOGS_PUSH_URL"] = "http://stray.invalid/logs/push"
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		auths, bodies := rec.snapshot()
+		require.NotEmpty(t, bodies,
+			"log push must hit the provisioning logs URL with the scoped token")
+		for _, a := range auths {
+			assert.Equal(t, "Bearer "+scopedToken, a)
+		}
+	})
+
+	// A8 (log): a stale testRunToken living in the k6 config file must NOT
+	// override the run-scoped token in the self-provisioned flow.
+	t.Run("self-provisioned log push ignores a stale config-file token", func(t *testing.T) {
+		t.Parallel()
+
+		ts := makeTestState(t, script, []string{"--local-execution"})
+		rec := setupLocalExecutionProvMock(t, ts)
+		cfg := []byte(`{"collectors":{"cloud":{"testRunToken":"` + staleConfigToken + `"}}}`)
+		require.NoError(t, ts.FS.MkdirAll(filepath.Dir(ts.Flags.ConfigFilePath), 0o755))
+		require.NoError(t, fsext.WriteFile(ts.FS, ts.Flags.ConfigFilePath, cfg, 0o644))
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		auths, bodies := rec.snapshot()
+		require.NotEmpty(t, bodies, "expected at least one cloud log push")
+		for _, a := range auths {
+			assert.Equalf(t, "Bearer "+scopedToken, a,
+				"log push must use the run-scoped token, not the stale config token %q", staleConfigToken)
+		}
+	})
+
+	// B2 (log): partial scoped creds (only the token) must error before any
+	// log push happens.
+	t.Run("errors on partial scoped creds and pushes no logs", func(t *testing.T) {
+		t.Parallel()
+
+		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"})
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = "99999"
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = extToken // only one of the required pair
+		ts.ExpectedExitCode = -1
+
+		rec := &logPushRecorder{}
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^" + logsPushPath + "$": http.HandlerFunc(rec.handler),
+		})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		out := ts.Stdout.String() + ts.Stderr.String()
+		assert.Contains(t, out, "must be set together",
+			"expected a clear both-or-neither error for partial scoped creds")
+		_, bodies := rec.snapshot()
+		assert.Empty(t, bodies, "no cloud log push should happen when the run errors out")
+	})
+
+	// A5/A6 (log): the legacy `k6 run --out=cloud` path must not register a
+	// cloud log pusher at all (log streaming is a --local-execution feature).
+	t.Run("does not register the pusher for k6 run --out=cloud", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSingleFileTestState(t, script, []string{"-v", "--log-output=stdout", "--out=cloud"}, 0)
+		ts.Env["K6_CLOUD_TOKEN"] = orgToken
+		const refID = 1337
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^/v1/tests$": http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = fmt.Fprintf(w, `{"reference_id": "%d", "config": {}}`, refID)
+			}),
+		})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		assert.Nil(t, ts.CloudLogPusher,
+			"cloud log streaming is only for cloud run --local-execution, not --out=cloud")
+	})
+
+	// A6 (log): a PushRefID relay run with no scoped creds and no logs push
+	// URL must not push logs anywhere (the pusher stays unconfigured).
+	t.Run("relay run without a logs push URL pushes no logs", func(t *testing.T) {
+		t.Parallel()
+
+		ts := makeTestState(t, script, []string{"--local-execution"})
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = "99999"
+
+		rec := &logPushRecorder{}
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^/v1/tests$":            failHandler(t, "CreateTestRun must not be called with PushRefID"),
+			"POST ^/provisioning/v1/":     failHandler(t, "provisioning API must not be called with PushRefID"),
+			"POST ^" + logsPushPath + "$": http.HandlerFunc(rec.handler),
+		})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		_, bodies := rec.snapshot()
+		assert.Empty(t, bodies,
+			"a relay run with no logs push URL must not push logs anywhere")
+	})
+
+	// "and more" (beyond the metrics matrix): the pusher must honour the
+	// backend-configured log level. The logger runs at debug (-v) so
+	// console.debug reaches the pusher hook; the provisioning logs config
+	// (level=info) must then drop it before pushing, while info survives.
+	t.Run("self-provisioned log push filters lines below the configured level", func(t *testing.T) {
+		t.Parallel()
+
+		lvlScript := `
+export const options = { cloud: { name: 'Test cloud logs', projectID: 123456 } };
+export default function() {
+	console.debug('debug-line-must-be-filtered');
+	console.log('info-line-must-be-pushed');
+};`
+		ts := makeTestState(t, lvlScript, []string{"--local-execution", "-v", "--log-output=stdout"})
+		rec := setupLocalExecutionProvMock(t, ts)
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		_, bodies := rec.snapshot()
+		require.NotEmpty(t, bodies, "expected at least one cloud log push")
+		all := strings.Join(bodies, "\n")
+		assert.Contains(t, all, "info-line-must-be-pushed",
+			"info-level lines should be pushed")
+		assert.NotContains(t, all, "debug-line-must-be-filtered",
+			"debug-level lines must be filtered out by the configured level (info)")
 	})
 }
 

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -628,6 +628,36 @@ export default function() { console.log('hello from the vu'); };`
 		assert.Contains(t, bodies[0], `"test_run_id":"`+pushRefID+`"`)
 	})
 
+	t.Run("externally-provisioned run keeps test_run_id with empty allowed labels", func(t *testing.T) {
+		t.Parallel()
+
+		rec := &logPushRecorder{}
+		const pushRefID = "99999"
+
+		srv := getTestServer(t, map[string]http.Handler{
+			"POST ^" + logsPushPath + "$": http.HandlerFunc(rec.handler),
+		})
+		t.Cleanup(srv.Close)
+
+		ts := makeTestState(t, script, []string{"--local-execution"})
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = pushRefID
+		ts.Env["K6_CLOUD_LOGS_PUSH_URL"] = srv.URL + logsPushPath
+		ts.Env["K6_CLOUD_METRICS_PUSH_URL"] = srv.URL + "/v1/metrics"
+		ts.Env["K6_CLOUD_TEST_RUN_TOKEN"] = "ext-token"
+		// An explicitly empty allow-list decodes to []string{}; the required
+		// test_run_id label must still survive rather than be stripped.
+		ts.Env["K6_CLOUD_LOGS_ALLOWED_LABELS"] = ""
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		_, bodies := rec.snapshot()
+		require.NotEmpty(t, bodies, "expected at least one cloud log push")
+		assert.Contains(t, bodies[0], `"test_run_id":"`+pushRefID+`"`,
+			"test_run_id must survive an empty K6_CLOUD_LOGS_ALLOWED_LABELS")
+	})
+
 	t.Run("does not register the pusher with --no-cloud-logs", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -772,6 +772,29 @@ export default function() { console.log('hello from the vu'); };`
 		assert.Empty(t, bodies, "no cloud log push should happen when the run errors out")
 	})
 
+	// A logs push URL in the externally-provisioned flow is useless without the
+	// scoped token; it must error rather than silently stream nothing.
+	t.Run("errors when a logs push URL is set without a token", func(t *testing.T) {
+		t.Parallel()
+
+		ts := makeTestState(t, script, []string{"--local-execution", "--log-output=stdout"})
+		ts.Env["K6_CLOUD_PUSH_REF_ID"] = "99999"
+		ts.Env["K6_CLOUD_LOGS_PUSH_URL"] = "http://logs.invalid/push"
+		// No K6_CLOUD_TEST_RUN_TOKEN (nor the K6_CLOUD_METRICS_PUSH_URL it
+		// pairs with), so there is no token to authenticate the logs push.
+		ts.ExpectedExitCode = -1
+
+		srv := getTestServer(t, map[string]http.Handler{})
+		t.Cleanup(srv.Close)
+		ts.Env["K6_CLOUD_HOST"] = srv.URL
+		ts.Env["K6_CLOUD_HOST_V6"] = srv.URL
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		out := ts.Stdout.String() + ts.Stderr.String()
+		assert.Contains(t, out, "K6_CLOUD_LOGS_PUSH_URL requires K6_CLOUD_TEST_RUN_TOKEN")
+	})
+
 	// A5/A6 (log): the legacy `k6 run --out=cloud` path must not register a
 	// cloud log pusher at all (log streaming is a --local-execution feature).
 	t.Run("does not register the pusher for k6 run --out=cloud", func(t *testing.T) {

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -632,12 +632,14 @@ export default function() { console.log('hello from the vu'); };`
 		t.Parallel()
 
 		ts := makeTestState(t, script, []string{"--local-execution", "--no-cloud-logs"})
-		setupLocalExecutionProvMock(t, ts)
+		rec := setupLocalExecutionProvMock(t, ts)
 
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		assert.Nil(t, ts.CloudLogPusher,
 			"cloud log pusher should not be registered when --no-cloud-logs is set")
+		_, bodies := rec.snapshot()
+		assert.Empty(t, bodies, "no logs should be pushed when --no-cloud-logs is set")
 	})
 
 	t.Run("does not register the pusher for non-local-execution", func(t *testing.T) {

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -869,6 +869,38 @@ export default function() {
 		assert.NotContains(t, all, "debug-line-must-be-filtered",
 			"debug-level lines must be filtered out by the configured level (info)")
 	})
+
+	// A logged secret must reach the cloud only in redacted form: the
+	// secrets-redaction hook runs before the pusher observes an entry
+	// (root.go), so the push never carries the raw value. Guards that
+	// property end to end.
+	t.Run("redacts secrets before pushing logs", func(t *testing.T) {
+		t.Parallel()
+
+		const secret = "super-secret-value"
+		secretScript := `
+import secrets from "k6/secrets";
+export const options = { cloud: { name: 'Test cloud logs', projectID: 123456 } };
+export default async function() {
+	const s = await secrets.get("mykey");
+	console.log("the secret is " + s);
+};`
+		ts := makeTestState(t, secretScript, []string{
+			"--local-execution", "--no-cloud-secrets",
+			"--secret-source=mock=mykey=" + secret,
+		})
+		rec := setupLocalExecutionProvMock(t, ts)
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		_, bodies := rec.snapshot()
+		require.NotEmpty(t, bodies, "expected at least one cloud log push")
+		all := strings.Join(bodies, "\n")
+		assert.Contains(t, all, "***SECRET_REDACTED***",
+			"the log line should reach the cloud only in redacted form")
+		assert.NotContains(t, all, secret,
+			"the raw secret must never reach the cloud log push")
+	})
 }
 
 // logsPushPath is the path the local-execution mocks use for the cloud

--- a/internal/log/cloud/cloud.go
+++ b/internal/log/cloud/cloud.go
@@ -1,0 +1,171 @@
+// Package cloudlog implements a logrus hook that pushes k6's own logs to the
+// Grafana Cloud k6 logs backend for 'k6 cloud run --local-execution'.
+//
+// The package lives in directory internal/log/cloud but is named cloudlog
+// (not cloud) so that call sites which also import internal/secretsource/cloud
+// do not have a package-name collision.
+//
+// It takes a plain Config struct and does not import cloudapi or
+// internal/cloudapi/provisioning (avoiding an import cycle); the cmd layer
+// translates the provisioning response or environment into Config.
+package cloudlog
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	"go.k6.io/k6/v2/internal/log"
+)
+
+// bufferCap bounds the pre-configuration entry buffer. It matches the loki
+// hook's own channel capacity so Fire stays non-blocking under the same load.
+const bufferCap = 1000
+
+// testRunIDLabel is the stream label the backend requires on every push: a
+// push whose stream lacks it, or carries a value not matching the token's run,
+// is rejected with 401.
+const testRunIDLabel = "test_run_id"
+
+// Config is the log-push configuration, translated by the cmd layer from the
+// provisioning response or the environment. It intentionally depends on no
+// cloudapi or provisioning types.
+type Config struct {
+	PushURL       string        // loki push endpoint (empty => unconfigured)
+	Token         string        // scoped test-run token, sent as Authorization: Bearer
+	TestRunID     string        // added as the required test_run_id stream label
+	Level         string        // minimum level; "" => all levels
+	Limit         int           // max entries per push period
+	PushPeriod    time.Duration // how often batches are flushed
+	MsgMaxSize    int           // per-message truncation size
+	AllowedLabels []string      // stream labels to keep; empty => keep all
+}
+
+// Pusher is a logrus AsyncHook that buffers log entries until SetConfig
+// supplies the push URL and scoped token (available only after provisioning),
+// then forwards buffered and subsequent entries to the cloud through an
+// internal/log loki hook. It mirrors the cloud secret source's pre-register +
+// SetConfig + lazy-init pattern.
+type Pusher struct {
+	fallbackLogger logrus.FieldLogger
+	cfg            atomic.Pointer[Config]
+	ready          chan struct{} // closed once by SetConfig when configured
+	readyOnce      sync.Once
+	buf            chan *logrus.Entry
+	dropped        atomic.Int64
+}
+
+// Compile-time check that Pusher is usable as a logrus async hook.
+var _ log.AsyncHook = (*Pusher)(nil)
+
+// New creates a Pusher that buffers entries until SetConfig configures it.
+func New(fallbackLogger logrus.FieldLogger) *Pusher {
+	return &Pusher{
+		fallbackLogger: fallbackLogger,
+		ready:          make(chan struct{}),
+		buf:            make(chan *logrus.Entry, bufferCap),
+	}
+}
+
+// SetConfig stores the push configuration and signals readiness once. It is
+// safe to call before or after Listen starts. An empty PushURL, TestRunID, or
+// Token leaves the Pusher unconfigured (it keeps buffering and never pushes),
+// since the backend requires all three.
+func (p *Pusher) SetConfig(c Config) {
+	if c.PushURL == "" || c.TestRunID == "" || c.Token == "" {
+		if p.fallbackLogger != nil {
+			p.fallbackLogger.Debug("cloud log push not configured: missing push URL, test run ID, or token")
+		}
+		return
+	}
+	p.cfg.Store(&c)
+	p.readyOnce.Do(func() { close(p.ready) })
+}
+
+// Levels reports all levels; the underlying loki hook re-filters by its own
+// configured level.
+func (p *Pusher) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire buffers the entry without blocking. If the buffer is full the entry is
+// dropped and counted, so the logging path is never blocked.
+func (p *Pusher) Fire(entry *logrus.Entry) error {
+	select {
+	case p.buf <- entry:
+	default:
+		p.dropped.Add(1)
+	}
+	return nil
+}
+
+// Listen blocks until SetConfig has configured the Pusher or ctx is done. If
+// ctx fires first (e.g. --no-cloud-logs or an early exit) it returns without
+// pushing. Once configured it builds the loki hook and forwards buffered and
+// subsequent entries to it, stopping when ctx is cancelled. It returns only
+// after the loki hook's own final flush has completed.
+func (p *Pusher) Listen(ctx context.Context) {
+	select {
+	case <-p.ready:
+	case <-ctx.Done():
+		return
+	}
+
+	c := p.cfg.Load()
+
+	lokiHook, err := log.NewLokiHook(p.fallbackLogger, log.LokiHookOptions{
+		Addr:          c.PushURL,
+		Level:         c.Level,
+		Limit:         c.Limit,
+		PushPeriod:    c.PushPeriod,
+		MsgMaxSize:    c.MsgMaxSize,
+		AllowedLabels: allowedLabelsWithTestRunID(c.AllowedLabels),
+		Labels:        [][2]string{{testRunIDLabel, c.TestRunID}},
+		Headers:       [][2]string{{"Authorization", "Bearer " + c.Token}},
+	})
+	if err != nil {
+		if p.fallbackLogger != nil {
+			p.fallbackLogger.WithError(err).Error("cloud log push disabled: could not build the loki hook")
+		}
+		return
+	}
+
+	lokiDone := make(chan struct{})
+	go func() {
+		lokiHook.Listen(ctx)
+		close(lokiDone)
+	}()
+
+	// Single consumer of buf, forwarding to the loki hook (the single
+	// producer stays Fire). lokiHook.Fire is a blocking send, so once ctx is
+	// cancelled we must stop forwarding: the loki hook's Listen has exited and
+	// no longer drains its channel. Wait for its final flush before returning
+	// so callers (loggersWg) don't tear down mid-flush.
+	for {
+		select {
+		case e := <-p.buf:
+			_ = lokiHook.Fire(e)
+		case <-ctx.Done():
+			<-lokiDone
+			return
+		}
+	}
+}
+
+// allowedLabelsWithTestRunID ensures the required test_run_id label survives
+// the loki hook's label filtering, which drops any label not in the allow-list
+// when that list is non-empty. An empty list keeps all labels, so it is
+// returned unchanged.
+func allowedLabelsWithTestRunID(allowed []string) []string {
+	if len(allowed) == 0 {
+		return allowed
+	}
+	if slices.Contains(allowed, testRunIDLabel) {
+		return allowed
+	}
+	return append(slices.Clone(allowed), testRunIDLabel)
+}

--- a/internal/log/cloud/cloud.go
+++ b/internal/log/cloud/cloud.go
@@ -166,6 +166,27 @@ func (p *Pusher) Listen(ctx context.Context) { //nolint:contextcheck
 		return
 	}
 
+	// The loki hook's Fire enqueues unconditionally (its Levels() dispatch is
+	// bypassed on the forward path), so filter by the configured level here,
+	// where the level is known. logrus orders levels by severity (lower =
+	// more severe), so an entry passes iff it is at least as severe as the
+	// configured level: e.Level <= minLevel. An unset level keeps all.
+	minLevel := logrus.TraceLevel // "" => keep all levels
+	if c.Level != "" {
+		if lvl, err := logrus.ParseLevel(c.Level); err == nil {
+			minLevel = lvl
+		} else if p.fallbackLogger != nil {
+			p.fallbackLogger.WithField("level", c.Level).
+				Warn("invalid cloud log level; pushing all levels")
+		}
+	}
+
+	forward := func(e *logrus.Entry) {
+		if e.Level <= minLevel {
+			_ = lokiHook.Fire(e)
+		}
+	}
+
 	// The loki hook runs on its own context so the final flush is triggered
 	// only after buffered entries have been forwarded (see finish), not
 	// concurrently with the forwarding.
@@ -184,7 +205,7 @@ func (p *Pusher) Listen(ctx context.Context) { //nolint:contextcheck
 		for {
 			select {
 			case e := <-p.buf:
-				_ = lokiHook.Fire(e)
+				forward(e)
 			default:
 				lokiCancel()
 				<-lokiDone
@@ -199,7 +220,7 @@ func (p *Pusher) Listen(ctx context.Context) { //nolint:contextcheck
 	for {
 		select {
 		case e := <-p.buf:
-			_ = lokiHook.Fire(e)
+			forward(e)
 		case <-p.drainCh:
 			finish()
 			return

--- a/internal/log/cloud/cloud.go
+++ b/internal/log/cloud/cloud.go
@@ -57,6 +57,9 @@ type Pusher struct {
 	readyOnce      sync.Once
 	buf            chan *logrus.Entry
 	dropped        atomic.Int64
+	drainCh        chan struct{} // closed once by Drain to request a final flush
+	drainOnce      sync.Once
+	doneCh         chan struct{} // closed by Listen on return, signalling Drain
 }
 
 // Compile-time check that Pusher is usable as a logrus async hook.
@@ -68,6 +71,8 @@ func New(fallbackLogger logrus.FieldLogger) *Pusher {
 		fallbackLogger: fallbackLogger,
 		ready:          make(chan struct{}),
 		buf:            make(chan *logrus.Entry, bufferCap),
+		drainCh:        make(chan struct{}),
+		doneCh:         make(chan struct{}),
 	}
 }
 
@@ -103,12 +108,39 @@ func (p *Pusher) Fire(entry *logrus.Entry) error {
 	return nil
 }
 
+// Drain flushes buffered logs to the backend and returns once the flush has
+// completed (or ctx is done). It is safe to call when unconfigured (a no-op)
+// and idempotent. Best-effort: entries still in flight inside the loki hook's
+// channel at flush time may not be sent (see the package notes).
+func (p *Pusher) Drain(ctx context.Context) error {
+	select {
+	case <-p.ready:
+	default:
+		return nil // never configured => nothing to flush
+	}
+	p.drainOnce.Do(func() { close(p.drainCh) })
+	select {
+	case <-p.doneCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // Listen blocks until SetConfig has configured the Pusher or ctx is done. If
 // ctx fires first (e.g. --no-cloud-logs or an early exit) it returns without
 // pushing. Once configured it builds the loki hook and forwards buffered and
-// subsequent entries to it, stopping when ctx is cancelled. It returns only
-// after the loki hook's own final flush has completed.
-func (p *Pusher) Listen(ctx context.Context) {
+// subsequent entries to it. A Drain request or a ctx cancel both forward the
+// buffered entries and trigger the loki hook's synchronous final flush; Listen
+// returns only after that flush has completed. It always closes doneCh on
+// return, so a concurrent Drain never blocks.
+//
+// The loki hook deliberately runs on its own background-derived context (not
+// ctx) so its final flush is triggered only after buffered entries have been
+// forwarded; hence the contextcheck exception.
+func (p *Pusher) Listen(ctx context.Context) { //nolint:contextcheck
+	defer close(p.doneCh)
+
 	select {
 	case <-p.ready:
 	case <-ctx.Done():
@@ -134,23 +166,45 @@ func (p *Pusher) Listen(ctx context.Context) {
 		return
 	}
 
+	// The loki hook runs on its own context so the final flush is triggered
+	// only after buffered entries have been forwarded (see finish), not
+	// concurrently with the forwarding.
+	lokiCtx, lokiCancel := context.WithCancel(context.Background())
 	lokiDone := make(chan struct{})
 	go func() {
-		lokiHook.Listen(ctx)
+		lokiHook.Listen(lokiCtx)
 		close(lokiDone)
 	}()
 
-	// Single consumer of buf, forwarding to the loki hook (the single
-	// producer stays Fire). lokiHook.Fire is a blocking send, so once ctx is
-	// cancelled we must stop forwarding: the loki hook's Listen has exited and
-	// no longer drains its channel. Wait for its final flush before returning
-	// so callers (loggersWg) don't tear down mid-flush.
+	// finish forwards everything currently buffered, then cancels the loki
+	// hook so it runs its synchronous final flush, and waits for that to
+	// complete. lokiHook.Fire is a blocking send, so forwarding must happen
+	// while the loki hook is still draining its channel (before lokiCancel).
+	finish := func() {
+		for {
+			select {
+			case e := <-p.buf:
+				_ = lokiHook.Fire(e)
+			default:
+				lokiCancel()
+				<-lokiDone
+				return
+			}
+		}
+	}
+
+	// Single consumer of buf, forwarding to the loki hook (the single producer
+	// stays Fire). A drain request or ctx cancel both run finish, then return;
+	// after a drain the later logger-shutdown ctx cancel is a no-op.
 	for {
 		select {
 		case e := <-p.buf:
 			_ = lokiHook.Fire(e)
+		case <-p.drainCh:
+			finish()
+			return
 		case <-ctx.Done():
-			<-lokiDone
+			finish()
 			return
 		}
 	}

--- a/internal/log/cloud/cloud.go
+++ b/internal/log/cloud/cloud.go
@@ -149,9 +149,12 @@ func (p *Pusher) Listen(ctx context.Context) { //nolint:contextcheck
 
 	c := p.cfg.Load()
 
+	// Level is intentionally omitted here: cloudlog filters by level itself in
+	// forward (below), so the hook's own Levels() dispatch is unused. Handing an
+	// invalid backend level to NewLokiHook would make it fail and disable the
+	// whole push, so we parse the level ourselves and fall back gracefully.
 	lokiHook, err := log.NewLokiHook(p.fallbackLogger, log.LokiHookOptions{
 		Addr:          c.PushURL,
-		Level:         c.Level,
 		Limit:         c.Limit,
 		PushPeriod:    c.PushPeriod,
 		MsgMaxSize:    c.MsgMaxSize,
@@ -171,13 +174,19 @@ func (p *Pusher) Listen(ctx context.Context) { //nolint:contextcheck
 	// where the level is known. logrus orders levels by severity (lower =
 	// more severe), so an entry passes iff it is at least as severe as the
 	// configured level: e.Level <= minLevel. An unset level keeps all.
-	minLevel := logrus.TraceLevel // "" => keep all levels
+	minLevel := logrus.TraceLevel // "" => keep all levels (defer to the logger)
 	if c.Level != "" {
 		if lvl, err := logrus.ParseLevel(c.Level); err == nil {
 			minLevel = lvl
-		} else if p.fallbackLogger != nil {
-			p.fallbackLogger.WithField("level", c.Level).
-				Warn("invalid cloud log level; pushing all levels")
+		} else {
+			// The level comes from the backend, not the user, so a bad value
+			// falls back to info (the backend's own default) rather than
+			// pushing everything or disabling the push entirely.
+			minLevel = logrus.InfoLevel
+			if p.fallbackLogger != nil {
+				p.fallbackLogger.WithField("level", c.Level).
+					Warn("invalid cloud log level; defaulting to info")
+			}
 		}
 	}
 

--- a/internal/log/cloud/cloud.go
+++ b/internal/log/cloud/cloud.go
@@ -242,11 +242,13 @@ func (p *Pusher) Listen(ctx context.Context) { //nolint:contextcheck
 
 // allowedLabelsWithTestRunID ensures the required test_run_id label survives
 // the loki hook's label filtering, which drops any label not in the allow-list
-// when that list is non-empty. An empty list keeps all labels, so it is
-// returned unchanged.
+// when that list is non-empty. An empty list must normalise to nil: the loki
+// hook treats nil as "keep all labels", whereas a non-nil empty slice (which
+// an explicitly empty K6_CLOUD_LOGS_ALLOWED_LABELS decodes to) means "keep
+// none" and would strip test_run_id from the stream, getting the push 401'd.
 func allowedLabelsWithTestRunID(allowed []string) []string {
 	if len(allowed) == 0 {
-		return allowed
+		return nil
 	}
 	if slices.Contains(allowed, testRunIDLabel) {
 		return allowed

--- a/internal/log/cloud/cloud_test.go
+++ b/internal/log/cloud/cloud_test.go
@@ -179,3 +179,101 @@ func TestPusher_TestRunIDLabelKept(t *testing.T) {
 	cancel()
 	<-listenDone
 }
+
+// TestPusher_Drain covers the pre-notify drain: after entries are pushed while
+// the run is open, Drain returns without hanging, drives Listen to return even
+// though ctx was never cancelled, and is idempotent on a second call.
+func TestPusher_Drain(t *testing.T) {
+	t.Parallel()
+
+	type received struct {
+		body string
+		auth string
+	}
+	recvCh := make(chan received, 8)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, _ := io.ReadAll(req.Body)
+		select {
+		case recvCh <- received{body: string(b), auth: req.Header.Get("Authorization")}:
+		default:
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := New(testutils.NewLogger(t))
+	p.SetConfig(Config{
+		PushURL:    srv.URL,
+		Token:      "drain-token",
+		TestRunID:  "run-drain",
+		PushPeriod: 20 * time.Millisecond,
+	})
+
+	for _, msg := range []string{"entry-a", "entry-b", "entry-c"} {
+		require.NoError(t, p.Fire(&logrus.Entry{Time: time.Now(), Level: logrus.InfoLevel, Message: msg}))
+	}
+
+	// ctx stays alive for the whole test: shutdown must be driven by Drain,
+	// not by a ctx cancel.
+	ctx := t.Context()
+	listenDone := make(chan struct{})
+	go func() {
+		p.Listen(ctx)
+		close(listenDone)
+	}()
+
+	// Entries reach the backend via the periodic push while the run is open,
+	// carrying the bearer token and the required test_run_id label.
+	var got received
+	select {
+	case got = <-recvCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no push received from the pusher")
+	}
+	assert.Equal(t, "Bearer drain-token", got.auth)
+	assert.Contains(t, got.body, `"test_run_id":"run-drain"`)
+
+	// Drain returns once the flush has completed; it must not hang.
+	require.NoError(t, p.Drain(context.Background()))
+
+	// Drain drove Listen to return, even though ctx was never cancelled.
+	select {
+	case <-listenDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Listen did not return after Drain")
+	}
+
+	// Idempotent: a second Drain returns nil immediately.
+	require.NoError(t, p.Drain(context.Background()))
+}
+
+// TestPusher_DrainUnconfigured covers the --out cloud / --no-cloud-logs case:
+// without SetConfig, Drain is a no-op that returns nil immediately and makes
+// no HTTP request.
+func TestPusher_DrainUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	p := New(testutils.NewLogger(t))
+	require.NoError(t, p.Fire(&logrus.Entry{Time: time.Now(), Level: logrus.InfoLevel, Message: "buffered"}))
+
+	require.NoError(t, p.Drain(context.Background()))
+}
+
+// TestPusher_DrainContextTimeout locks Drain's ctx contract: when the flush
+// cannot complete (here Listen is never started, so doneCh never closes), a
+// done ctx unblocks Drain with the ctx error rather than blocking forever.
+func TestPusher_DrainContextTimeout(t *testing.T) {
+	t.Parallel()
+
+	p := New(testutils.NewLogger(t))
+	p.SetConfig(Config{
+		PushURL:   "http://127.0.0.1:0",
+		Token:     "tok",
+		TestRunID: "run",
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorIs(t, p.Drain(ctx), context.Canceled)
+}

--- a/internal/log/cloud/cloud_test.go
+++ b/internal/log/cloud/cloud_test.go
@@ -1,0 +1,181 @@
+package cloudlog
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/internal/lib/testutils"
+)
+
+// TestPusher is the canonical case: entries fired before and after SetConfig
+// are buffered and then pushed to the configured endpoint, carrying the
+// bearer token and the required test_run_id label.
+func TestPusher(t *testing.T) {
+	t.Parallel()
+
+	type received struct {
+		body string
+		auth string
+	}
+	recvCh := make(chan received, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, _ := io.ReadAll(req.Body)
+		select {
+		case recvCh <- received{body: string(b), auth: req.Header.Get("Authorization")}:
+		default:
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := New(testutils.NewLogger(t))
+
+	// Fired BEFORE SetConfig: must be buffered until the pusher is configured.
+	require.NoError(t, p.Fire(&logrus.Entry{Time: time.Now(), Level: logrus.InfoLevel, Message: "before-config"}))
+
+	p.SetConfig(Config{
+		PushURL:    srv.URL,
+		Token:      "test-token",
+		TestRunID:  "run-123",
+		PushPeriod: 20 * time.Millisecond,
+	})
+
+	// Fired AFTER SetConfig: still buffered until Listen drains.
+	require.NoError(t, p.Fire(&logrus.Entry{Time: time.Now(), Level: logrus.InfoLevel, Message: "after-config"}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	listenDone := make(chan struct{})
+	go func() {
+		p.Listen(ctx)
+		close(listenDone)
+	}()
+
+	var got received
+	select {
+	case got = <-recvCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("no push received from the pusher")
+	}
+
+	assert.Equal(t, "Bearer test-token", got.auth)
+	assert.Contains(t, got.body, "before-config")
+	assert.Contains(t, got.body, "after-config")
+	assert.Contains(t, got.body, `"test_run_id":"run-123"`)
+
+	cancel()
+	select {
+	case <-listenDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Listen did not return after ctx was cancelled")
+	}
+}
+
+// TestPusher_UnconfiguredDrainsOnCtxDone covers the --no-cloud-logs / early
+// exit path: without SetConfig, Listen returns promptly on ctx.Done and never
+// pushes.
+func TestPusher_UnconfiguredDrainsOnCtxDone(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Errorf("pusher made an HTTP request while unconfigured")
+	}))
+	defer srv.Close()
+
+	p := New(testutils.NewLogger(t))
+	require.NoError(t, p.Fire(&logrus.Entry{Time: time.Now(), Level: logrus.InfoLevel, Message: "buffered"}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	listenDone := make(chan struct{})
+	go func() {
+		p.Listen(ctx)
+		close(listenDone)
+	}()
+
+	cancel()
+	select {
+	case <-listenDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Listen did not return promptly on ctx.Done while unconfigured")
+	}
+}
+
+// TestPusher_FireNeverBlocks keeps the logging path non-blocking: with no
+// Listen draining, Fire returns immediately even past the buffer capacity and
+// over-cap entries are counted as dropped.
+func TestPusher_FireNeverBlocks(t *testing.T) {
+	t.Parallel()
+
+	p := New(testutils.NewLogger(t))
+
+	const overflow = 10
+	total := bufferCap + overflow
+
+	fired := make(chan struct{})
+	go func() {
+		for range total {
+			_ = p.Fire(&logrus.Entry{Time: time.Now(), Level: logrus.InfoLevel, Message: "x"})
+		}
+		close(fired)
+	}()
+
+	select {
+	case <-fired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Fire blocked when the buffer was full")
+	}
+
+	assert.Equal(t, int64(overflow), p.dropped.Load())
+}
+
+// TestPusher_TestRunIDLabelKept locks the backend's hard requirement: even
+// when AllowedLabels omits test_run_id, the pushed stream still carries it as
+// a label (the backend 401s a push whose stream lacks it).
+func TestPusher_TestRunIDLabelKept(t *testing.T) {
+	t.Parallel()
+
+	recvCh := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, _ := io.ReadAll(req.Body)
+		select {
+		case recvCh <- string(b):
+		default:
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := New(testutils.NewLogger(t))
+	p.SetConfig(Config{
+		PushURL:       srv.URL,
+		Token:         "tok",
+		TestRunID:     "run-xyz",
+		PushPeriod:    20 * time.Millisecond,
+		AllowedLabels: []string{"level"}, // deliberately omits test_run_id
+	})
+	require.NoError(t, p.Fire(&logrus.Entry{Time: time.Now(), Level: logrus.InfoLevel, Message: "hello"}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	listenDone := make(chan struct{})
+	go func() {
+		p.Listen(ctx)
+		close(listenDone)
+	}()
+
+	select {
+	case body := <-recvCh:
+		assert.Contains(t, body, `"test_run_id":"run-xyz"`)
+	case <-time.After(2 * time.Second):
+		t.Fatal("no push received from the pusher")
+	}
+
+	cancel()
+	<-listenDone
+}

--- a/internal/log/cloud/cloud_test.go
+++ b/internal/log/cloud/cloud_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -276,4 +278,126 @@ func TestPusher_DrainContextTimeout(t *testing.T) {
 	cancel()
 
 	require.ErrorIs(t, p.Drain(ctx), context.Canceled)
+}
+
+// TestPusher_FiltersBelowConfiguredLevel locks the backend-level directive:
+// with Level "info" the pusher pushes info/warn/error entries but filters out
+// the less-severe debug entry, even though the loki hook's Fire enqueues
+// unconditionally. Entries reach the backend via the periodic push.
+func TestPusher_FiltersBelowConfiguredLevel(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu   sync.Mutex
+		body strings.Builder
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, _ := io.ReadAll(req.Body)
+		mu.Lock()
+		body.Write(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := New(testutils.NewLogger(t))
+	p.SetConfig(Config{
+		PushURL:    srv.URL,
+		Token:      "tok",
+		TestRunID:  "run-lvl",
+		Level:      "info",
+		PushPeriod: 20 * time.Millisecond,
+	})
+
+	// Fired debug-first, so by the time the others are pushed the debug entry
+	// has already been through the forward path (and been filtered).
+	for _, e := range []*logrus.Entry{
+		{Time: time.Now(), Level: logrus.DebugLevel, Message: "msg-debug"},
+		{Time: time.Now(), Level: logrus.InfoLevel, Message: "msg-info"},
+		{Time: time.Now(), Level: logrus.WarnLevel, Message: "msg-warn"},
+		{Time: time.Now(), Level: logrus.ErrorLevel, Message: "msg-error"},
+	} {
+		require.NoError(t, p.Fire(e))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	listenDone := make(chan struct{})
+	go func() {
+		p.Listen(ctx)
+		close(listenDone)
+	}()
+
+	got := func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return body.String()
+	}
+
+	// The info/warn/error entries (at or above the configured level) are pushed.
+	require.Eventually(t, func() bool {
+		b := got()
+		return strings.Contains(b, "msg-info") &&
+			strings.Contains(b, "msg-warn") &&
+			strings.Contains(b, "msg-error")
+	}, 2*time.Second, 10*time.Millisecond, "info/warn/error entries were not pushed")
+
+	// The debug entry is below the configured level, so it is never pushed.
+	assert.NotContains(t, got(), "msg-debug")
+
+	cancel()
+	select {
+	case <-listenDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Listen did not return after ctx was cancelled")
+	}
+}
+
+// TestPusher_EmptyLevelKeepsAll is the variant: an unset Level keeps all
+// levels, so even a debug entry is pushed.
+func TestPusher_EmptyLevelKeepsAll(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu   sync.Mutex
+		body strings.Builder
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, _ := io.ReadAll(req.Body)
+		mu.Lock()
+		body.Write(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := New(testutils.NewLogger(t))
+	p.SetConfig(Config{
+		PushURL:    srv.URL,
+		Token:      "tok",
+		TestRunID:  "run-empty",
+		Level:      "", // unset => keep all levels
+		PushPeriod: 20 * time.Millisecond,
+	})
+
+	require.NoError(t, p.Fire(&logrus.Entry{Time: time.Now(), Level: logrus.DebugLevel, Message: "msg-debug"}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	listenDone := make(chan struct{})
+	go func() {
+		p.Listen(ctx)
+		close(listenDone)
+	}()
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return strings.Contains(body.String(), "msg-debug")
+	}, 2*time.Second, 10*time.Millisecond, "debug entry was not pushed with empty level")
+
+	cancel()
+	select {
+	case <-listenDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Listen did not return after ctx was cancelled")
+	}
 }

--- a/internal/log/cloud/cloud_test.go
+++ b/internal/log/cloud/cloud_test.go
@@ -401,3 +401,73 @@ func TestPusher_EmptyLevelKeepsAll(t *testing.T) {
 		t.Fatal("Listen did not return after ctx was cancelled")
 	}
 }
+
+// TestPusher_InvalidLevelDefaultsToInfo verifies that an unparseable Level
+// (which can only come from the backend) neither disables the push nor keeps
+// all levels: it falls back to info, so debug is dropped while info and above
+// are still pushed.
+func TestPusher_InvalidLevelDefaultsToInfo(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu   sync.Mutex
+		body strings.Builder
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, _ := io.ReadAll(req.Body)
+		mu.Lock()
+		body.Write(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := New(testutils.NewLogger(t))
+	p.SetConfig(Config{
+		PushURL:    srv.URL,
+		Token:      "tok",
+		TestRunID:  "run-badlvl",
+		Level:      "bogus", // invalid => fall back to info
+		PushPeriod: 20 * time.Millisecond,
+	})
+
+	// Debug fired first, so if it were going to be pushed it would land no
+	// later than the info/error entries.
+	for _, e := range []*logrus.Entry{
+		{Time: time.Now(), Level: logrus.DebugLevel, Message: "msg-debug"},
+		{Time: time.Now(), Level: logrus.InfoLevel, Message: "msg-info"},
+		{Time: time.Now(), Level: logrus.ErrorLevel, Message: "msg-error"},
+	} {
+		require.NoError(t, p.Fire(e))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	listenDone := make(chan struct{})
+	go func() {
+		p.Listen(ctx)
+		close(listenDone)
+	}()
+
+	got := func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return body.String()
+	}
+
+	// info/error (at or above the info fallback) are pushed despite the
+	// invalid level, proving the push is not disabled.
+	require.Eventually(t, func() bool {
+		b := got()
+		return strings.Contains(b, "msg-info") && strings.Contains(b, "msg-error")
+	}, 2*time.Second, 10*time.Millisecond, "info/error not pushed with an invalid level")
+
+	// debug (below info) is dropped, proving the fallback is info, not all.
+	assert.NotContains(t, got(), "msg-debug")
+
+	cancel()
+	select {
+	case <-listenDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Listen did not return after ctx was cancelled")
+	}
+}

--- a/internal/log/cloud/cloud_test.go
+++ b/internal/log/cloud/cloud_test.go
@@ -182,6 +182,52 @@ func TestPusher_TestRunIDLabelKept(t *testing.T) {
 	<-listenDone
 }
 
+// TestPusher_EmptyAllowedLabelsKeepsTestRunID guards the empty-slice edge: an
+// explicitly empty K6_CLOUD_LOGS_ALLOWED_LABELS decodes to a non-nil []string{},
+// which must still keep the required test_run_id label rather than strip every
+// label from the stream.
+func TestPusher_EmptyAllowedLabelsKeepsTestRunID(t *testing.T) {
+	t.Parallel()
+
+	recvCh := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, _ := io.ReadAll(req.Body)
+		select {
+		case recvCh <- string(b):
+		default:
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	p := New(testutils.NewLogger(t))
+	p.SetConfig(Config{
+		PushURL:       srv.URL,
+		Token:         "tok",
+		TestRunID:     "run-empty-labels",
+		PushPeriod:    20 * time.Millisecond,
+		AllowedLabels: []string{}, // non-nil empty, as envconfig decodes ""
+	})
+	require.NoError(t, p.Fire(&logrus.Entry{Time: time.Now(), Level: logrus.InfoLevel, Message: "hello"}))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	listenDone := make(chan struct{})
+	go func() {
+		p.Listen(ctx)
+		close(listenDone)
+	}()
+
+	select {
+	case body := <-recvCh:
+		assert.Contains(t, body, `"test_run_id":"run-empty-labels"`)
+	case <-time.After(2 * time.Second):
+		t.Fatal("no push received from the pusher")
+	}
+
+	cancel()
+	<-listenDone
+}
+
 // TestPusher_Drain covers the pre-notify drain: after entries are pushed while
 // the run is open, Drain returns without hanging, drives Listen to return even
 // though ctx was never cancelled, and is idempotent on a second call.

--- a/internal/log/loki.go
+++ b/internal/log/loki.go
@@ -47,24 +47,51 @@ func getDefaultLoki() *lokiHook {
 	}
 }
 
-// LokiFromConfigLine returns a new logrus.Hook
-// that pushes logrus.Entrys to loki and is configured
-// through the provided line.
-func LokiFromConfigLine(fallbackLogger logrus.FieldLogger, line string) (AsyncHook, error) {
+// LokiHookOptions configures a loki push hook built by NewLokiHook.
+// Zero-valued fields take the built-in defaults.
+type LokiHookOptions struct {
+	Addr          string        // default http://127.0.0.1:3100/loki/api/v1/push
+	PushPeriod    time.Duration // default 1s
+	Limit         int           // default 100
+	MsgMaxSize    int           // default 1MB
+	Level         string        // "" => all levels; else parseLevels
+	AllowedLabels []string
+	Labels        [][2]string // static labels (e.g. test_run_id)
+	Headers       [][2]string // e.g. Authorization: Bearer <token>
+	Profile       bool
+}
+
+// NewLokiHook returns a new AsyncHook that pushes logrus.Entrys to loki,
+// configured from opts. Zero-valued opts fields take the built-in defaults.
+func NewLokiHook(fallbackLogger logrus.FieldLogger, opts LokiHookOptions) (AsyncHook, error) {
 	h := getDefaultLoki()
 	h.fallbackLogger = fallbackLogger
 
-	if line != "loki" {
-		logOutput, _, _ := strings.Cut(line, "=")
-		if logOutput != "loki" {
-			return nil, fmt.Errorf("loki configuration should be in the form `loki=url-to-push` but is `%s`", line)
-		}
-
-		err := h.parseArgs(line)
+	if opts.Addr != "" {
+		h.addr = opts.Addr
+	}
+	if opts.PushPeriod != 0 {
+		h.pushPeriod = opts.PushPeriod
+	}
+	if opts.Limit != 0 {
+		h.limit = opts.Limit
+	}
+	if opts.MsgMaxSize != 0 {
+		h.msgMaxSize = opts.MsgMaxSize
+	}
+	if opts.Level != "" {
+		levels, err := parseLevels(opts.Level)
 		if err != nil {
 			return nil, err
 		}
+		h.levels = levels
 	}
+	if opts.AllowedLabels != nil {
+		h.allowedLabels = opts.AllowedLabels
+	}
+	h.labels = append(h.labels, opts.Labels...)
+	h.headers = append(h.headers, opts.Headers...)
+	h.profile = opts.Profile
 
 	h.droppedLabels = make(map[string]string, 2+len(h.labels))
 	h.droppedLabels["level"] = logrus.WarnLevel.String()
@@ -74,10 +101,31 @@ func LokiFromConfigLine(fallbackLogger logrus.FieldLogger, line string) (AsyncHo
 
 	h.droppedMsg = h.filterLabels(h.droppedLabels, h.droppedMsg)
 	h.client = &http.Client{Timeout: h.pushPeriod}
+
 	return h, nil
 }
 
-func (h *lokiHook) parseArgs(line string) error {
+// LokiFromConfigLine returns a new logrus.Hook
+// that pushes logrus.Entrys to loki and is configured
+// through the provided line.
+func LokiFromConfigLine(fallbackLogger logrus.FieldLogger, line string) (AsyncHook, error) {
+	var opts LokiHookOptions
+
+	if line != "loki" {
+		logOutput, _, _ := strings.Cut(line, "=")
+		if logOutput != "loki" {
+			return nil, fmt.Errorf("loki configuration should be in the form `loki=url-to-push` but is `%s`", line)
+		}
+
+		if err := opts.parseArgs(line); err != nil {
+			return nil, err
+		}
+	}
+
+	return NewLokiHook(fallbackLogger, opts)
+}
+
+func (opts *LokiHookOptions) parseArgs(line string) error {
 	tokens, err := strvals.Parse(line)
 	if err != nil {
 		return fmt.Errorf("error while parsing loki configuration %w", err)
@@ -90,46 +138,41 @@ func (h *lokiHook) parseArgs(line string) error {
 		var err error
 		switch key {
 		case "loki":
-			h.addr = value
+			opts.Addr = value
 		case "pushPeriod":
-			h.pushPeriod, err = time.ParseDuration(value)
+			opts.PushPeriod, err = time.ParseDuration(value)
 			if err != nil {
 				return fmt.Errorf("couldn't parse the loki pushPeriod %w", err)
 			}
 		case "profile":
-			h.profile = true
+			opts.Profile = true
 		case "limit":
-			h.limit, err = strconv.Atoi(value)
+			opts.Limit, err = strconv.Atoi(value)
 			if err != nil {
 				return fmt.Errorf("couldn't parse the loki limit as a number %w", err)
 			}
-			if h.limit < 1 {
-				return fmt.Errorf("loki limit needs to be a positive number, is %d", h.limit)
+			if opts.Limit < 1 {
+				return fmt.Errorf("loki limit needs to be a positive number, is %d", opts.Limit)
 			}
 		case "msgMaxSize":
-			h.msgMaxSize, err = strconv.Atoi(value)
+			opts.MsgMaxSize, err = strconv.Atoi(value)
 			if err != nil {
 				return fmt.Errorf("couldn't parse the loki msgMaxSize as a number %w", err)
 			}
-			if h.msgMaxSize < 1 {
-				return fmt.Errorf("loki msgMaxSize needs to be a positive number, is %d", h.msgMaxSize)
+			if opts.MsgMaxSize < 1 {
+				return fmt.Errorf("loki msgMaxSize needs to be a positive number, is %d", opts.MsgMaxSize)
 			}
 		case "level":
-			h.levels, err = parseLevels(value)
-			if err != nil {
-				return err
-			}
+			opts.Level = value
 		case "allowedLabels":
-			h.allowedLabels = strings.Split(value, ",")
+			opts.AllowedLabels = strings.Split(value, ",")
 		default:
 			if after, ok := strings.CutPrefix(key, "label."); ok {
-				labelKey := after
-				h.labels = append(h.labels, [2]string{labelKey, value})
+				opts.Labels = append(opts.Labels, [2]string{after, value})
 
 				continue
 			} else if after, ok := strings.CutPrefix(key, "header."); ok {
-				headerKey := after
-				h.headers = append(h.headers, [2]string{headerKey, value})
+				opts.Headers = append(opts.Headers, [2]string{after, value})
 
 				continue
 			}

--- a/internal/log/loki.go
+++ b/internal/log/loki.go
@@ -70,14 +70,29 @@ func NewLokiHook(fallbackLogger logrus.FieldLogger, opts LokiHookOptions) (Async
 	if opts.Addr != "" {
 		h.addr = opts.Addr
 	}
-	if opts.PushPeriod != 0 {
+	// Limit, PushPeriod and MsgMaxSize fall back to their defaults on a
+	// non-positive value. Negatives can only arrive programmatically
+	// (K6_CLOUD_LOGS_* / a backend logs config bypass the config-line
+	// validation) and would otherwise panic in Listen — make([]tmpMsg, limit)
+	// and time.NewTicker(pushPeriod) — or on push (msgMaxSize slicing); warn so
+	// a bad value is visible.
+	if opts.PushPeriod > 0 {
 		h.pushPeriod = opts.PushPeriod
+	} else if opts.PushPeriod < 0 && fallbackLogger != nil {
+		fallbackLogger.WithField("pushPeriod", opts.PushPeriod).
+			Warn("negative loki push period; using default")
 	}
-	if opts.Limit != 0 {
+	if opts.Limit > 0 {
 		h.limit = opts.Limit
+	} else if opts.Limit < 0 && fallbackLogger != nil {
+		fallbackLogger.WithField("limit", opts.Limit).
+			Warn("negative loki limit; using default")
 	}
-	if opts.MsgMaxSize != 0 {
+	if opts.MsgMaxSize > 0 {
 		h.msgMaxSize = opts.MsgMaxSize
+	} else if opts.MsgMaxSize < 0 && fallbackLogger != nil {
+		fallbackLogger.WithField("msgMaxSize", opts.MsgMaxSize).
+			Warn("negative loki message size; using default")
 	}
 	if opts.Level != "" {
 		levels, err := parseLevels(opts.Level)

--- a/internal/log/loki_test.go
+++ b/internal/log/loki_test.go
@@ -93,6 +93,74 @@ func TestSyslogFromConfigLine(t *testing.T) {
 	}
 }
 
+func TestNewLokiHook(t *testing.T) {
+	t.Parallel()
+
+	opts := LokiHookOptions{
+		Addr:          "somewhere:1233",
+		PushPeriod:    time.Minute*5 + time.Second*32,
+		Limit:         32,
+		MsgMaxSize:    1231,
+		Level:         "info",
+		AllowedLabels: []string{"something"},
+		Labels:        [][2]string{{"something", "else"}, {"foo", "bar"}},
+		Headers:       [][2]string{{"x-test", "123"}, {"authorization", "token foobar"}},
+		Profile:       true,
+	}
+
+	res, err := NewLokiHook(nil, opts)
+	require.NoError(t, err)
+	hook, ok := res.(*lokiHook)
+	require.True(t, ok)
+
+	assert.Equal(t, "somewhere:1233", hook.addr)
+	assert.Equal(t, time.Minute*5+time.Second*32, hook.pushPeriod)
+	assert.Equal(t, 32, hook.limit)
+	assert.Equal(t, 1231, hook.msgMaxSize)
+	assert.Equal(t, logrus.AllLevels[:5], hook.levels)
+	assert.Equal(t, []string{"something"}, hook.allowedLabels)
+	assert.Equal(t, [][2]string{{"something", "else"}, {"foo", "bar"}}, hook.labels)
+	assert.Equal(t, [][2]string{{"x-test", "123"}, {"authorization", "token foobar"}}, hook.headers)
+	assert.True(t, hook.profile)
+
+	// The tail-end setup (droppedLabels/droppedMsg/client) must have run:
+	// non-allowed labels are folded into droppedMsg and dropped from droppedLabels.
+	assert.Equal(t, map[string]string{"something": "else"}, hook.droppedLabels)
+	assert.Equal(t,
+		"k6 dropped %d log messages because they were above the limit of %d messages / %s foo=bar level=warning",
+		hook.droppedMsg)
+	require.NotNil(t, hook.client)
+	assert.Equal(t, time.Minute*5+time.Second*32, hook.client.Timeout)
+}
+
+func TestNewLokiHook_Defaults(t *testing.T) {
+	t.Parallel()
+
+	res, err := NewLokiHook(nil, LokiHookOptions{})
+	require.NoError(t, err)
+	hook, ok := res.(*lokiHook)
+	require.True(t, ok)
+
+	assert.Equal(t, "http://127.0.0.1:3100/loki/api/v1/push", hook.addr)
+	assert.Equal(t, time.Second*1, hook.pushPeriod)
+	assert.Equal(t, 100, hook.limit)
+	assert.Equal(t, 1024*1024, hook.msgMaxSize)
+	assert.Equal(t, logrus.AllLevels, hook.levels)
+	assert.Nil(t, hook.allowedLabels)
+	assert.Nil(t, hook.labels)
+	assert.Nil(t, hook.headers)
+	assert.False(t, hook.profile)
+
+	// The tail-end setup runs even with defaults: only the level label is seeded,
+	// and with no allowedLabels the droppedMsg is left untouched.
+	assert.Equal(t, map[string]string{"level": "warning"}, hook.droppedLabels)
+	assert.Equal(t,
+		"k6 dropped %d log messages because they were above the limit of %d messages / %s",
+		hook.droppedMsg)
+	require.NotNil(t, hook.client)
+	assert.Equal(t, time.Second*1, hook.client.Timeout)
+}
+
 func TestLogEntryMarshal(t *testing.T) {
 	t.Parallel()
 	entry := logEntry{

--- a/internal/log/loki_test.go
+++ b/internal/log/loki_test.go
@@ -355,3 +355,21 @@ func TestNewLokiHookClampsNonPositiveOptions(t *testing.T) {
 		t.Fatal("no logs received; hook did not push with clamped defaults")
 	}
 }
+
+// TestLokiFromConfigLineEmptyAddr documents that `--log-output=loki=` (an empty
+// URL) is rejected up front by the config parser rather than silently falling
+// back to the default endpoint — so there is no empty-address case reaching the
+// constructor. Bare `loki` still uses the default. This is unchanged from
+// before the NewLokiHook extraction, since parseArgs still runs strvals.Parse
+// first.
+func TestLokiFromConfigLineEmptyAddr(t *testing.T) {
+	t.Parallel()
+
+	_, err := LokiFromConfigLine(nil, "loki=")
+	require.Error(t, err, "an empty loki address must be rejected, not defaulted")
+	assert.Contains(t, err.Error(), "no value")
+
+	bare, err := LokiFromConfigLine(nil, "loki")
+	require.NoError(t, err)
+	assert.NotEmpty(t, bare.(*lokiHook).addr, "bare loki uses the default endpoint")
+}

--- a/internal/log/loki_test.go
+++ b/internal/log/loki_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/internal/lib/testutils"
 )
 
 func TestSyslogFromConfigLine(t *testing.T) {
@@ -286,5 +288,70 @@ func TestLokiHeaders(t *testing.T) {
 		require.Equal(t, []string{"hello world"}, headers["Test"])
 	default:
 		t.Fatal("No logs were received from loki before hook has finished")
+	}
+}
+
+// TestNewLokiHookClampsNonPositiveOptions verifies that non-positive Limit,
+// PushPeriod and MsgMaxSize fall back to the built-in defaults (with a warning)
+// instead of panicking. These values can only arrive programmatically — e.g.
+// via K6_CLOUD_LOGS_* or a backend logs config — which bypass the config-line
+// validation that otherwise rejects them.
+func TestNewLokiHookClampsNonPositiveOptions(t *testing.T) {
+	t.Parallel()
+
+	logger, hook := testutils.NewLoggerWithHook(t, logrus.WarnLevel)
+
+	receivedData := make(chan string, 1)
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+			b, err := io.ReadAll(req.Body)
+			if err != nil {
+				t.Error(err)
+				return
+			}
+			select {
+			case receivedData <- string(b):
+			default:
+			}
+		}),
+	)
+	defer srv.Close()
+
+	// Without the clamp these panic in Listen — make([]tmpMsg, limit) and
+	// time.NewTicker(pushPeriod) — and on push (msgMaxSize slicing).
+	h, err := NewLokiHook(logger, LokiHookOptions{
+		Addr:       srv.URL,
+		Limit:      -5,
+		PushPeriod: -1 * time.Second,
+		MsgMaxSize: -10,
+	})
+	require.NoError(t, err)
+
+	// Each bad value is warned about (and falls back to its default).
+	entries := hook.Drain()
+	assert.True(t, testutils.LogContains(entries, logrus.WarnLevel, "limit"),
+		"expected a warning about the negative limit")
+	assert.True(t, testutils.LogContains(entries, logrus.WarnLevel, "push period"),
+		"expected a warning about the negative push period")
+	assert.True(t, testutils.LogContains(entries, logrus.WarnLevel, "message size"),
+		"expected a warning about the negative message size")
+
+	// Listen must not panic, and the entry is pushed using the defaults.
+	ctx, cancel := context.WithCancel(context.Background())
+	wg := new(sync.WaitGroup)
+	now := time.Now()
+	wg.Go(func() {
+		require.NoError(t, h.Fire(&logrus.Entry{Time: now, Level: logrus.InfoLevel, Message: "clamp message"}))
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	})
+	h.Listen(ctx)
+	wg.Wait()
+
+	select {
+	case data := <-receivedData:
+		require.Contains(t, data, "clamp message")
+	default:
+		t.Fatal("no logs received; hook did not push with clamped defaults")
 	}
 }

--- a/internal/output/cloud/output.go
+++ b/internal/output/cloud/output.go
@@ -69,6 +69,14 @@ type provisioningNotifier interface {
 	NotifyTestRunCompleted(ctx context.Context, testRunID int64, token string, testErr error) error
 }
 
+// logDrainer flushes buffered cloud logs so they reach the backend before the
+// run is notified complete (afterwards the backend rejects late pushes). Kept
+// structural (no import of internal/log/cloud) to avoid coupling the output to
+// that package. Production implementation: *cloudlog.Pusher.
+type logDrainer interface {
+	Drain(context.Context) error
+}
+
 type apiVersion int64
 
 const (
@@ -110,6 +118,10 @@ type Output struct {
 	// lazyInitProvisioning after both deps are constructed; read by
 	// startVersionedOutput and testFinished.
 	provisioningMode bool
+
+	// logDrainer, when set, is flushed before notify so in-run logs land while
+	// the run is still open. nil for --out cloud / --no-cloud-logs.
+	logDrainer logDrainer
 
 	usage *usage.Usage
 }
@@ -315,6 +327,11 @@ func (out *Output) SetArchive(archive *lib.Archive) {
 	out.testArchive = archive
 }
 
+// SetLogDrainer sets the cloud-log drainer flushed before end-of-test notify.
+func (out *Output) SetLogDrainer(d logDrainer) {
+	out.logDrainer = d
+}
+
 var _ output.WithArchive = &Output{}
 
 // Stop gracefully stops all metric emission from the output: when all metric
@@ -333,6 +350,17 @@ func (out *Output) StopWithTestError(testErr error) error {
 	if err != nil {
 		out.logger.WithError(err).Error("An error occurred stopping the output")
 		// to notify the cloud backend we have no return here
+	}
+
+	// Flush buffered cloud logs before notify: once the run is notified
+	// complete the backend rejects late log pushes, so the final batch would
+	// be lost. Best-effort and bounded by the configured request timeout.
+	if out.logDrainer != nil {
+		dctx, cancel := context.WithTimeout(context.Background(), out.config.Timeout.TimeDuration())
+		if err := out.logDrainer.Drain(dctx); err != nil {
+			out.logger.WithError(err).Warn("could not drain cloud logs before notify")
+		}
+		cancel()
 	}
 
 	out.logger.Debug("Metric emission stopped, calling cloud API...")

--- a/internal/output/cloud/output.go
+++ b/internal/output/cloud/output.go
@@ -354,13 +354,13 @@ func (out *Output) StopWithTestError(testErr error) error {
 
 	// Flush buffered cloud logs before notify: once the run is notified
 	// complete the backend rejects late log pushes, so the final batch would
-	// be lost. Best-effort and bounded by the configured request timeout.
+	// be lost. The push is already bounded by the loki hook's own HTTP client
+	// timeout, so the drain just waits for it on a fresh context — fresh
+	// because the run's context is already cancelled at shutdown.
 	if out.logDrainer != nil {
-		dctx, cancel := context.WithTimeout(context.Background(), out.config.Timeout.TimeDuration())
-		if err := out.logDrainer.Drain(dctx); err != nil {
+		if err := out.logDrainer.Drain(context.Background()); err != nil {
 			out.logger.WithError(err).Warn("could not drain cloud logs before notify")
 		}
-		cancel()
 	}
 
 	out.logger.Debug("Metric emission stopped, calling cloud API...")

--- a/internal/output/cloud/output_test.go
+++ b/internal/output/cloud/output_test.go
@@ -430,6 +430,21 @@ func (m *provisioningNotifierMock) NotifyTestRunCompleted(_ context.Context, tes
 	return nil
 }
 
+// logDrainerMock implements the output's logDrainer for tests. onDrain, when
+// set, runs inside Drain so a test can observe ordering relative to notify.
+type logDrainerMock struct {
+	called  atomic.Bool
+	onDrain func()
+}
+
+func (m *logDrainerMock) Drain(_ context.Context) error {
+	m.called.Store(true)
+	if m.onDrain != nil {
+		m.onDrain()
+	}
+	return nil
+}
+
 func TestOutputStart_ProvisioningMode(t *testing.T) {
 	t.Parallel()
 
@@ -768,5 +783,74 @@ func TestOutputStopWithTestError_PushRefID_NoNotifyNoTestFinished(t *testing.T) 
 		// PushRefID short-circuits: NEITHER notify NOR TestFinished called.
 		assert.False(t, notifierMock.called.Load())
 		assert.False(t, clientMock.testFinishedCalled)
+	})
+}
+
+// TestOutputStopWithTestError_DrainsLogsBeforeNotify locks the ordering fix:
+// the cloud log drainer is flushed before the run is notified complete, so
+// in-run logs land while the run is still open (afterwards the backend
+// rejects late pushes).
+func TestOutputStopWithTestError_DrainsLogsBeforeNotify(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		notifierMock := &provisioningNotifierMock{}
+		clientMock := &cloudClientMock{}
+		drainerMock := &logDrainerMock{
+			onDrain: func() {
+				// Drain must run before notify: the notifier has not been
+				// called yet at drain time.
+				assert.Equal(t, int32(0), notifierMock.callCount.Load(),
+					"Drain must be called before NotifyTestRunCompleted")
+			},
+		}
+
+		out := &Output{
+			logger:    testutils.NewLogger(t),
+			testRunID: "12345",
+			config: cloudapi.Config{
+				MetricsPushURL: null.StringFrom("https://metrics.example.com/v2/metrics/123"),
+				TestRunToken:   null.StringFrom("scoped-test-run-token"),
+				Timeout:        types.NullDurationFrom(60 * time.Second),
+			},
+			client:               clientMock,
+			provisioningNotifier: notifierMock,
+			provisioningMode:     true,
+			logDrainer:           drainerMock,
+		}
+		out.versionedOutput = versionedOutputMock{callback: func(string) {}}
+
+		require.NoError(t, out.StopWithTestError(nil))
+
+		assert.True(t, drainerMock.called.Load(), "Drain must be called")
+		assert.True(t, notifierMock.called.Load(), "notify must still happen after drain")
+	})
+}
+
+// TestOutputStopWithTestError_NilLogDrainerStillNotifies covers the
+// --out cloud / --no-cloud-logs case: with no drainer set, Stop neither
+// panics nor skips notify.
+func TestOutputStopWithTestError_NilLogDrainerStillNotifies(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		notifierMock := &provisioningNotifierMock{}
+		clientMock := &cloudClientMock{}
+
+		out := &Output{
+			logger:    testutils.NewLogger(t),
+			testRunID: "12345",
+			config: cloudapi.Config{
+				MetricsPushURL: null.StringFrom("https://metrics.example.com/v2/metrics/123"),
+				TestRunToken:   null.StringFrom("scoped-test-run-token"),
+				Timeout:        types.NullDurationFrom(60 * time.Second),
+			},
+			client:               clientMock,
+			provisioningNotifier: notifierMock,
+			provisioningMode:     true,
+			logDrainer:           nil,
+		}
+		out.versionedOutput = versionedOutputMock{callback: func(string) {}}
+
+		require.NoError(t, out.StopWithTestError(nil))
+		assert.True(t, notifierMock.called.Load())
 	})
 }

--- a/internal/output/cloud/output_test.go
+++ b/internal/output/cloud/output_test.go
@@ -432,13 +432,17 @@ func (m *provisioningNotifierMock) NotifyTestRunCompleted(_ context.Context, tes
 
 // logDrainerMock implements the output's logDrainer for tests. onDrain, when
 // set, runs inside Drain so a test can observe ordering relative to notify.
+// ctxErr records ctx.Err() at call time so a test can assert the drain wasn't
+// handed an already-expired context.
 type logDrainerMock struct {
 	called  atomic.Bool
+	ctxErr  error
 	onDrain func()
 }
 
-func (m *logDrainerMock) Drain(_ context.Context) error {
+func (m *logDrainerMock) Drain(ctx context.Context) error {
 	m.called.Store(true)
+	m.ctxErr = ctx.Err()
 	if m.onDrain != nil {
 		m.onDrain()
 	}
@@ -859,6 +863,40 @@ func TestOutputStopWithTestError_PushRefID_DrainsLogs(t *testing.T) {
 		assert.True(t, drainerMock.called.Load(), "Drain must run on the PushRefID path too")
 		assert.False(t, notifierMock.called.Load(), "PushRefID path must not notify")
 		assert.False(t, clientMock.testFinishedCalled, "PushRefID path must not call TestFinished")
+	})
+}
+
+// TestOutputStopWithTestError_ZeroTimeoutDrainsWithoutDeadline guards that
+// K6_CLOUD_TIMEOUT=0 ("no timeout", as the other cloud clients treat it) does
+// not hand the drain an already-expired context, which would skip the flush
+// and let notify race it.
+func TestOutputStopWithTestError_ZeroTimeoutDrainsWithoutDeadline(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		notifierMock := &provisioningNotifierMock{}
+		clientMock := &cloudClientMock{}
+		drainerMock := &logDrainerMock{}
+
+		out := &Output{
+			logger:    testutils.NewLogger(t),
+			testRunID: "12345",
+			config: cloudapi.Config{
+				MetricsPushURL: null.StringFrom("https://metrics.example.com/v2/metrics/123"),
+				TestRunToken:   null.StringFrom("scoped-test-run-token"),
+				Timeout:        types.NewNullDuration(0, true), // K6_CLOUD_TIMEOUT=0
+			},
+			client:               clientMock,
+			provisioningNotifier: notifierMock,
+			provisioningMode:     true,
+			logDrainer:           drainerMock,
+		}
+		out.versionedOutput = versionedOutputMock{callback: func(string) {}}
+
+		require.NoError(t, out.StopWithTestError(nil))
+
+		assert.True(t, drainerMock.called.Load(), "Drain must be called")
+		assert.NoError(t, drainerMock.ctxErr,
+			"drain context must not be already expired when the timeout is 0 (no timeout)")
 	})
 }
 

--- a/internal/output/cloud/output_test.go
+++ b/internal/output/cloud/output_test.go
@@ -826,6 +826,42 @@ func TestOutputStopWithTestError_DrainsLogsBeforeNotify(t *testing.T) {
 	})
 }
 
+// TestOutputStopWithTestError_PushRefID_DrainsLogs guards that the cloud log
+// drain runs even on the externally-provisioned (PushRefID) path, where notify
+// is skipped. If a future change tied the drain to notify, this flow would
+// silently lose its final log batch and no other test would catch it.
+func TestOutputStopWithTestError_PushRefID_DrainsLogs(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		notifierMock := &provisioningNotifierMock{}
+		clientMock := &cloudClientMock{}
+		drainerMock := &logDrainerMock{}
+
+		out := &Output{
+			logger:    testutils.NewLogger(t),
+			testRunID: "12345",
+			config: cloudapi.Config{
+				PushRefID:      null.StringFrom("99999"),
+				MetricsPushURL: null.StringFrom("https://metrics.example.com/v2/metrics/123"),
+				TestRunToken:   null.StringFrom("scoped-test-run-token"),
+				Timeout:        types.NullDurationFrom(60 * time.Second),
+			},
+			client:               clientMock,
+			provisioningNotifier: notifierMock,
+			provisioningMode:     true,
+			logDrainer:           drainerMock,
+		}
+		out.versionedOutput = versionedOutputMock{callback: func(string) {}}
+
+		require.NoError(t, out.StopWithTestError(nil))
+
+		// Drain runs even though the PushRefID path skips notify/TestFinished.
+		assert.True(t, drainerMock.called.Load(), "Drain must run on the PushRefID path too")
+		assert.False(t, notifierMock.called.Load(), "PushRefID path must not notify")
+		assert.False(t, clientMock.testFinishedCalled, "PushRefID path must not call TestFinished")
+	})
+}
+
 // TestOutputStopWithTestError_NilLogDrainerStillNotifies covers the
 // --out cloud / --no-cloud-logs case: with no drainer set, Stop neither
 // panics nor skips notify.


### PR DESCRIPTION
## What?

Stacked on #6170 (external-provisioning), now on `master` after the provisioning migration (#6169) merged. Stream `k6 cloud run --local-execution` logs to Grafana Cloud k6, using the logs configuration the provisioning API already returns from `start_local_execution` (`runtime_config.logs`) but which was decoded and then dropped.

The flow:
1. Map `runtime_config.logs` (push URL, level, limit, push period, message max size, allowed labels) into the provisioning response instead of dropping it.
2. A cloud log pusher — a logrus hook that wraps the existing `internal/log` loki hook — is auto-registered on the logger for `--local-execution` (unless `--no-cloud-logs`) and **buffers** entries until it is configured (the push URL/token are only known after provisioning).
3. It is configured from the provisioning response (self-provisioned) or from env vars (externally-provisioned, mirroring the metrics push in #6170), then pushes k6's own logs to the logs `push_url` with the scoped `test_run_token` as `Authorization: Bearer` and the required `test_run_id` stream label.
4. Logs are **drained before the run is notified complete** (otherwise the backend rejects the final batch with 403), and **filtered to the backend-configured level** (so `--verbose` still honours a `level=info` directive for the cloud; local output is unaffected).

Notable pieces:
- New `internal/log/cloud` package (the pusher). It reuses the loki hook via a new programmatic constructor `log.NewLokiHook` (extracted from the existing config-line parser, no behaviour change) — no reimplementation of Loki batching/format.
- `cloudapi.Config` gains env-only (`json:"-"`) `K6_CLOUD_LOGS_*` fields, mirroring `LogsTailURL`, for the externally-provisioned case.
- `--no-cloud-logs` opts out (mirrors `--no-cloud-secrets`).
- The pusher is attached **after** the secrets-redaction hook, so secrets are redacted before logs are pushed (verified end-to-end).

`k6 run --out cloud` (path B) and managed cloud execution's `--show-logs` tail path are **unchanged** — no client-side log push there. Eight atomic commits, each individually buildable + lintable + green.

## Why?

For `--local-execution` the test runs on the client, so its logs are produced locally and never reached the cloud run's log view (only managed cloud execution had server-side logs, tailed via `--show-logs`). This closes that gap — local-execution logs now stream to the run, matching how metrics were migrated. The externally-provisioned path lets an orchestrator that provisioned the run itself hand k6 the logs config via env.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Supersedes #6166 (rebased onto the signed take3 stack). Same change, moved from `local-exec-prov-external` to `local-exec-prov-external-take3` and adapted to the SDK's `int64` resource IDs.
- Stacked on #6170 — base branch is `local-exec-prov-external-take3`, so this PR's diff is only the log-streaming increment. The migration #6169 is already merged into `master`; review #6170 first, and retarget this PR to `master` once #6170 merges.
- Verified end-to-end against a real stack: self-provisioned push, `--no-cloud-logs`, `--out cloud` (no push), externally-provisioned (env creds), and secrets-redaction. Real testing found and fixed two issues now in the branch: the final log batch 403'd because it flushed after notify (fixed by draining before notify), and the backend log level wasn't honoured under `--verbose` (fixed by filtering in the pusher).

