### PR TITLE
Fix loki shutdown log loss and surface dropped cloud logs

### DIFF
--- a/internal/log/cloud/cloud.go
+++ b/internal/log/cloud/cloud.go
@@ -12,6 +12,7 @@ package cloudlog
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -210,6 +211,11 @@ func (p *Pusher) Listen(ctx context.Context) { //nolint:contextcheck
 	// hook so it runs its synchronous final flush, and waits for that to
 	// complete. lokiHook.Fire is a blocking send, so forwarding must happen
 	// while the loki hook is still draining its channel (before lokiCancel).
+	//
+	// reportDropped runs last, after the final flush has been pushed: its
+	// notice shares the "warning" stream with the loki hook's own limit-drop
+	// message, so it must carry the newest timestamp and be pushed after it —
+	// otherwise Loki with unordered_writes=false rejects the older flush write.
 	finish := func() {
 		for {
 			select {
@@ -218,6 +224,7 @@ func (p *Pusher) Listen(ctx context.Context) { //nolint:contextcheck
 			default:
 				lokiCancel()
 				<-lokiDone
+				p.reportDropped(lokiHook)
 				return
 			}
 		}
@@ -237,6 +244,31 @@ func (p *Pusher) Listen(ctx context.Context) { //nolint:contextcheck
 			finish()
 			return
 		}
+	}
+}
+
+// reportDropped surfaces the entries Fire dropped when the buffer was full, so
+// the loss is visible rather than silent. The count is read once as a shutdown
+// summary; drops after this point are not reported.
+//
+// It uses the loki hook's NoticePusher capability, which pushes the notice
+// immediately and exempt from the hook's per-batch limit — otherwise a full
+// final batch (many buffered entries at shutdown, exactly when drops are
+// likely) would swallow the notice itself.
+func (p *Pusher) reportDropped(h log.AsyncHook) {
+	n := p.dropped.Load()
+	if n == 0 {
+		return
+	}
+
+	np, ok := h.(log.NoticePusher)
+	if !ok {
+		return
+	}
+
+	msg := fmt.Sprintf("k6 dropped %d log messages because the cloud log buffer was full", n)
+	if err := np.PushNotice(msg); err != nil && p.fallbackLogger != nil {
+		p.fallbackLogger.WithError(err).Warn("could not push the dropped-cloud-logs notice")
 	}
 }
 

--- a/internal/log/cloud/cloud_test.go
+++ b/internal/log/cloud/cloud_test.go
@@ -2,9 +2,11 @@ package cloudlog
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -135,6 +137,106 @@ func TestPusher_FireNeverBlocks(t *testing.T) {
 	}
 
 	assert.Equal(t, int64(overflow), p.dropped.Load())
+}
+
+// TestPusher_ReportsDroppedLogs proves the front-buffer drop counter is
+// surfaced rather than silently discarded, even when the loki hook's own
+// per-batch limit is already exhausted: the notice must bypass that limit. The
+// limit is set well below the number of forwarded entries so a naive push
+// (subject to the limit) would drop the notice itself.
+//
+// It also asserts push ordering: the notice shares the "warning" stream with
+// the loki hook's own limit-drop message, so across pushes that stream's
+// timestamps must be non-decreasing, otherwise Loki with unordered_writes=false
+// rejects the older write.
+func TestPusher_ReportsDroppedLogs(t *testing.T) {
+	t.Parallel()
+
+	var (
+		mu       sync.Mutex
+		requests []string // request bodies, in the order the server received them
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		b, _ := io.ReadAll(req.Body)
+		mu.Lock()
+		requests = append(requests, string(b))
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	const overflow = 7
+
+	p := New(testutils.NewLogger(t))
+	p.SetConfig(Config{
+		PushURL:   srv.URL,
+		Token:     "tok",
+		TestRunID: "run-dropped",
+		// Deliberately far below bufferCap: forwarding the buffered entries
+		// exhausts the loki per-batch limit, so the notice must bypass it.
+		Limit:      10,
+		PushPeriod: time.Hour, // only the shutdown push
+	})
+
+	// Overflow the buffer before Listen consumes anything, so exactly `overflow`
+	// entries are dropped by Fire.
+	for range bufferCap + overflow {
+		require.NoError(t, p.Fire(&logrus.Entry{Time: time.Now(), Level: logrus.InfoLevel, Message: "x"}))
+	}
+	require.Equal(t, int64(overflow), p.dropped.Load())
+
+	ctx := t.Context()
+	listenDone := make(chan struct{})
+	go func() {
+		p.Listen(ctx)
+		close(listenDone)
+	}()
+
+	require.NoError(t, p.Drain(context.Background()))
+	select {
+	case <-listenDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Listen did not return after Drain")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.Contains(t, strings.Join(requests, ""),
+		"dropped 7 log messages because the cloud log buffer was full",
+		"the front-buffer drop count must survive the loki per-batch limit")
+
+	// Collect the "warning" stream timestamps in the order they were pushed and
+	// assert they never go backwards across requests.
+	type lokiPush struct {
+		Streams []struct {
+			Stream map[string]string `json:"stream"`
+			Values [][]string        `json:"values"`
+		} `json:"streams"`
+	}
+	var warnTS []int64
+	for _, body := range requests {
+		var lp lokiPush
+		require.NoError(t, json.Unmarshal([]byte(body), &lp))
+		for _, s := range lp.Streams {
+			if s.Stream["level"] != logrus.WarnLevel.String() {
+				continue
+			}
+			for _, v := range s.Values {
+				require.GreaterOrEqual(t, len(v), 1)
+				ts, err := strconv.ParseInt(v[0], 10, 64)
+				require.NoError(t, err)
+				warnTS = append(warnTS, ts)
+			}
+		}
+	}
+	require.GreaterOrEqual(t, len(warnTS), 2,
+		"expected both the loki limit-drop warning and the cloud-buffer notice")
+	for i := 1; i < len(warnTS); i++ {
+		assert.GreaterOrEqual(t, warnTS[i], warnTS[i-1],
+			"warning-stream timestamps must not go backwards across pushes "+
+				"(an out-of-order write is rejected by Loki with unordered_writes=false)")
+	}
 }
 
 // TestPusher_TestRunIDLabelKept locks the backend's hard requirement: even

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -16,3 +16,11 @@ type AsyncHook interface {
 	// It stops when the context is canceled.
 	Listen(ctx context.Context)
 }
+
+// NoticePusher is an optional capability of an AsyncHook: it pushes a single
+// diagnostic line immediately, exempt from any per-batch limit the hook
+// normally enforces. Callers type-assert an AsyncHook to it to surface events
+// (such as an upstream buffer overflow) that must not be lost to that limit.
+type NoticePusher interface {
+	PushNotice(message string) error
+}

--- a/internal/log/loki.go
+++ b/internal/log/loki.go
@@ -418,6 +418,28 @@ func (h *lokiHook) createPushMessage(msgs []tmpMsg, cutOffIndex, dropped int) *l
 	return pushMsg
 }
 
+// PushNotice synchronously pushes a single warning line to loki, exempt from
+// the per-batch limit the main push loop enforces. It surfaces out-of-band
+// drops (for example an upstream buffer overflow) that must not be lost to that
+// limit. The line carries the hook's configured labels, so it is not rejected
+// for a missing test_run_id.
+func (h *lokiHook) PushNotice(message string) error {
+	pushMsg := new(lokiPushMessage)
+	pushMsg.maxSize = h.msgMaxSize
+	pushMsg.add(tmpMsg{
+		labels: h.droppedLabels,
+		msg:    message,
+		t:      time.Now().UnixNano(),
+	})
+
+	var b bytes.Buffer
+	if _, err := pushMsg.WriteTo(&b); err != nil {
+		return err
+	}
+
+	return h.push(b)
+}
+
 func (h *lokiHook) push(b bytes.Buffer) error {
 	body := b.Bytes()
 

--- a/internal/log/loki.go
+++ b/internal/log/loki.go
@@ -204,7 +204,7 @@ func (opts *LokiHookOptions) parseArgs(line string) error {
 //
 // TODO benchmark this
 //
-//nolint:funlen
+//nolint:funlen,gocognit
 func (h *lokiHook) Listen(ctx context.Context) {
 	var (
 		msgs       = make([]tmpMsg, h.limit)
@@ -311,6 +311,26 @@ func (h *lokiHook) Listen(ctx context.Context) {
 		count++
 	}
 
+	// drainQueued flushes entries still buffered in h.ch into msgs without
+	// blocking. Called on shutdown so the final push includes everything Fire
+	// already accepted; best-effort, it does not wait for entries still being
+	// Fired concurrently with the shutdown.
+	drainQueued := func() {
+		for {
+			select {
+			case entry, ok := <-h.ch:
+				if !ok {
+					// h.ch is never closed today; this guards a future close
+					// from spinning on nil receives.
+					return
+				}
+				appendEntry(entry)
+			default:
+				return
+			}
+		}
+	}
+
 	for {
 		select {
 		case entry := <-h.ch:
@@ -321,6 +341,8 @@ func (h *lokiHook) Listen(ctx context.Context) {
 			ch <- t.Add(-(h.pushPeriod / 2)).UnixNano()
 			<-ch
 		case <-ctx.Done():
+			drainQueued()
+
 			ch := make(chan int64)
 			pushCh <- ch
 			ch <- time.Now().Add(time.Second).UnixNano()

--- a/internal/log/loki.go
+++ b/internal/log/loki.go
@@ -274,39 +274,47 @@ func (h *lokiHook) Listen(ctx context.Context) {
 		}
 	}()
 
+	// appendEntry buffers one entry into msgs, or counts it as dropped once the
+	// per-push-period limit is reached. It mutates the count, dropped and msgs
+	// loop state, so it must run only on the main goroutine — never while the
+	// push goroutine is swapping msgs and resetting the counters.
+	appendEntry := func(entry *logrus.Entry) {
+		if count == h.limit {
+			dropped++
+
+			return
+		}
+
+		// Arguably we can directly generate the final marshalled version of the labels right here
+		// through sorting the entry.Data, removing additionalparams from it and then dumping it
+		// as the final marshal and appending level and h.labels after it.
+		// If we reuse some kind of big enough `[]byte` buffer we can also possibly skip on some
+		// of allocation. Combined with the cutoff part and directly pushing in the final data
+		// type this can be really a lot faster and to use a lot less memory
+		labels := make(map[string]string, len(entry.Data)+1)
+		for k, v := range entry.Data {
+			labels[k] = fmt.Sprint(v) // TODO optimize ?
+		}
+		for _, params := range h.labels {
+			labels[params[0]] = params[1]
+		}
+		labels["level"] = entry.Level.String()
+		msg := h.filterLabels(labels, entry.Message) // TODO we can do this while constructing
+		// have the cutoff here ?
+		// if we cutoff here we can cut somewhat on the backbuffers and optimize the inserting
+		// in/creating of the final Streams that we push
+		msgs[count] = tmpMsg{
+			labels: labels,
+			msg:    msg,
+			t:      entry.Time.UnixNano(),
+		}
+		count++
+	}
+
 	for {
 		select {
 		case entry := <-h.ch:
-			if count == h.limit {
-				dropped++
-
-				continue
-			}
-
-			// Arguably we can directly generate the final marshalled version of the labels right here
-			// through sorting the entry.Data, removing additionalparams from it and then dumping it
-			// as the final marshal and appending level and h.labels after it.
-			// If we reuse some kind of big enough `[]byte` buffer we can also possibly skip on some
-			// of allocation. Combined with the cutoff part and directly pushing in the final data
-			// type this can be really a lot faster and to use a lot less memory
-			labels := make(map[string]string, len(entry.Data)+1)
-			for k, v := range entry.Data {
-				labels[k] = fmt.Sprint(v) // TODO optimize ?
-			}
-			for _, params := range h.labels {
-				labels[params[0]] = params[1]
-			}
-			labels["level"] = entry.Level.String()
-			msg := h.filterLabels(labels, entry.Message) // TODO we can do this while constructing
-			// have the cutoff here ?
-			// if we cutoff here we can cut somewhat on the backbuffers and optimize the inserting
-			// in/creating of the final Streams that we push
-			msgs[count] = tmpMsg{
-				labels: labels,
-				msg:    msg,
-				t:      entry.Time.UnixNano(),
-			}
-			count++
+			appendEntry(entry)
 		case t := <-ticker.C:
 			ch := make(chan int64)
 			pushCh <- ch

--- a/internal/log/loki_test.go
+++ b/internal/log/loki_test.go
@@ -373,3 +373,60 @@ func TestLokiFromConfigLineEmptyAddr(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, bare.(*lokiHook).addr, "bare loki uses the default endpoint")
 }
+
+// TestLokiHookDrainsQueuedEntriesOnShutdown pins that a ctx-cancel shutdown
+// flushes every entry already queued in the hook's channel, not just the ones
+// the run loop happened to consume before the cancel was selected. The entries
+// are pre-loaded and the context is already cancelled, so Listen takes its
+// shutdown branch with the whole batch still queued; without draining the
+// channel it would lose a suffix of them.
+func TestLokiHookDrainsQueuedEntriesOnShutdown(t *testing.T) {
+	t.Parallel()
+
+	const n = 100
+
+	var (
+		mu  sync.Mutex
+		got string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		mu.Lock()
+		got += string(b)
+		mu.Unlock()
+	}))
+	defer srv.Close()
+
+	// Limit well above n so nothing is limit-dropped, and a long push period so
+	// the shutdown push is the only one.
+	h, err := NewLokiHook(testutils.NewLogger(t), LokiHookOptions{
+		Addr:       srv.URL,
+		Limit:      2 * n,
+		PushPeriod: time.Hour,
+	})
+	require.NoError(t, err)
+
+	// Queue every entry before Listen starts (white-box: this test is in
+	// package log), so the shutdown branch must drain the channel to send them.
+	for i := range n {
+		h.(*lokiHook).ch <- &logrus.Entry{
+			Time:    time.Now(),
+			Level:   logrus.InfoLevel,
+			Message: fmt.Sprintf("msg-%d", i),
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	h.Listen(ctx)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i := range n {
+		assert.Contains(t, got, fmt.Sprintf("msg-%d", i), "entry %d was lost on shutdown", i)
+	}
+}


### PR DESCRIPTION
> **Follow-up to #6171** (now merged), rebased directly onto `master`. Addresses two review threads deferred from that PR. All commits signed.

## What?

Two fixes deferred from #6171's review:

1. **Drain the loki hook on shutdown** (`internal/log/loki.go`). `lokiHook.Listen`'s `ctx.Done()` branch pushed only the entries it had already consumed into its buffer and never drained what was still queued in the channel, so a shutdown could lose a tail of logs. It now drains the channel before the final push. This is shared code — it also fixes `--out loki`'s final-batch loss — and the loss was made observable by #6171's cloud-log `Drain()` path. Split into a pure-refactor commit (extract the per-entry buffering into an `appendEntry` helper) and the fix itself.

2. **Report dropped cloud logs** (`internal/log/cloud/cloud.go`). The cloud log `Pusher.Fire` counted entries it dropped when the front buffer was full, but nothing read that counter, so a full buffer lost logs silently. It now emits a synthetic `k6 dropped N log messages…` warning at shutdown, mirroring how `--out loki` reports its own limit drops. The notice is pushed via a new `log.NoticePusher` capability on the loki hook, which sends it as a standalone request exempt from the hook's per-batch limit (a full final batch would otherwise swallow it), and it is pushed *after* the final flush so it carries the newest timestamp in the `warning` stream it shares with the hook's own limit-drop message — avoiding an out-of-order write that Loki rejects with `unordered_writes=false`.

Three atomic commits, each individually buildable + lintable + green under `make check`.

## Why?

Both were flagged in #6171's review as pre-existing gaps that its `Drain()` path exposed, but that belonged in a dedicated follow-up rather than widening that PR:

- The shutdown tail-loss lives in the shared loki hook (also used by `--out loki`), so fixing it there benefits both paths and was kept out of the cloud-logs PR.
- The write-only dropped counter only becomes reliably reportable once the drain is fixed — otherwise the "dropped N" notice could itself be lost on shutdown, which is why it is sequenced after the drain fix here.

## Checklist

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

- Follows #6171 (cloud log streaming for `k6 cloud run --local-execution`), now merged; addresses two of its deferred review threads.
- Drain tail-loss discussion: https://github.com/grafana/k6/pull/6171#discussion_r3675784259
