### PR TITLE
fix(browser): use filepath.ToSlash for URL paths in file persister

### DIFF
--- a/internal/js/modules/k6/browser/storage/file_persister.go
+++ b/internal/js/modules/k6/browser/storage/file_persister.go
@@ -169,7 +169,7 @@ func buildPresignedRequestBody(basePath, path string) ([]byte, error) {
 			Name string `json:"name"`
 		}{
 			{
-				Name: filepath.Join(basePath, path),
+				Name: filepath.ToSlash(filepath.Join(basePath, path)),
 			},
 		},
 	}

--- a/internal/js/modules/k6/browser/storage/file_persister_test.go
+++ b/internal/js/modules/k6/browser/storage/file_persister_test.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -82,11 +82,6 @@ func TestLocalFilePersister(t *testing.T) {
 
 func TestRemoteFilePersister(t *testing.T) {
 	t.Parallel()
-	if runtime.GOOS == "windows" {
-		t.Skip("not supported on windows for now")
-		// actual problem is that the paths used are with reverse slash even when they get to be inside JSON
-		// which leads to them being parsed as escepe codes when they shouldn't
-	}
 
 	const (
 		basePath          = "screenshots"
@@ -239,7 +234,7 @@ func TestRemoteFilePersister(t *testing.T) {
 					// Does the response match the expected format?
 					wantPresignedURLBody := fmt.Sprintf(
 						tt.wantPresignedURLBody,
-						filepath.Join(basePath, tt.path),
+						path.Join(basePath, tt.path),
 					)
 					assert.JSONEq(t, wantPresignedURLBody, string(bb))
 


### PR DESCRIPTION
## What

`buildPresignedRequestBody` was using `filepath.Join` to construct the file path embedded in the JSON request body. On Windows, `filepath.Join` produces backslashes (e.g. `screenshots\some\path\file.png`). When that string is inserted into a raw JSON template via `fmt.Sprintf` in the test, backslash sequences like `\s` and `\p` are invalid JSON escape sequences — `assert.JSONEq` cannot parse the expected value and the test fails.

## Fix

Wrap `filepath.Join` with `filepath.ToSlash` in `buildPresignedRequestBody` so the path always uses forward slashes before being JSON-marshaled. Also update the test to use `path.Join` (always `/`) instead of `filepath.Join` for the expected-body string, and remove the `runtime.GOOS == "windows"` skip.

## Changes

- `file_persister.go`: `filepath.ToSlash(filepath.Join(basePath, path))` in `buildPresignedRequestBody`
- `file_persister_test.go`: remove Windows skip, fix expected-body path join, remove unused `runtime` import

## Testing

```
go test ./internal/js/modules/k6/browser/storage/... -v
```

All 9 tests pass (including `TestRemoteFilePersister` which was previously skipped on Windows).

Closes #902