### PR TITLE
Fix urlencoded form bodies encoding null as <nil> and objects as map[...]

### DIFF
--- a/js/modules/k6/http/request.go
+++ b/js/modules/k6/http/request.go
@@ -178,9 +178,36 @@ func (c *Client) parseRequest(
 		result.ResponseType = httpext.ResponseTypeText
 	}
 
+	// formatFormVal converts a single value from a JS object body into its
+	// application/x-www-form-urlencoded string representation.
+	//
+	// JavaScript null and undefined are both exported to a nil Go value; they
+	// are encoded as an empty value (e.g. "key=") instead of Go's default
+	// "<nil>" string. This matches how Node's querystring and jQuery.param
+	// serialize null/undefined. See https://github.com/grafana/k6/issues/1185.
+	//
+	// Nested objects and arrays-of-objects cannot be represented in a flat
+	// urlencoded form body. Rather than emitting Go's "map[...]"/"[...]"
+	// representation, they are encoded as an empty value and a warning is
+	// logged. Users who need to send structured data should serialize it
+	// explicitly, e.g. with JSON.stringify().
+	// See https://github.com/grafana/k6/issues/2369.
 	formatFormVal := func(v any) string {
-		// TODO: handle/warn about unsupported/nested values
-		return fmt.Sprintf("%v", v)
+		switch val := v.(type) {
+		case nil:
+			return ""
+		case string:
+			return val
+		case map[string]any, []any:
+			state.Logger.Warnf(
+				"cannot urlencode a nested %T value in a request form body; encoding it "+
+					"as an empty value, use JSON.stringify() to send structured data",
+				val,
+			)
+			return ""
+		default:
+			return fmt.Sprintf("%v", val)
+		}
 	}
 
 	handleObjectBody := func(data map[string]any) error {

--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -1314,6 +1314,72 @@ func TestRequest(t *testing.T) {
 	})
 }
 
+// TestRequestFormBodyEncoding verifies how JS object bodies that get
+// auto-encoded as application/x-www-form-urlencoded handle null/undefined and
+// nested values. See https://github.com/grafana/k6/issues/1185.
+func TestRequestFormBodyEncoding(t *testing.T) {
+	t.Parallel()
+	ts := newTestCase(t)
+	tb := ts.tb
+	rt := ts.runtime.VU.Runtime()
+	sr := tb.Replacer.Replace
+
+	// url.Values.Encode sorts keys alphabetically and preserves slice order
+	// within a key, so the encoded body is deterministic and can be asserted
+	// on directly.
+	t.Run("null and undefined are encoded as empty values", func(t *testing.T) {
+		ts.hook.Reset()
+		_, err := rt.RunString(sr(`
+			var res = http.post("HTTPBIN_URL/post", {data: "something", another: null, missing: undefined});
+			if (res.status != 200) { throw new Error("wrong status: " + res.status); }
+			if (res.request.body !== "another=&data=something&missing=") {
+				throw new Error("wrong body: " + res.request.body);
+			}
+		`))
+		require.NoError(t, err)
+		assert.Nil(t, ts.hook.LastEntry())
+	})
+
+	t.Run("null inside an array is encoded as empty", func(t *testing.T) {
+		ts.hook.Reset()
+		_, err := rt.RunString(sr(`
+			var res = http.post("HTTPBIN_URL/post", {c: ["one", null]});
+			if (res.status != 200) { throw new Error("wrong status: " + res.status); }
+			if (res.request.body !== "c=one&c=") { throw new Error("wrong body: " + res.request.body); }
+		`))
+		require.NoError(t, err)
+		assert.Nil(t, ts.hook.LastEntry())
+	})
+
+	t.Run("nested objects are not encoded as map[...] and log a warning", func(t *testing.T) {
+		ts.hook.Reset()
+		_, err := rt.RunString(sr(`
+			var res = http.post("HTTPBIN_URL/post", {a: "x", nested: {inner: 1}});
+			if (res.status != 200) { throw new Error("wrong status: " + res.status); }
+			if (res.request.body !== "a=x&nested=") { throw new Error("wrong body: " + res.request.body); }
+		`))
+		require.NoError(t, err)
+		logEntry := ts.hook.LastEntry()
+		require.NotNil(t, logEntry)
+		assert.Equal(t, logrus.WarnLevel, logEntry.Level)
+		assert.Contains(t, logEntry.Message, "cannot urlencode a nested")
+	})
+
+	t.Run("arrays of objects are not encoded as map[...] and log a warning", func(t *testing.T) {
+		ts.hook.Reset()
+		_, err := rt.RunString(sr(`
+			var res = http.post("HTTPBIN_URL/post", {items: [{x: 1}, {y: 2}]});
+			if (res.status != 200) { throw new Error("wrong status: " + res.status); }
+			if (res.request.body !== "items=&items=") { throw new Error("wrong body: " + res.request.body); }
+		`))
+		require.NoError(t, err)
+		logEntry := ts.hook.LastEntry()
+		require.NotNil(t, logEntry)
+		assert.Equal(t, logrus.WarnLevel, logEntry.Level)
+		assert.Contains(t, logEntry.Message, "cannot urlencode a nested")
+	})
+}
+
 func TestRequestCancellation(t *testing.T) {
 	t.Parallel()
 	ts := newTestCase(t)


### PR DESCRIPTION
Closes #1185

When a JS object is passed as an HTTP request body, k6 auto-encodes it as
`application/x-www-form-urlencoded`. The encoder formatted every value with
`fmt.Sprintf("%v", ...)`, so a JavaScript `null`/`undefined` became the literal
string `<nil>` and a nested object/array became `map[...]`/`[...]`.

## Changes
- `formatFormVal` now encodes `null`/`undefined` (both export to a nil Go value)
  as an empty value (e.g. `key=`), matching Node's `querystring` and jQuery's
  `$.param`.
- Nested objects and arrays-of-objects cannot be represented in a flat
  urlencoded body, so they are encoded as an empty value and a warning is logged
  instead of emitting Go's `map[...]` representation (per maintainer guidance in
  the issue thread, values are not JSON-encoded). See #2369.
- Resolves the pre-existing `TODO` on unsupported/nested values.

## Compatibility
Backward-compatible: requests still succeed; only the encoded output for
previously-broken `null`/nested values changes.

## Tests
Adds `TestRequestFormBodyEncoding` covering null, undefined, null inside arrays,
nested objects, and arrays of objects.