### PR TITLE
Fix extension usage reporting gaps

### DIFF
--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -55,7 +55,9 @@ func addEnvironmentInfo(m map[string]any, lookupEnv func(string) (string, bool))
 // scheduler and recorded usage, keeping only the used extensions advertised in
 // the public catalog. It is the run report k6 has always sent, with the
 // extensions field added.
-func createReport(u *usage.Usage, execScheduler *execution.Scheduler, catalog map[string]struct{}) map[string]any {
+func createReport(
+	u *usage.Usage, execScheduler *execution.Scheduler, catalog func() map[string]struct{},
+) map[string]any {
 	execState := execScheduler.GetState()
 	m := u.Map()
 
@@ -83,23 +85,24 @@ func createSubcommandReport(ctx context.Context, gs *state.GlobalState, extensio
 	m := make(map[string]any)
 	addEnvironmentInfo(m, envLookup(gs.Env))
 	m["extensions"] = []any{extension}
-	resolveExtensions(m, catalogModulePaths(ctx, gs))
+	resolveExtensions(m, func() map[string]struct{} { return catalogModulePaths(ctx, gs) })
 
 	return m
 }
 
 // resolveExtensions replaces the used extensions recorded under "extensions" in
 // usage with report entries, keeping only those advertised in the public
-// catalog. Fail closed: dropping the raw list first means an empty catalog
-// reports no extensions rather than leaking it, and the key stays omitted when
-// nothing survives instead of sending [].
-func resolveExtensions(m map[string]any, catalog map[string]struct{}) {
+// catalog. The catalog func runs only when extensions were recorded, so a run
+// that used none never fetches the catalog. Fail closed: dropping the raw list
+// first means an empty catalog reports no extensions rather than leaking it,
+// and the key stays omitted when nothing survives instead of sending [].
+func resolveExtensions(m map[string]any, catalog func() map[string]struct{}) {
 	used, ok := m["extensions"].([]any)
 	if !ok {
 		return
 	}
 	delete(m, "extensions")
-	if entries := filterExtensions(used, catalog); len(entries) > 0 {
+	if entries := filterExtensions(used, catalog()); len(entries) > 0 {
 		m["extensions"] = entries
 	}
 }

--- a/internal/cmd/report_test.go
+++ b/internal/cmd/report_test.go
@@ -36,6 +36,11 @@ func TestCreateReport(t *testing.T) {
 		}, local.NewController())
 	}
 
+	// A nil func would also work while no case records an extension, but this
+	// stays fail-closed if one ever does: filtering against a nil catalog
+	// drops the extensions instead of panicking.
+	noCatalog := func() map[string]struct{} { return nil }
+
 	t.Run("default (no env)", func(t *testing.T) {
 		t.Parallel()
 
@@ -50,7 +55,7 @@ func TestCreateReport(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 		s.GetState().MarkEnded()
 
-		m := createReport(usage.New(), s, nil)
+		m := createReport(usage.New(), s, noCatalog)
 
 		assert.Equal(t, build.Version, m["k6_version"])
 		assert.EqualValues(t, map[string]int{"shared-iterations": 1}, m["executors"])
@@ -71,7 +76,7 @@ func TestCreateReport(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		m := createReport(usage.New(), s, nil)
+		m := createReport(usage.New(), s, noCatalog)
 
 		assert.Equal(t, build.Version, m["k6_version"])
 		assert.EqualValues(t, map[string]int{"shared-iterations": 1}, m["executors"])
@@ -92,7 +97,7 @@ func TestCreateReport(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		m := createReport(usage.New(), s, nil)
+		m := createReport(usage.New(), s, noCatalog)
 
 		assert.Equal(t, build.Version, m["k6_version"])
 		assert.EqualValues(t, map[string]int{"shared-iterations": 1}, m["executors"])

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -461,7 +461,9 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 	if !conf.NoUsageReport.Bool {
 		backgroundProcesses.Go(func() {
 			reportUsage(globalCtx, c.gs, func(ctx context.Context) map[string]any {
-				return createReport(test.preInitState.Usage, execScheduler, catalogModulePaths(ctx, c.gs))
+				return createReport(test.preInitState.Usage, execScheduler, func() map[string]struct{} {
+					return catalogModulePaths(ctx, c.gs)
+				})
 			})
 		})
 	}

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -90,8 +90,10 @@ Run "k6 x explore" to see the full list of official and community-provided subco
 // the catch-all `x` help, `k6 run`, builtins sharing an extension's name,
 // completions, and provisioning stubs are ignored. A nested invocation
 // (`k6 x <name> <child>`) counts toward the extension that owns the child.
+// Displaying an extension's help counts too, whether requested with the flag
+// (`k6 x <name> --help`) or the help command (`k6 help x <name>`).
 func reportSubcommandUsage(gs *state.GlobalState, executed *cobra.Command) {
-	extension, ok := subcommandExtension(executed)
+	extension, ok := subcommandExtension(helpTarget(executed))
 	if !ok {
 		return
 	}
@@ -114,6 +116,23 @@ func reportSubcommandUsage(gs *state.GlobalState, executed *cobra.Command) {
 	reportUsage(gs.Ctx, gs, func(ctx context.Context) map[string]any {
 		return createSubcommandReport(ctx, gs, extension)
 	})
+}
+
+// helpTarget resolves the root help command to the command whose help it
+// displayed, so `k6 help x <name>` counts toward the extension like
+// `k6 x <name> --help` does. Any other command passes through unchanged. The
+// lookup repeats the one cobra's help command ran on its positional args,
+// which its flag set still holds after execution.
+func helpTarget(executed *cobra.Command) *cobra.Command {
+	if executed == nil || executed.Name() != "help" ||
+		!executed.HasParent() || executed.Parent().HasParent() {
+		return executed
+	}
+	target, _, err := executed.Root().Find(executed.Flags().Args())
+	if err != nil {
+		return executed
+	}
+	return target
 }
 
 // subcommandExtension resolves the executed command to the registered

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -95,7 +95,20 @@ func reportSubcommandUsage(gs *state.GlobalState, executed *cobra.Command) {
 	if !ok {
 		return
 	}
-	if conf, err := readEnvConfig(gs.Env); err != nil || conf.NoUsageReport.Bool {
+	// The opt-out honors both sources that reach this path, the config file
+	// and the env var, with the env winning like on the run path. An
+	// unreadable source fails closed by skipping the send.
+	fileConf, err := readDiskConfig(gs)
+	if err != nil {
+		gs.Logger.WithError(err).Debug("Skipping the usage report")
+		return
+	}
+	envConf, err := readEnvConfig(gs.Env)
+	if err != nil {
+		gs.Logger.WithError(err).Debug("Skipping the usage report")
+		return
+	}
+	if fileConf.Apply(envConf).NoUsageReport.Bool {
 		return
 	}
 	reportUsage(gs.Ctx, gs, func(ctx context.Context) map[string]any {

--- a/internal/cmd/subcommand.go
+++ b/internal/cmd/subcommand.go
@@ -86,13 +86,12 @@ Run "k6 x explore" to see the full list of official and community-provided subco
 // reportSubcommandUsage reports usage for a subcommand extension after it runs.
 // It is called with the command cobra actually executed, whether that command
 // succeeded or failed, so a subcommand that exits non-zero is still counted. It
-// reports only for a name backed by a registered subcommand extension, so the
-// catch-all `x` help, `k6 run`, completions, and provisioning stubs are ignored.
+// reports only for a command backed by a registered subcommand extension, so
+// the catch-all `x` help, `k6 run`, builtins sharing an extension's name,
+// completions, and provisioning stubs are ignored. A nested invocation
+// (`k6 x <name> <child>`) counts toward the extension that owns the child.
 func reportSubcommandUsage(gs *state.GlobalState, executed *cobra.Command) {
-	if executed == nil {
-		return
-	}
-	extension, ok := ext.Get(ext.SubcommandExtension)[executed.Name()]
+	extension, ok := subcommandExtension(executed)
 	if !ok {
 		return
 	}
@@ -102,6 +101,25 @@ func reportSubcommandUsage(gs *state.GlobalState, executed *cobra.Command) {
 	reportUsage(gs.Ctx, gs, func(ctx context.Context) map[string]any {
 		return createSubcommandReport(ctx, gs, extension)
 	})
+}
+
+// subcommandExtension resolves the executed command to the registered
+// subcommand extension it belongs to: the direct child of the root-level `x`
+// command on the executed command's parent chain. Matching by position rather
+// than by the executed command's bare name keeps a builtin sharing an
+// extension's name unreported and lets a nested invocation count toward its
+// extension. cobra returns the deepest command it ran, so the walk climbs from
+// there.
+func subcommandExtension(executed *cobra.Command) (*ext.Extension, bool) {
+	for cmd := executed; cmd != nil && cmd.HasParent(); cmd = cmd.Parent() {
+		parent := cmd.Parent()
+		if parent.Name() != "x" || parent.Parent() == nil || parent.Parent().HasParent() {
+			continue
+		}
+		extension, ok := ext.Get(ext.SubcommandExtension)[cmd.Name()]
+		return extension, ok
+	}
+	return nil, false
 }
 
 // registryStubs returns cobra stubs for registry-advertised subcommands not

--- a/internal/cmd/tests/cmd_optout_config_file_test.go
+++ b/internal/cmd/tests/cmd_optout_config_file_test.go
@@ -15,10 +15,10 @@ import (
 	"go.k6.io/k6/v2/lib/fsext"
 )
 
-// TestConfigFileOptOutSuppressesReports covers the config-file opt-out
-// (noUsageReport: true) with K6_NO_USAGE_REPORT unset: it must suppress the
-// usage report on every reporting path, matching the documented opt-out.
-func TestConfigFileOptOutSuppressesReports(t *testing.T) {
+// TestConfigFileOptOut covers the config-file opt-out (noUsageReport: true)
+// on every reporting path: alone it must suppress the usage report, and
+// K6_NO_USAGE_REPORT=false must win over it and re-enable reporting.
+func TestConfigFileOptOut(t *testing.T) {
 	t.Parallel()
 
 	registerReportTestSubcommand(t)
@@ -26,9 +26,11 @@ func TestConfigFileOptOutSuppressesReports(t *testing.T) {
 	testSubModule := "go.k6.io/k6/v2/internal/cmd/tests"
 
 	tt := []struct {
-		name  string
-		args  []string
-		stdin string
+		name        string
+		args        []string
+		stdin       string
+		envOptOut   string // K6_NO_USAGE_REPORT; empty leaves it unset
+		wantReports int32
 	}{
 		{
 			name:  "config file opt-out suppresses the run report",
@@ -38,6 +40,19 @@ func TestConfigFileOptOutSuppressesReports(t *testing.T) {
 		{
 			name: "config file opt-out suppresses the subcommand report",
 			args: []string{"x", "testsub"},
+		},
+		{
+			name:        "env re-enables the run report over the config file",
+			args:        []string{"run", "-"},
+			stdin:       `export default function() {};`,
+			envOptOut:   "false",
+			wantReports: 1,
+		},
+		{
+			name:        "env re-enables the subcommand report over the config file",
+			args:        []string{"x", "testsub"},
+			envOptOut:   "false",
+			wantReports: 1,
 		},
 	}
 
@@ -61,8 +76,11 @@ func TestConfigFileOptOutSuppressesReports(t *testing.T) {
 			t.Cleanup(catalogServer.Close)
 
 			ts := NewGlobalTestState(t)
-			// The env opt-out must stay unset so the config file is the only gate.
+			// The default env opt-out would mask the config file gate.
 			delete(ts.Env, "K6_NO_USAGE_REPORT")
+			if tc.envOptOut != "" {
+				ts.Env["K6_NO_USAGE_REPORT"] = tc.envOptOut
+			}
 			ts.Env[state.UsageReportURL] = reportServer.URL
 			ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
 
@@ -78,8 +96,8 @@ func TestConfigFileOptOutSuppressesReports(t *testing.T) {
 
 			cmd.ExecuteWithGlobalState(ts.GlobalState)
 
-			require.Equal(t, int32(0), reportCount.Load(),
-				"expected the config-file opt-out to suppress the usage report")
+			require.Equal(t, tc.wantReports, reportCount.Load(),
+				"unexpected usage report count with noUsageReport set in the config file")
 		})
 	}
 }

--- a/internal/cmd/tests/cmd_optout_config_file_test.go
+++ b/internal/cmd/tests/cmd_optout_config_file_test.go
@@ -1,0 +1,85 @@
+package tests
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/lib/fsext"
+)
+
+// TestConfigFileOptOutSuppressesReports covers the config-file opt-out
+// (noUsageReport: true) with K6_NO_USAGE_REPORT unset: it must suppress the
+// usage report on every reporting path, matching the documented opt-out.
+func TestConfigFileOptOutSuppressesReports(t *testing.T) {
+	t.Parallel()
+
+	registerReportTestSubcommand(t)
+
+	testSubModule := "go.k6.io/k6/v2/internal/cmd/tests"
+
+	tt := []struct {
+		name  string
+		args  []string
+		stdin string
+	}{
+		{
+			name:  "config file opt-out suppresses the run report",
+			args:  []string{"run", "-"},
+			stdin: `export default function() {};`,
+		},
+		{
+			name: "config file opt-out suppresses the subcommand report",
+			args: []string{"x", "testsub"},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var reportCount atomic.Int32
+			reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					reportCount.Add(1)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(reportServer.Close)
+
+			catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"testsub": {"subcommands":["testsub"],"module":"` + testSubModule + `"}}`))
+			}))
+			t.Cleanup(catalogServer.Close)
+
+			ts := NewGlobalTestState(t)
+			// The env opt-out must stay unset so the config file is the only gate.
+			delete(ts.Env, "K6_NO_USAGE_REPORT")
+			ts.Env[state.UsageReportURL] = reportServer.URL
+			ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
+
+			require.NoError(t, ts.FS.MkdirAll(filepath.Dir(ts.Flags.ConfigFilePath), 0o755))
+			require.NoError(t, fsext.WriteFile(ts.FS, ts.Flags.ConfigFilePath,
+				[]byte(`{"noUsageReport": true}`), 0o600))
+
+			ts.CmdArgs = append([]string{"k6"}, tc.args...)
+			if tc.stdin != "" {
+				ts.Stdin = bytes.NewBufferString(tc.stdin)
+			}
+			ts.ReparseFlags()
+
+			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			require.Equal(t, int32(0), reportCount.Load(),
+				"expected the config-file opt-out to suppress the usage report")
+		})
+	}
+}

--- a/internal/cmd/tests/cmd_optout_config_file_test.go
+++ b/internal/cmd/tests/cmd_optout_config_file_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/ext"
 	"go.k6.io/k6/v2/internal/cmd"
 	"go.k6.io/k6/v2/lib/fsext"
 )
@@ -24,7 +25,7 @@ func TestConfigFileOptOut(t *testing.T) {
 
 	registerReportTestSubcommand(t)
 
-	testSubModule := "go.k6.io/k6/v2/internal/cmd/tests"
+	testSubModule := ext.Get(ext.SubcommandExtension)["testsub"].Path
 
 	tt := []struct {
 		name        string

--- a/internal/cmd/tests/cmd_optout_config_file_test.go
+++ b/internal/cmd/tests/cmd_optout_config_file_test.go
@@ -16,8 +16,9 @@ import (
 )
 
 // TestConfigFileOptOut covers the config-file opt-out (noUsageReport: true)
-// on every reporting path: alone it must suppress the usage report, and
-// K6_NO_USAGE_REPORT=false must win over it and re-enable reporting.
+// on every reporting path: alone it must suppress the usage report,
+// K6_NO_USAGE_REPORT=false must win over it and re-enable reporting, and an
+// unreadable config file must fail closed by skipping the report.
 func TestConfigFileOptOut(t *testing.T) {
 	t.Parallel()
 
@@ -29,6 +30,7 @@ func TestConfigFileOptOut(t *testing.T) {
 		name        string
 		args        []string
 		stdin       string
+		config      string // config file content; empty means {"noUsageReport": true}
 		envOptOut   string // K6_NO_USAGE_REPORT; empty leaves it unset
 		wantReports int32
 	}{
@@ -53,6 +55,15 @@ func TestConfigFileOptOut(t *testing.T) {
 			args:        []string{"x", "testsub"},
 			envOptOut:   "false",
 			wantReports: 1,
+		},
+		{
+			// An unreadable config file must fail closed: no report, while
+			// the subcommand still runs (the zero exit code is asserted by
+			// the test state).
+			name:      "unreadable config file skips the subcommand report",
+			args:      []string{"x", "testsub"},
+			config:    `{not json`,
+			envOptOut: "false",
 		},
 	}
 
@@ -84,9 +95,12 @@ func TestConfigFileOptOut(t *testing.T) {
 			ts.Env[state.UsageReportURL] = reportServer.URL
 			ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
 
+			config := tc.config
+			if config == "" {
+				config = `{"noUsageReport": true}`
+			}
 			require.NoError(t, ts.FS.MkdirAll(filepath.Dir(ts.Flags.ConfigFilePath), 0o755))
-			require.NoError(t, fsext.WriteFile(ts.FS, ts.Flags.ConfigFilePath,
-				[]byte(`{"noUsageReport": true}`), 0o600))
+			require.NoError(t, fsext.WriteFile(ts.FS, ts.Flags.ConfigFilePath, []byte(config), 0o600))
 
 			ts.CmdArgs = append([]string{"k6"}, tc.args...)
 			if tc.stdin != "" {

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -88,6 +88,7 @@ func TestRunReportsExtensions(t *testing.T) {
 		optOut              bool
 		wantExtensions      []map[string]any
 		wantNoExtensionsKey bool
+		wantNoCatalogFetch  bool
 		wantOutputs         []any
 	}{
 		{
@@ -95,10 +96,13 @@ func TestRunReportsExtensions(t *testing.T) {
 			script: `export default function() {};`,
 		},
 		{
+			// A run that used no extensions has nothing to filter, so the
+			// catalog must not be consulted at all.
 			name:                "compiled but unused extension omits the extensions key",
 			script:              `export default function() {};`,
 			catalog:             `{"k6/x/testimport": {"module":"` + testImportModule + `"}}`,
 			wantNoExtensionsKey: true,
+			wantNoCatalogFetch:  true,
 		},
 		{
 			name:    "used public import is reported",
@@ -267,6 +271,10 @@ func TestRunReportsExtensions(t *testing.T) {
 			}
 
 			require.True(t, reported.Load(), "expected the usage report to reach the configured endpoint")
+
+			if tc.wantNoCatalogFetch {
+				require.False(t, catalogHit.Load(), "expected no catalog fetch when the run used no extensions")
+			}
 
 			if tc.wantOutputs != nil {
 				raw, ok := gotBody.Load().([]byte)

--- a/internal/cmd/tests/cmd_subcommand_help_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_help_report_test.go
@@ -1,0 +1,93 @@
+package tests
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/ext"
+	"go.k6.io/k6/v2/internal/cmd"
+)
+
+// TestHelpInvocationReportsUsage covers help invocations of a subcommand
+// extension: both `k6 x <name> --help` and `k6 help x <name>` display the
+// extension's help, so both count as usage. `k6 help x` describes the x
+// namespace itself, and `k6 x help <name>` also falls back to the namespace
+// help, so neither reports.
+func TestHelpInvocationReportsUsage(t *testing.T) {
+	t.Parallel()
+
+	registerReportTestSubcommand(t)
+
+	testSubModule := ext.Get(ext.SubcommandExtension)["testsub"].Path
+	wantExtensions := []map[string]any{
+		{
+			"module":  testSubModule,
+			"version": ext.Get(ext.SubcommandExtension)["testsub"].Version,
+			"kind":    "subcommand",
+		},
+	}
+
+	tt := []struct {
+		name        string
+		args        []string
+		wantReports int32
+	}{
+		{name: "flag help on the extension is reported", args: []string{"x", "testsub", "--help"}, wantReports: 1},
+		{name: "help command on the extension is reported", args: []string{"help", "x", "testsub"}, wantReports: 1},
+		{name: "help of the x namespace is not reported", args: []string{"help", "x"}},
+		{name: "namespace help under x is not reported", args: []string{"x", "help", "testsub"}},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var reportCount atomic.Int32
+			var gotBody atomic.Value
+			reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					body, _ := io.ReadAll(r.Body)
+					gotBody.Store(body)
+					reportCount.Add(1)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(reportServer.Close)
+
+			catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"testsub": {"subcommands":["testsub"],"module":"` + testSubModule + `"}}`))
+			}))
+			t.Cleanup(catalogServer.Close)
+
+			ts := NewGlobalTestState(t)
+			ts.Env["K6_NO_USAGE_REPORT"] = "false"
+			ts.Env[state.UsageReportURL] = reportServer.URL
+			ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
+			ts.CmdArgs = append([]string{"k6"}, tc.args...)
+			ts.ReparseFlags()
+
+			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			require.Equal(t, tc.wantReports, reportCount.Load(), "unexpected usage report count for a help invocation")
+
+			if tc.wantReports == 0 {
+				return
+			}
+			raw, ok := gotBody.Load().([]byte)
+			require.True(t, ok, "expected a report body")
+			var report struct {
+				Extensions []map[string]any `json:"extensions"`
+			}
+			require.NoError(t, json.Unmarshal(raw, &report))
+			require.ElementsMatch(t, wantExtensions, report.Extensions)
+		})
+	}
+}

--- a/internal/cmd/tests/cmd_subcommand_nested_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_nested_report_test.go
@@ -73,42 +73,57 @@ func registerBuiltinNamedTestSubcommand(t *testing.T) {
 	})
 }
 
-// TestBuiltinNamedSubcommandExtensionIsNotReported covers a subcommand
-// extension sharing a builtin command's name: running the builtin must not
-// report the extension, even when the catalog lists it.
-func TestBuiltinNamedSubcommandExtensionIsNotReported(t *testing.T) {
+// TestBuiltinNamedSubcommandExtension covers a subcommand extension sharing a
+// builtin command's name: running the builtin must not report the extension,
+// even when the catalog lists it, while running the extension under x must.
+func TestBuiltinNamedSubcommandExtension(t *testing.T) {
 	t.Parallel()
 
 	registerBuiltinNamedTestSubcommand(t)
 
 	versionModule := ext.Get(ext.SubcommandExtension)["version"].Path
 
-	var reportCount atomic.Int32
-	reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPost {
-			reportCount.Add(1)
-		}
-		w.WriteHeader(http.StatusOK)
-	}))
-	t.Cleanup(reportServer.Close)
+	tt := []struct {
+		name        string
+		args        []string
+		wantReports int32
+	}{
+		{name: "the builtin does not report the extension", args: []string{"version"}},
+		{name: "the extension under x is reported", args: []string{"x", "version"}, wantReports: 1},
+	}
 
-	catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"version": {"subcommands":["version"],"module":"` + versionModule + `"}}`))
-	}))
-	t.Cleanup(catalogServer.Close)
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-	ts := NewGlobalTestState(t)
-	ts.Env["K6_NO_USAGE_REPORT"] = "false"
-	ts.Env[state.UsageReportURL] = reportServer.URL
-	ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
-	ts.CmdArgs = []string{"k6", "version"}
-	ts.ReparseFlags()
+			var reportCount atomic.Int32
+			reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					reportCount.Add(1)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(reportServer.Close)
 
-	cmd.ExecuteWithGlobalState(ts.GlobalState)
+			catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"version": {"subcommands":["version"],"module":"` + versionModule + `"}}`))
+			}))
+			t.Cleanup(catalogServer.Close)
 
-	require.Equal(t, int32(0), reportCount.Load(),
-		"expected the builtin run to send no report despite an extension sharing its name")
+			ts := NewGlobalTestState(t)
+			ts.Env["K6_NO_USAGE_REPORT"] = "false"
+			ts.Env[state.UsageReportURL] = reportServer.URL
+			ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
+			ts.CmdArgs = append([]string{"k6"}, tc.args...)
+			ts.ReparseFlags()
+
+			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			require.Equal(t, tc.wantReports, reportCount.Load(),
+				"unexpected usage report count for a builtin-named extension")
+		})
+	}
 }
 
 func TestNestedSubcommandReportsUsage(t *testing.T) {

--- a/internal/cmd/tests/cmd_subcommand_nested_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_nested_report_test.go
@@ -1,0 +1,162 @@
+package tests
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/cmd/state"
+	"go.k6.io/k6/v2/ext"
+	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/subcommand"
+)
+
+// registerNestedTestSubcommandOnce guards process-global ext.Register, which
+// panics on a duplicate name/type.
+var registerNestedTestSubcommandOnce sync.Once //nolint:gochecknoglobals
+
+func registerNestedTestSubcommand(t *testing.T) {
+	t.Helper()
+
+	registerNestedTestSubcommandOnce.Do(func() {
+		subcommand.RegisterExtension("testnest", func(*state.GlobalState) *cobra.Command {
+			root := &cobra.Command{
+				Use: "testnest",
+				Run: func(*cobra.Command, []string) {},
+			}
+			root.AddCommand(&cobra.Command{
+				Use: "child",
+				Run: func(*cobra.Command, []string) {},
+			})
+			return root
+		})
+	})
+}
+
+// registerBuiltinNamedTestSubcommandOnce guards process-global ext.Register,
+// which panics on a duplicate name/type.
+var registerBuiltinNamedTestSubcommandOnce sync.Once //nolint:gochecknoglobals
+
+func registerBuiltinNamedTestSubcommand(t *testing.T) {
+	t.Helper()
+
+	registerBuiltinNamedTestSubcommandOnce.Do(func() {
+		subcommand.RegisterExtension("version", func(*state.GlobalState) *cobra.Command {
+			return &cobra.Command{
+				Use: "version",
+				Run: func(*cobra.Command, []string) {},
+			}
+		})
+	})
+}
+
+// TestBuiltinNamedSubcommandExtensionIsNotReported covers a subcommand
+// extension sharing a builtin command's name: running the builtin must not
+// report the extension, even when the catalog lists it.
+func TestBuiltinNamedSubcommandExtensionIsNotReported(t *testing.T) {
+	t.Parallel()
+
+	registerBuiltinNamedTestSubcommand(t)
+
+	versionModule := ext.Get(ext.SubcommandExtension)["version"].Path
+
+	var reportCount atomic.Int32
+	reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			reportCount.Add(1)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(reportServer.Close)
+
+	catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"version": {"subcommands":["version"],"module":"` + versionModule + `"}}`))
+	}))
+	t.Cleanup(catalogServer.Close)
+
+	ts := NewGlobalTestState(t)
+	ts.Env["K6_NO_USAGE_REPORT"] = "false"
+	ts.Env[state.UsageReportURL] = reportServer.URL
+	ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
+	ts.CmdArgs = []string{"k6", "version"}
+	ts.ReparseFlags()
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	require.Equal(t, int32(0), reportCount.Load(),
+		"expected the builtin run to send no report despite an extension sharing its name")
+}
+
+func TestNestedSubcommandReportsUsage(t *testing.T) {
+	t.Parallel()
+
+	registerNestedTestSubcommand(t)
+
+	testNestModule := ext.Get(ext.SubcommandExtension)["testnest"].Path
+	wantExtensions := []map[string]any{
+		{
+			"module":  testNestModule,
+			"version": ext.Get(ext.SubcommandExtension)["testnest"].Version,
+			"kind":    "subcommand",
+		},
+	}
+
+	tt := []struct {
+		name string
+		args []string
+	}{
+		{name: "root invocation is reported", args: []string{"x", "testnest"}},
+		{name: "child invocation is reported under the extension", args: []string{"x", "testnest", "child"}},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var reportCount atomic.Int32
+			var gotBody atomic.Value
+			reportServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPost {
+					body, _ := io.ReadAll(r.Body)
+					gotBody.Store(body)
+					reportCount.Add(1)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			t.Cleanup(reportServer.Close)
+
+			catalogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"testnest": {"subcommands":["testnest"],"module":"` + testNestModule + `"}}`))
+			}))
+			t.Cleanup(catalogServer.Close)
+
+			ts := NewGlobalTestState(t)
+			ts.Env["K6_NO_USAGE_REPORT"] = "false"
+			ts.Env[state.UsageReportURL] = reportServer.URL
+			ts.Env[state.ProvisionCatalogURL] = catalogServer.URL
+			ts.CmdArgs = append([]string{"k6"}, tc.args...)
+			ts.ReparseFlags()
+
+			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			require.Equal(t, int32(1), reportCount.Load(), "expected exactly one usage report")
+
+			raw, ok := gotBody.Load().([]byte)
+			require.True(t, ok, "expected a report body")
+			var report struct {
+				Extensions []map[string]any `json:"extensions"`
+			}
+			require.NoError(t, json.Unmarshal(raw, &report))
+			require.ElementsMatch(t, wantExtensions, report.Extensions)
+		})
+	}
+}

--- a/internal/cmd/tests/cmd_subcommand_nested_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_nested_report_test.go
@@ -31,10 +31,26 @@ func registerNestedTestSubcommand(t *testing.T) {
 				Use: "testnest",
 				Run: func(*cobra.Command, []string) {},
 			}
-			root.AddCommand(&cobra.Command{
+			child := &cobra.Command{
 				Use: "child",
 				Run: func(*cobra.Command, []string) {},
+			}
+			child.AddCommand(&cobra.Command{
+				Use: "grandchild",
+				Run: func(*cobra.Command, []string) {},
 			})
+			// An x-named nested subcommand exercises the walk's root-level
+			// check: the walk must climb past it to the extension under the
+			// real x.
+			nestedX := &cobra.Command{
+				Use: "x",
+				Run: func(*cobra.Command, []string) {},
+			}
+			nestedX.AddCommand(&cobra.Command{
+				Use: "leaf",
+				Run: func(*cobra.Command, []string) {},
+			})
+			root.AddCommand(child, nestedX)
 			return root
 		})
 	})
@@ -115,6 +131,9 @@ func TestNestedSubcommandReportsUsage(t *testing.T) {
 	}{
 		{name: "root invocation is reported", args: []string{"x", "testnest"}},
 		{name: "child invocation is reported under the extension", args: []string{"x", "testnest", "child"}},
+		{name: "grandchild invocation is reported under the extension", args: []string{"x", "testnest", "child", "grandchild"}},
+		{name: "x-named nested invocation is reported under the extension", args: []string{"x", "testnest", "x"}},
+		{name: "invocation under an x-named nested subcommand is reported", args: []string{"x", "testnest", "x", "leaf"}},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
## What?

Fixes three reporting gaps in extension usage telemetry:

- A run that used no extensions no longer contacts the catalog; the report goes out without the needless fetch.
- A nested subcommand (`k6 x docs search`) is reported. A builtin sharing an extension's name is not.
- `noUsageReport` suppresses the subcommand report, matching the run report; the env var keeps precedence.

## Why?

Extension telemetry should count what users actually run and respect opt-outs.