### PR TITLE
Fix WebCrypto digest BufferSource handling

### DIFF
--- a/internal/js/modules/k6/webcrypto/cmd_run_test.go
+++ b/internal/js/modules/k6/webcrypto/cmd_run_test.go
@@ -99,6 +99,148 @@ func TestExamplesInputOutput(t *testing.T) {
 	}
 }
 
+func TestDigestBufferSources(t *testing.T) {
+	t.Parallel()
+
+	const script = `
+function toHex(buffer) {
+    return Array.from(new Uint8Array(buffer), (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+async function assertDigestMatches(value, expectedBytes, label) {
+    const [actual, expected] = await Promise.all([
+        crypto.subtle.digest("SHA-256", value),
+        crypto.subtle.digest("SHA-256", expectedBytes.buffer),
+    ]);
+    if (toHex(actual) !== toHex(expected)) {
+        throw new Error(label + " used the wrong bytes");
+    }
+}
+
+async function assertSnapshot(view, backingBytes, label) {
+    const expectedBytes = backingBytes.slice(view.byteOffset, view.byteOffset + view.byteLength);
+    const actualPromise = crypto.subtle.digest("SHA-256", view);
+    const expectedPromise = crypto.subtle.digest("SHA-256", expectedBytes.buffer);
+    backingBytes.fill(255);
+    const [actual, expected] = await Promise.all([actualPromise, expectedPromise]);
+    if (toHex(actual) !== toHex(expected)) {
+        throw new Error(label + " did not copy its view bytes");
+    }
+}
+
+async function assertRejected(value, label) {
+    try {
+        await crypto.subtle.digest("SHA-256", value);
+    } catch (error) {
+        if (error.name !== "OperationError") {
+            throw new Error(label + " threw " + error.name + " instead of OperationError");
+        }
+        return;
+    }
+    throw new Error(label + " was accepted");
+}
+
+export default async function () {
+    ArrayBuffer.isView = () => false;
+    await assertDigestMatches(
+        new Uint8Array([1, 2, 3, 4]).subarray(1, 3),
+        new Uint8Array([2, 3]),
+        "first call after isView=false",
+    );
+
+    const overriddenArrayBuffer = new Uint8Array([1, 2, 3, 4]).buffer;
+    overriddenArrayBuffer.constructor = Object;
+    await assertDigestMatches(overriddenArrayBuffer, new Uint8Array([1, 2, 3, 4]), "ArrayBuffer constructor override");
+
+    const overriddenTypedArray = new Uint8Array([1, 2, 3, 4]).subarray(1, 3);
+    overriddenTypedArray.constructor = Object;
+    await assertDigestMatches(overriddenTypedArray, new Uint8Array([2, 3]), "TypedArray constructor override");
+
+    const overriddenDataView = new DataView(new Uint8Array([1, 2, 3, 4]).buffer, 1, 2);
+    overriddenDataView.constructor = Object;
+    await assertDigestMatches(overriddenDataView, new Uint8Array([2, 3]), "DataView constructor override");
+
+    class CustomArrayBuffer extends ArrayBuffer {}
+    const customArrayBuffer = new CustomArrayBuffer(4);
+    new Uint8Array(customArrayBuffer).set([1, 2, 3, 4]);
+    await assertDigestMatches(customArrayBuffer, new Uint8Array([1, 2, 3, 4]), "ArrayBuffer subclass");
+
+    class CustomUint8Array extends Uint8Array {}
+    await assertDigestMatches(
+        new CustomUint8Array([1, 2, 3, 4]).subarray(1, 3),
+        new Uint8Array([2, 3]),
+        "TypedArray subclass",
+    );
+
+    class CustomDataView extends DataView {}
+    await assertDigestMatches(
+        new CustomDataView(new Uint8Array([1, 2, 3, 4]).buffer, 1, 2),
+        new Uint8Array([2, 3]),
+        "DataView subclass",
+    );
+
+    ArrayBuffer.isView = () => true;
+    await assertDigestMatches(new Uint8Array([5, 6]), new Uint8Array([5, 6]), "real view after isView=true");
+    await assertRejected(
+        { constructor: Uint8Array, length: 2, 0: 2, 1: 3 },
+        "constructor-spoofed array-like",
+    );
+    await assertRejected(
+        Object.setPrototypeOf(
+            { length: 2, 0: 2, 1: 3, [Symbol.iterator]: undefined },
+            Uint8Array.prototype,
+        ),
+        "prototype-spoofed array-like",
+    );
+
+    ArrayBuffer.isView = null;
+    await assertDigestMatches(new Uint8Array([7, 8]), new Uint8Array([7, 8]), "real view after non-function isView");
+    await assertRejected(
+        Object.setPrototypeOf({ length: 2, 0: 7, 1: 8 }, DataView.prototype),
+        "DataView prototype-spoofed array-like",
+    );
+
+    const typedArrayConstructors = [
+        Int8Array,
+        Uint8Array,
+        Uint8ClampedArray,
+        Int16Array,
+        Uint16Array,
+        Int32Array,
+        Uint32Array,
+        Float32Array,
+        Float64Array,
+        BigInt64Array,
+        BigUint64Array,
+    ];
+    for (const TypedArray of typedArrayConstructors) {
+        const bytesPerElement = TypedArray.BYTES_PER_ELEMENT;
+        const buffer = new ArrayBuffer(bytesPerElement * 5);
+        const backingBytes = new Uint8Array(buffer);
+        backingBytes.forEach((_, index) => { backingBytes[index] = index + 1; });
+        const view = new TypedArray(buffer, bytesPerElement, 2);
+        await assertSnapshot(view, backingBytes, TypedArray.name);
+    }
+
+    const dataViewBuffer = new ArrayBuffer(8);
+    const dataViewBytes = new Uint8Array(dataViewBuffer);
+    dataViewBytes.set([1, 2, 3, 4, 5, 6, 7, 8]);
+    await assertSnapshot(new DataView(dataViewBuffer, 2, 4), dataViewBytes, "DataView");
+
+    console.log("digest BufferSource checks passed");
+}
+`
+
+	ts := getSingleFileTestState(t, script, []string{"--quiet", "--no-color", "--log-output=stdout"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	assert.Contains(t, stdout, "digest BufferSource checks passed")
+	assert.NotContains(t, stdout, "Uncaught")
+	assert.NotContains(t, stdout, "level=error")
+	assert.Empty(t, ts.Stderr.String())
+}
+
 func getFiles(t *testing.T, path string) []string {
 	t.Helper()
 

--- a/internal/js/modules/k6/webcrypto/module.go
+++ b/internal/js/modules/k6/webcrypto/module.go
@@ -62,10 +62,14 @@ func newCryptoObject(vu modules.VU) *sobek.Object {
 	rt := vu.Runtime()
 
 	obj := rt.NewObject()
+	arrayBufferIsView, err := getArrayBufferIsView(rt)
+	if err != nil {
+		common.Throw(rt, NewError(ImplementationError, err.Error()))
+	}
 
 	crypto := &Crypto{
 		vu:        vu,
-		Subtle:    &SubtleCrypto{vu: vu},
+		Subtle:    &SubtleCrypto{vu: vu, arrayBufferIsView: arrayBufferIsView},
 		CryptoKey: &CryptoKey{},
 	}
 
@@ -77,7 +81,11 @@ func newCryptoObject(vu modules.VU) *sobek.Object {
 		common.Throw(rt, NewError(ImplementationError, err.Error()))
 	}
 
-	if err := setReadOnlyPropertyOf(obj, "subtle", rt.ToValue(newSubtleCryptoObject(vu))); err != nil {
+	if err := setReadOnlyPropertyOf(
+		obj,
+		"subtle",
+		rt.ToValue(newSubtleCryptoObject(vu, arrayBufferIsView)),
+	); err != nil {
 		common.Throw(rt, NewError(ImplementationError, err.Error()))
 	}
 
@@ -88,12 +96,12 @@ func newCryptoObject(vu modules.VU) *sobek.Object {
 	return obj
 }
 
-func newSubtleCryptoObject(vu modules.VU) *sobek.Object {
+func newSubtleCryptoObject(vu modules.VU, arrayBufferIsView sobek.Callable) *sobek.Object {
 	rt := vu.Runtime()
 
 	obj := rt.NewObject()
 
-	subtleCrypto := &SubtleCrypto{vu: vu}
+	subtleCrypto := &SubtleCrypto{vu: vu, arrayBufferIsView: arrayBufferIsView}
 
 	if err := setReadOnlyPropertyOf(obj, "decrypt", rt.ToValue(subtleCrypto.Decrypt)); err != nil {
 		common.Throw(rt, NewError(ImplementationError, err.Error()))

--- a/internal/js/modules/k6/webcrypto/sobek.go
+++ b/internal/js/modules/k6/webcrypto/sobek.go
@@ -2,6 +2,7 @@ package webcrypto
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/grafana/sobek"
@@ -10,37 +11,61 @@ import (
 
 // exportArrayBuffer interprets the given value as an ArrayBuffer, TypedArray or DataView
 // and returns a copy of the underlying byte slice.
-func exportArrayBuffer(rt *sobek.Runtime, v sobek.Value) ([]byte, error) {
+func exportArrayBuffer(rt *sobek.Runtime, v sobek.Value, arrayBufferIsView sobek.Callable) ([]byte, error) {
 	if common.IsNullish(v) {
 		return nil, NewError(TypeError, "data is null or undefined")
 	}
 
-	asObject := v.ToObject(rt)
-
-	var ab sobek.ArrayBuffer
-	var ok bool
-
-	if IsTypedArray(rt, v) {
-		ab, ok = asObject.Get("buffer").Export().(sobek.ArrayBuffer)
-		if !ok {
-			return nil, NewError(TypeError, "TypedArray.buffer is not an ArrayBuffer")
+	if v.ExportType() != reflect.TypeFor[sobek.ArrayBuffer]() {
+		isView, err := isArrayBufferView(v, arrayBufferIsView)
+		if err != nil {
+			return nil, NewError(OperationError, err.Error())
 		}
-	} else {
-		ab, ok = asObject.Export().(sobek.ArrayBuffer)
-		if !ok {
+		if !isView {
 			return nil, NewError(OperationError, "data is neither an ArrayBuffer, nor a TypedArray nor DataView")
 		}
+	}
+
+	var bytes []byte
+	if err := rt.ExportTo(v, &bytes); err != nil {
+		return nil, NewError(OperationError, err.Error())
 	}
 
 	// Copy the underlying byte slice to avoid the caller modifying it.
 	// Ensures this step complies with the expactations of the
 	// specification: "Let [...] be the result of getting a copy of the
 	// bytes held by the [...] parameter"
-	bytes := ab.Bytes()
 	bytesCopy := make([]byte, len(bytes))
 	copy(bytesCopy, bytes)
 
 	return bytesCopy, nil
+}
+
+func getArrayBufferIsView(rt *sobek.Runtime) (sobek.Callable, error) {
+	var value sobek.Value
+	if exception := rt.Try(func() {
+		value = rt.Get(string(ArrayBufferConstructor)).ToObject(rt).Get("isView")
+	}); exception != nil {
+		return nil, exception
+	}
+
+	isView, ok := sobek.AssertFunction(value)
+	if !ok {
+		return nil, fmt.Errorf("ArrayBuffer.isView is not a function")
+	}
+	return isView, nil
+}
+
+func isArrayBufferView(v sobek.Value, isView sobek.Callable) (bool, error) {
+	if isView == nil {
+		return false, fmt.Errorf("ArrayBuffer.isView was not captured")
+	}
+
+	result, err := isView(nil, v)
+	if err != nil {
+		return false, err
+	}
+	return result.ToBoolean(), nil
 }
 
 // traverseObject traverses the given object using the given fields and returns the value

--- a/internal/js/modules/k6/webcrypto/subtle_crypto.go
+++ b/internal/js/modules/k6/webcrypto/subtle_crypto.go
@@ -17,7 +17,8 @@ import (
 
 // SubtleCrypto represents the SubtleCrypto interface of the Web Crypto API.
 type SubtleCrypto struct {
-	vu modules.VU
+	vu                modules.VU
+	arrayBufferIsView sobek.Callable
 }
 
 // Encrypt encrypts data.
@@ -50,7 +51,7 @@ func (sc *SubtleCrypto) Encrypt( //nolint:dupl // we have two similar methods
 	err := func() error {
 		var err error
 
-		plaintext, err = exportArrayBuffer(rt, data)
+		plaintext, err = exportArrayBuffer(rt, data, sc.arrayBufferIsView)
 		if err != nil {
 			return err
 		}
@@ -140,7 +141,7 @@ func (sc *SubtleCrypto) Decrypt( //nolint:dupl // we have two similar methods
 
 	err := func() error {
 		var err error
-		ciphertext, err = exportArrayBuffer(rt, data)
+		ciphertext, err = exportArrayBuffer(rt, data, sc.arrayBufferIsView)
 		if err != nil {
 			return err
 		}
@@ -230,7 +231,7 @@ func (sc *SubtleCrypto) Sign(algorithm, key, data sobek.Value) (*sobek.Promise, 
 		var err error
 		// 2.
 		// We obtain a copy of the key data, because we might need to modify it.
-		dataToSign, err = exportArrayBuffer(rt, data)
+		dataToSign, err = exportArrayBuffer(rt, data, sc.arrayBufferIsView)
 		if err != nil {
 			return err
 		}
@@ -325,12 +326,12 @@ func (sc *SubtleCrypto) Verify(algorithm, key, signature, data sobek.Value) (*so
 	err := func() error {
 		var err error
 
-		signatureData, err = exportArrayBuffer(sc.vu.Runtime(), signature)
+		signatureData, err = exportArrayBuffer(sc.vu.Runtime(), signature, sc.arrayBufferIsView)
 		if err != nil {
 			return err
 		}
 
-		signedData, err = exportArrayBuffer(sc.vu.Runtime(), data)
+		signedData, err = exportArrayBuffer(sc.vu.Runtime(), data, sc.arrayBufferIsView)
 		if err != nil {
 			return err
 		}
@@ -416,14 +417,7 @@ func (sc *SubtleCrypto) Digest(algorithm sobek.Value, data sobek.Value) (*sobek.
 	err := func() error {
 		var err error
 
-		// Validate that the value we received is either an ArrayBuffer, TypedArray, or DataView
-		// This uses the technique described in https://github.com/dop251/goja/issues/379#issuecomment-1164441879
-		if !IsInstanceOf(sc.vu.Runtime(), data, ArrayBufferConstructor, DataViewConstructor) &&
-			!IsTypedArray(sc.vu.Runtime(), data) {
-			return errors.New("data must be an ArrayBuffer, TypedArray, or DataView")
-		}
-
-		bytes, err = exportArrayBuffer(rt, data)
+		bytes, err = exportArrayBuffer(rt, data, sc.arrayBufferIsView)
 		if err != nil {
 			return err
 		}
@@ -835,7 +829,7 @@ func (sc *SubtleCrypto) ImportKey( //nolint:funlen // we have a lot of error han
 	err := func() error {
 		switch format {
 		case Pkcs8KeyFormat, RawKeyFormat, SpkiKeyFormat:
-			ab, err := exportArrayBuffer(rt, keyData)
+			ab, err := exportArrayBuffer(rt, keyData, sc.arrayBufferIsView)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## What?

- Copy only the visible bytes from `TypedArray` and `DataView` inputs instead of their entire backing buffers.
- Capture the native `ArrayBuffer.isView` callable before user code runs, so public constructor overrides and later global mutations do not affect BufferSource validation.
- Add public `crypto.subtle.digest()` regression coverage for view offsets and lengths, snapshot semantics, subclasses, constructor overrides, and spoofed array-like objects.

## Why?

`TypedArray.prototype.subarray()` and `DataView` can expose only part of a larger backing buffer. The previous extraction path copied the complete backing buffer, so WebCrypto operations could process bytes outside the supplied view instead of following Web IDL's BufferSource copy semantics.

## Checklist

- [ ] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

Verification completed:

- `go test -count=1 ./internal/js/modules/k6/webcrypto/...`
- `go test -race -count=1 ./internal/js/modules/k6/webcrypto/...`
- `go vet ./internal/js/modules/k6/webcrypto/...`
- Full-repository `golangci-lint` with the pinned v2.10.1: `0 issues`
- Full-repository race tests with proxy variables disabled passed all packages except `TestGRPCInputOutput/Client_Streaming`, which cannot connect because this environment resolves `localhost` to a different loopback address than the test fixture listener (`127.0.1.1:PORT: connection refused`).
- The WPT suite was skipped because its separate checkout is not present.

## Related PR(s)/Issue(s)

Closes #4259