### PR TITLE
examples/browser: add catch blocks for clearer error UX

### DIFF
--- a/examples/browser/colorscheme.js
+++ b/examples/browser/colorscheme.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -33,6 +34,8 @@ export default async function() {
       'isDarkColorScheme':
         p => p.evaluate(() => window.matchMedia('(prefers-color-scheme: dark)').matches)
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/cookies.js
+++ b/examples/browser/cookies.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -120,6 +121,8 @@ export default async function () {
     await check(await context.cookies(), {
       'number of cookies should be zero': c => c.length === 0,
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/device_emulation.js
+++ b/examples/browser/device_emulation.js
@@ -1,4 +1,5 @@
 import { browser, devices } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -45,6 +46,8 @@ export default async function() {
     if (!__ENV.K6_BROWSER_HEADLESS) {
       await page.waitForTimeout(10000);
     }
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/dispatch.js
+++ b/examples/browser/dispatch.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -33,6 +34,8 @@ export default async function() {
         return text == 'Contact us';
       }
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/evaluate.js
+++ b/examples/browser/evaluate.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -39,6 +40,8 @@ export default async function() {
         return n == 25;
       }
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/fillform.js
+++ b/examples/browser/fillform.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -54,6 +55,8 @@ export default async function() {
         return cookies.find(c => c.name == 'AWSALB') !== undefined;
       }
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/framelocator.js
+++ b/examples/browser/framelocator.js
@@ -1,5 +1,5 @@
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check, fail } from 'k6';
 
 export const options = {
   scenarios: {
@@ -65,6 +65,8 @@ export default async function () {
       'found heading inside iframe': (text) => text === 'Inside iframe',
     });
 
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/getattribute.js
+++ b/examples/browser/getattribute.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -31,6 +32,8 @@ export default async function() {
         return await e.getAttribute('mode') === 'light';
       }
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/grant_permission.js
+++ b/examples/browser/grant_permission.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 
 export const options = {
   scenarios: {
@@ -29,6 +30,8 @@ export default async function() {
     await page.goto('https://quickpizza.grafana.com/test.k6.io/');
     await page.screenshot({ path: `example-chromium.png` });
     await context.clearPermissions();
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/hosts.js
+++ b/examples/browser/hosts.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -29,6 +30,8 @@ export default async function() {
     await check(res, {
       'null response': r => r === null,
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/locator.js
+++ b/examples/browser/locator.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 
 export const options = {
   scenarios: {
@@ -68,6 +69,8 @@ export default async function() {
       tails.click(),
     ]);
     console.log(await currentBet.innerText());
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/locator_pom.js
+++ b/examples/browser/locator_pom.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 
 export const options = {
   scenarios: {
@@ -71,6 +72,8 @@ export default async function() {
     console.log("Current bet:", await bet.current());
     await bet.heads();
     console.log("Current bet:", await bet.current());
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/multiple-scenario.js
+++ b/examples/browser/multiple-scenario.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 
 export const options = {
   scenarios: {
@@ -37,6 +38,8 @@ export async function messages() {
 
   try {
     await page.goto('https://quickpizza.grafana.com/my_messages.php', { waitUntil: 'networkidle' });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }
@@ -47,6 +50,8 @@ export async function news() {
 
   try {
     await page.goto('https://quickpizza.grafana.com/news.php', { waitUntil: 'networkidle' });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/page_waitForEvent.js
+++ b/examples/browser/page_waitForEvent.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 
 export const options = {
   scenarios: {
@@ -40,6 +41,8 @@ export default async function() {
 
     const response = await responsePromise;
     console.log(`Response received: ${response.url()}`);
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/pageon-metric.js
+++ b/examples/browser/pageon-metric.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 
 export const options = {
   scenarios: {
@@ -28,6 +29,8 @@ export default async function() {
   try {
     await page.goto('https://quickpizza.grafana.com/test.k6.io/?q=abc123');
     await page.goto('https://quickpizza.grafana.com/test.k6.io/?q=def456');
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/pageon.js
+++ b/examples/browser/pageon.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -39,6 +40,8 @@ export default async function() {
     }));
 
     await page.evaluate(() => console.log('this is a console.log message', 42));
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/querying.js
+++ b/examples/browser/querying.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -34,6 +35,8 @@ export default async function() {
         return await e.textContent() === 'QuickPizza Legacy';
       }
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/route.js
+++ b/examples/browser/route.js
@@ -1,5 +1,5 @@
 import { browser } from 'k6/browser';
-import { check } from 'k6';
+import { check, fail } from 'k6';
 
 export const options = {
   scenarios: {
@@ -64,6 +64,8 @@ export default async function () {
       'pizza API status is 200': (r) => r.status() === 200,
       'pizza API URL is correct': (r) => r.url() === 'https://quickpizza.grafana.com/api/pizza',
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/route_continue.js
+++ b/examples/browser/route_continue.js
@@ -1,4 +1,4 @@
-import { sleep } from 'k6';
+import { sleep, fail } from 'k6';
 import { browser } from 'k6/browser';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
@@ -37,6 +37,8 @@ export default async function () {
     check(null, {
       pizzaName: await e.innerText() === 'Name: My Pizza',
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/screenshot.js
+++ b/examples/browser/screenshot.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 
 export const options = {
   scenarios: {
@@ -25,6 +26,8 @@ export default async function() {
     await page.screenshot({ path: 'screenshot.png' });
     // TODO: Assert this somehow. Upload as CI artifact or just an external `ls`?
     // Maybe even do a fuzzy image comparison against a preset known good screenshot?
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/throttle.js
+++ b/examples/browser/throttle.js
@@ -1,4 +1,5 @@
 import { browser, networkProfiles } from 'k6/browser';
+import { fail } from 'k6';
 
 export const options = {
   scenarios: {
@@ -46,6 +47,8 @@ export async function normal() {
 
   try {
     await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }
@@ -59,6 +62,8 @@ export async function networkThrottled() {
     await page.throttleNetwork(networkProfiles["Slow 3G"]);
 
     await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }
@@ -72,6 +77,8 @@ export async function cpuThrottled() {
     await page.throttleCPU({ rate: 4 });
 
     await page.goto('https://quickpizza.grafana.com/test.k6.io/', { waitUntil: 'networkidle' });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }

--- a/examples/browser/waitforfunction.js
+++ b/examples/browser/waitforfunction.js
@@ -1,4 +1,5 @@
 import { browser } from 'k6/browser';
+import { fail } from 'k6';
 import { check } from 'https://jslib.k6.io/k6-utils/1.5.0/index.js';
 
 export const options = {
@@ -41,6 +42,8 @@ export default async function() {
         return await e.innerHTML() === 'Hello';
       }
     });
+  } catch (error) {
+    fail(`Browser iteration failed: ${error.message}`);
   } finally {
     await page.close();
   }


### PR DESCRIPTION
## What?

Add `catch` blocks to the browser JS examples that already use `try`/`finally`, following the same pattern as the official browser script template (`internal/cmd/templates/browser.js`):

```js
} catch (error) {
  fail(`Browser iteration failed: ${error.message}`);
} finally {
  await page.close();
}
```

Updated 22 files under `examples/browser/`. Left alone examples that intentionally swallow navigation errors (e.g. `pageon-requestfailed.js`) and examples that do not use `try`/`finally`.

Also fix the `test-xk6` CI job for fork PRs: after the `go.k6.io/k6/v2` module move, `XK6_K6_REPO` pointing at a remote fork fails Go module path validation ([grafana/xk6#476](https://github.com/grafana/xk6/issues/476)). PR checkouts already contain the merge of the head commit, so the workflow now builds with a local `--replace` of the k6 module instead of fetching the fork by SHA.

## Why?

Without a `catch`, when the body of a `try` fails and `page.close()` in `finally` also fails (for example because the browser already shut down), JavaScript replaces the original error with the cleanup error. Users then only see the `page.close` failure and miss the real root cause (e.g. a missing selector).

Adding `catch` + `fail()` surfaces the original error while still closing the page in `finally`, which is better UX for people copying these examples.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

N/A for tests/lint on the example scripts. The xk6 workflow change was verified locally with `xk6 build --replace go.k6.io/k6/v2=$PWD ...` and the existing xk6-test.js suite.

## Related PR(s)/Issue(s)

Fixes #4389

Related: grafana/xk6-browser#590, grafana/xk6-browser#697, grafana/xk6#476