### PR TITLE
ci: let a failed SBOM stop the release instead of shipping without one

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -557,7 +557,6 @@ jobs:
       - name: Generate checksum file
         run: cd dist && sha256sum * > "k6-${VERSION}-checksums.txt"
       - name: Anchore SBOM Action
-        continue-on-error: true
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           artifact-name: k6-${{ env.VERSION }}-spdx.json


### PR DESCRIPTION
Hi, and thanks for k6.

In the release job in `.github/workflows/build.yml`, the SBOM step is marked `continue-on-error: true`:

```yaml
      - name: Anchore SBOM Action
        continue-on-error: true
        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
        with:
          artifact-name: k6-${{ env.VERSION }}-spdx.json
          upload-release-assets: false
          output-file: dist/k6-${{ env.VERSION }}-spdx.json
```

and the next step builds the release asset list by globbing whatever is in `dist`:

```yaml
      - name: Create release
        ...
          for asset in ./dist/*; do
```

So if the SBOM step fails, `dist/k6-<version>-spdx.json` is never written, the glob simply picks up one file fewer, and the release publishes without an SBOM. The job stays green and nothing in the run says the SBOM is missing — you would only notice by looking at the release assets afterwards.

That is the part I think is worth changing: not that the SBOM can fail, but that it can fail silently on a release that ships anyway.

This PR removes the one line, so a failed SBOM stops the release rather than quietly dropping the artifact.

I am aware that may not be the trade-off you want — if the Anchore action has been flaky and blocking a release on it is worse than shipping without the SBOM, that is a reasonable call and this PR is the wrong fix. In that case a small alternative would keep `continue-on-error` and add a check before "Create release" that fails, or at least emits `::warning::`, when the expected `dist/k6-${VERSION}-spdx.json` is absent. Happy to switch this PR to that shape instead — I just did not want to guess which you would prefer.

Nothing else in the workflow is touched; this is a single deleted line.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the release job and its asset globbing myself.
