### PR TITLE
Fix frozen pages on shared browser connections

### DIFF
--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -160,12 +160,16 @@ func (b *Browser) connect() error {
 		return fmt.Errorf("connecting to browser DevTools URL: %w", err)
 	}
 
-	// We don't need to lock this because `connect()` is called only in NewBrowser
-	b.defaultContext, err = NewBrowserContext(b.vuCtx, b, "", DefaultBrowserContextOptions(), b.logger)
+	defaultContext, err := NewBrowserContext(b.vuCtx, b, "", DefaultBrowserContextOptions(), b.logger)
 	if err != nil {
 		return fmt.Errorf("browser connect: %w", err)
 	}
-	b.runOnClose = append(b.runOnClose, b.defaultContext.cleanup)
+	// The connection's recvLoop reads defaultContext through
+	// connectionOnAttachedToTarget, so publish it under contextMu.
+	b.contextMu.Lock()
+	b.defaultContext = defaultContext
+	b.contextMu.Unlock()
+	b.runOnClose = append(b.runOnClose, defaultContext.cleanup)
 
 	return b.initEvents()
 }
@@ -279,7 +283,10 @@ func (b *Browser) connectionOnAttachedToTarget(eva *target.EventAttachedToTarget
 	isAllowedBrowserContext := func() bool {
 		b.contextMu.RLock()
 		defer b.contextMu.RUnlock()
-		return b.context == nil || b.context.id == eva.TargetInfo.BrowserContextID
+		if b.context != nil && b.context.id == eva.TargetInfo.BrowserContextID {
+			return true
+		}
+		return b.defaultContext.id == eva.TargetInfo.BrowserContextID
 	}
 
 	return isAllowedBrowserContext()
@@ -295,15 +302,19 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) error {
 		browserCtx = b.getDefaultBrowserContextOrMatchedID(targetPage.BrowserContextID)
 	)
 
-	if !b.isAttachedPageValid(ev, browserCtx) {
-		return nil // Ignore this page.
-	}
 	session := b.conn.getSession(ev.SessionID)
 	if session == nil {
 		b.logger.Debugf("Browser:onAttachedToTarget",
 			"session closed before attachToTarget is handled. sid:%v tid:%v",
 			ev.SessionID, targetPage.TargetID)
 		return nil // ignore
+	}
+	if !b.isAttachedPageValid(ev, browserCtx) {
+		// Never ignore an attached target without releasing it: as long as
+		// this client stays attached without resuming the target, the
+		// browser keeps it paused for every other client.
+		detachSession(b.browserCtx, session)
+		return nil // Ignore this page.
 	}
 
 	var (

--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -310,10 +310,10 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) error {
 		return nil // ignore
 	}
 	if !b.isAttachedPageValid(ev, browserCtx) {
-		// Never ignore an attached target without releasing it: as long as
-		// this client stays attached without resuming the target, the
-		// browser keeps it paused for every other client.
-		detachSession(b.browserCtx, session)
+		// Never ignore an attached target without detaching from it: the
+		// browser keeps the target paused until every attached client
+		// releases it, and detaching drops this client's hold.
+		detachSession(session)
 		return nil // Ignore this page.
 	}
 
@@ -333,7 +333,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) error {
 	if err != nil && b.isPageAttachmentErrorIgnorable(ev, session, err) {
 		if b.closing.Load() {
 			b.logger.Debugf("Browser:onAttachedToTarget", "new page failed; browser is closing: sid:%v", ev.SessionID)
-			detachSession(b.browserCtx, session)
+			detachSession(session)
 		}
 		return nil // Ignore this page.
 	}
@@ -360,7 +360,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) error {
 			)
 		}
 
-		detachSession(b.browserCtx, session)
+		detachSession(session)
 
 		return nil
 	}

--- a/internal/js/modules/k6/browser/common/browser_test.go
+++ b/internal/js/modules/k6/browser/common/browser_test.go
@@ -189,6 +189,58 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	})
 }
 
+func TestConnectionOnAttachedToTarget(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ownContextID     cdp.BrowserContextID = "own"
+		foreignContextID cdp.BrowserContextID = "foreign"
+	)
+
+	newTestBrowser := func(t *testing.T, withOwnContext bool) *Browser {
+		t.Helper()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		b := newBrowser(context.Background(), ctx, cancel, nil, NewLocalBrowserOptions(), log.NewNullLogger())
+
+		var err error
+		b.defaultContext, err = NewBrowserContext(k6ext.WithVU(ctx, k6test.NewVU(t)), b, "", nil, nil)
+		require.NoError(t, err)
+		if withOwnContext {
+			b.context, err = NewBrowserContext(k6ext.WithVU(ctx, k6test.NewVU(t)), b, ownContextID, nil, nil)
+			require.NoError(t, err)
+		}
+
+		return b
+	}
+
+	tests := []struct {
+		name            string
+		withOwnContext  bool
+		targetContextID cdp.BrowserContextID
+		want            bool
+	}{
+		{"own_context_target", true, ownContextID, true},
+		{"foreign_target", true, foreignContextID, false},
+		{"foreign_target_without_own_context", false, foreignContextID, false},
+		{"default_context_target", false, "", true},
+		{"default_context_target_with_own_context", true, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := newTestBrowser(t, tt.withOwnContext)
+			ev := &target.EventAttachedToTarget{
+				TargetInfo: &target.Info{BrowserContextID: tt.targetContextID},
+			}
+			require.Equal(t, tt.want, b.connectionOnAttachedToTarget(ev))
+		})
+	}
+}
+
 type fakeConn struct {
 	connection
 	execute func(context.Context, string, any, any) error

--- a/internal/js/modules/k6/browser/common/browser_test.go
+++ b/internal/js/modules/k6/browser/common/browser_test.go
@@ -3,16 +3,24 @@ package common
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/url"
 	"testing"
 	"time"
 
+	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
+	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
+	jsonv2 "github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
+	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/k6ext"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/k6ext/k6test"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/log"
+	"go.k6.io/k6/v2/internal/js/modules/k6/browser/tests/ws"
 )
 
 func TestBrowserNewPageInContext(t *testing.T) {
@@ -238,6 +246,107 @@ func TestConnectionOnAttachedToTarget(t *testing.T) {
 			}
 			require.Equal(t, tt.want, b.connectionOnAttachedToTarget(ev))
 		})
+	}
+}
+
+// TestBrowserRejectedTarget ensures a target the connection accepts but the
+// browser rejects (isAttachedPageValid) is both resumed and detached from,
+// like the connection-level rejection in TestConnectionRejectedTarget.
+// Runtime.runIfWaitingForDebugger must target the child session, while
+// Target.detachFromTarget is a browser-level command: the session to detach
+// goes in the params, not in the message's session ID.
+func TestBrowserRejectedTarget(t *testing.T) {
+	t.Parallel()
+
+	const rejectedSessionID = "session_id_0123456789"
+
+	attachedEvent := fmt.Sprintf(`
+	{
+		"sessionId": %q,
+		"targetInfo": {
+			"targetId": "target_id_0123456789",
+			"type": "service_worker",
+			"title": "",
+			"url": "http://example.com/worker.js",
+			"attached": true,
+			"browserContextId": ""
+		},
+		"waitingForDebugger": true
+	}`, rejectedSessionID)
+
+	received := make(chan cdproto.Message, 16)
+	handler := func(conn *websocket.Conn, msg *cdproto.Message, writeCh chan cdproto.Message, done chan struct{}) {
+		if msg.Method == "" {
+			return
+		}
+		received <- *msg
+		if msg.Method == cdproto.MethodType(cdproto.CommandTargetSetDiscoverTargets) {
+			writeCh <- cdproto.Message{
+				Method: cdproto.EventTargetAttachedToTarget,
+				Params: jsontext.Value(attachedEvent),
+			}
+			writeCh <- cdproto.Message{
+				ID:     msg.ID,
+				Result: jsontext.Value([]byte("{}")),
+			}
+		}
+	}
+
+	server := ws.NewServer(t, ws.WithCDPHandler("/cdp", handler, nil))
+
+	vuCtx, vuCancel := context.WithCancel(context.Background())
+	t.Cleanup(vuCancel)
+	b := newBrowser(context.Background(), vuCtx, vuCancel, nil, NewLocalBrowserOptions(), log.NewNullLogger())
+	var err error
+	b.defaultContext, err = NewBrowserContext(k6ext.WithVU(vuCtx, k6test.NewVU(t)), b, "", nil, nil)
+	require.NoError(t, err)
+
+	u, err := url.Parse(server.ServerHTTP.URL)
+	require.NoError(t, err)
+	conn, err := NewConnection(
+		b.browserCtx, fmt.Sprintf("ws://%s/cdp", u.Host), log.NewNullLogger(), b.connectionOnAttachedToTarget,
+	)
+	require.NoError(t, err)
+	t.Cleanup(conn.Close)
+	b.conn = conn
+
+	evCh := make(chan Event)
+	conn.on(b.browserCtx, []string{cdproto.EventTargetAttachedToTarget}, evCh)
+
+	action := target.SetDiscoverTargets(true)
+	require.NoError(t, action.Do(cdp.WithExecutor(b.browserCtx, conn)))
+
+	select {
+	case event := <-evCh:
+		ev, ok := event.data.(*target.EventAttachedToTarget)
+		require.True(t, ok)
+		require.NoError(t, b.onAttachedToTarget(ev))
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the attached target event")
+	}
+
+	timeout := time.After(5 * time.Second)
+	var gotRunIfWaiting, gotDetach bool
+	for !gotRunIfWaiting || !gotDetach {
+		select {
+		case msg := <-received:
+			switch msg.Method {
+			case cdproto.MethodType(cdpruntime.CommandRunIfWaitingForDebugger):
+				require.Equal(t, target.SessionID(rejectedSessionID), msg.SessionID)
+				gotRunIfWaiting = true
+			case cdproto.MethodType(target.CommandDetachFromTarget):
+				require.Empty(t, msg.SessionID)
+				var params target.DetachFromTargetParams
+				require.NoError(t, jsonv2.Unmarshal(msg.Params, &params, defaultJSONV2Options))
+				require.Equal(t, target.SessionID(rejectedSessionID), params.SessionID)
+				gotDetach = true
+			}
+		case <-timeout:
+			t.Fatalf(
+				"timed out waiting for the rejected target to be released: runIfWaitingForDebugger=%t detachFromTarget=%t",
+				gotRunIfWaiting, gotDetach,
+			)
+		}
 	}
 }
 

--- a/internal/js/modules/k6/browser/common/browser_test.go
+++ b/internal/js/modules/k6/browser/common/browser_test.go
@@ -250,9 +250,8 @@ func TestConnectionOnAttachedToTarget(t *testing.T) {
 }
 
 // TestBrowserRejectedTarget ensures a target the connection accepts but the
-// browser rejects (isAttachedPageValid) is both resumed and detached from,
-// like the connection-level rejection in TestConnectionRejectedTarget.
-// Runtime.runIfWaitingForDebugger must target the child session, while
+// browser rejects (isAttachedPageValid) is detached from, and only detached
+// from, like the connection-level rejection in TestConnectionRejectedTarget.
 // Target.detachFromTarget is a browser-level command: the session to detach
 // goes in the params, not in the message's session ID.
 func TestBrowserRejectedTarget(t *testing.T) {
@@ -326,14 +325,13 @@ func TestBrowserRejectedTarget(t *testing.T) {
 	}
 
 	timeout := time.After(5 * time.Second)
-	var gotRunIfWaiting, gotDetach bool
-	for !gotRunIfWaiting || !gotDetach {
+	var sawResume, gotDetach bool
+	for !gotDetach {
 		select {
 		case msg := <-received:
 			switch msg.Method {
 			case cdproto.MethodType(cdpruntime.CommandRunIfWaitingForDebugger):
-				require.Equal(t, target.SessionID(rejectedSessionID), msg.SessionID)
-				gotRunIfWaiting = true
+				sawResume = true
 			case cdproto.MethodType(target.CommandDetachFromTarget):
 				require.Empty(t, msg.SessionID)
 				var params target.DetachFromTargetParams
@@ -342,12 +340,12 @@ func TestBrowserRejectedTarget(t *testing.T) {
 				gotDetach = true
 			}
 		case <-timeout:
-			t.Fatalf(
-				"timed out waiting for the rejected target to be released: runIfWaitingForDebugger=%t detachFromTarget=%t",
-				gotRunIfWaiting, gotDetach,
-			)
+			t.Fatal("timed out waiting for the rejected target to be detached from")
 		}
 	}
+	// The websocket preserves ordering, so a resume would have arrived
+	// before the detach.
+	require.False(t, sawResume, "expected no Runtime.runIfWaitingForDebugger for a rejected target")
 }
 
 type fakeConn struct {

--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
-	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
 	jsonv2 "github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
@@ -368,7 +367,6 @@ func (c *Connection) recvLoop() {
 				// if a session should be created for the target.
 				ok := c.onTargetAttachedToTarget(eva)
 				if !ok {
-					c.stopWaitingForDebugger(sid)
 					c.detachFromTarget(sid)
 					continue
 				}
@@ -446,40 +444,16 @@ func (c *Connection) recvLoop() {
 	}
 }
 
-// stopWaitingForDebugger tells the browser to stop waiting for the
-// debugger to attach to the page's session.
-//
-// Whether we're not sharing pages among browser contexts, Chromium
-// still does so (since we're auto-attaching all browser targets).
-// This means that if we don't stop waiting for the debugger, the
-// browser will wait for the debugger to attach to the new page
-// indefinitely, even if the page is not part of the browser context
-// we're using.
-//
-// We don't return an error because the browser might have already
-// closed the connection. In that case, handling the error would
-// be redundant. This operation is best-effort.
-func (c *Connection) stopWaitingForDebugger(sid target.SessionID) {
-	msg := &cdproto.Message{
-		ID:        c.msgIDGen.newID(),
-		SessionID: sid,
-		Method:    cdproto.MethodType(cdpruntime.CommandRunIfWaitingForDebugger),
-	}
-	err := c.send(c.ctx, msg, nil, nil)
-	if err != nil {
-		c.logger.Errorf("Connection:stopWaitingForDebugger", "sid:%v wsURL:%q, err:%v", sid, c.wsURL, err)
-	}
-}
-
 // detachFromTarget detaches the connection from the target's session.
-// A rejected target must not stay attached, since an attached client
-// keeps holding the target back.
+// A rejected target must not stay attached: the browser keeps a new
+// target paused until every client attached with waitForDebuggerOnStart
+// releases it, and detaching drops this client's hold.
 //
 // Target.detachFromTarget is a browser-level command: the session to
 // detach goes in the params, not in the message's session ID.
 //
-// Like stopWaitingForDebugger, this operation is best-effort, so we
-// don't return an error.
+// The browser might have already closed the connection or the session,
+// so this operation is best-effort and we don't return an error.
 func (c *Connection) detachFromTarget(sid target.SessionID) {
 	buf, err := jsonv2.Marshal(&target.DetachFromTargetParams{SessionID: sid}, defaultJSONV2Options)
 	if err != nil {

--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -369,6 +369,7 @@ func (c *Connection) recvLoop() {
 				ok := c.onTargetAttachedToTarget(eva)
 				if !ok {
 					c.stopWaitingForDebugger(sid)
+					c.detachFromTarget(sid)
 					continue
 				}
 			}
@@ -467,6 +468,31 @@ func (c *Connection) stopWaitingForDebugger(sid target.SessionID) {
 	err := c.send(c.ctx, msg, nil, nil)
 	if err != nil {
 		c.logger.Errorf("Connection:stopWaitingForDebugger", "sid:%v wsURL:%q, err:%v", sid, c.wsURL, err)
+	}
+}
+
+// detachFromTarget detaches the connection from the target's session.
+// A rejected target must not stay attached, since an attached client
+// keeps holding the target back.
+//
+// Target.detachFromTarget is a browser-level command: the session to
+// detach goes in the params, not in the message's session ID.
+//
+// Like stopWaitingForDebugger, this operation is best-effort, so we
+// don't return an error.
+func (c *Connection) detachFromTarget(sid target.SessionID) {
+	buf, err := jsonv2.Marshal(&target.DetachFromTargetParams{SessionID: sid}, defaultJSONV2Options)
+	if err != nil {
+		c.logger.Errorf("Connection:detachFromTarget", "sid:%v wsURL:%q, err:%v", sid, c.wsURL, err)
+		return
+	}
+	msg := &cdproto.Message{
+		ID:     c.msgIDGen.newID(),
+		Method: cdproto.MethodType(target.CommandDetachFromTarget),
+		Params: buf,
+	}
+	if err := c.send(c.ctx, msg, nil, nil); err != nil {
+		c.logger.Errorf("Connection:detachFromTarget", "sid:%v wsURL:%q, err:%v", sid, c.wsURL, err)
 	}
 }
 

--- a/internal/js/modules/k6/browser/common/connection_test.go
+++ b/internal/js/modules/k6/browser/common/connection_test.go
@@ -82,12 +82,10 @@ func TestConnectionSendRecv(t *testing.T) {
 }
 
 // TestConnectionRejectedTarget ensures a target rejected by the attach filter
-// is both resumed and detached from. Staying attached without resuming keeps
-// the target paused for every client; staying attached after resuming can
-// still stall it later, since the browser waits on all attached clients for
-// some events (e.g. after a crash-reload). Resuming alone is enough to make
-// TestContextlessConnectionDoesNotStallNavigation pass, so this is the only
-// test that catches a missing detach.
+// is detached from, and only detached from. The browser keeps a new target
+// paused until every client attached with waitForDebuggerOnStart releases it,
+// and detaching drops this client's hold. Like Playwright, rejection sends no
+// separate resume: a client either adopts a target or detaches from it.
 func TestConnectionRejectedTarget(t *testing.T) {
 	t.Parallel()
 
@@ -140,14 +138,13 @@ func TestConnectionRejectedTarget(t *testing.T) {
 	require.NoError(t, action.Do(cdp.WithExecutor(ctx, conn)))
 
 	timeout := time.After(5 * time.Second)
-	var gotRunIfWaiting, gotDetach bool
-	for !gotRunIfWaiting || !gotDetach {
+	var sawResume, gotDetach bool
+	for !gotDetach {
 		select {
 		case msg := <-received:
 			switch msg.Method {
 			case cdproto.MethodType(cdpruntime.CommandRunIfWaitingForDebugger):
-				require.Equal(t, target.SessionID(rejectedSessionID), msg.SessionID)
-				gotRunIfWaiting = true
+				sawResume = true
 			case cdproto.MethodType(target.CommandDetachFromTarget):
 				// Target.detachFromTarget is a browser-level command: the
 				// session goes in the params, not in the message session ID.
@@ -158,12 +155,12 @@ func TestConnectionRejectedTarget(t *testing.T) {
 				gotDetach = true
 			}
 		case <-timeout:
-			t.Fatalf(
-				"timed out waiting for the rejected target to be released: runIfWaitingForDebugger=%t detachFromTarget=%t",
-				gotRunIfWaiting, gotDetach,
-			)
+			t.Fatal("timed out waiting for the rejected target to be detached from")
 		}
 	}
+	// The websocket preserves ordering, so a resume would have arrived
+	// before the detach.
+	require.False(t, sawResume, "expected no Runtime.runIfWaitingForDebugger for a rejected target")
 }
 
 func TestConnectionCreateSession(t *testing.T) {

--- a/internal/js/modules/k6/browser/common/connection_test.go
+++ b/internal/js/modules/k6/browser/common/connection_test.go
@@ -5,13 +5,16 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
+	"time"
 
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/log"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/tests/ws"
 
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
+	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
+	jsonv2 "github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
@@ -76,6 +79,89 @@ func TestConnectionSendRecv(t *testing.T) {
 			require.NoError(t, err)
 		}
 	})
+}
+
+// A target rejected by onTargetAttachedToTarget must be released
+// (Runtime.runIfWaitingForDebugger) and detached from
+// (Target.detachFromTarget); otherwise this connection's
+// waitForDebuggerOnStart hold keeps the target paused for every other
+// client of the browser.
+func TestConnectionRejectedTarget(t *testing.T) {
+	t.Parallel()
+
+	const rejectedSessionID = "session_id_0123456789"
+
+	attachedEvent := fmt.Sprintf(`
+	{
+		"sessionId": %q,
+		"targetInfo": {
+			"targetId": "target_id_0123456789",
+			"type": "page",
+			"title": "",
+			"url": "about:blank",
+			"attached": true,
+			"browserContextId": "browser_context_id_0123456789"
+		},
+		"waitingForDebugger": true
+	}`, rejectedSessionID)
+
+	received := make(chan cdproto.Message, 16)
+	handler := func(conn *websocket.Conn, msg *cdproto.Message, writeCh chan cdproto.Message, done chan struct{}) {
+		if msg.Method == "" {
+			return
+		}
+		received <- *msg
+		if msg.Method == cdproto.MethodType(cdproto.CommandTargetSetDiscoverTargets) {
+			writeCh <- cdproto.Message{
+				Method: cdproto.EventTargetAttachedToTarget,
+				Params: jsontext.Value(attachedEvent),
+			}
+			writeCh <- cdproto.Message{
+				ID:     msg.ID,
+				Result: jsontext.Value([]byte("{}")),
+			}
+		}
+	}
+
+	server := ws.NewServer(t, ws.WithCDPHandler("/cdp", handler, nil))
+
+	ctx := context.Background()
+	u, err := url.Parse(server.ServerHTTP.URL)
+	require.NoError(t, err)
+	wsURL := fmt.Sprintf("ws://%s/cdp", u.Host)
+	rejectAll := func(*target.EventAttachedToTarget) bool { return false }
+	conn, err := NewConnection(ctx, wsURL, log.NewNullLogger(), rejectAll)
+	require.NoError(t, err)
+	t.Cleanup(conn.Close)
+
+	action := target.SetDiscoverTargets(true)
+	require.NoError(t, action.Do(cdp.WithExecutor(ctx, conn)))
+
+	timeout := time.After(5 * time.Second)
+	var gotRunIfWaiting, gotDetach bool
+	for !gotRunIfWaiting || !gotDetach {
+		select {
+		case msg := <-received:
+			switch msg.Method {
+			case cdproto.MethodType(cdpruntime.CommandRunIfWaitingForDebugger):
+				require.Equal(t, target.SessionID(rejectedSessionID), msg.SessionID)
+				gotRunIfWaiting = true
+			case cdproto.MethodType(target.CommandDetachFromTarget):
+				// Target.detachFromTarget is a browser-level command: the
+				// session goes in the params, not in the message session ID.
+				require.Empty(t, msg.SessionID)
+				var params target.DetachFromTargetParams
+				require.NoError(t, jsonv2.Unmarshal(msg.Params, &params, defaultJSONV2Options))
+				require.Equal(t, target.SessionID(rejectedSessionID), params.SessionID)
+				gotDetach = true
+			}
+		case <-timeout:
+			t.Fatalf(
+				"timed out waiting for the rejected target to be released: runIfWaitingForDebugger=%t detachFromTarget=%t",
+				gotRunIfWaiting, gotDetach,
+			)
+		}
+	}
 }
 
 func TestConnectionCreateSession(t *testing.T) {

--- a/internal/js/modules/k6/browser/common/connection_test.go
+++ b/internal/js/modules/k6/browser/common/connection_test.go
@@ -81,11 +81,13 @@ func TestConnectionSendRecv(t *testing.T) {
 	})
 }
 
-// A target rejected by onTargetAttachedToTarget must be released
-// (Runtime.runIfWaitingForDebugger) and detached from
-// (Target.detachFromTarget); otherwise this connection's
-// waitForDebuggerOnStart hold keeps the target paused for every other
-// client of the browser.
+// TestConnectionRejectedTarget ensures a target rejected by the attach filter
+// is both resumed and detached from. Staying attached without resuming keeps
+// the target paused for every client; staying attached after resuming can
+// still stall it later, since the browser waits on all attached clients for
+// some events (e.g. after a crash-reload). Resuming alone is enough to make
+// TestContextlessConnectionDoesNotStallNavigation pass, so this is the only
+// test that catches a missing detach.
 func TestConnectionRejectedTarget(t *testing.T) {
 	t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -969,7 +969,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 	default:
 		fs.logger.Debugf("FrameSession:onAttachedToTarget",
 			"unsupported target type %q sid:%v", ti.Type, session.ID())
-		detachSession(fs.teardownCtx, session)
+		detachSession(session)
 	}
 	if err == nil {
 		return
@@ -1020,7 +1020,7 @@ func (fs *FrameSession) attachIFrameToTarget(ti *target.Info, session *Session) 
 	if fs.page.isClosing() {
 		fs.logger.Debugf("FrameSession:attachIFrameToTarget",
 			"rejected frame; page is closing: tid=%v", ti.TargetID)
-		detachSession(fs.teardownCtx, session)
+		detachSession(session)
 		return nil
 	}
 
@@ -1059,7 +1059,7 @@ func (fs *FrameSession) attachIFrameToTarget(ti *target.Info, session *Session) 
 		if errors.Is(err, errPageClosing) {
 			fs.logger.Debugf("FrameSession:attachIFrameToTarget",
 				"rejected frame; page is closing: tid=%v", ti.TargetID)
-			detachSession(fs.teardownCtx, session)
+			detachSession(session)
 			return nil
 		}
 		return err
@@ -1073,7 +1073,7 @@ func (fs *FrameSession) attachWorkerToTarget(ti *target.Info, session *Session) 
 	if fs.page.isClosing() {
 		fs.logger.Debugf("FrameSession:attachWorkerToTarget",
 			"rejected worker; page is closing: tid=%v", ti.TargetID)
-		detachSession(fs.teardownCtx, session)
+		detachSession(session)
 		return nil
 	}
 
@@ -1289,11 +1289,9 @@ func (fs *FrameSession) executionContextForID(
 	return nil, fmt.Errorf("no execution context found for id: %v", executionContextID)
 }
 
-// detachSession unblocks a target waiting for debugger and detaches from it.
-// Prevents the browser from hanging on rejected targets during close.
-// The resume must target the child session, while the detach is a
-// browser-level command that carries the session ID in its params.
-func detachSession(ctx context.Context, session *Session) {
-	_ = session.ExecuteWithoutExpectationOnReply(ctx, cdpruntime.CommandRunIfWaitingForDebugger, nil, nil)
+// detachSession detaches from a rejected target's session. Detaching also
+// releases this client's waitForDebuggerOnStart hold, letting the target
+// run for its other clients.
+func detachSession(session *Session) {
 	session.conn.detachFromTarget(session.id)
 }

--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -1290,9 +1290,10 @@ func (fs *FrameSession) executionContextForID(
 }
 
 // detachSession unblocks a target waiting for debugger and detaches from it.
-// Prevents the browser from hanging on rejected targets during close
+// Prevents the browser from hanging on rejected targets during close.
+// The resume must target the child session, while the detach is a
+// browser-level command that carries the session ID in its params.
 func detachSession(ctx context.Context, session *Session) {
 	_ = session.ExecuteWithoutExpectationOnReply(ctx, cdpruntime.CommandRunIfWaitingForDebugger, nil, nil)
-	_ = session.ExecuteWithoutExpectationOnReply(ctx, target.CommandDetachFromTarget,
-		&target.DetachFromTargetParams{SessionID: session.id}, nil)
+	session.conn.detachFromTarget(session.id)
 }

--- a/internal/js/modules/k6/browser/tests/browser_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_test.go
@@ -351,9 +351,13 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 	require.NoError(t, err, "failed to close page #2")
 }
 
-// A connection that hasn't created a browser context still auto-attaches
-// to every new page with waitForDebuggerOnStart. Unless it releases and
-// detaches from foreign pages, they stay paused and navigation stalls.
+// TestContextlessConnectionDoesNotStallNavigation guards against connections
+// freezing each other's pages when they share a browser instance. Every new
+// page starts paused until all auto-attached connections resume it. A
+// connection that hadn't created its browser context yet used to claim other
+// connections' pages without ever resuming them, stalling their navigations
+// until it disconnected. The second connection here never creates a context,
+// which reproduces that state deterministically.
 func TestContextlessConnectionDoesNotStallNavigation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/js/modules/k6/browser/tests/browser_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_test.go
@@ -355,7 +355,7 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 // freezing each other's pages when they share a browser instance. Every new
 // page starts paused until all auto-attached connections resume it. A
 // connection that hadn't created its browser context yet used to claim other
-// connections' pages without ever resuming them, stalling their navigations
+// connections' pages without ever releasing them, stalling their navigations
 // until it disconnected. The second connection here never creates a context,
 // which reproduces that state deterministically.
 func TestContextlessConnectionDoesNotStallNavigation(t *testing.T) {

--- a/internal/js/modules/k6/browser/tests/browser_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_test.go
@@ -351,6 +351,31 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 	require.NoError(t, err, "failed to close page #2")
 }
 
+// A connection that hasn't created a browser context still auto-attaches
+// to every new page with waitForDebuggerOnStart. Unless it releases and
+// detaches from foreign pages, they stay paused and navigation stalls.
+func TestContextlessConnectionDoesNotStallNavigation(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t)
+
+	b2, err := tb.browserType.Connect(context.Background(), tb.context(), tb.wsURL)
+	require.NoError(t, err)
+	t.Cleanup(b2.Close)
+
+	bctx, err := tb.NewContext(nil)
+	require.NoError(t, err)
+	p, err := bctx.NewPage()
+	require.NoError(t, err)
+
+	err = tb.awaitWithTimeout(10*time.Second, func() error {
+		opts := &common.FrameGotoOptions{Timeout: 10 * time.Second}
+		_, err := p.Goto("data:text/html,hello", opts)
+		return err
+	})
+	require.NoError(t, err)
+}
+
 func TestCloseContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What?

When multiple VUs share the same remote Chrome instance, each VU gets notified about every new page opened in that browser, including pages opened by other VUs. With this change, a VU only keeps hold of the pages it opened itself. A page that belongs to another VU is immediately released, so its owner can work with it right away.

## Why?

When working with remote Chrome instances, let's say 2 of them, and a test that requires 50 VUs, we found that the browser module would indeed start all 50 VUs, but only 2 would be able to work with the Chrome browsers. All the others had to wait until a running iteration ended before one of them could take the freed spot, so the test effectively ran 2 VUs at a time instead of 50.

The cause: a new page always starts out paused, and it only starts running once every VU connected to that browser gives it the green light. A VU that was still setting up its own session would take hold of pages belonging to other VUs and never give that green light. Those pages stayed paused until the holding VU finished its iteration and disconnected.

This can only happen when VUs share a browser instance (remote browsers via `K6_BROWSER_WS_URL`). When every VU launches its own browser, which is what local runs do, nothing is shared, so this never showed up locally.

Playwright follows the same rule we adopt here: every target it gets attached to is either adopted and resumed ([crPage.ts#L549](https://github.com/microsoft/playwright/blob/2b1e2f67e84904b816d0ca0c8f2dcad5588d82e4/packages/playwright-core/src/server/chromium/crPage.ts#L549)) or detached ([crBrowser.ts#L205-L212](https://github.com/microsoft/playwright/blob/2b1e2f67e84904b816d0ca0c8f2dcad5588d82e4/packages/playwright-core/src/server/chromium/crBrowser.ts#L205-L212), where the comment describes this exact stall), never silently held.

The new test reproduces the freeze on master and passes in under a second with the fix.

Tested with `-race` on the browser packages, no new lint issues. Full `make check` not run yet (draft).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.