### PR TITLE
feat(grpc): add opt-in connection sharing across VUs

### DIFF
--- a/internal/js/modules/k6/grpc/client.go
+++ b/internal/js/modules/k6/grpc/client.go
@@ -41,6 +41,11 @@ type Client struct {
 
 	types    *protoregistry.Types
 	typesMtx sync.Mutex
+
+	connPool *connectionPool
+	// sharedKey is set while this client uses a connection from connPool, and
+	// identifies the entry to give back when the client is closed.
+	sharedKey *connectionKey
 }
 
 // Load will parse the given proto files and make the file descriptors available to request.
@@ -265,7 +270,7 @@ func (c *Client) Connect(addr string, params sobek.Value) (bool, error) {
 	}
 
 	c.addr = addr
-	c.conn, err = grpcext.Dial(ctx, addr, c.types, opts...)
+	c.conn, err = c.dial(ctx, addr, p, opts...)
 	if err != nil {
 		return false, err
 	}
@@ -286,6 +291,33 @@ func (c *Client) Connect(addr string, params sobek.Value) (bool, error) {
 	}
 
 	return true, err
+}
+
+// dial establishes a gRPC connection, either shared with the other clients
+// connected to the same server with the same parameters, or as a new dedicated
+// connection.
+func (c *Client) dial(
+	ctx context.Context, addr string, p *connectParams, opts ...grpc.DialOption,
+) (*grpcext.Conn, error) {
+	if !p.ConnectionSharing {
+		return grpcext.Dial(ctx, addr, c.types, opts...)
+	}
+
+	key, err := newConnectionKey(addr, p)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := c.connPool.getOrDial(ctx, key, addr, c.types, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only track the connection once it is ours to give back, so that a failed
+	// dial doesn't make a later Close() release somebody else's connection.
+	c.sharedKey = &key
+
+	return conn, nil
 }
 
 // HealthCheck checks if the server side is up and ready to serve responses
@@ -477,7 +509,14 @@ func (c *Client) Close() error {
 	if c.conn == nil {
 		return nil
 	}
-	err := c.conn.Close()
+
+	var err error
+	if c.sharedKey != nil {
+		err = c.connPool.release(*c.sharedKey)
+		c.sharedKey = nil
+	} else {
+		err = c.conn.Close()
+	}
 	c.conn = nil
 
 	return err

--- a/internal/js/modules/k6/grpc/client_test.go
+++ b/internal/js/modules/k6/grpc/client_test.go
@@ -355,6 +355,34 @@ func TestClient(t *testing.T) {
 			},
 		},
 		{
+			name: "ConnectionSharing",
+			initString: codeBlock{code: `
+				var client = new grpc.Client();
+				client.load([], "../../../../lib/testutils/httpmultibin/grpc_testing/test.proto");
+
+				var otherClient = new grpc.Client();
+				otherClient.load([], "../../../../lib/testutils/httpmultibin/grpc_testing/test.proto");`},
+			setup: func(tb *httpmultibin.HTTPMultiBin) {
+				tb.GRPCStub.EmptyCallFunc = func(context.Context, *grpc_testing.Empty) (*grpc_testing.Empty, error) {
+					return &grpc_testing.Empty{}, nil
+				}
+			},
+			vuString: codeBlock{
+				code: `
+				client.connect("GRPCBIN_ADDR", { connectionSharing: true });
+				otherClient.connect("GRPCBIN_ADDR", { connectionSharing: true });
+
+				// Closing one client must leave the shared connection open for the other one.
+				client.close();
+
+				var resp = otherClient.invoke("grpc.testing.TestService/EmptyCall", {})
+				if (resp.status !== grpc.StatusOK) {
+					throw new Error("unexpected error: " + JSON.stringify(resp.error) + "or status: " + resp.status)
+				}
+				otherClient.close();`,
+			},
+		},
+		{
 			name: "InvokeDiscardResponseMessage",
 			initString: codeBlock{code: `
 				var client = new grpc.Client();

--- a/internal/js/modules/k6/grpc/conn_pool.go
+++ b/internal/js/modules/k6/grpc/conn_pool.go
@@ -1,0 +1,165 @@
+package grpc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"go.k6.io/k6/v2/internal/lib/netext/grpcext"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// connectionKey identifies a gRPC connection by every connect() parameter that
+// gRPC binds to the ClientConn at dial time: the transport credentials, the
+// authority and the maximum call sizes. Clients that disagree on any of them
+// cannot share a connection, since the first one to dial would silently impose
+// its own settings on all the later ones.
+type connectionKey struct {
+	addr           string
+	isPlaintext    bool
+	authority      string
+	maxReceiveSize int64
+	maxSendSize    int64
+
+	// tls is the canonical JSON encoding of the tls parameter, so that the key
+	// stays comparable and can be used as a map key.
+	tls string
+}
+
+// newConnectionKey builds the pool key for a connection made to addr with the
+// given parameters.
+func newConnectionKey(addr string, p *connectParams) (connectionKey, error) {
+	tls, err := json.Marshal(p.TLS)
+	if err != nil {
+		return connectionKey{}, fmt.Errorf("unable to identify the connection to %q for sharing: %w", addr, err)
+	}
+
+	return connectionKey{
+		// Host names are case-insensitive, so clients that spell the same
+		// server differently still share a connection.
+		addr:           strings.ToLower(addr),
+		isPlaintext:    p.IsPlaintext,
+		authority:      p.Authority,
+		maxReceiveSize: p.MaxReceiveSize,
+		maxSendSize:    p.MaxSendSize,
+		tls:            string(tls),
+	}, nil
+}
+
+// sharedConn holds a gRPC connection that can be shared across multiple VUs.
+type sharedConn struct {
+	// ready is closed once the client that created this entry is done dialing,
+	// after which conn and err are safe to read.
+	ready chan struct{}
+	conn  *grpcext.Conn
+	err   error
+
+	// refCount tracks how many clients are currently using this connection.
+	// It is guarded by the pool's mutex.
+	refCount int
+}
+
+// connectionPool manages shared gRPC connections keyed by their connection
+// parameters. It is held by RootModule and shared across all VU instances.
+type connectionPool struct {
+	mu    sync.Mutex
+	conns map[connectionKey]*sharedConn
+}
+
+// newConnectionPool creates a new connectionPool.
+func newConnectionPool() *connectionPool {
+	return &connectionPool{
+		conns: make(map[connectionKey]*sharedConn),
+	}
+}
+
+// getOrDial returns the connection shared under key, dialing addr if no client
+// has established it yet. The returned connection resolves protobuf types with
+// the given registry, so clients keep their own types even while sharing the
+// underlying connection.
+//
+// Every successful call must be paired with a release of the same key.
+func (p *connectionPool) getOrDial(
+	ctx context.Context,
+	key connectionKey,
+	addr string,
+	types *protoregistry.Types,
+	opts ...grpc.DialOption,
+) (*grpcext.Conn, error) {
+	p.mu.Lock()
+	if sc, ok := p.conns[key]; ok {
+		sc.refCount++
+		p.mu.Unlock()
+
+		// The connection may still be in the process of being dialed by
+		// another client. Wait on the entry rather than on the pool's mutex,
+		// which would also block every unrelated connect() in the meantime.
+		<-sc.ready
+		if sc.err != nil {
+			// The client that dialed has already dropped this entry from the
+			// pool, so give back the reference taken above instead of calling
+			// release, which by now may refer to a newer entry for this key.
+			p.mu.Lock()
+			sc.refCount--
+			p.mu.Unlock()
+
+			return nil, sc.err
+		}
+
+		return sc.conn.WithTypes(types), nil
+	}
+
+	sc := &sharedConn{ready: make(chan struct{}), refCount: 1}
+	p.conns[key] = sc
+	p.mu.Unlock()
+
+	// Dialing is done outside of the pool's mutex: k6 dials with
+	// grpc.WithBlock(), so holding it here would serialize every VU's
+	// connect() behind this handshake.
+	sc.conn, sc.err = grpcext.Dial(ctx, addr, types, opts...)
+	close(sc.ready)
+
+	if sc.err != nil {
+		// A failed connection must not be handed out to the clients coming
+		// after this one, they get to retry the dial themselves.
+		p.mu.Lock()
+		if p.conns[key] == sc {
+			delete(p.conns, key)
+		}
+		p.mu.Unlock()
+
+		return nil, sc.err
+	}
+
+	return sc.conn, nil
+}
+
+// release gives back one reference to the connection shared under key. The
+// connection is closed and dropped from the pool once no client is using it.
+func (p *connectionPool) release(key connectionKey) error {
+	p.mu.Lock()
+	sc, ok := p.conns[key]
+	if !ok {
+		p.mu.Unlock()
+		return nil
+	}
+
+	sc.refCount--
+	if sc.refCount > 0 {
+		p.mu.Unlock()
+		return nil
+	}
+
+	delete(p.conns, key)
+	p.mu.Unlock()
+
+	if sc.conn == nil {
+		return nil
+	}
+
+	return sc.conn.Close()
+}

--- a/internal/js/modules/k6/grpc/conn_pool_test.go
+++ b/internal/js/modules/k6/grpc/conn_pool_test.go
@@ -1,0 +1,338 @@
+package grpc
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/v2/internal/lib/netext/grpcext"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/protobuf/reflect/protoregistry"
+)
+
+// startTestServer starts a gRPC server exposing the health service and returns
+// its address.
+func startTestServer(t *testing.T) string {
+	t.Helper()
+
+	var lc net.ListenConfig
+	lis, err := lc.Listen(context.Background(), "tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	srv := grpc.NewServer()
+	healthpb.RegisterHealthServer(srv, health.NewServer())
+
+	go func() {
+		_ = srv.Serve(lis)
+	}()
+	t.Cleanup(srv.Stop)
+
+	return lis.Addr().String()
+}
+
+// testDialOptions are the dial options used to reach the test server.
+func testDialOptions() []grpc.DialOption {
+	return []grpc.DialOption{
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(), //nolint:staticcheck
+	}
+}
+
+// getOrDialTest dials addr through the pool, with a key derived from the given
+// parameters.
+func getOrDialTest(t *testing.T, pool *connectionPool, addr string, p *connectParams) (*grpcext.Conn, error) {
+	t.Helper()
+
+	key, err := newConnectionKey(addr, p)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	return pool.getOrDial(ctx, key, addr, new(protoregistry.Types), testDialOptions()...)
+}
+
+// requireServing asserts that the connection can still reach the server.
+func requireServing(t *testing.T, conn *grpcext.Conn) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	res, err := conn.HealthCheck(ctx, "")
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, res.Status)
+}
+
+// entry returns the pool entry for key, if any.
+func (p *connectionPool) entry(key connectionKey) (*sharedConn, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	sc, ok := p.conns[key]
+	return sc, ok
+}
+
+// refCountOf returns the number of clients using the connection under key.
+func (p *connectionPool) refCountOf(key connectionKey) int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	sc, ok := p.conns[key]
+	if !ok {
+		return 0
+	}
+	return sc.refCount
+}
+
+// size returns the number of connections held by the pool.
+func (p *connectionPool) size() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return len(p.conns)
+}
+
+func TestConnectionPool_NewIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	assert.Zero(t, newConnectionPool().size())
+}
+
+func TestConnectionPool_SameParamsShareOneConnection(t *testing.T) {
+	t.Parallel()
+
+	addr := startTestServer(t)
+	pool := newConnectionPool()
+	params := &connectParams{IsPlaintext: true}
+
+	first, err := getOrDialTest(t, pool, addr, params)
+	require.NoError(t, err)
+
+	second, err := getOrDialTest(t, pool, addr, params)
+	require.NoError(t, err)
+
+	key, err := newConnectionKey(addr, params)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, pool.size())
+	assert.Equal(t, 2, pool.refCountOf(key))
+
+	// Each client gets its own view of the connection, so that they keep
+	// resolving protobuf types with their own registry.
+	assert.NotSame(t, first, second)
+
+	requireServing(t, first)
+	requireServing(t, second)
+}
+
+func TestConnectionPool_DifferentParamsDoNotShare(t *testing.T) {
+	t.Parallel()
+
+	addr := startTestServer(t)
+
+	testCases := []struct {
+		name   string
+		params *connectParams
+	}{
+		{
+			name:   "Authority",
+			params: &connectParams{IsPlaintext: true, Authority: "test.k6.io"},
+		},
+		{
+			name:   "MaxReceiveSize",
+			params: &connectParams{IsPlaintext: true, MaxReceiveSize: 1024},
+		},
+		{
+			name:   "MaxSendSize",
+			params: &connectParams{IsPlaintext: true, MaxSendSize: 1024},
+		},
+		{
+			name:   "TLS",
+			params: &connectParams{IsPlaintext: true, TLS: map[string]any{"cacerts": "-----BEGIN CERTIFICATE-----"}},
+		},
+	}
+
+	base := &connectParams{IsPlaintext: true}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			pool := newConnectionPool()
+
+			_, err := getOrDialTest(t, pool, addr, base)
+			require.NoError(t, err)
+
+			_, err = getOrDialTest(t, pool, addr, tc.params)
+			require.NoError(t, err)
+
+			assert.Equal(t, 2, pool.size(),
+				"clients with different connection parameters must not share a connection")
+		})
+	}
+}
+
+func TestConnectionPool_AddressIsCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	params := &connectParams{IsPlaintext: true}
+
+	lower, err := newConnectionKey("localhost:50051", params)
+	require.NoError(t, err)
+
+	upper, err := newConnectionKey("LOCALHOST:50051", params)
+	require.NoError(t, err)
+
+	assert.Equal(t, lower, upper)
+
+	// The same server spelled with a different casing shares one connection.
+	addr := startTestServer(t)
+	_, port, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+
+	pool := newConnectionPool()
+
+	_, err = getOrDialTest(t, pool, "localhost:"+port, params)
+	require.NoError(t, err)
+
+	_, err = getOrDialTest(t, pool, "LOCALHOST:"+port, params)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, pool.size())
+}
+
+func TestConnectionPool_ReleaseDecrementsRefCount(t *testing.T) {
+	t.Parallel()
+
+	addr := startTestServer(t)
+	pool := newConnectionPool()
+	params := &connectParams{IsPlaintext: true}
+
+	first, err := getOrDialTest(t, pool, addr, params)
+	require.NoError(t, err)
+
+	_, err = getOrDialTest(t, pool, addr, params)
+	require.NoError(t, err)
+
+	key, err := newConnectionKey(addr, params)
+	require.NoError(t, err)
+
+	require.NoError(t, pool.release(key))
+
+	assert.Equal(t, 1, pool.refCountOf(key), "the connection is still in use by another client")
+
+	// The connection must stay open while a client is still using it.
+	requireServing(t, first)
+}
+
+func TestConnectionPool_ReleaseClosesTheConnectionAtZero(t *testing.T) {
+	t.Parallel()
+
+	addr := startTestServer(t)
+	pool := newConnectionPool()
+	params := &connectParams{IsPlaintext: true}
+
+	first, err := getOrDialTest(t, pool, addr, params)
+	require.NoError(t, err)
+
+	second, err := getOrDialTest(t, pool, addr, params)
+	require.NoError(t, err)
+
+	key, err := newConnectionKey(addr, params)
+	require.NoError(t, err)
+
+	require.NoError(t, pool.release(key))
+	require.NoError(t, pool.release(key))
+
+	_, ok := pool.entry(key)
+	assert.False(t, ok, "the connection must be dropped from the pool once nobody uses it")
+	assert.Zero(t, pool.size())
+
+	// Both views of the connection are backed by the closed one.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err = first.HealthCheck(ctx, "")
+	assert.Error(t, err, "the connection must be closed once nobody uses it")
+
+	_, err = second.HealthCheck(ctx, "")
+	assert.Error(t, err, "the connection must be closed once nobody uses it")
+}
+
+func TestConnectionPool_ReleaseUnknownKey(t *testing.T) {
+	t.Parallel()
+
+	pool := newConnectionPool()
+
+	key, err := newConnectionKey("nonexistent:50051", &connectParams{IsPlaintext: true})
+	require.NoError(t, err)
+
+	assert.NoError(t, pool.release(key))
+}
+
+func TestConnectionPool_ConcurrentDialSharesOneConnection(t *testing.T) {
+	t.Parallel()
+
+	const clients = 20
+
+	addr := startTestServer(t)
+	pool := newConnectionPool()
+	params := &connectParams{IsPlaintext: true}
+
+	conns := make([]*grpcext.Conn, clients)
+	errs := make([]error, clients)
+
+	var wg sync.WaitGroup
+	wg.Add(clients)
+	for i := range clients {
+		go func() {
+			defer wg.Done()
+			conns[i], errs[i] = getOrDialTest(t, pool, addr, params)
+		}()
+	}
+	wg.Wait()
+
+	key, err := newConnectionKey(addr, params)
+	require.NoError(t, err)
+
+	for i := range clients {
+		require.NoError(t, errs[i])
+		requireServing(t, conns[i])
+	}
+
+	assert.Equal(t, 1, pool.size())
+	assert.Equal(t, clients, pool.refCountOf(key))
+}
+
+func TestConnectionPool_FailedDialIsNotPooled(t *testing.T) {
+	t.Parallel()
+
+	pool := newConnectionPool()
+	params := &connectParams{IsPlaintext: true}
+
+	// Nothing is listening on this address, so the dial gets refused.
+	addr := "127.0.0.1:1"
+	key, err := newConnectionKey(addr, params)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	opts := append(testDialOptions(),
+		grpc.FailOnNonTempDialError(true), //nolint:staticcheck
+		grpc.WithReturnConnectionError(),  //nolint:staticcheck
+	)
+
+	_, err = pool.getOrDial(ctx, key, addr, new(protoregistry.Types), opts...)
+	require.Error(t, err)
+
+	assert.Zero(t, pool.size(), "a failed connection must not be handed out to the next client")
+}

--- a/internal/js/modules/k6/grpc/grpc.go
+++ b/internal/js/modules/k6/grpc/grpc.go
@@ -19,13 +19,16 @@ import (
 type (
 	// RootModule is the global module instance that will create module
 	// instances for each VU.
-	RootModule struct{}
+	RootModule struct {
+		connPool *connectionPool
+	}
 
 	// ModuleInstance represents an instance of the GRPC module for every VU.
 	ModuleInstance struct {
-		vu      modules.VU
-		exports map[string]any
-		metrics *instanceMetrics
+		vu       modules.VU
+		exports  map[string]any
+		metrics  *instanceMetrics
+		connPool *connectionPool
 	}
 )
 
@@ -36,7 +39,9 @@ var (
 
 // New returns a pointer to a new RootModule instance.
 func New() *RootModule {
-	return &RootModule{}
+	return &RootModule{
+		connPool: newConnectionPool(),
+	}
 }
 
 // NewModuleInstance implements the modules.Module interface to return
@@ -48,9 +53,10 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	}
 
 	mi := &ModuleInstance{
-		vu:      vu,
-		exports: make(map[string]any),
-		metrics: metrics,
+		vu:       vu,
+		exports:  make(map[string]any),
+		metrics:  metrics,
+		connPool: r.connPool,
 	}
 
 	mi.exports["Client"] = mi.NewClient
@@ -63,7 +69,7 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 // NewClient is the JS constructor for the grpc Client.
 func (mi *ModuleInstance) NewClient(_ sobek.ConstructorCall) *sobek.Object {
 	rt := mi.vu.Runtime()
-	return rt.ToValue(&Client{vu: mi.vu, types: new(protoregistry.Types)}).ToObject(rt)
+	return rt.ToValue(&Client{vu: mi.vu, types: new(protoregistry.Types), connPool: mi.connPool}).ToObject(rt)
 }
 
 // defineConstants defines the constant variables of the module.

--- a/internal/js/modules/k6/grpc/params.go
+++ b/internal/js/modules/k6/grpc/params.go
@@ -132,9 +132,18 @@ type connectParams struct {
 	MaxSendSize           int64
 	TLS                   map[string]any
 	Authority             string
+
+	// ConnectionSharing lets this client reuse a connection already established
+	// by another VU to the same server with the same parameters, instead of
+	// dialing its own. It only shares connections within a k6 instance, so in a
+	// distributed execution each instance keeps its own set of connections.
+	//
+	// This is experimental: the conditions under which a connection is shared
+	// may change in a future release.
+	ConnectionSharing bool
 }
 
-func newConnectParams(vu modules.VU, input sobek.Value) (*connectParams, error) { //nolint:gocognit
+func newConnectParams(vu modules.VU, input sobek.Value) (*connectParams, error) { //nolint:gocognit,funlen
 	result := &connectParams{
 		IsPlaintext:           false,
 		UseReflectionProtocol: false,
@@ -208,6 +217,12 @@ func newConnectParams(vu modules.VU, input sobek.Value) (*connectParams, error) 
 			result.Authority, ok = v.(string)
 			if !ok {
 				return result, fmt.Errorf("invalid authority value: '%#v', it needs to be a string", v)
+			}
+		case "connectionSharing":
+			var ok bool
+			result.ConnectionSharing, ok = v.(bool)
+			if !ok {
+				return result, fmt.Errorf("invalid connectionSharing value: '%#v', it needs to be boolean", v)
 			}
 		default:
 			return result, fmt.Errorf("unknown connect param: %q", k)

--- a/internal/js/modules/k6/grpc/params_test.go
+++ b/internal/js/modules/k6/grpc/params_test.go
@@ -206,6 +206,56 @@ func TestConnectParamsAuthority(t *testing.T) {
 	}
 }
 
+func TestConnectParamsConnectionSharing(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		Name        string
+		JSON        string
+		Expected    bool
+		ErrContains string
+	}{
+		{
+			Name:     "Unset",
+			JSON:     `{}`,
+			Expected: false,
+		},
+		{
+			Name:     "Enabled",
+			JSON:     `{connectionSharing: true}`,
+			Expected: true,
+		},
+		{
+			Name:     "Disabled",
+			JSON:     `{connectionSharing: false}`,
+			Expected: false,
+		},
+		{
+			Name:        "NotABoolean",
+			JSON:        `{connectionSharing: "true"}`,
+			ErrContains: "invalid connectionSharing value",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			testRuntime, params := newParamsTestRuntime(t, tc.JSON)
+
+			p, err := newConnectParams(testRuntime.VU, params)
+
+			if tc.ErrContains != "" {
+				require.ErrorContains(t, err, tc.ErrContains)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.Expected, p.ConnectionSharing)
+		})
+	}
+}
+
 // newParamsTestRuntime creates a new test runtime
 // that could be used to test the params
 // it also moves to the VU context and creates the params

--- a/internal/lib/netext/grpcext/conn.go
+++ b/internal/lib/netext/grpcext/conn.go
@@ -106,6 +106,16 @@ func Dial(ctx context.Context, addr string, types *protoregistry.Types, options 
 	}, nil
 }
 
+// WithTypes returns a copy of the connection that resolves protobuf types with
+// the given registry. The underlying gRPC client connection is shared with the
+// original, so closing either of them closes both.
+func (c *Conn) WithTypes(types *protoregistry.Types) *Conn {
+	return &Conn{
+		raw:   c.raw,
+		types: types,
+	}
+}
+
 // Reflect returns using the reflection the FileDescriptorSet describing the service.
 func (c *Conn) Reflect(ctx context.Context) (*descriptorpb.FileDescriptorSet, error) {
 	rc := reflectionClient{Conn: c.raw}


### PR DESCRIPTION
## Summary

Replaces #5835, which could not be merged because its first commit was unsigned. This PR is the same feature, rebuilt on top of `master` as a single signed commit, with the review feedback from #5835 addressed.

Adds a `connectionSharing` option to `grpc.Client.connect()`. When it is set, the client takes a connection from a pool held by the module and shared across the VUs, instead of dialing its own. The pool reference counts its connections, so a connection is closed once its last user calls `close()`. gRPC's `ClientConn` multiplexes HTTP/2 streams internally, so no per-connection client limit is needed.

By default nothing changes: every VU still dials its own connection.

### Usage

```javascript
import grpc from 'k6/net/grpc';

const client = new grpc.Client();

export default () => {
  client.connect('localhost:50051', {
    plaintext: true,
    connectionSharing: true,
  });

  // All VUs share the same underlying grpc.ClientConn
  const response = client.invoke('my.Service/Method', { key: 'value' });
  client.close();
};
```

## Changes since #5835

Addressing @oleiade's and @joanlopez's review:

- **Connections are keyed on every parameter gRPC binds to the `ClientConn`**, not on the address alone: the address, `plaintext`, the `tls` configuration, the `authority` and the maximum call sizes. Clients that disagree on any of them get their own connection, so the first client to reach a server can no longer silently impose its transport credentials or authority on the ones that follow ([grpc/grpc-go#195](https://github.com/grpc/grpc-go/issues/195)).
- **Dialing happens outside of the pool's lock.** k6 dials with `grpc.WithBlock()`, so holding the lock across the handshake serialized every VU's `connect()`. Clients waiting for a connection another one is still dialing now wait on that connection rather than on the pool, and a failed dial is dropped instead of being handed out to the next client.
- **Each client keeps its own protobuf type registry** over the shared connection (`grpcext.Conn.WithTypes`). Without it, every client sharing a connection would resolve its types — `Any`, extensions — through the registry of whichever VU happened to dial first.
- **The connection pool tests now run against a real gRPC server**, covering sharing, the parameters that prevent it, the case-insensitive address matching, concurrent dials, a failed dial, and closing the connection once its last user releases it. The previous `CaseInsensitiveKey` test asserted nothing about casing and the ref-count test skipped the close path.
- **Documented as experimental and instance-local**: sharing happens within a k6 instance, so in a distributed execution every instance keeps its own set of connections, and the conditions under which a connection is shared may change.

## Related

- Closes #3188
- Replaces #5835
- Previous attempts: #3179, grafana/xk6-grpc#31 (both closed); xk6-grpc is archived, so this is implemented directly in k6

## Test plan

- [x] `go test -race ./internal/js/modules/k6/grpc/... ./internal/lib/netext/grpcext/...` passes
- [x] `golangci-lint run` (v2.10.1, the pinned version) on both packages reports 0 issues
- [x] `go build ./...` and `gofmt -s -l` clean
- [x] End-to-end test that closing one client leaves the shared connection open for the other
