### PR TITLE
fix(browser): unflake TestPageOnResponse nil panic

### DIFF
--- a/internal/js/modules/k6/browser/k6ext/k6test/vu.go
+++ b/internal/js/modules/k6/browser/k6ext/k6test/vu.go
@@ -165,6 +165,11 @@ func (v *VU) SetVar(tb testing.TB, name string, value any) {
 func ToPromise(tb testing.TB, gv sobek.Value) *sobek.Promise {
 	tb.Helper()
 
+	// RunAsync can return a nil value when the event loop is interrupted
+	// (e.g. Abortf during IterStart). Guard before Export to avoid a nil
+	// pointer panic and surface a clear assertion failure instead.
+	require.NotNil(tb, gv, "expected a Promise, got nil sobek.Value (event loop likely interrupted)")
+
 	p, ok := gv.Export().(*sobek.Promise)
 	require.True(tb, ok, "got: %T, want *sobek.Promise", gv.Export())
 	return p

--- a/internal/js/modules/k6/browser/k6ext/k6test/vu_test.go
+++ b/internal/js/modules/k6/browser/k6ext/k6test/vu_test.go
@@ -1,0 +1,43 @@
+package k6test
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// recordingTB is a minimal testing.TB that records failures without
+// failing the surrounding real test.
+type recordingTB struct {
+	testing.TB
+	failed bool
+}
+
+func (r *recordingTB) Helper() {}
+
+func (r *recordingTB) Errorf(string, ...any) { r.failed = true }
+
+func (r *recordingTB) FailNow() {
+	r.failed = true
+	runtime.Goexit()
+}
+
+// TestToPromiseNilValue guards against the nil-pointer panic from #5124:
+// when RunAsync is interrupted (e.g. Abortf on IterStart failure), the
+// returned sobek.Value can be nil. ToPromise must fail the test cleanly
+// instead of panicking on gv.Export().
+func TestToPromiseNilValue(t *testing.T) {
+	t.Parallel()
+
+	tb := &recordingTB{TB: t}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer func() { _ = recover() }()
+		ToPromise(tb, nil)
+	}()
+	<-done
+
+	require.True(t, tb.failed, "ToPromise(nil) should fail the test without panicking")
+}

--- a/internal/js/modules/k6/browser/tests/page_test.go
+++ b/internal/js/modules/k6/browser/tests/page_test.go
@@ -2569,8 +2569,12 @@ type response struct {
 func TestPageOnResponse(t *testing.T) {
 	t.Parallel()
 
-	// Start and setup a webserver to test the page.on('request') handler.
-	tb := newTestBrowser(t, withHTTPServer())
+	// Skip the Go-level Chromium launch: this test only needs the HTTP server
+	// and drives the browser through the JS module after StartIteration.
+	// Launching both (newTestBrowser + IterStart) doubles Chromium processes
+	// and has caused flaky "error building browser on IterStart: canceled"
+	// failures under CI load (see #5124).
+	tb := newTestBrowser(t, withHTTPServer(), withSkipLaunch())
 
 	tb.withHandler("/home", func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintf(w, `<!DOCTYPE html>
@@ -2620,7 +2624,9 @@ func TestPageOnResponse(t *testing.T) {
 	//
 	// The code below is the JavaScript code that is executed in the k6 iteration.
 	// It will wait for all requests to be captured in returnValue, before returning.
-	gv, err := tb.vu.RunAsync(t, `
+	// Use RunPromise so a failed/interrupted RunAsync fails fast instead of
+	// panicking in ToPromise on a nil sobek.Value (#5124).
+	got := tb.vu.RunPromise(t, `
 		const context = await browser.newContext({locale: 'en-US', userAgent: 'some-user-agent'});
 		const page = await context.newPage();
 
@@ -2660,13 +2666,10 @@ func TestPageOnResponse(t *testing.T) {
 
 		return JSON.stringify(returnValue, null, 2);
 	`, tb.url("/home"))
-	require.NoError(t, err)
-
-	got := k6test.ToPromise(t, gv)
 
 	// Convert the result to a string and then to a slice of requests.
 	var responses []response
-	err = json.Unmarshal([]byte(got.Result().String()), &responses)
+	err := json.Unmarshal([]byte(got.Result().String()), &responses)
 	require.NoError(t, err)
 
 	// Normalize the date

--- a/internal/js/modules/k6/browser/tests/test_browser.go
+++ b/internal/js/modules/k6/browser/tests/test_browser.go
@@ -57,6 +57,8 @@ type testBrowser struct {
 	samples chan k6metrics.SampleContainer
 	// skipClose is set by the withSkipClose option.
 	skipClose bool
+	// skipLaunch is set by the withSkipLaunch option.
+	skipLaunch bool
 }
 
 // newTestBrowser configures and launches a new chrome browser.
@@ -70,6 +72,10 @@ type testBrowser struct {
 //   - withLogCache: enables the log cache.
 //   - withSamples: provides a channel to receive the browser metrics.
 //   - withSkipClose: skips closing the browser when the test finishes.
+//   - withSkipLaunch: skips launching the Go-level browser. Use this when the
+//     test only needs the VU + HTTP server and will build a managed browser via
+//     StartIteration (e.g. scripts that call browser.newContext()). Launching
+//     both browsers doubles Chromium processes and contributes to CI flakiness.
 func newTestBrowser(tb testing.TB, opts ...func(*testBrowser)) *testBrowser {
 	tb.Helper()
 
@@ -81,6 +87,13 @@ func newTestBrowser(tb testing.TB, opts ...func(*testBrowser)) *testBrowser {
 	tbr.vu.ActivateVU()
 	tbr.isBrowserTypeInitialized = true // some option require the browser type to be initialized.
 	tbr.applyOptions(opts...)           // apply post-init stage options.
+
+	if tbr.skipLaunch {
+		// Keep a usable context for helpers that call testBrowser.context()
+		// even when no Go-level browser is launched.
+		tbr.ctx = tbr.vu.Context()
+		return tbr
+	}
 
 	b, pid, err := tbr.browserType.Launch(context.Background(), tbr.vu.Context())
 	if err != nil {
@@ -301,6 +314,18 @@ func withSamples(sc chan k6metrics.SampleContainer) func(*testBrowser) {
 //	b := TestBrowser(t, withSkipClose())
 func withSkipClose() func(*testBrowser) {
 	return func(tb *testBrowser) { tb.skipClose = true }
+}
+
+// withSkipLaunch skips launching the Go-level Chromium process in
+// newTestBrowser. Use when the test drives the browser only through the JS
+// module (browser.newContext / newPage) after StartIteration, and only needs
+// the VU + optional HTTP test server from newTestBrowser.
+//
+// example:
+//
+//	b := newTestBrowser(t, withHTTPServer(), withSkipLaunch())
+func withSkipLaunch() func(*testBrowser) {
+	return func(tb *testBrowser) { tb.skipLaunch = true }
 }
 
 // GotoNewPage is a wrapper around testBrowser.NewPage and Page.Goto that fails


### PR DESCRIPTION
## Summary
- Stop launching an unused Go-level Chromium in `TestPageOnResponse` via `withSkipLaunch()`; the test only needs the HTTP server and the managed browser from `StartIteration`. Double launches contributed to flaky `error building browser on IterStart: canceled` under CI load.
- Harden `k6test.ToPromise` against a nil `sobek.Value` so interrupted event loops fail the test cleanly instead of panicking on `Export()` (the panic in #5124).
- Switch the test to `RunPromise` and add a regression unit test for the nil-value path.

Fixes #5124

## Test plan
- [x] `go test -run TestToPromiseNilValue ./internal/js/modules/k6/browser/k6ext/k6test/`
- [x] `go test -run '^TestPageOnResponse$' ./internal/js/modules/k6/browser/tests/`
- [x] `go test -count=10 -parallel 4 -run '^TestPageOnResponse$' ./internal/js/modules/k6/browser/tests/`
- [ ] CI browser tests on this PR