### PR TITLE
Use Docker Images in Browser e2e Tests

### DIFF
--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -89,8 +89,6 @@ jobs:
           for f in *.js; do
             docker run --rm \
               --pull never \
-#              --security-opt apparmor=unconfined \
-#              --user "$(id -u):$(id -g)" \
               --env K6_NO_USAGE_REPORT=true \
               -v "$PWD:/tests" \
             k6-browser:test run -q "/tests/$f"

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -80,7 +80,7 @@ jobs:
           set -x
           export K6_BROWSER_HEADLESS=true
           export K6_NO_USAGE_REPORT=true
-          export E2E_OUTPUT_PATH=${{ env.TEST_OUTPUT_DIR }}
+          export E2E_OUTPUT_PATH="${{ env.TEST_OUTPUT_DIR }}"
 
           for f in examples/browser/*.js; do
             if [ "$f" == "examples/browser/hosts.js" ] && [ "$RUNNER_OS" == "Windows" ]; then

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -85,14 +85,20 @@ jobs:
       - name: Run E2E tests
         run: |
           set -x
+          TEST_OUTPUT_DIR=${{ github.workspace }}/output
+
+          mkdir "$TEST_OUTPUT_DIR"
+
           cd examples/browser
           for f in *.js; do
             docker run --rm \
               --pull never \
               --env K6_NO_USAGE_REPORT=true \
+              --env E2E_OUTPUT_PATH=output \
               -v "$PWD:/home/k6/tests" \
+              -v "$TEST_OUTPUT_DIR:/home/k6/output" \
             k6-browser:test run -q "./tests/$f"
           done
       - name: Check screenshot
         # TODO: Do something more sophisticated?
-        run: test -s screenshot.png
+        run: test -s "$TEST_OUTPUT_DIR/screenshot.png"

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -89,7 +89,7 @@ jobs:
           for f in examples/browser/*.js; do
             docker run --rm \
               --pull never \
-              --security-opt apparmor=unconfined \                                         
+              --security-opt apparmor=unconfined \
               --user "$(id -u):$(id -g)" \
               --env K6_BROWSER_HEADLESS=true \
               --env K6_NO_USAGE_REPORT=true \

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -65,20 +65,35 @@ jobs:
 
           go build .
           ./k6 version
+      - name: Build docker image
+        run: docker buildx build --target with-browser --load -t k6-browser:test .
+#      - name: Run E2E tests
+#        run: |
+#          set -x
+#          if [ "$RUNNER_OS" == "Linux" ] && [ "$RUNNER_ARCH" == "X64" ]; then
+#            export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
+#          fi
+#          export K6_BROWSER_HEADLESS=true
+#          export K6_NO_USAGE_REPORT=true
+#          for f in examples/browser/*.js; do
+#            if [ "$f" == "examples/browser/hosts.js" ] && [ "$RUNNER_OS" == "Windows" ]; then
+#              echo "skipping $f on Windows"
+#              continue
+#            fi
+#            ./k6 run -q "$f"
+#          done
       - name: Run E2E tests
         run: |
           set -x
-          if [ "$RUNNER_OS" == "Linux" ] && [ "$RUNNER_ARCH" == "X64" ]; then
-            export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
-          fi
-          export K6_BROWSER_HEADLESS=true
-          export K6_NO_USAGE_REPORT=true
+
           for f in examples/browser/*.js; do
-            if [ "$f" == "examples/browser/hosts.js" ] && [ "$RUNNER_OS" == "Windows" ]; then
-              echo "skipping $f on Windows"
-              continue
-            fi
-            ./k6 run -q "$f"
+            docker run --rm \
+              --pull never \
+              --user "$(id -u):$(id -g)" \
+              --env K6_BROWSER_HEADLESS=true \
+              --env K6_NO_USAGE_REPORT=true \
+              -v "$PWD:/home/k6" \
+            k6-browser:test run -q "$f"
           done
       - name: Check screenshot
         # TODO: Do something more sophisticated?

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -27,9 +27,20 @@ jobs:
       matrix:
 #        go: [stable, tip]
         go: [stable]
-#        platform: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+#        platform: [ubuntu-latest]
+        include:
+          - platform: ubuntu-latest
+            docker: true
+          - platform: ubuntu-24.04-arm
+            docker: true
+          - platform: windows-latest
+            docker: false
+          - platform: macos-latest
+            docker: false
     runs-on: ${{ matrix.platform }}
+    env:
+      TEST_OUTPUT_DIR: ${{ github.workspace }}/e2e-output
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -52,12 +63,6 @@ jobs:
           echo "GOPATH=$HOME/go" >> "$GITHUB_ENV"
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
           echo "$HOME/sdk/gotip/bin" >> "$GITHUB_PATH"
-      - name: Install chromium
-        # This is only needed on arm images, chromium comes preinstalled on amd64 runner images.
-        if: contains(matrix.platform, 'arm')
-        run: |
-          sudo apt update && sudo apt install chromium-browser
-          chromium --version
       - name: Build k6
         run: |
           which go
@@ -65,41 +70,46 @@ jobs:
 
           go build .
           ./k6 version
-      - name: Build docker image
-        run: docker buildx build --target with-browser --load -t k6-browser:test .
-#      - name: Run E2E tests
-#        run: |
-#          set -x
-#          if [ "$RUNNER_OS" == "Linux" ] && [ "$RUNNER_ARCH" == "X64" ]; then
-#            export K6_BROWSER_EXECUTABLE_PATH=/usr/bin/google-chrome
-#          fi
-#          export K6_BROWSER_HEADLESS=true
-#          export K6_NO_USAGE_REPORT=true
-#          for f in examples/browser/*.js; do
-#            if [ "$f" == "examples/browser/hosts.js" ] && [ "$RUNNER_OS" == "Windows" ]; then
-#              echo "skipping $f on Windows"
-#              continue
-#            fi
-#            ./k6 run -q "$f"
-#          done
-      - name: Run E2E tests
+      - name: Prepare Output Directory
+        run: |
+          mkdir -p "${{ env.TEST_OUTPUT_DIR }}"
+          chmod 777 "${{ env.TEST_OUTPUT_DIR }}"
+      - name: Run E2E tests - On host
+        if: matrix.docker == false
         run: |
           set -x
-          TEST_OUTPUT_DIR=${{ github.workspace }}/e2e-output
+          export K6_BROWSER_HEADLESS=true
+          export K6_NO_USAGE_REPORT=true
+          export E2E_OUTPUT_PATH=${{ env.TEST_OUTPUT_DIR }}
 
-          mkdir "$TEST_OUTPUT_DIR"
-          chmod 777 "$TEST_OUTPUT_DIR"
+          for f in examples/browser/*.js; do
+            if [ "$f" == "examples/browser/hosts.js" ] && [ "$RUNNER_OS" == "Windows" ]; then
+              echo "skipping $f on Windows"
+              continue
+            fi
+            ./k6 run -q "$f"
+          done
+
+      - name: Build docker image
+        if: matrix.docker == true
+        run: docker buildx build --target with-browser --load -t k6-browser:test .
+      - name: Run E2E tests - In Docker
+        if: matrix.docker == true
+        run: |
+          set -x
 
           cd examples/browser
           for f in *.js; do
+            # E2E_OUTPUT_PATH controls where the screenshot test stores the screenshot.
+            # By default it writes into the home directory, which we can't mount to without breaking Chrome.
             docker run --rm \
               --pull never \
               --env K6_NO_USAGE_REPORT=true \
               --env E2E_OUTPUT_PATH=/output \
               -v "$PWD:/tests" \
-              -v "$TEST_OUTPUT_DIR:/output" \
+              -v "${{ env.TEST_OUTPUT_DIR }}:/output" \
             k6-browser:test run -q "/tests/$f"
           done
       - name: Check screenshot
         # TODO: Do something more sophisticated?
-        run: test -s "${{ github.workspace }}/e2e-output"
+        run: test -s "${{ env.TEST_OUTPUT_DIR }}/screenshot.png"

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -90,9 +90,9 @@ jobs:
             docker run --rm \
               --pull never \
               --env K6_NO_USAGE_REPORT=true \
-              -v "$PWD:/tests" \
-            k6-browser:test run -q "/tests/$f"
+              -v "$PWD:/home/k6/tests" \
+            k6-browser:test run -q "./tests/$f"
           done
-#      - name: Check screenshot
-#        # TODO: Do something more sophisticated?
-#        run: test -s screenshot.png
+      - name: Check screenshot
+        # TODO: Do something more sophisticated?
+        run: test -s screenshot.png

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -104,7 +104,7 @@ jobs:
               --pull never \
               --env K6_NO_USAGE_REPORT=true \
               --env E2E_OUTPUT_PATH=/output \
-              -v "$PWD:/tests" \
+              -v "$PWD:/tests:ro" \
               -v "${{ env.TEST_OUTPUT_DIR }}:/output" \
             k6-browser:test run -q "/tests/$f"
           done

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -25,8 +25,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [stable, tip]
-        platform: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+#        go: [stable, tip]
+        go: [stable]
+#        platform: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
+        platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout code

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -85,17 +85,16 @@ jobs:
       - name: Run E2E tests
         run: |
           set -x
-
-          for f in examples/browser/*.js; do
+          cd examples/browser
+          for f in *.js; do
             docker run --rm \
               --pull never \
               --security-opt apparmor=unconfined \
               --user "$(id -u):$(id -g)" \
-              --env K6_BROWSER_HEADLESS=true \
               --env K6_NO_USAGE_REPORT=true \
-              -v "$PWD:/home/k6" \
-            k6-browser:test run -q "$f"
+              -v "$PWD:/tests" \
+            k6-browser:test run -q "/tests/$f"
           done
-      - name: Check screenshot
-        # TODO: Do something more sophisticated?
-        run: test -s screenshot.png
+#      - name: Check screenshot
+#        # TODO: Do something more sophisticated?
+#        run: test -s screenshot.png

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -88,16 +88,17 @@ jobs:
           TEST_OUTPUT_DIR=${{ github.workspace }}/e2e-output
 
           mkdir "$TEST_OUTPUT_DIR"
+          chmod 777 "$TEST_OUTPUT_DIR"
 
           cd examples/browser
           for f in *.js; do
             docker run --rm \
               --pull never \
               --env K6_NO_USAGE_REPORT=true \
-              --env E2E_OUTPUT_PATH=output \
-              -v "$PWD:/home/k6/tests" \
-              -v "$TEST_OUTPUT_DIR:/home/k6/output" \
-            k6-browser:test run -q "./tests/$f"
+              --env E2E_OUTPUT_PATH=/output \
+              -v "$PWD:/tests" \
+              -v "$TEST_OUTPUT_DIR:/output" \
+            k6-browser:test run -q "/tests/$f"
           done
       - name: Check screenshot
         # TODO: Do something more sophisticated?

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -89,8 +89,8 @@ jobs:
           for f in *.js; do
             docker run --rm \
               --pull never \
-              --security-opt apparmor=unconfined \
-              --user "$(id -u):$(id -g)" \
+#              --security-opt apparmor=unconfined \
+#              --user "$(id -u):$(id -g)" \
               --env K6_NO_USAGE_REPORT=true \
               -v "$PWD:/tests" \
             k6-browser:test run -q "/tests/$f"

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -89,6 +89,7 @@ jobs:
           for f in examples/browser/*.js; do
             docker run --rm \
               --pull never \
+              --security-opt apparmor=unconfined \                                         
               --user "$(id -u):$(id -g)" \
               --env K6_BROWSER_HEADLESS=true \
               --env K6_NO_USAGE_REPORT=true \

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -25,10 +25,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-#        go: [stable, tip]
-        go: [stable]
+        go: [stable, tip]
         platform: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
-#        platform: [ubuntu-latest]
         include:
           - platform: ubuntu-latest
             docker: true

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Run E2E tests
         run: |
           set -x
-          TEST_OUTPUT_DIR=${{ github.workspace }}/output
+          TEST_OUTPUT_DIR=${{ github.workspace }}/e2e-output
 
           mkdir "$TEST_OUTPUT_DIR"
 

--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -102,4 +102,4 @@ jobs:
           done
       - name: Check screenshot
         # TODO: Do something more sophisticated?
-        run: test -s "$TEST_OUTPUT_DIR/screenshot.png"
+        run: test -s "${{ github.workspace }}/e2e-output"

--- a/examples/browser/screenshot.js
+++ b/examples/browser/screenshot.js
@@ -20,10 +20,12 @@ export const options = {
 export default async function() {
   const context = await browser.newContext();
   const page = await context.newPage();
-  
+
   try {
     await page.goto('https://quickpizza.grafana.com/test.k6.io/');
-    await page.screenshot({ path: 'screenshot.png' });
+
+	const outputPath = __ENV.E2E_OUTPUT_PATH || '.'
+  	await page.screenshot({ path: `${outputPath}/screenshot.png` });
     // TODO: Assert this somehow. Upload as CI artifact or just an external `ls`?
     // Maybe even do a fuzzy image comparison against a preset known good screenshot?
   } catch (error) {

--- a/examples/browser/screenshot.js
+++ b/examples/browser/screenshot.js
@@ -7,7 +7,7 @@ export const options = {
       executor: 'shared-iterations',
       options: {
         browser: {
-            type: 'chromium',
+          type: 'chromium',
         },
       },
     },
@@ -24,8 +24,8 @@ export default async function() {
   try {
     await page.goto('https://quickpizza.grafana.com/test.k6.io/');
 
-	const outputPath = __ENV.E2E_OUTPUT_PATH || '.'
-  	await page.screenshot({ path: `${outputPath}/screenshot.png` });
+    const outputPath = __ENV.E2E_OUTPUT_PATH || '.';
+    await page.screenshot({ path: `${outputPath}/screenshot.png` });
     // TODO: Assert this somehow. Upload as CI artifact or just an external `ls`?
     // Maybe even do a fuzzy image comparison against a preset known good screenshot?
   } catch (error) {

--- a/examples/browser/screenshot.js
+++ b/examples/browser/screenshot.js
@@ -29,7 +29,7 @@ export default async function() {
     // TODO: Assert this somehow. Upload as CI artifact or just an external `ls`?
     // Maybe even do a fuzzy image comparison against a preset known good screenshot?
   } catch (error) {
-    fail(`Browser iteration failed: ${error.message}`);
+    fail(`Browser iteration failed: ${error}`);
   } finally {
     await page.close();
   }


### PR DESCRIPTION
## What?

Adjusted the e2e testing workflow to execute the scripts in docker containers on Linux based runners. Windows and MacOS still run k6 directly.
Introduced an environment Variable E2E_OUTPUT_PATH to control where output generated by tests (e.g. a screenshot) is stored. Currently only used in `screenshot.js`.

## Why?
Running our tests in docker containers ensures that our images stay functional and we can catch issues early.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes #5701 
