### PR TITLE
perf(grpc): avoid response JSON round-trip

### DIFF
--- a/internal/js/modules/k6/grpc/client_benchmark_test.go
+++ b/internal/js/modules/k6/grpc/client_benchmark_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/grafana/sobek"
 	"go.k6.io/k6/v2/internal/lib/netext/grpcext"
-	grpc_testing "go.k6.io/k6/v2/internal/lib/testutils/httpmultibin/grpc_testing"
+	"go.k6.io/k6/v2/internal/lib/testutils/httpmultibin/grpc_testing"
 	"go.k6.io/k6/v2/js/modulestest"
 	"go.k6.io/k6/v2/lib"
 	"go.k6.io/k6/v2/metrics"

--- a/internal/js/modules/k6/grpc/client_benchmark_test.go
+++ b/internal/js/modules/k6/grpc/client_benchmark_test.go
@@ -1,0 +1,143 @@
+package grpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/grafana/sobek"
+	"go.k6.io/k6/v2/internal/lib/netext/grpcext"
+	grpc_testing "go.k6.io/k6/v2/internal/lib/testutils/httpmultibin/grpc_testing"
+	"go.k6.io/k6/v2/js/modulestest"
+	"go.k6.io/k6/v2/lib"
+	"go.k6.io/k6/v2/metrics"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+const benchmarkClientInvokeMethod = "grpc.testing.TestService/UnaryCall"
+
+func BenchmarkClientInvokeResponse(b *testing.B) {
+	for _, responseSize := range []struct {
+		name string
+		size int
+	}{
+		{name: "128B", size: 128},
+		{name: "16KiB", size: 16 * 1024},
+	} {
+		b.Run(responseSize.name, func(b *testing.B) {
+			client, request := newBenchmarkClient(b, responseSize.size)
+			expectedBodyLength := base64.StdEncoding.EncodedLen(responseSize.size)
+
+			response, err := client.Invoke(benchmarkClientInvokeMethod, request, nil)
+			if err != nil {
+				b.Fatal(err)
+			}
+			validateBenchmarkResponse(b, response.Message, expectedBodyLength)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				response, err := client.Invoke(benchmarkClientInvokeMethod, request, nil)
+				if err != nil {
+					b.Fatal(err)
+				}
+				validateBenchmarkResponse(b, response.Message, expectedBodyLength)
+			}
+		})
+	}
+}
+
+func newBenchmarkClient(b *testing.B, responseSize int) (*Client, sobek.Value) {
+	b.Helper()
+
+	runtime := modulestest.NewRuntime(b)
+	registry := metrics.NewRegistry()
+	runtime.MoveToVUContext(&lib.State{
+		BuiltinMetrics: metrics.RegisterBuiltinMetrics(registry),
+		Options: lib.Options{
+			SystemTags: metrics.NewSystemTagSet(),
+		},
+		Samples: make(chan metrics.SampleContainer),
+		Tags:    lib.NewVUStateTags(registry.RootTagSet()),
+	})
+
+	client := &Client{
+		vu:    runtime.VU,
+		types: new(protoregistry.Types),
+	}
+	descriptors := &descriptorpb.FileDescriptorSet{
+		File: walkFileDescriptors(make(map[string]struct{}), grpc_testing.File_test_grpc_testing_test_proto),
+	}
+	if _, err := client.convertToMethodInfo(descriptors); err != nil {
+		b.Fatal(err)
+	}
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	grpc_testing.RegisterTestServiceServer(server, benchmarkTestService{
+		response: &grpc_testing.SimpleResponse{
+			Payload: &grpc_testing.Payload{
+				Body: bytes.Repeat([]byte("x"), responseSize),
+			},
+		},
+	})
+	go func() { _ = server.Serve(listener) }()
+	b.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	conn, err := grpcext.Dial(ctx, "bufconn", client.types,
+		grpc.WithBlock(), //nolint:staticcheck // grpcext.Dial uses grpc.DialContext, which supports WithBlock.
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		b.Fatal(err)
+	}
+	client.conn = conn
+	b.Cleanup(func() { _ = client.Close() })
+
+	return client, runtime.VU.Runtime().ToValue(map[string]any{"responseSize": responseSize})
+}
+
+func validateBenchmarkResponse(b *testing.B, message any, expectedBodyLength int) {
+	b.Helper()
+
+	response, ok := message.(map[string]any)
+	if !ok {
+		b.Fatalf("response message has type %T, want map[string]any", message)
+	}
+	payload, ok := response["payload"].(map[string]any)
+	if !ok {
+		b.Fatalf("response payload has type %T, want map[string]any", response["payload"])
+	}
+	body, ok := payload["body"].(string)
+	if !ok {
+		b.Fatalf("response body has type %T, want string", payload["body"])
+	}
+	if len(body) != expectedBodyLength {
+		b.Fatalf("response body has length %d, want %d", len(body), expectedBodyLength)
+	}
+}
+
+type benchmarkTestService struct {
+	grpc_testing.UnimplementedTestServiceServer
+
+	response *grpc_testing.SimpleResponse
+}
+
+func (s benchmarkTestService) UnaryCall(context.Context, *grpc_testing.SimpleRequest) (*grpc_testing.SimpleResponse, error) {
+	return s.response, nil
+}

--- a/internal/lib/netext/grpcext/convert.go
+++ b/internal/lib/netext/grpcext/convert.go
@@ -1,0 +1,538 @@
+package grpcext
+
+// This file mirrors vendored protojson conversion. TestConvertMatchesProtoJSON differentially pins
+// conversion parity against that implementation so protobuf upgrades fail the test rather than
+// silently diverging.
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+const (
+	anyMessageName       = "google.protobuf.Any"
+	durationMessageName  = "google.protobuf.Duration"
+	emptyMessageName     = "google.protobuf.Empty"
+	fieldMaskMessageName = "google.protobuf.FieldMask"
+	listValueMessageName = "google.protobuf.ListValue"
+	nullValueEnumName    = "google.protobuf.NullValue"
+	structMessageName    = "google.protobuf.Struct"
+	timestampMessageName = "google.protobuf.Timestamp"
+	valueMessageName     = "google.protobuf.Value"
+	wrapperPackageName   = "google.protobuf"
+
+	maxDurationSeconds = 315576000000
+	maxTimestampSecond = 253402300799
+	minTimestampSecond = -62135596800
+	maxNanos           = 999999999
+)
+
+var errDirectConversion = errors.New("cannot directly convert protobuf message")
+
+// convert turns a dynamic response into map and slice values Sobek can expose to JavaScript.
+// Sobek property access requires a real map-like value; a dynamic message can stringify correctly
+// while yielding undefined properties. When enabled, EmitUnpopulated retains zero/default fields
+// expected by JavaScript callers.
+//
+// It directly builds the values decoding protojson output would produce without a JSON buffer.
+// The protojson path remains a fallback for malformed messages or unsupported descriptor behavior.
+// Callers must provide an allocated message, as required by the legacy protojson conversion.
+func convert(marshaler protojson.MarshalOptions, message *dynamicpb.Message) (any, error) {
+	if message != nil {
+		converted, err := convertDirect(marshaler, message)
+		if err == nil {
+			return converted, nil
+		}
+	}
+
+	return convertWithJSON(marshaler, message)
+}
+
+func convertWithJSON(marshaler protojson.MarshalOptions, message *dynamicpb.Message) (any, error) {
+	raw, err := marshaler.Marshal(message)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal the message: %w", err)
+	}
+
+	var converted any
+	if err := json.Unmarshal(raw, &converted); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the message: %w", err)
+	}
+
+	return converted, nil
+}
+
+func convertDirect(marshaler protojson.MarshalOptions, message *dynamicpb.Message) (any, error) {
+	if message == nil || strings.Trim(marshaler.Indent, " \t") != "" {
+		return nil, errDirectConversion
+	}
+
+	converter := responseConverter{marshaler: marshaler}
+	converted, err := converter.message(message.ProtoReflect(), "")
+	if err != nil {
+		return nil, err
+	}
+	if !marshaler.AllowPartial {
+		if err := proto.CheckInitialized(message); err != nil {
+			return nil, err
+		}
+	}
+
+	return converted, nil
+}
+
+type responseConverter struct {
+	marshaler protojson.MarshalOptions
+}
+
+func (c responseConverter) message(message protoreflect.Message, typeURL string) (any, error) {
+	if !message.IsValid() || isMessageSet(message.Descriptor()) {
+		return nil, errDirectConversion
+	}
+
+	switch message.Descriptor().FullName() {
+	case anyMessageName:
+		return c.any(message)
+	case durationMessageName:
+		return c.duration(message)
+	case emptyMessageName:
+		return map[string]any{}, nil
+	case fieldMaskMessageName:
+		return c.fieldMask(message)
+	case listValueMessageName:
+		field := message.Descriptor().Fields().ByNumber(1)
+		if field == nil {
+			return nil, errDirectConversion
+		}
+		return c.list(message.Get(field), field)
+	case structMessageName:
+		field := message.Descriptor().Fields().ByNumber(1)
+		if field == nil {
+			return nil, errDirectConversion
+		}
+		return c.mapValue(message.Get(field), field)
+	case timestampMessageName:
+		return c.timestamp(message)
+	case valueMessageName:
+		return c.value(message)
+	}
+
+	if isWrapperMessage(message.Descriptor().FullName()) {
+		field := message.Descriptor().Fields().ByNumber(1)
+		return c.singular(message.Get(field), field)
+	}
+
+	return c.object(message, typeURL)
+}
+
+// any mirrors protojson's marshalAny behavior.
+func (c responseConverter) any(message protoreflect.Message) (any, error) {
+	fields := message.Descriptor().Fields()
+	typeField := fields.ByNumber(1)
+	valueField := fields.ByNumber(2)
+	if typeField == nil || valueField == nil {
+		return nil, errDirectConversion
+	}
+
+	if !message.Has(typeField) {
+		if !message.Has(valueField) {
+			return map[string]any{}, nil
+		}
+		return nil, errDirectConversion
+	}
+
+	typeURL := message.Get(typeField).String()
+	if !utf8.ValidString(typeURL) {
+		return nil, errDirectConversion
+	}
+
+	resolver := c.resolver()
+	embeddedType, err := resolver.FindMessageByURL(typeURL)
+	if err != nil {
+		return nil, errDirectConversion
+	}
+
+	embedded := embeddedType.New()
+	if err := (proto.UnmarshalOptions{AllowPartial: true, Resolver: resolver}).Unmarshal(
+		message.Get(valueField).Bytes(), embedded.Interface(),
+	); err != nil {
+		return nil, errDirectConversion
+	}
+
+	converted, err := c.message(embedded, typeURL)
+	if err != nil {
+		return nil, err
+	}
+	if isWellKnownMessage(embedded.Descriptor().FullName()) {
+		return map[string]any{"@type": typeURL, "value": converted}, nil
+	}
+
+	object, ok := converted.(map[string]any)
+	if !ok {
+		return nil, errDirectConversion
+	}
+	return object, nil
+}
+
+// duration mirrors protojson's marshalDuration behavior.
+func (c responseConverter) duration(message protoreflect.Message) (any, error) {
+	fields := message.Descriptor().Fields()
+	secondsField := fields.ByNumber(1)
+	nanosField := fields.ByNumber(2)
+	if secondsField == nil || nanosField == nil {
+		return nil, errDirectConversion
+	}
+
+	seconds := message.Get(secondsField).Int()
+	nanos := message.Get(nanosField).Int()
+	if seconds < -maxDurationSeconds || seconds > maxDurationSeconds || nanos < -maxNanos || nanos > maxNanos {
+		return nil, errDirectConversion
+	}
+	if (seconds > 0 && nanos < 0) || (seconds < 0 && nanos > 0) {
+		return nil, errDirectConversion
+	}
+
+	sign := ""
+	if seconds < 0 || nanos < 0 {
+		sign, seconds, nanos = "-", -seconds, -nanos
+	}
+	formatted := fmt.Sprintf("%s%d.%09d", sign, seconds, nanos)
+	formatted = strings.TrimSuffix(formatted, "000")
+	formatted = strings.TrimSuffix(formatted, "000")
+	formatted = strings.TrimSuffix(formatted, ".000")
+	return formatted + "s", nil
+}
+
+// fieldMask mirrors protojson's marshalFieldMask behavior.
+func (c responseConverter) fieldMask(message protoreflect.Message) (any, error) {
+	field := message.Descriptor().Fields().ByNumber(1)
+	if field == nil {
+		return nil, errDirectConversion
+	}
+
+	paths := message.Get(field).List()
+	converted := make([]string, 0, paths.Len())
+	for i := 0; i < paths.Len(); i++ {
+		path := paths.Get(i).String()
+		if !protoreflect.FullName(path).IsValid() {
+			return nil, errDirectConversion
+		}
+		camelCase := jsonCamelCase(path)
+		if path != jsonSnakeCase(camelCase) {
+			return nil, errDirectConversion
+		}
+		converted = append(converted, camelCase)
+	}
+	return strings.Join(converted, ","), nil
+}
+
+// timestamp mirrors protojson's marshalTimestamp behavior.
+func (c responseConverter) timestamp(message protoreflect.Message) (any, error) {
+	fields := message.Descriptor().Fields()
+	secondsField := fields.ByNumber(1)
+	nanosField := fields.ByNumber(2)
+	if secondsField == nil || nanosField == nil {
+		return nil, errDirectConversion
+	}
+
+	seconds := message.Get(secondsField).Int()
+	nanos := message.Get(nanosField).Int()
+	if seconds < minTimestampSecond || seconds > maxTimestampSecond || nanos < 0 || nanos > maxNanos {
+		return nil, errDirectConversion
+	}
+
+	formatted := time.Unix(seconds, nanos).UTC().Format("2006-01-02T15:04:05.000000000")
+	formatted = strings.TrimSuffix(formatted, "000")
+	formatted = strings.TrimSuffix(formatted, "000")
+	formatted = strings.TrimSuffix(formatted, ".000")
+	return formatted + "Z", nil
+}
+
+// value mirrors protojson's marshalKnownValue behavior.
+func (c responseConverter) value(message protoreflect.Message) (any, error) {
+	oneof := message.Descriptor().Oneofs().ByName("kind")
+	if oneof == nil {
+		return nil, errDirectConversion
+	}
+
+	field := message.WhichOneof(oneof)
+	if field == nil {
+		return nil, errDirectConversion
+	}
+	value := message.Get(field)
+	if field.Number() == 2 && (math.IsNaN(value.Float()) || math.IsInf(value.Float(), 0)) {
+		return nil, errDirectConversion
+	}
+	return c.singular(value, field)
+}
+
+func (c responseConverter) object(message protoreflect.Message, typeURL string) (map[string]any, error) {
+	fields := c.fields(message)
+	converted := make(map[string]any, len(fields)+1)
+	if typeURL != "" {
+		converted["@type"] = typeURL
+	}
+
+	for _, field := range fields {
+		name := field.descriptor.JSONName()
+		if c.marshaler.UseProtoNames {
+			name = field.descriptor.TextName()
+		}
+		if !utf8.ValidString(name) {
+			return nil, errDirectConversion
+		}
+
+		convertedValue, err := c.fieldValue(field.value, field.descriptor)
+		if err != nil {
+			return nil, fmt.Errorf("convert field %q: %w", name, err)
+		}
+		converted[name] = convertedValue
+	}
+	return converted, nil
+}
+
+type messageField struct {
+	descriptor protoreflect.FieldDescriptor
+	value      protoreflect.Value
+}
+
+// fields mirrors protojson's unpopulatedFieldRanger behavior.
+func (c responseConverter) fields(message protoreflect.Message) []messageField {
+	fields := make([]messageField, 0, message.Descriptor().Fields().Len())
+	if c.marshaler.EmitUnpopulated || c.marshaler.EmitDefaultValues {
+		descriptors := message.Descriptor().Fields()
+		for i := 0; i < descriptors.Len(); i++ {
+			descriptor := descriptors.Get(i)
+			if message.Has(descriptor) || descriptor.ContainingOneof() != nil {
+				continue
+			}
+			if descriptor.HasPresence() {
+				if !c.marshaler.EmitUnpopulated && c.marshaler.EmitDefaultValues {
+					continue
+				}
+				fields = append(fields, messageField{descriptor: descriptor})
+				continue
+			}
+			fields = append(fields, messageField{descriptor: descriptor, value: message.Get(descriptor)})
+		}
+	}
+	message.Range(func(descriptor protoreflect.FieldDescriptor, value protoreflect.Value) bool {
+		fields = append(fields, messageField{descriptor: descriptor, value: value})
+		return true
+	})
+	// This order is load-bearing: map insertion must preserve protojson's last-write-wins behavior
+	// for colliding JSON names.
+	sort.Slice(fields, func(i, j int) bool {
+		left, right := fields[i].descriptor, fields[j].descriptor
+		if left.IsExtension() != right.IsExtension() {
+			return !left.IsExtension()
+		}
+		if left.IsExtension() {
+			return left.FullName() < right.FullName()
+		}
+		return left.Index() < right.Index()
+	})
+	return fields
+}
+
+func (c responseConverter) fieldValue(value protoreflect.Value, descriptor protoreflect.FieldDescriptor) (any, error) {
+	switch {
+	case descriptor.IsList():
+		return c.list(value, descriptor)
+	case descriptor.IsMap():
+		return c.mapValue(value, descriptor)
+	default:
+		return c.singular(value, descriptor)
+	}
+}
+
+func (c responseConverter) list(value protoreflect.Value, descriptor protoreflect.FieldDescriptor) (any, error) {
+	list := value.List()
+	converted := make([]any, list.Len())
+	for i := 0; i < list.Len(); i++ {
+		item, err := c.singular(list.Get(i), descriptor)
+		if err != nil {
+			return nil, err
+		}
+		converted[i] = item
+	}
+	return converted, nil
+}
+
+func (c responseConverter) mapValue(value protoreflect.Value, descriptor protoreflect.FieldDescriptor) (any, error) {
+	m := value.Map()
+	converted := make(map[string]any, m.Len())
+	var err error
+	m.Range(func(key protoreflect.MapKey, value protoreflect.Value) bool {
+		name := key.String()
+		if !utf8.ValidString(name) {
+			err = errDirectConversion
+			return false
+		}
+		convertedValue, conversionErr := c.singular(value, descriptor.MapValue())
+		if conversionErr != nil {
+			err = conversionErr
+			return false
+		}
+		converted[name] = convertedValue
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return converted, nil
+}
+
+func (c responseConverter) singular(value protoreflect.Value, descriptor protoreflect.FieldDescriptor) (any, error) {
+	if !value.IsValid() {
+		return nil, nil //nolint:nilnil // null is a valid protojson value
+	}
+
+	switch descriptor.Kind() {
+	case protoreflect.BoolKind:
+		return value.Bool(), nil
+	case protoreflect.StringKind:
+		if !utf8.ValidString(value.String()) {
+			return nil, errDirectConversion
+		}
+		return value.String(), nil
+	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
+		return float64(value.Int()), nil
+	case protoreflect.Uint32Kind, protoreflect.Fixed32Kind:
+		return float64(value.Uint()), nil
+	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Uint64Kind,
+		protoreflect.Sfixed64Kind, protoreflect.Fixed64Kind:
+		return value.String(), nil
+	case protoreflect.FloatKind:
+		return jsonFloat(value.Float(), 32)
+	case protoreflect.DoubleKind:
+		return jsonFloat(value.Float(), 64)
+	case protoreflect.BytesKind:
+		return base64.StdEncoding.EncodeToString(value.Bytes()), nil
+	case protoreflect.EnumKind:
+		if string(descriptor.Enum().FullName()) == nullValueEnumName {
+			return nil, nil //nolint:nilnil // null is a valid protojson value
+		}
+		enumValue := descriptor.Enum().Values().ByNumber(value.Enum())
+		if c.marshaler.UseEnumNumbers || enumValue == nil {
+			return float64(value.Enum()), nil
+		}
+		name := string(enumValue.Name())
+		if !utf8.ValidString(name) {
+			return nil, errDirectConversion
+		}
+		return name, nil
+	case protoreflect.MessageKind, protoreflect.GroupKind:
+		return c.message(value.Message(), "")
+	default:
+		return nil, errDirectConversion
+	}
+}
+
+func (c responseConverter) resolver() interface {
+	protoregistry.ExtensionTypeResolver
+	protoregistry.MessageTypeResolver
+} {
+	if c.marshaler.Resolver != nil {
+		return c.marshaler.Resolver
+	}
+	return protoregistry.GlobalTypes
+}
+
+func isMessageSet(descriptor protoreflect.MessageDescriptor) bool {
+	messageSet, ok := descriptor.(interface{ IsMessageSet() bool })
+	return ok && messageSet.IsMessageSet()
+}
+
+func isWellKnownMessage(name protoreflect.FullName) bool {
+	switch name {
+	case anyMessageName, durationMessageName, emptyMessageName, fieldMaskMessageName, listValueMessageName,
+		structMessageName, timestampMessageName, valueMessageName:
+		return true
+	}
+	return isWrapperMessage(name)
+}
+
+func isWrapperMessage(name protoreflect.FullName) bool {
+	if name.Parent() != wrapperPackageName {
+		return false
+	}
+	switch name.Name() {
+	case "BoolValue", "Int32Value", "Int64Value", "UInt32Value", "UInt64Value", "FloatValue",
+		"DoubleValue", "StringValue", "BytesValue":
+		return true
+	default:
+		return false
+	}
+}
+
+// jsonFloat mirrors protojson's internal json.Encoder.WriteFloat behavior.
+func jsonFloat(value float64, bitSize int) (any, error) {
+	switch {
+	case math.IsNaN(value):
+		return "NaN", nil
+	case math.IsInf(value, 1):
+		return "Infinity", nil
+	case math.IsInf(value, -1):
+		return "-Infinity", nil
+	}
+
+	format := byte('f')
+	absolute := math.Abs(value)
+	if absolute != 0 && ((bitSize == 64 && (absolute < 1e-6 || absolute >= 1e21)) ||
+		(bitSize == 32 && (float32(absolute) < 1e-6 || float32(absolute) >= 1e21))) {
+		format = 'e'
+	}
+	converted, err := strconv.ParseFloat(strconv.FormatFloat(value, format, -1, bitSize), 64)
+	if err != nil {
+		return nil, errDirectConversion
+	}
+	return converted, nil
+}
+
+// jsonCamelCase mirrors protojson's internal strs.JSONCamelCase behavior.
+func jsonCamelCase(value string) string {
+	var builder strings.Builder
+	builder.Grow(len(value))
+	underscore := false
+	for i := 0; i < len(value); i++ {
+		character := value[i]
+		if character != '_' {
+			if underscore && 'a' <= character && character <= 'z' {
+				character -= 'a' - 'A'
+			}
+			builder.WriteByte(character)
+		}
+		underscore = character == '_'
+	}
+	return builder.String()
+}
+
+// jsonSnakeCase mirrors protojson's internal strs.JSONSnakeCase behavior.
+func jsonSnakeCase(value string) string {
+	var builder strings.Builder
+	builder.Grow(len(value))
+	for i := 0; i < len(value); i++ {
+		character := value[i]
+		if 'A' <= character && character <= 'Z' {
+			builder.WriteByte('_')
+			character += 'a' - 'A'
+		}
+		builder.WriteByte(character)
+	}
+	return builder.String()
+}

--- a/internal/lib/netext/grpcext/convert_test.go
+++ b/internal/lib/netext/grpcext/convert_test.go
@@ -1,0 +1,311 @@
+package grpcext
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/bufbuild/protocompile"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+func TestConvertMatchesProtoJSON(t *testing.T) {
+	t.Parallel()
+
+	file := compileTestFile(t, "convert_test.proto", `
+syntax = "proto3";
+package converttest;
+
+import "google/protobuf/any.proto";
+import "google/protobuf/duration.proto";
+import "google/protobuf/timestamp.proto";
+import "google/protobuf/struct.proto";
+
+message Nested {
+  int32 count = 1;
+  repeated string tags = 2;
+}
+
+enum State {
+  STATE_UNSPECIFIED = 0;
+  STATE_READY = 1;
+}
+
+message Envelope {
+  string snake_case = 1;
+  int32 int32_value = 2;
+  int64 int64_value = 3;
+  uint64 uint64_value = 4;
+  float float_value = 5;
+  double double_value = 6;
+  bytes bytes_value = 7;
+  bool bool_value = 8;
+  State state = 9;
+  repeated int64 values = 10;
+  map<string, int64> labels = 11;
+  map<bool, Nested> flags = 12;
+  Nested child = 13;
+  oneof selection {
+    string name = 14;
+    int32 id = 15;
+  }
+  optional string optional_value = 16;
+  google.protobuf.Timestamp timestamp = 17;
+  google.protobuf.Duration duration = 18;
+  google.protobuf.Value value = 19;
+  google.protobuf.Any detail = 20;
+}
+`)
+	message := file.Messages().ByName("Envelope")
+	nested := file.Messages().ByName("Nested")
+	types := new(protoregistry.Types)
+	require.NoError(t, types.RegisterMessage(dynamicpb.NewMessageType(nested)))
+
+	complexMessage := messageFromJSON(t, message, `{
+  "snakeCase": "response",
+  "int32Value": 7,
+  "int64Value": "9007199254740993",
+  "uint64Value": "18446744073709551615",
+  "floatValue": "NaN",
+  "doubleValue": "-Infinity",
+  "bytesValue": "AQI=",
+  "boolValue": true,
+  "state": "STATE_READY",
+  "values": ["1", "2"],
+  "labels": {"first": "3", "second": "4"},
+  "flags": {"true": {"count": 5, "tags": ["nested"]}},
+  "child": {"count": 6},
+  "name": "oneof",
+  "optionalValue": "present",
+  "timestamp": "2024-02-03T04:05:06.007008009Z",
+  "duration": "-3.004005006s",
+  "value": {"items": [null, true, 1.5, "text"]},
+  "detail": {
+    "@type": "type.googleapis.com/converttest.Nested",
+    "count": 8,
+    "tags": ["any"]
+  }
+}`, protojson.UnmarshalOptions{Resolver: types})
+
+	legacyFile := compileTestFile(t, "legacy_test.proto", `
+syntax = "proto2";
+package convertlegacy;
+
+message Legacy {
+  optional string optional_string = 1 [default = "default"];
+  optional int64 optional_id = 2;
+  optional Legacy child = 3;
+  repeated string names = 4;
+}
+`)
+	legacyMessage := dynamicpb.NewMessage(legacyFile.Messages().ByName("Legacy"))
+
+	anyTimestamp := messageFromJSON(t, (&anypb.Any{}).ProtoReflect().Descriptor(), `{
+  "@type": "type.googleapis.com/google.protobuf.Timestamp",
+  "value": "2024-02-03T04:05:06.007008009Z"
+}`, protojson.UnmarshalOptions{})
+	fieldMask := messageFromJSON(t, (&fieldmaskpb.FieldMask{}).ProtoReflect().Descriptor(), `"snakeCase,nested.value"`, protojson.UnmarshalOptions{})
+	structValue := messageFromJSON(t, (&structpb.Struct{}).ProtoReflect().Descriptor(), `{"number": 1.5, "null": null, "list": [true, "text"]}`, protojson.UnmarshalOptions{})
+	listValue := messageFromJSON(t, (&structpb.ListValue{}).ProtoReflect().Descriptor(), `[null, true, 1.5, "text"]`, protojson.UnmarshalOptions{})
+	knownValue := messageFromJSON(t, (&structpb.Value{}).ProtoReflect().Descriptor(), `{"nested": [null, "text"]}`, protojson.UnmarshalOptions{})
+	timestamp := messageFromJSON(t, (&timestamppb.Timestamp{}).ProtoReflect().Descriptor(), `"2024-02-03T04:05:06.007008009Z"`, protojson.UnmarshalOptions{})
+	duration := messageFromJSON(t, (&durationpb.Duration{}).ProtoReflect().Descriptor(), `"-3.004005006s"`, protojson.UnmarshalOptions{})
+	wrapper := messageFromJSON(t, (&wrapperspb.Int64Value{}).ProtoReflect().Descriptor(), `"9007199254740993"`, protojson.UnmarshalOptions{})
+	empty := dynamicpb.NewMessage((&emptypb.Empty{}).ProtoReflect().Descriptor())
+
+	tests := []struct {
+		name      string
+		marshaler protojson.MarshalOptions
+		message   *dynamicpb.Message
+	}{
+		{
+			name:      "complex message with populated values",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true, Resolver: types},
+			message:   complexMessage,
+		},
+		{
+			name:      "proto names and enum numbers",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true, UseProtoNames: true, UseEnumNumbers: true, Resolver: types},
+			message:   complexMessage,
+		},
+		{
+			name:      "proto2 unpopulated fields",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true, AllowPartial: true},
+			message:   legacyMessage,
+		},
+		{
+			name:      "emit default values without presence fields",
+			marshaler: protojson.MarshalOptions{EmitDefaultValues: true, AllowPartial: true},
+			message:   legacyMessage,
+		},
+		{
+			name:      "any containing timestamp",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   anyTimestamp,
+		},
+		{
+			name:      "field mask",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   fieldMask,
+		},
+		{
+			name:      "struct",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   structValue,
+		},
+		{
+			name:      "list value",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   listValue,
+		},
+		{
+			name:      "value",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   knownValue,
+		},
+		{
+			name:      "timestamp",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   timestamp,
+		},
+		{
+			name:      "duration",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   duration,
+		},
+		{
+			name:      "wrapper",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   wrapper,
+		},
+		{
+			name:      "empty",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   empty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			want, err := referenceConvertWithJSON(tt.marshaler, tt.message)
+			require.NoError(t, err)
+
+			got, err := convert(tt.marshaler, tt.message)
+			require.NoError(t, err)
+			assert.Equal(t, want, got)
+		})
+	}
+}
+
+func BenchmarkConnInvokeResponse(b *testing.B) {
+	method := benchmarkMethodDescriptor(b)
+	fields := method.Output().Fields()
+	bodyField := fields.ByName("body")
+	sequenceField := fields.ByName("sequence")
+	request := InvokeRequest{
+		Method:           "/benchmark.Conversion/Invoke",
+		MethodDescriptor: method,
+		Message:          []byte(`{}`),
+	}
+
+	for _, size := range []struct {
+		name string
+		body string
+	}{
+		{name: "128B", body: strings.Repeat("x", 128)},
+		{name: "16KiB", body: strings.Repeat("x", 16*1024)},
+	} {
+		b.Run(size.name, func(b *testing.B) {
+			conn := Conn{raw: invokemock(func(_ *dynamicpb.Message, out *dynamicpb.Message, _ ...grpc.CallOption) error {
+				out.Set(bodyField, protoreflect.ValueOfString(size.body))
+				out.Set(sequenceField, protoreflect.ValueOfInt64(9007199254740993))
+				return nil
+			})}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				response, err := conn.Invoke(context.Background(), request)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if response.Message == nil {
+					b.Fatal("expected converted response message")
+				}
+			}
+		})
+	}
+}
+
+func compileTestFile(tb testing.TB, filename, source string) protoreflect.FileDescriptor {
+	tb.Helper()
+
+	resolver := protocompile.WithStandardImports(&protocompile.SourceResolver{
+		Accessor: protocompile.SourceAccessorFromMap(map[string]string{filename: source}),
+	})
+	compiler := protocompile.Compiler{Resolver: resolver}
+	files, err := compiler.Compile(context.Background(), filename)
+	require.NoError(tb, err)
+	require.Len(tb, files, 1)
+	return files[0]
+}
+
+func messageFromJSON(
+	tb testing.TB,
+	descriptor protoreflect.MessageDescriptor,
+	input string,
+	unmarshaler protojson.UnmarshalOptions,
+) *dynamicpb.Message {
+	tb.Helper()
+
+	message := dynamicpb.NewMessage(descriptor)
+	require.NoError(tb, unmarshaler.Unmarshal([]byte(input), message))
+	return message
+}
+
+func referenceConvertWithJSON(marshaler protojson.MarshalOptions, message *dynamicpb.Message) (any, error) {
+	raw, err := marshaler.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+
+	var converted any
+	if err := json.Unmarshal(raw, &converted); err != nil {
+		return nil, err
+	}
+	return converted, nil
+}
+
+func benchmarkMethodDescriptor(b *testing.B) protoreflect.MethodDescriptor {
+	file := compileTestFile(b, "benchmark.proto", `
+syntax = "proto3";
+package benchmark;
+
+service Conversion {
+  rpc Invoke(Request) returns (Response);
+}
+
+message Request {}
+
+message Response {
+  string body = 1;
+  int64 sequence = 2;
+}
+`)
+	return file.Services().ByName("Conversion").Methods().ByName("Invoke")
+}

--- a/internal/lib/netext/grpcext/convert_test.go
+++ b/internal/lib/netext/grpcext/convert_test.go
@@ -3,6 +3,7 @@ package grpcext
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"strings"
 	"testing"
 
@@ -68,6 +69,9 @@ message Envelope {
   google.protobuf.Duration duration = 18;
   google.protobuf.Value value = 19;
   google.protobuf.Any detail = 20;
+  map<int32, uint64> numeric_labels = 21;
+  map<string, State> states = 22;
+  repeated float float_values = 23;
 }
 `)
 	message := file.Messages().ByName("Envelope")
@@ -98,8 +102,21 @@ message Envelope {
     "@type": "type.googleapis.com/converttest.Nested",
     "count": 8,
     "tags": ["any"]
-  }
+  },
+  "numericLabels": {"-1": "18446744073709551615"},
+  "states": {"known": "STATE_READY", "unknown": 99},
+  "floatValues": [0.1, 0.0000001]
 }`, protojson.UnmarshalOptions{Resolver: types})
+	finiteMessage := messageFromJSON(t, message, `{
+  "floatValue": 0.1,
+  "doubleValue": 0.0000001,
+  "state": 99,
+  "numericLabels": {"-1": "18446744073709551615"},
+  "states": {"known": "STATE_READY", "unknown": 99},
+  "floatValues": [0.1, 0.0000001]
+}`, protojson.UnmarshalOptions{Resolver: types})
+	replacementMessage := messageFromJSON(t, message, `{"snakeCase": "replacement \uFFFD"}`, protojson.UnmarshalOptions{Resolver: types})
+	emptyMessage := dynamicpb.NewMessage(message)
 
 	legacyFile := compileTestFile(t, "legacy_test.proto", `
 syntax = "proto2";
@@ -118,13 +135,22 @@ message Legacy {
   "@type": "type.googleapis.com/google.protobuf.Timestamp",
   "value": "2024-02-03T04:05:06.007008009Z"
 }`, protojson.UnmarshalOptions{})
+	emptyAny := dynamicpb.NewMessage((&anypb.Any{}).ProtoReflect().Descriptor())
 	fieldMask := messageFromJSON(t, (&fieldmaskpb.FieldMask{}).ProtoReflect().Descriptor(), `"snakeCase,nested.value"`, protojson.UnmarshalOptions{})
+	emptyFieldMask := dynamicpb.NewMessage((&fieldmaskpb.FieldMask{}).ProtoReflect().Descriptor())
 	structValue := messageFromJSON(t, (&structpb.Struct{}).ProtoReflect().Descriptor(), `{"number": 1.5, "null": null, "list": [true, "text"]}`, protojson.UnmarshalOptions{})
+	emptyStruct := dynamicpb.NewMessage((&structpb.Struct{}).ProtoReflect().Descriptor())
 	listValue := messageFromJSON(t, (&structpb.ListValue{}).ProtoReflect().Descriptor(), `[null, true, 1.5, "text"]`, protojson.UnmarshalOptions{})
+	emptyList := dynamicpb.NewMessage((&structpb.ListValue{}).ProtoReflect().Descriptor())
 	knownValue := messageFromJSON(t, (&structpb.Value{}).ProtoReflect().Descriptor(), `{"nested": [null, "text"]}`, protojson.UnmarshalOptions{})
+	nullValue := messageFromJSON(t, (&structpb.Value{}).ProtoReflect().Descriptor(), `null`, protojson.UnmarshalOptions{})
 	timestamp := messageFromJSON(t, (&timestamppb.Timestamp{}).ProtoReflect().Descriptor(), `"2024-02-03T04:05:06.007008009Z"`, protojson.UnmarshalOptions{})
+	zeroTimestamp := dynamicpb.NewMessage((&timestamppb.Timestamp{}).ProtoReflect().Descriptor())
 	duration := messageFromJSON(t, (&durationpb.Duration{}).ProtoReflect().Descriptor(), `"-3.004005006s"`, protojson.UnmarshalOptions{})
+	zeroDuration := dynamicpb.NewMessage((&durationpb.Duration{}).ProtoReflect().Descriptor())
 	wrapper := messageFromJSON(t, (&wrapperspb.Int64Value{}).ProtoReflect().Descriptor(), `"9007199254740993"`, protojson.UnmarshalOptions{})
+	zeroWrapper := dynamicpb.NewMessage((&wrapperspb.Int64Value{}).ProtoReflect().Descriptor())
+	bytesWrapper := messageFromJSON(t, (&wrapperspb.BytesValue{}).ProtoReflect().Descriptor(), `"AQI="`, protojson.UnmarshalOptions{})
 	empty := dynamicpb.NewMessage((&emptypb.Empty{}).ProtoReflect().Descriptor())
 
 	tests := []struct {
@@ -136,6 +162,21 @@ message Legacy {
 			name:      "complex message with populated values",
 			marshaler: protojson.MarshalOptions{EmitUnpopulated: true, Resolver: types},
 			message:   complexMessage,
+		},
+		{
+			name:      "finite floats and unknown enums",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true, Resolver: types},
+			message:   finiteMessage,
+		},
+		{
+			name:      "replacement character",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true, Resolver: types},
+			message:   replacementMessage,
+		},
+		{
+			name:      "unpopulated proto3 fields",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true, Resolver: types},
+			message:   emptyMessage,
 		},
 		{
 			name:      "proto names and enum numbers",
@@ -153,9 +194,19 @@ message Legacy {
 			message:   legacyMessage,
 		},
 		{
+			name:      "unpopulated takes precedence over default values",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true, EmitDefaultValues: true, AllowPartial: true},
+			message:   legacyMessage,
+		},
+		{
 			name:      "any containing timestamp",
 			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
 			message:   anyTimestamp,
+		},
+		{
+			name:      "empty any",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   emptyAny,
 		},
 		{
 			name:      "field mask",
@@ -163,9 +214,19 @@ message Legacy {
 			message:   fieldMask,
 		},
 		{
+			name:      "empty field mask",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   emptyFieldMask,
+		},
+		{
 			name:      "struct",
 			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
 			message:   structValue,
+		},
+		{
+			name:      "empty struct",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   emptyStruct,
 		},
 		{
 			name:      "list value",
@@ -173,9 +234,19 @@ message Legacy {
 			message:   listValue,
 		},
 		{
+			name:      "empty list value",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   emptyList,
+		},
+		{
 			name:      "value",
 			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
 			message:   knownValue,
+		},
+		{
+			name:      "null value",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   nullValue,
 		},
 		{
 			name:      "timestamp",
@@ -183,14 +254,34 @@ message Legacy {
 			message:   timestamp,
 		},
 		{
+			name:      "zero timestamp",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   zeroTimestamp,
+		},
+		{
 			name:      "duration",
 			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
 			message:   duration,
 		},
 		{
+			name:      "zero duration",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   zeroDuration,
+		},
+		{
 			name:      "wrapper",
 			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
 			message:   wrapper,
+		},
+		{
+			name:      "zero wrapper",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   zeroWrapper,
+		},
+		{
+			name:      "bytes wrapper",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   bytesWrapper,
 		},
 		{
 			name:      "empty",
@@ -206,6 +297,10 @@ message Legacy {
 			want, err := referenceConvertWithJSON(tt.marshaler, tt.message)
 			require.NoError(t, err)
 
+			direct, err := convertDirect(tt.marshaler, tt.message)
+			require.NoError(t, err)
+			assert.Equal(t, want, direct)
+
 			got, err := convert(tt.marshaler, tt.message)
 			require.NoError(t, err)
 			assert.Equal(t, want, got)
@@ -213,6 +308,126 @@ message Legacy {
 	}
 }
 
+func TestConvertFallsBackToProtoJSON(t *testing.T) {
+	t.Parallel()
+
+	requiredFile := compileTestFile(t, "required_test.proto", `
+syntax = "proto2";
+package convertrequired;
+
+message Required {
+  required string value = 1;
+}
+
+message Text {
+  optional string value = 1;
+}
+`)
+	requiredMessage := dynamicpb.NewMessage(requiredFile.Messages().ByName("Required"))
+	invalidText := dynamicpb.NewMessage(requiredFile.Messages().ByName("Text"))
+	invalidText.Set(invalidText.Descriptor().Fields().ByNumber(1), protoreflect.ValueOfString(string([]byte{0xff})))
+	invalidValue := dynamicpb.NewMessage((&structpb.Value{}).ProtoReflect().Descriptor())
+	unknownAny := dynamicpb.NewMessage((&anypb.Any{}).ProtoReflect().Descriptor())
+	unknownAny.Set(
+		unknownAny.Descriptor().Fields().ByNumber(1),
+		protoreflect.ValueOfString("type.googleapis.com/missing.Message"),
+	)
+
+	tests := []struct {
+		name      string
+		marshaler protojson.MarshalOptions
+		message   *dynamicpb.Message
+	}{
+		{
+			name:      "missing required field",
+			marshaler: protojson.MarshalOptions{EmitUnpopulated: true},
+			message:   requiredMessage,
+		},
+		{
+			name:      "invalid UTF-8",
+			marshaler: protojson.MarshalOptions{},
+			message:   invalidText,
+		},
+		{
+			name:      "value without a oneof field",
+			marshaler: protojson.MarshalOptions{},
+			message:   invalidValue,
+		},
+		{
+			name:      "unresolvable any",
+			marshaler: protojson.MarshalOptions{},
+			message:   unknownAny,
+		},
+		{
+			name:      "invalid indent",
+			marshaler: protojson.MarshalOptions{Indent: "x"},
+			message:   dynamicpb.NewMessage((&emptypb.Empty{}).ProtoReflect().Descriptor()),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			expected, expectedErr := convertWithJSON(tt.marshaler, tt.message)
+			require.Error(t, expectedErr)
+
+			_, directErr := convertDirect(tt.marshaler, tt.message)
+			require.Error(t, directErr)
+
+			actual, actualErr := convert(tt.marshaler, tt.message)
+			assert.Equal(t, expected, actual)
+			assert.EqualError(t, actualErr, expectedErr.Error())
+		})
+	}
+}
+
+func TestConvertPreservesNilMessageContract(t *testing.T) {
+	t.Parallel()
+
+	marshaler := protojson.MarshalOptions{EmitUnpopulated: true}
+	// Conn and Stream allocate responses before conversion. A nil dynamic message remains unsupported,
+	// as it was when conversion consisted only of the protojson path.
+	require.Panics(t, func() {
+		_, _ = referenceConvertWithJSON(marshaler, nil)
+	})
+	require.Panics(t, func() {
+		_, _ = convert(marshaler, nil)
+	})
+}
+
+func TestConvertDirectPreservesNegativeZero(t *testing.T) {
+	t.Parallel()
+
+	file := compileTestFile(t, "float_test.proto", `
+syntax = "proto3";
+package convertfloat;
+
+message Floats {
+  float float_value = 1;
+  double double_value = 2;
+}
+`)
+	message := messageFromJSON(t, file.Messages().ByName("Floats"), `{
+  "floatValue": -0,
+  "doubleValue": -0
+}`, protojson.UnmarshalOptions{})
+	marshaler := protojson.MarshalOptions{EmitUnpopulated: true}
+
+	expected, err := referenceConvertWithJSON(marshaler, message)
+	require.NoError(t, err)
+	direct, err := convertDirect(marshaler, message)
+	require.NoError(t, err)
+	assert.Equal(t, expected, direct)
+
+	expectedValues := expected.(map[string]any)
+	directValues := direct.(map[string]any)
+	assert.Equal(t, math.Signbit(expectedValues["floatValue"].(float64)), math.Signbit(directValues["floatValue"].(float64)))
+	assert.Equal(t, math.Signbit(expectedValues["doubleValue"].(float64)), math.Signbit(directValues["doubleValue"].(float64)))
+}
+
+// BenchmarkConnInvokeResponse lives with converter tests because it measures response conversion
+// through Conn.Invoke.
 func BenchmarkConnInvokeResponse(b *testing.B) {
 	method := benchmarkMethodDescriptor(b)
 	fields := method.Output().Fields()

--- a/internal/lib/netext/grpcext/stream.go
+++ b/internal/lib/netext/grpcext/stream.go
@@ -1,7 +1,6 @@
 package grpcext
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -70,42 +69,6 @@ func (s *Stream) receive() (msg *dynamicpb.Message, err error) {
 	}
 
 	return nil, err
-}
-
-// convert converts the message to the interface{}
-// which could be returned to the JS
-// there is a lot of marshaling/unmarshaling here, but if we just pass the dynamic message
-// the default Marshaller would be used, which would strip any zero/default values from the JSON.
-// eg. given this message:
-//
-//	message Point {
-//	   double x = 1;
-//		  double y = 2;
-//		  double z = 3;
-//	}
-//
-// and a value like this:
-// msg := Point{X: 6, Y: 4, Z: 0}
-// would result in JSON output:
-// {"x":6,"y":4}
-// rather than the desired:
-// {"x":6,"y":4,"z":0}
-func convert(marshaler protojson.MarshalOptions, msg *dynamicpb.Message) (any, error) {
-	// TODO(olegbespalov): add the test that checks that message is not nil
-
-	raw, err := marshaler.Marshal(msg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal the message: %w", err)
-	}
-
-	var back any
-
-	err = json.Unmarshal(raw, &back)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal the message: %w", err)
-	}
-
-	return back, err
 }
 
 // CloseSend closes the stream


### PR DESCRIPTION
## What?

Convert non-discarded unary gRPC response messages into Sobek-compatible Go maps and slices directly from protobuf reflection. Preserve `protojson` field naming, default emission, and scalar conventions, while retaining the existing `protojson`/`encoding/json` route as a fallback for unsupported or malformed forms.

## Why?

`Client.Invoke` needs a map-like response value for JavaScript property access. Previously, supported dynamic responses were serialized to JSON and immediately parsed back into that representation. Building it directly removes that intermediate buffer and parse while leaving response behavior protected by the fallback.

## Testing

Added differential coverage against the existing conversion for defaults, nested/repeated/map fields, enums, 64-bit values, special floats, `Any`, well-known types, and fallback cases. The response benchmark exercises `Client.Invoke` through a loopback gRPC server. Focused affected-package checks and lint were used; the full `make check` suite was not run.

**Workload:** `16 KiB unary gRPC response through Client.Invoke`

| Metric | Before | After | Change |
| --- | --- | --- | --- |
| `ns/op` | 401783 | 161791 | 59.7% lower |
| `B/op` | 135442 | 84569 | 37.6% lower |
| `allocs/op` | 300 | 277 | 7.7% lower |
All 3 declared correctness checks passed.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

Not applicable: this does not change a user-facing API or require documentation updates.

## Related PR(s)/Issue(s)

- None.

---

Authored and verified by [Perfloop](https://app.perfloop.ai): every claim above was co-measured on both trees and independently re-verified before submission — the full record is public: [case_0ba99ytksb](https://app.perfloop.ai/t/oss/case_0ba99ytksb). Replies from this account are human-approved, and a human operator is accountable for this contribution.