### PR TITLE
Address cloud provisioning review nits

### DIFF
--- a/internal/cloudapi/provisioning/api.go
+++ b/internal/cloudapi/provisioning/api.go
@@ -115,13 +115,12 @@ func (c *Client) UploadArchive(ctx context.Context, uploadURL string, body []byt
 // backend status becomes "initializing" (signalling that k6 can begin
 // local execution). Returns an error if the test run reaches "aborted"
 // or "completed" first. Cancellable via context. Logs status transitions
-// at Info level once per change.
+// at Debug level once per change.
 //
 // If pollInterval is <= 0 the defaultWaitPollInterval is used.
 func (c *Client) WaitForTestRunReady(ctx context.Context, testRunID int64, pollInterval time.Duration) error {
 	if pollInterval <= 0 {
 		pollInterval = defaultWaitPollInterval
-		c.logger.WithField("interval", pollInterval).Info("using default poll interval")
 	}
 
 	var lastStatus string
@@ -157,7 +156,7 @@ func (c *Client) WaitForTestRunReady(ctx context.Context, testRunID int64, pollI
 		default:
 			// created, queued, or any unrecognised state — keep polling.
 			if status != lastStatus {
-				c.logger.WithField("status", progress.FormatStatus()).Info("test status")
+				c.logger.WithField("status", progress.FormatStatus()).Debug("test status")
 				lastStatus = status
 			}
 		}

--- a/internal/cloudapi/provisioning/api_test.go
+++ b/internal/cloudapi/provisioning/api_test.go
@@ -442,7 +442,7 @@ func TestWaitForTestRunReady_LogsTransitionsOnce(t *testing.T) {
 		{Status: v6.StatusInitializing},
 	})
 
-	logger, hook := testutils.NewLoggerWithHook(t, logrus.InfoLevel)
+	logger, hook := testutils.NewLoggerWithHook(t, logrus.DebugLevel)
 	client, err := NewClient(logger, "test-token", srv.URL, "0.42.0", 7, 5*time.Second)
 	require.NoError(t, err)
 
@@ -450,10 +450,10 @@ func TestWaitForTestRunReady_LogsTransitionsOnce(t *testing.T) {
 	require.NoError(t, err)
 
 	entries := hook.Drain()
-	// Filter to only info-level entries with a "status" field.
+	// Filter to only debug-level entries with a "status" field.
 	var statusEntries []logrus.Entry
 	for _, e := range entries {
-		if e.Level == logrus.InfoLevel {
+		if e.Level == logrus.DebugLevel {
 			if _, ok := e.Data["status"]; ok {
 				statusEntries = append(statusEntries, e)
 			}

--- a/internal/output/cloud/output.go
+++ b/internal/output/cloud/output.go
@@ -228,7 +228,7 @@ func (out *Output) Start() error {
 		// env case (internal/cmd/outputs_cloud.go); this is the defensive
 		// backstop for any other source (e.g. a hand-written cloud config).
 		if out.config.MetricsPushURL.Valid != out.config.TestRunToken.Valid {
-			return fmt.Errorf(
+			return errors.New(
 				"both K6_CLOUD_METRICS_PUSH_URL and K6_CLOUD_TEST_RUN_TOKEN " +
 					"must be set together")
 		}


### PR DESCRIPTION
## What?

Two small follow-ups from review of the recently-merged cloud
provisioning work (`k6 cloud run --local-execution`):

- **Quieten `WaitForTestRunReady` polling logs**
  (`internal/cloudapi/provisioning/api.go`): remove the
  `Info("using default poll interval")` log, and drop the per-transition
  `test status` log from `Info` to `Debug`. The existing
  transition-logging test is updated to assert the new level.
- **Use `errors.New` for the scoped-cred error**
  (`internal/output/cloud/output.go`): the both-or-neither message has no
  format arguments, so `errors.New` fits better than `fmt.Errorf`.

## Why?

Reviewer feedback ([#6169 review][r1], [#6170 review][r2]).

The polling logs didn't match how the rest of the cloud subsystem logs.
No cloud output logs its poll/retry interval — they're silent constants
(the cloud-executed poll ticker, the API retry interval) — the only
`using default …` logs in the tree are `Warn`s about *invalid* input, and
routine status is surfaced via a progress bar or logged at `Debug` (final
run status) / `Trace` (periodic flushes), never per-transition at `Info`.
Removing the interval log and moving the transition log to `Debug` brings
this wait phase in line while keeping a `Debug` breadcrumb for
troubleshooting.

`errors.New` is the idiomatic choice for a static error string.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Follow-up to #6169 and #6170 (both merged).

[r1]: https://github.com/grafana/k6/pull/6169#pullrequestreview-4788049032
[r2]: https://github.com/grafana/k6/pull/6170#pullrequestreview-4810550412
