### PR TITLE
Extension telemetry: Rename extension kind to type

### DIFF
--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -17,11 +17,11 @@ import (
 )
 
 // extensionEntry identifies a used extension in the usage report by its Go
-// module path, along with its version and kind.
+// module path, along with its version and type.
 type extensionEntry struct {
 	Module  string `json:"module"`
 	Version string `json:"version"`
-	Kind    string `json:"kind"`
+	Type    string `json:"type"`
 }
 
 // newExtensionEntry builds the usage-report entry for a registered extension.
@@ -29,7 +29,7 @@ func newExtensionEntry(e *ext.Extension) extensionEntry {
 	return extensionEntry{
 		Module:  e.Path,
 		Version: e.Version,
-		Kind:    e.Type.String(),
+		Type:    e.Type.String(),
 	}
 }
 
@@ -109,7 +109,7 @@ func resolveExtensions(m map[string]any, catalog func() map[string]struct{}) {
 
 // filterExtensions turns the recorded used extensions into report entries,
 // keeping only those whose module path is advertised in the public catalog and
-// de-duplicating per (module, kind).
+// de-duplicating per (module, type).
 func filterExtensions(used []any, public map[string]struct{}) []extensionEntry {
 	seen := make(map[[2]string]struct{}, len(used))
 	entries := make([]extensionEntry, 0, len(used))

--- a/internal/cmd/tests/cmd_run_report_test.go
+++ b/internal/cmd/tests/cmd_run_report_test.go
@@ -112,7 +112,7 @@ func TestRunReportsExtensions(t *testing.T) {
 				{
 					"module":  testImportModule,
 					"version": ext.Get(ext.JSExtension)["k6/x/testimport"].Version,
-					"kind":    "js",
+					"type":    "js",
 				},
 			},
 		},
@@ -125,7 +125,7 @@ func TestRunReportsExtensions(t *testing.T) {
 				{
 					"module":  testImportModule,
 					"version": ext.Get(ext.JSExtension)["k6/x/testimport"].Version,
-					"kind":    "js",
+					"type":    "js",
 				},
 			},
 		},
@@ -137,12 +137,12 @@ func TestRunReportsExtensions(t *testing.T) {
 				{
 					"module":  testImportModule,
 					"version": ext.Get(ext.JSExtension)["k6/x/testimport"].Version,
-					"kind":    "js",
+					"type":    "js",
 				},
 				{
 					"module":  testImportModule2,
 					"version": ext.Get(ext.JSExtension)["k6/x/testimport2"].Version,
-					"kind":    "js",
+					"type":    "js",
 				},
 			},
 		},
@@ -155,7 +155,7 @@ func TestRunReportsExtensions(t *testing.T) {
 				{
 					"module":  ext.Get(ext.OutputExtension)["testoutput"].Path,
 					"version": ext.Get(ext.OutputExtension)["testoutput"].Version,
-					"kind":    "output",
+					"type":    "output",
 				},
 			},
 		},
@@ -186,7 +186,7 @@ func TestRunReportsExtensions(t *testing.T) {
 				{
 					"module":  testImportModule2,
 					"version": ext.Get(ext.JSExtension)["k6/x/testimport2"].Version,
-					"kind":    "js",
+					"type":    "js",
 				},
 			},
 		},
@@ -286,7 +286,7 @@ func TestRunReportsExtensions(t *testing.T) {
 				require.NoError(t, json.Unmarshal(raw, &report))
 				require.Equal(t, tc.wantOutputs, report.Outputs, "expected the built-in output to stay listed under outputs")
 				for _, e := range report.Extensions {
-					require.NotEqual(t, "output", e["kind"], "expected no output-kind extension entry for a built-in output")
+					require.NotEqual(t, "output", e["type"], "expected no output-type extension entry for a built-in output")
 				}
 			}
 

--- a/internal/cmd/tests/cmd_subcommand_help_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_help_report_test.go
@@ -30,7 +30,7 @@ func TestHelpInvocationReportsUsage(t *testing.T) {
 		{
 			"module":  testSubModule,
 			"version": ext.Get(ext.SubcommandExtension)["testsub"].Version,
-			"kind":    "subcommand",
+			"type":    "subcommand",
 		},
 	}
 

--- a/internal/cmd/tests/cmd_subcommand_nested_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_nested_report_test.go
@@ -136,7 +136,7 @@ func TestNestedSubcommandReportsUsage(t *testing.T) {
 		{
 			"module":  testNestModule,
 			"version": ext.Get(ext.SubcommandExtension)["testnest"].Version,
-			"kind":    "subcommand",
+			"type":    "subcommand",
 		},
 	}
 

--- a/internal/cmd/tests/cmd_subcommand_report_test.go
+++ b/internal/cmd/tests/cmd_subcommand_report_test.go
@@ -68,7 +68,7 @@ func TestSubcommandReportsUsage(t *testing.T) {
 				{
 					"module":  testSubModule,
 					"version": ext.Get(ext.SubcommandExtension)["testsub"].Version,
-					"kind":    "subcommand",
+					"type":    "subcommand",
 				},
 			},
 		},


### PR DESCRIPTION
## What?

Extension entries in the usage report now carry `type` instead of `kind`:

```json
// before
{"module": "github.com/grafana/xk6-sql", "version": "v1.0.5", "kind": "js"}
// after
{"module": "github.com/grafana/xk6-sql", "version": "v1.0.5", "type": "js"}
```

## Why?

The extension registry already calls this concept the extension's type, and the field's values (`js`, `output`, `subcommand`) come straight from it. The report introduced `kind` as a second name for the same thing. Nothing consumes the field yet, so renaming now keeps one term across the code, the report, and the docs; after release the wire name freezes and a rename would leave old and new reports disagreeing forever.

- Prompted by [@janHildebrandt98's review comment](https://github.com/grafana/k6/pull/6126#discussion_r3681893423)
- Follow-up to #6126 and #6224
- Related to #6109
