### PR TITLE
Fix GaugeSink maximum for negative samples

### DIFF
--- a/metrics/sink.go
+++ b/metrics/sink.go
@@ -90,7 +90,7 @@ func (g *GaugeSink) IsEmpty() bool { return !g.minSet }
 // Add a single sample to the sink
 func (g *GaugeSink) Add(s Sample) {
 	g.Value = s.Value
-	if s.Value > g.Max {
+	if s.Value > g.Max || !g.minSet {
 		g.Max = s.Value
 	}
 	if s.Value < g.Min || !g.minSet {

--- a/metrics/sink_test.go
+++ b/metrics/sink_test.go
@@ -80,6 +80,16 @@ func TestGaugeSink(t *testing.T) {
 			assert.Equal(t, true, sink.minSet)
 			assert.Equal(t, 1.0, sink.Max)
 		})
+		t.Run("negative values", func(t *testing.T) {
+			t.Parallel()
+			sink := GaugeSink{}
+			for _, s := range []float64{-5.0, -3.0, -8.0} {
+				sink.Add(Sample{TimeSeries: TimeSeries{Metric: &Metric{}}, Value: s})
+			}
+			assert.Equal(t, -8.0, sink.Value)
+			assert.Equal(t, -8.0, sink.Min)
+			assert.Equal(t, -3.0, sink.Max)
+		})
 		t.Run("values", func(t *testing.T) {
 			t.Parallel()
 			sink := GaugeSink{}


### PR DESCRIPTION
## What?

Initialize `GaugeSink.Max` from the first observed sample, just as the existing
minimum tracking already does. This keeps all-negative gauge series from
reporting the zero value as their maximum.

The regression test covers `-5`, `-3`, and `-8`, and verifies the final value,
minimum, and maximum.

## Why?

`GaugeSink.Max` starts at zero and was only updated when a sample was greater
than zero. For a gauge containing only negative samples, summaries therefore
reported `max=0` even though zero was never observed.

This reuses the existing `minSet` first-sample guard, so the fix does not add a
field or increase the sink's memory use.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

Local verification completed:

- `go test ./metrics -run '^TestGaugeSink$' -count=1`
- `go test -race ./metrics -count=1`
- `golangci-lint v2.10.1 run ./metrics/...` (`0 issues`)
- `gofmt -s` and `git diff --check`

The full repository lint currently reports an existing `modernize` finding in
`internal/js/modules/k6/browser/common/kill_other.go`, which this change does
not modify. A full `go test ./...` run also encountered unrelated network and
browser integration failures and exceeded the local 600-second limit.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes #6181

<!-- Thanks for your contribution! 🙏🏼 -->
