### PR TITLE
Stop enabling the cloud secret source by default

### DIFF
--- a/internal/cmd/cloud_run.go
+++ b/internal/cmd/cloud_run.go
@@ -31,9 +31,6 @@ type cmdCloudRun struct {
 	// archive to the cloud service.
 	noArchiveUpload bool
 
-	// noCloudSecrets stores the state of the --no-cloud-secrets flag.
-	noCloudSecrets bool
-
 	// runCmd holds an instance of the k6 run command that we store
 	// in order to be able to call its run method to support
 	// the --local-execution flag mode.
@@ -100,6 +97,12 @@ func getCmdCloudRun(cloudCmd *cmdCloud) *cobra.Command {
 }
 
 func (c *cmdCloudRun) preRun(cmd *cobra.Command, args []string) error {
+	if !c.localExecution {
+		if err := validateNoCloudSecretSource(c.runCmd.gs.Flags.SecretSource); err != nil {
+			return err
+		}
+	}
+
 	if c.localExecution {
 		if cmd.Flags().Changed("exit-on-running") {
 			return errext.WithExitCodeIfNone(
@@ -121,13 +124,6 @@ func (c *cmdCloudRun) preRun(cmd *cobra.Command, args []string) error {
 	if c.linger {
 		return errext.WithExitCodeIfNone(
 			fmt.Errorf("the --linger flag can only be used in conjunction with the --local-execution flag"),
-			exitcodes.InvalidConfig,
-		)
-	}
-
-	if c.noCloudSecrets {
-		return errext.WithExitCodeIfNone(
-			fmt.Errorf("the --no-cloud-secrets flag can only be used in conjunction with the --local-execution flag"),
 			exitcodes.InvalidConfig,
 		)
 	}
@@ -185,12 +181,6 @@ func (c *cmdCloudRun) flagSet() *pflag.FlagSet {
 		"no-archive-upload",
 		c.noArchiveUpload,
 		"only when using the local-execution mode, don't upload the test archive to the cloud service",
-	)
-	flags.BoolVar(
-		&c.noCloudSecrets,
-		"no-cloud-secrets",
-		c.noCloudSecrets,
-		"only when using the local-execution mode, don't automatically configure the cloud secret source",
 	)
 
 	return flags

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -143,27 +143,7 @@ func newRootCommand(gs *state.GlobalState) *rootCommand {
 	return c
 }
 
-func (c *rootCommand) persistentPreRunE(cmd *cobra.Command, _ []string) error {
-	// The 'cloud' secret source is managed automatically and is not a valid value for
-	// --secret-source. Reject it here, before auto-injection, so the check only sees
-	// user-provided values. The logger is not yet configured at this point, so write
-	// the error directly to gs.Stderr and return errAlreadyReported to suppress the
-	// duplicate log entry that execute() would otherwise emit.
-	if err := validateNoCloudSecretSource(c.globalState.Flags.SecretSource); err != nil {
-		_, _ = fmt.Fprintln(c.globalState.Stderr, err.Error())
-		return errext.WithExitCodeIfNone(errAlreadyReported, exitcodes.InvalidConfig)
-	}
-
-	// For 'k6 cloud run --local-execution', automatically register the cloud secret source
-	// so scripts can call secrets.get() without any extra flags.
-	// This must happen before setupLoggers, which calls createSecretSources internally.
-	if isCloudRunWithLocalExecution(cmd) {
-		f := cmd.Flag("no-cloud-secrets")
-		if f == nil || f.Value.String() != "true" {
-			c.globalState.Flags.SecretSource = append(c.globalState.Flags.SecretSource, "cloud")
-		}
-	}
-
+func (c *rootCommand) persistentPreRunE(_ *cobra.Command, _ []string) error {
 	err := c.setupLoggers(c.stopLoggersCh)
 	if err != nil {
 		return err
@@ -487,14 +467,15 @@ func createSecretSources(gs *state.GlobalState) (map[string]secretsource.Source,
 		}
 	}
 
-	// Capture the cloud source instance if it was registered (via local-execution auto-injection
-	// or the env-var path below), so createCloudTest can call SetConfig on it later.
+	// Capture the cloud source instance if it was registered (via --secret-source=cloud or
+	// the PLZ env-var path below), so createCloudTest can call SetConfig on it later.
 	if cs, ok := result["cloud"].(*cloudsecrets.SecretSource); ok {
 		gs.CloudSecretSource = cs
 	}
 
-	// When  K6_CLOUD_SECRETS_TOKEN + K6_CLOUD_SECRETS_ENDPOINT are injected, create and configure the cloud source
-	// directly from env vars without a /v1/tests round-trip. Set it as the default source if none was chosen.
+	// PLZ path: the k6-operator injects K6_CLOUD_SECRETS_TOKEN + K6_CLOUD_SECRETS_ENDPOINT
+	// via environment variables because it never calls createCloudTest (no /v1/tests round-trip).
+	// Create and configure the cloud source here; set it as the default if none was chosen.
 	if token := gs.Env["K6_CLOUD_SECRETS_TOKEN"]; token != "" {
 		if gs.CloudSecretSource == nil {
 			cloudSource, err := cloudsecrets.New(baseParams)
@@ -517,23 +498,6 @@ func createSecretSources(gs *state.GlobalState) (map[string]secretsource.Source,
 	return result, nil
 }
 
-// isCloudRunWithLocalExecution returns true when the command being executed is
-// 'k6 cloud run' with the --local-execution flag set.
-func isCloudRunWithLocalExecution(cmd *cobra.Command) bool {
-	if cmd == nil || cmd.Name() != cloudRunCommandName {
-		return false
-	}
-	parent := cmd.Parent()
-	if parent == nil || parent.Name() != "cloud" {
-		return false
-	}
-	localExecution, err := cmd.Flags().GetBool("local-execution")
-	if err != nil {
-		return false
-	}
-	return localExecution
-}
-
 // hasCloudSecretSource returns true if the 'cloud' secret source type appears in sources.
 func hasCloudSecretSource(sources []string) bool {
 	for _, s := range sources {
@@ -545,14 +509,12 @@ func hasCloudSecretSource(sources []string) bool {
 	return false
 }
 
-// validateNoCloudSecretSource returns an error if sources contains 'cloud', which is not
-// a valid value for --secret-source. Cloud secrets are automatically available for
-// 'k6 cloud run --local-execution' and do not require explicit configuration.
+// validateNoCloudSecretSource returns an error if any source in sources is of type 'cloud'.
+// The cloud secret source is only valid for 'k6 cloud run --local-execution'.
 func validateNoCloudSecretSource(sources []string) error {
 	if hasCloudSecretSource(sources) {
 		return errext.WithExitCodeIfNone(
-			fmt.Errorf("'cloud' is not a valid value for --secret-source; "+
-				"cloud secrets are automatically available for 'k6 cloud run --local-execution'"),
+			fmt.Errorf("the 'cloud' secret source can only be used with 'k6 cloud run --local-execution'"),
 			exitcodes.InvalidConfig,
 		)
 	}

--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -589,8 +589,10 @@ func getCmdRun(gs *state.GlobalState) *cobra.Command {
 		Long: `Start a test. This also exposes a REST API to interact with it. Various k6 subcommands offer
 a commandline interface for interacting with it.`,
 		Example: exampleText,
-		Args: exactArgsWithMsg(1,
-			"arg should either be \"-\", if reading script from stdin, or a path to a script file"),
+		Args:    exactArgsWithMsg(1, "arg should either be \"-\", if reading script from stdin, or a path to a script file"),
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return validateNoCloudSecretSource(gs.Flags.SecretSource)
+		},
 		RunE: c.run,
 	}
 

--- a/internal/cmd/tests/cmd_cloud_run_test.go
+++ b/internal/cmd/tests/cmd_cloud_run_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -52,19 +53,9 @@ func TestCloudRunCommandIncompatibleFlags(t *testing.T) {
 			wantStderrContains: "the --local-execution flag is not compatible with the --show-logs flag",
 		},
 		{
-			name:               "--secret-source=cloud is not a valid value",
+			name:               "using --secret-source=cloud without --local-execution should fail",
 			cliArgs:            []string{"--secret-source=cloud"},
-			wantStderrContains: "'cloud' is not a valid value for --secret-source",
-		},
-		{
-			name:               "--secret-source=cloud is not a valid value even with --local-execution",
-			cliArgs:            []string{"--local-execution", "--secret-source=cloud"},
-			wantStderrContains: "'cloud' is not a valid value for --secret-source",
-		},
-		{
-			name:               "using --no-cloud-secrets without --local-execution should fail",
-			cliArgs:            []string{"--no-cloud-secrets"},
-			wantStderrContains: "the --no-cloud-secrets flag can only be used in conjunction with the --local-execution flag",
+			wantStderrContains: "the 'cloud' secret source can only be used with 'k6 cloud run --local-execution'",
 		},
 	}
 
@@ -262,33 +253,91 @@ export default function() {
 	})
 }
 
-func TestCloudRunLocalExecutionNoCloudSecrets(t *testing.T) {
+// TestCloudRunLocalExecutionUserSecretSourceStaysDefault is a regression test for #6093:
+// a single user-configured secret source must remain the implicit 'default' one under
+// 'k6 cloud run --local-execution', so scripts calling secrets.get() keep working.
+func TestCloudRunLocalExecutionUserSecretSourceStaysDefault(t *testing.T) {
 	t.Parallel()
 
 	script := `
+import secrets from "k6/secrets";
+
 export const options = {
   cloud: {
-      name: 'Test no-cloud-secrets',
+      name: 'Hello k6 Cloud!',
       projectID: 123456,
   },
 };
-export default function() {};`
 
-	ts := makeTestState(t, script, []string{"--local-execution", "--no-cloud-secrets"})
+export default async function() {
+	await secrets.get("cool");
+	console.log("resolved from the implicit default source");
+};`
+
+	ts := makeTestState(t, script, []string{
+		"--local-execution", "--log-output=stdout",
+		"--secret-source=mock=cool=sekrit-value",
+	})
+
+	srv := getCloudTestEndChecker(t, 1337, nil, cloudapi.RunStatusFinished, cloudapi.ResultStatusPassed)
+	ts.Env["K6_CLOUD_HOST"] = srv.URL
+
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.Contains(t, stdout, "resolved from the implicit default source")
+	assert.NotContains(t, stdout, `no secret source with name "default" is configured`)
+}
+
+// TestCloudRunLocalExecutionOptInCloudSecrets verifies that cloud secrets remain available
+// under 'k6 cloud run --local-execution' when explicitly requested via --secret-source=cloud,
+// configured from the CreateTestRun API response.
+func TestCloudRunLocalExecutionOptInCloudSecrets(t *testing.T) {
+	t.Parallel()
+
+	// Mock the secrets endpoint the cloud API points k6 at.
+	secretsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer mock-test-run-token", r.Header.Get("Authorization"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"plaintext":"cloud-secret-value"}`))
+	}))
+	t.Cleanup(secretsSrv.Close)
+
+	script := `
+import secrets from "k6/secrets";
+
+export const options = {
+  cloud: {
+      name: 'Hello k6 Cloud!',
+      projectID: 123456,
+  },
+};
+
+export default async function() {
+	const v = await secrets.source("cloud").get("mykey");
+	if (v === "cloud-secret-value") {
+		console.log("cloud secret resolved");
+	}
+};`
+
+	ts := makeTestState(t, script, []string{
+		"--local-execution", "--log-output=stdout", "--secret-source=cloud",
+	})
 
 	testServerHandlerFunc := http.HandlerFunc(func(resp http.ResponseWriter, _ *http.Request) {
 		resp.WriteHeader(http.StatusOK)
-		_, err := fmt.Fprint(resp, `{
+		_, err := fmt.Fprintf(resp, `{
 			"reference_id": "1337",
 			"test_run_token": "mock-test-run-token",
 			"secrets_config": {
-				"endpoint": "https://mock-secrets.example.com/{key}",
+				"endpoint": %q,
 				"response_path": "plaintext"
 			},
 			"config": {
 				"testRunDetails": "https://some.other.url/foo/tests/org/1337?bar=baz"
 			}
-		}`)
+		}`, secretsSrv.URL+"/{key}")
 		assert.NoError(t, err)
 	})
 
@@ -297,8 +346,10 @@ export default function() {};`
 
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
-	// --no-cloud-secrets must prevent the cloud source from being registered.
-	assert.Nil(t, ts.CloudSecretSource, "cloud secret source should not be registered when --no-cloud-secrets is set")
+	stdout := ts.Stdout.String()
+	t.Log(stdout)
+	assert.NotNil(t, ts.CloudSecretSource, "cloud secret source should be registered with --secret-source=cloud")
+	assert.Contains(t, stdout, "cloud secret resolved")
 }
 
 func makeTestState(tb testing.TB, script string, cliFlags []string) *GlobalTestState {

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -3491,20 +3491,20 @@ func TestCloudSourceNotRegisteredForPlainRun(t *testing.T) {
 	assert.NotContains(t, stderr, "cloud secrets not configured")
 }
 
-// TestCloudSecretSourceInvalidForK6Run verifies that 'cloud' is not a valid value for
-// --secret-source; cloud secrets are automatic and not user-configurable via that flag.
-func TestCloudSecretSourceInvalidForK6Run(t *testing.T) {
+// TestCloudSecretSourceRejectedByK6Run verifies that --secret-source=cloud is rejected
+// by 'k6 run' since the cloud source is only valid with 'k6 cloud run --local-execution'.
+func TestCloudSecretSourceRejectedByK6Run(t *testing.T) {
 	t.Parallel()
 
 	ts := getSingleFileTestState(t, `export default function() {}`, []string{"--secret-source=cloud"}, exitcodes.InvalidConfig)
 	cmd.ExecuteWithGlobalState(ts.GlobalState)
 
-	assert.Contains(t, ts.Stderr.String(), "'cloud' is not a valid value for --secret-source")
+	assert.Contains(t, ts.Stderr.String(), "the 'cloud' secret source can only be used with 'k6 cloud run --local-execution'")
 }
 
 // TestPLZCloudSecretsEnvVars verifies that setting K6_CLOUD_SECRETS_TOKEN and
-// K6_CLOUD_SECRETS_ENDPOINT configures the cloud secret source without a /v1/tests
-// API round-trip (the PLZ operator path).
+// K6_CLOUD_SECRETS_ENDPOINT configures the cloud secret source without requiring
+// --secret-source=cloud or a /v1/tests API round-trip (the PLZ operator path).
 func TestPLZCloudSecretsEnvVars(t *testing.T) {
 	t.Parallel()
 
@@ -3529,7 +3529,7 @@ func TestPLZCloudSecretsEnvVars(t *testing.T) {
 
 	ts.Env["K6_CLOUD_SECRETS_TOKEN"] = "plz-token"
 	ts.Env["K6_CLOUD_SECRETS_ENDPOINT"] = srv.URL + "/secrets/{key}"
-	// Cloud source is auto-registered when PLZ env vars are set; no extra flags needed.
+	// No --secret-source flag: cloud source is auto-registered and PLZ env vars configure it.
 	ts.CmdArgs = []string{"k6", "run", "script.js"}
 
 	cmd.ExecuteWithGlobalState(ts.GlobalState)

--- a/internal/secretsource/cloud/cloud.go
+++ b/internal/secretsource/cloud/cloud.go
@@ -44,9 +44,11 @@ func init() {
 }
 
 // SecretSource wraps the URL secret source for cloud-based secrets.
-// It is automatically registered for 'k6 cloud run --local-execution' (unless
-// --no-cloud-secrets is passed). Configuration arrives via SetConfig from the
-// CreateTestRun API response (createCloudTest) before the first Get() call.
+// It must be explicitly requested via --secret-source=cloud (or K6_SECRET_SOURCE=cloud),
+// and is only valid for 'k6 cloud run --local-execution'. It is also auto-configured for
+// the PLZ operator path when K6_CLOUD_SECRETS_TOKEN is set. Configuration arrives via
+// SetConfig — either from the CreateTestRun API response (createCloudTest) or directly
+// from env vars — before the first Get() call.
 //
 // The URL source is rebuilt whenever configPtr changes (i.e. a new test run starts with
 // different credentials). This supports sequential test runs in the same process — each run


### PR DESCRIPTION
It reverts #5875, as it represents a breaking change for v1.x.

Fixes https://github.com/grafana/k6/issues/6093