### PR TITLE
chore: run CI on v1.x

### DIFF
--- a/.github/workflows/browser_e2e.yml
+++ b/.github/workflows/browser_e2e.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - v1.x
   pull_request:
   schedule:
     # At 06:00 AM UTC from Monday through Friday

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - master
+      - v1.x
     tags:
       - v*
   pull_request:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v1.x ]
 
 permissions:
   contents: read

--- a/.github/workflows/summary-code-generation.yml
+++ b/.github/workflows/summary-code-generation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - v1.x
   pull_request:
 
 defaults:

--- a/.github/workflows/tc39.yml
+++ b/.github/workflows/tc39.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - v1.x
   pull_request:
       paths:
           - 'js/**'

--- a/.github/workflows/test-browser.yml
+++ b/.github/workflows/test-browser.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - v.x
   pull_request:
 
 defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - v1.x
   pull_request:
 
 defaults:

--- a/.github/workflows/xk6.yml
+++ b/.github/workflows/xk6.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - v1.x
   pull_request:
 
 defaults:


### PR DESCRIPTION
## What?

Actually make v1.x run the same CI that master does.

 There is probably more concrete changes to be made - like publishing master-v1 ?!? But that is for a different PR

## Why?

We currently support v1 and v2 - but the CI deosn't run at all on the main v1 (v1.x) branch. This enables it so we can see problems earlier.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
