### PR TITLE
Introduce a smoke test of the browser image in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,13 +237,23 @@ jobs:
             -t $DOCKER_IMAGE_ID .
       - name: Check
         run: |
-          docker buildx build --load -t $DOCKER_IMAGE_ID .
+          set -x
+          CHECK_IMAGE_TAG="k6:check"
+          docker buildx build --target with-browser --load -t $CHECK_IMAGE_TAG .
           # Assert that simple cases works for the new built image
-          docker run $DOCKER_IMAGE_ID version
-          docker run $DOCKER_IMAGE_ID --help
-          docker run $DOCKER_IMAGE_ID help
-          docker run $DOCKER_IMAGE_ID run --help
-          docker run $DOCKER_IMAGE_ID inspect --help
+          docker run --rm --pull never $CHECK_IMAGE_TAG version
+          docker run --rm --pull never $CHECK_IMAGE_TAG --help
+          docker run --rm --pull never $CHECK_IMAGE_TAG help
+          docker run --rm --pull never $CHECK_IMAGE_TAG run --help
+          docker run --rm --pull never $CHECK_IMAGE_TAG inspect --help
+
+          # Run a browser script to smoke test the browser image
+          # Using framelocator.js because it does not depend on an external website
+          docker run --rm \
+            --pull never \
+            --env K6_NO_USAGE_REPORT=true \
+            -v "$PWD/examples/browser:/tests:ro" \
+            $CHECK_IMAGE_TAG run -q "/tests/framelocator.js"
       - name: Login to GAR (Docker Hub mirror)
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
         uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,13 +236,23 @@ jobs:
             -t $DOCKER_IMAGE_ID .
       - name: Check
         run: |
-          docker buildx build --load -t $DOCKER_IMAGE_ID .
+          set -x
+          CHECK_IMAGE_TAG="k6:check"
+          docker buildx build --target with-browser --load -t $CHECK_IMAGE_TAG .
           # Assert that simple cases works for the new built image
-          docker run $DOCKER_IMAGE_ID version
-          docker run $DOCKER_IMAGE_ID --help
-          docker run $DOCKER_IMAGE_ID help
-          docker run $DOCKER_IMAGE_ID run --help
-          docker run $DOCKER_IMAGE_ID inspect --help
+          docker run --rm --pull never $CHECK_IMAGE_TAG version
+          docker run --rm --pull never $CHECK_IMAGE_TAG --help
+          docker run --rm --pull never $CHECK_IMAGE_TAG help
+          docker run --rm --pull never $CHECK_IMAGE_TAG run --help
+          docker run --rm --pull never $CHECK_IMAGE_TAG inspect --help
+
+          # Run a browser script to smoke test the browser image
+          # Using framelocator.js because it does not depend on an external website
+          docker run --rm \
+            --pull never \
+            --env K6_NO_USAGE_REPORT=true \
+            -v "$PWD/examples/browser:/tests:ro" \
+            $CHECK_IMAGE_TAG run -q "/tests/framelocator.js"
       - name: Login to GAR (Docker Hub mirror)
         if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v') }}
         uses: grafana/shared-workflows/actions/login-to-gar@c7ad5f57693ac858c698d95783685a9cbfd91223 # login-to-gar/v1.0.1

--- a/examples/browser/framelocator.js
+++ b/examples/browser/framelocator.js
@@ -19,9 +19,11 @@ export const options = {
 }
 
 export default async function () {
-  const page = await browser.newPage();
+  let page;
 
   try {
+    page = await browser.newPage();
+
     // create a page with an iframe
     await page.setContent(`
       <html>
@@ -74,6 +76,8 @@ export default async function () {
     const message = error.message || error.toString();
     exec.test.fail(`Browser iteration failed: ${message}`);
   } finally {
-    await page.close();
+    if (page) {
+      await page.close();
+    }
   }
 }

--- a/examples/browser/framelocator.js
+++ b/examples/browser/framelocator.js
@@ -1,5 +1,6 @@
 import { browser } from 'k6/browser';
-import { check, fail } from 'k6';
+import { check } from 'k6';
+import exec from 'k6/execution';
 
 export const options = {
   scenarios: {
@@ -66,7 +67,12 @@ export default async function () {
     });
 
   } catch (error) {
-    fail(`Browser iteration failed: ${error.message}`);
+    // This script is run as a smoke test in the build workflow to verify the
+    // browser Docker image. exec.test.fail() is used here (instead of fail())
+    // to produce a non-zero exit code on exception, failing that CI check.
+    // error.message is empty for rejected promises, so fall back to error.toString()
+    const message = error.message || error.toString();
+    exec.test.fail(`Browser iteration failed: ${message}`);
   } finally {
     await page.close();
   }


### PR DESCRIPTION
## What?

Extends the check build step to run a single browser example script as a smoke test to ensure the with-browser image is functional.

Succeeds #6231 as we decided to change the approach.

## Why?

This allows us to catch issues early and avoid situations as described in #5701 

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

Closes #5701 

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
