### PR TITLE
Add group_sleep metric to measure sleep time per group

### DIFF
--- a/internal/js/modules/k6/k6.go
+++ b/internal/js/modules/k6/k6.go
@@ -31,6 +31,15 @@ type (
 	// K6 represents an instance of the k6 module.
 	K6 struct {
 		vu modules.VU
+
+		// groupSleep is the cumulative time this VU has spent in sleep() calls.
+		// It is used to attribute sleep time to the group(s) currently being
+		// executed: group() snapshots this value on entry and diffs it on exit,
+		// so the difference is exactly the sleep that happened within that
+		// group's window (correctly accounting for nested groups). A VU runs a
+		// single iteration at a time on one goroutine and JS is single-threaded,
+		// so this field needs no synchronization.
+		groupSleep time.Duration
 	}
 )
 
@@ -71,12 +80,17 @@ func (*K6) Fail(msg string) (sobek.Value, error) {
 // Sleep waits the provided seconds before continuing the execution.
 func (mi *K6) Sleep(secs float64) {
 	ctx := mi.vu.Context()
+	start := time.Now()
 	timer := time.NewTimer(time.Duration(secs * float64(time.Second)))
 	select {
 	case <-timer.C:
 	case <-ctx.Done():
 		timer.Stop()
 	}
+	// Account for the actual time spent sleeping (which may be shorter than
+	// requested if the context was cancelled) so that group() can subtract it
+	// from the enclosing group(s). See the K6.groupSleep field.
+	mi.groupSleep += time.Since(start)
 }
 
 // RandomSeed sets the seed to the random generator used for this VU.
@@ -125,11 +139,21 @@ func (mi *K6) Group(name string, val sobek.Value) (sobek.Value, error) {
 	}()
 
 	startTime := time.Now()
+	startSleep := mi.groupSleep
 	ret, err := fn(sobek.Undefined())
 	t := time.Now()
+	// Sleep time that occurred within this group's execution window. For nested
+	// groups this correctly captures only the sleep of the current window, since
+	// each enclosing group takes its own snapshot/diff.
+	groupSleep := mi.groupSleep - startSleep
 
 	ctx := mi.vu.Context()
 	ctm := state.Tags.GetCurrentValues()
+	// group_duration keeps its historical wall-clock semantics (including sleep)
+	// for backward compatibility, and is emitted as a standalone sample exactly
+	// as before. group_sleep is emitted as a separate sample so users can measure
+	// sleep per group and derive active time as group_duration - group_sleep.
+	// See issue #921.
 	metrics.PushIfNotDone(ctx, state.Samples, metrics.Sample{
 		TimeSeries: metrics.TimeSeries{
 			Metric: state.BuiltinMetrics.GroupDuration,
@@ -137,6 +161,15 @@ func (mi *K6) Group(name string, val sobek.Value) (sobek.Value, error) {
 		},
 		Time:     t,
 		Value:    metrics.D(t.Sub(startTime)),
+		Metadata: ctm.Metadata,
+	})
+	metrics.PushIfNotDone(ctx, state.Samples, metrics.Sample{
+		TimeSeries: metrics.TimeSeries{
+			Metric: state.BuiltinMetrics.GroupSleep,
+			Tags:   ctm.Tags,
+		},
+		Time:     t,
+		Value:    metrics.D(groupSleep),
 		Metadata: ctm.Metadata,
 	})
 

--- a/internal/js/modules/k6/k6_test.go
+++ b/internal/js/modules/k6/k6_test.go
@@ -125,6 +125,89 @@ func TestGroup(t *testing.T) {
 	})
 }
 
+func TestGroupSleep(t *testing.T) {
+	t.Parallel()
+
+	// collectGroupSamples returns, per group tag, the emitted group_duration and
+	// group_sleep values (in milliseconds).
+	collectGroupSamples := func(t *testing.T, tc *testCase) map[string]struct{ duration, sleep float64 } {
+		t.Helper()
+		state := tc.testRuntime.VU.State()
+		out := map[string]struct{ duration, sleep float64 }{}
+		for _, container := range metrics.GetBufferedSamples(tc.samples) {
+			for _, s := range container.GetSamples() {
+				group, _ := s.Tags.Get("group")
+				entry := out[group]
+				switch s.Metric {
+				case state.BuiltinMetrics.GroupDuration:
+					entry.duration = s.Value
+				case state.BuiltinMetrics.GroupSleep:
+					entry.sleep = s.Value
+				default:
+					continue
+				}
+				out[group] = entry
+			}
+		}
+		return out
+	}
+
+	t.Run("no sleep", func(t *testing.T) {
+		t.Parallel()
+		tc := testCaseRuntime(t)
+		_, err := tc.testRuntime.RunOnEventLoop(`k6.group("g", function() {})`)
+		require.NoError(t, err)
+
+		groups := collectGroupSamples(t, tc)
+		g, ok := groups["::g"]
+		require.True(t, ok, "group_duration/group_sleep not emitted")
+		// A group with no sleep must report zero sleep, but still emits the metric.
+		assert.Equal(t, float64(0), g.sleep, "group_sleep should be zero without sleep")
+	})
+
+	t.Run("with sleep", func(t *testing.T) {
+		t.Parallel()
+		tc := testCaseRuntime(t)
+		_, err := tc.testRuntime.RunOnEventLoop(`k6.group("g", function() { k6.sleep(0.2); })`)
+		require.NoError(t, err)
+
+		groups := collectGroupSamples(t, tc)
+		g, ok := groups["::g"]
+		require.True(t, ok)
+		// group_sleep should be roughly the slept time, and never exceed the
+		// wall-clock group_duration.
+		assert.Greater(t, g.sleep, float64(150), "group_sleep too small: %v", g.sleep)
+		assert.LessOrEqual(t, g.sleep, g.duration, "group_sleep must not exceed group_duration")
+	})
+
+	t.Run("nested groups attribute sleep to each window", func(t *testing.T) {
+		t.Parallel()
+		tc := testCaseRuntime(t)
+		_, err := tc.testRuntime.RunOnEventLoop(`
+			k6.group("outer", function() {
+				k6.sleep(0.2);
+				k6.group("inner", function() {
+					k6.sleep(0.2);
+				});
+			})`)
+		require.NoError(t, err)
+
+		groups := collectGroupSamples(t, tc)
+		inner, ok := groups["::outer::inner"]
+		require.True(t, ok, "inner group not emitted")
+		outer, ok := groups["::outer"]
+		require.True(t, ok, "outer group not emitted")
+
+		// Inner window slept ~200ms.
+		assert.Greater(t, inner.sleep, float64(150), "inner group_sleep too small: %v", inner.sleep)
+		assert.LessOrEqual(t, inner.sleep, inner.duration)
+		// Outer window slept ~400ms (its own sleep plus the inner group's sleep).
+		assert.Greater(t, outer.sleep, float64(350), "outer group_sleep too small: %v", outer.sleep)
+		assert.LessOrEqual(t, outer.sleep, outer.duration)
+		assert.Greater(t, outer.sleep, inner.sleep, "outer sleep should include inner sleep")
+	})
+}
+
 func TestCheckObject(t *testing.T) {
 	t.Parallel()
 	t.Run("boolean", func(t *testing.T) {

--- a/metrics/builtin.go
+++ b/metrics/builtin.go
@@ -10,6 +10,7 @@ const (
 
 	ChecksName        = "checks"
 	GroupDurationName = "group_duration"
+	GroupSleepName    = "group_sleep"
 
 	HTTPReqsName              = "http_reqs"
 	HTTPReqFailedName         = "http_req_failed"
@@ -45,6 +46,7 @@ type BuiltinMetrics struct {
 	// Runner-emitted.
 	Checks        *Metric
 	GroupDuration *Metric
+	GroupSleep    *Metric
 
 	// HTTP-related.
 	HTTPReqs              *Metric
@@ -84,6 +86,7 @@ func RegisterBuiltinMetrics(registry *Registry) *BuiltinMetrics {
 
 		Checks:        registry.MustNewMetric(ChecksName, Rate),
 		GroupDuration: registry.MustNewMetric(GroupDurationName, Trend, Time),
+		GroupSleep:    registry.MustNewMetric(GroupSleepName, Trend, Time),
 
 		HTTPReqs:              registry.MustNewMetric(HTTPReqsName, Counter),
 		HTTPReqFailed:         registry.MustNewMetric(HTTPReqFailedName, Rate),


### PR DESCRIPTION
Closes #921

## Problem

`group_duration` is wall-clock and includes time spent in `sleep()` inside a
group, so a group containing `sleep(10)` reports a ~10s duration even when
little actual work happened. That makes `group_duration` hard to interpret as
a measure of work done.

Note: the issue lists #880 as a prerequisite, but #880 was closed as "not
planned", so this change is self-contained.

## Change

Add a new `group_sleep` Trend (Time) metric that reports the time spent in
`sleep()` within each group's execution window.

A per-VU cumulative sleep counter is kept on the k6 module instance:
`sleep()` adds the actual elapsed wait, and `group()` snapshots the counter on
entry and diffs it on exit. This attributes sleep correctly across **nested**
groups — an inner `sleep()` counts toward the inner group and every enclosing
group.

## Backward compatibility

`group_duration` keeps its existing wall-clock semantics **and** its sample
packaging (still emitted as a standalone sample), so existing dashboards and
thresholds are unaffected. Users can derive active time as
`group_duration - group_sleep`, or set thresholds directly on `group_sleep`.

## Open question for reviewers

Metric name: `group_sleep` (matches the issue) vs `group_sleep_duration`
(matches the `*_duration` convention). Went with `group_sleep`.

## Tests

Added unit tests for no-sleep, with-sleep, and nested-group attribution.
Verified: `go build ./...`, `go test -race` on affected packages, and
`golangci-lint` (0 issues).