### PR TITLE
fix(ci): resolve xk6 fork PR proxy race by adding fork to GOPRIVATE

### DIFF
--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -71,9 +71,11 @@ jobs:
           echo "COMMIT_ID=$COMMIT_ID"
           cd .github/workflows/xk6-tests
           go install go.k6.io/xk6/cmd/xk6@master
+          GOPRIVATE="go.k6.io/k6"
           if [ "${{ github.event_name }}" == "pull_request" -a \
                "${PR_REPO}" != "${{ github.repository }}" ]; then
             export XK6_K6_REPO="github.com/${PR_REPO}"
+            GOPRIVATE="${GOPRIVATE},github.com/${PR_REPO}"
           fi
           # The following is a workaround for Windows, cause when using 'shell: bash', the PATH is expressed
           # with ':' as separator, but Go code, running on a Windows OS, expects ';' as separator.
@@ -82,7 +84,7 @@ jobs:
             XPATH="$HOME/sdk/gotip/bin;$XPATH"
           fi
           PATH="$XPATH" \
-          GOPRIVATE="go.k6.io/k6" xk6 build "$COMMIT_ID" \
+          GOPRIVATE="${GOPRIVATE}" xk6 build "$COMMIT_ID" \
             --output ./k6ext \
             --with github.com/grafana/xk6-js-test="$(pwd)/xk6-js-test" \
             --with github.com/grafana/xk6-output-test="$(pwd)/xk6-output-test"

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -75,7 +75,7 @@ jobs:
           if [ "${{ github.event_name }}" == "pull_request" -a \
                "${PR_REPO}" != "${{ github.repository }}" ]; then
             export XK6_K6_REPO="github.com/${PR_REPO}"
-            GOPRIVATE="${GOPRIVATE},github.com/${PR_REPO}"
+            GOPRIVATE="${GOPRIVATE},${XK6_K6_REPO}"
           fi
           # The following is a workaround for Windows, cause when using 'shell: bash', the PATH is expressed
           # with ':' as separator, but Go code, running on a Windows OS, expects ';' as separator.


### PR DESCRIPTION
When a pull request comes from a fork, the test-xk6 workflow fails intermittently on Linux/macOS runners due to a race between CI runners and proxy.golang.org populating brand-new pseudo-versions.

**Root cause**: Go module resolution for fork commits goes through the public proxy (since GOPRIVATE only covered go.k6.io/k6), causing concurrent matrix jobs to race on proxy population. Linux runners hit the proxy before it finished computing module hashes and got transient errors.

**Fix**: Extend GOPRIVATE to include the fork's GitHub path when it's a fork PR. This makes Go fetch the fork module directly from git, bypassing the proxy and checksum database entirely.

**Verification**: 
- Investigated via #6202 with detailed timing analysis
- Re-running failed jobs hours after push confirmed they pass with same commit
- Fresh build with clean module cache reproduces and verifies fix eliminates proxy race
- This is a one-line change that hardens the workflow with no behavioral impact to normal (non-fork) PR runs

Closes #6202