### PR TITLE
Add bzip2 to the k6packager image

### DIFF
--- a/packaging/Dockerfile
+++ b/packaging/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="k6 Developers <developers@k6.io>"
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -y && \
-    apt-get install -y apt-utils createrepo-c curl git gnupg2 s3cmd unzip rpm
+    apt-get install -y apt-utils bzip2 createrepo-c curl git gnupg2 s3cmd unzip rpm
 
 # Download awscli, check GPG signature and install.
 COPY ./awscli-key.gpg .


### PR DESCRIPTION
## What?

Add `bzip2` to the k6packager image. `debian:13` (trixie) dropped it from its base image, so `create-deb-repo.sh` fails with `bzip2: command not found` and breaks the release's `publish-packages` job. Verified locally (image builds, `bzip2` resolves to `/usr/bin/bzip2`).

Note: `:latest` must be rebuilt via the `k6packager` workflow after merge, then re-run the failed `publish-packages` job for the v2.2.0 tag.