### PR TITLE
Fix frozen pages on shared browser connections

### DIFF
--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -270,23 +270,16 @@ func (b *Browser) initEvents() error {
 }
 
 // connectionOnAttachedToTarget is called when Connection receives an attachedToTarget
-// event. Returning false will stop the event from being processed by the connection.
+// event. Returning false makes the connection release the target instead of
+// adopting it. Targets from the connection's own browser context and from
+// the default browser context are accepted.
 func (b *Browser) connectionOnAttachedToTarget(eva *target.EventAttachedToTarget) bool {
-	// This allows to attach targets to the same browser context as the current
-	// one, and to the default browser context.
-	//
-	// We don't want to hold the lock for the entire function
-	// (connectionOnAttachedToTarget) run duration, because we want to avoid
-	// possible lock contention issues with the browser context being closed while
-	// we're waiting for it. So, we do the lock management in a function with its
-	// own defer.
-	isAllowedBrowserContext := func() bool {
-		b.contextMu.RLock()
-		defer b.contextMu.RUnlock()
-		return b.context == nil || b.context.id == eva.TargetInfo.BrowserContextID
+	b.contextMu.RLock()
+	defer b.contextMu.RUnlock()
+	if b.context != nil && b.context.id == eva.TargetInfo.BrowserContextID {
+		return true
 	}
-
-	return isAllowedBrowserContext()
+	return b.defaultContext.id == eva.TargetInfo.BrowserContextID
 }
 
 // onAttachedToTarget is called when a new page is attached to the browser.

--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -292,15 +292,19 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) error {
 		browserCtx = b.getDefaultBrowserContextOrMatchedID(targetPage.BrowserContextID)
 	)
 
-	if !b.isAttachedPageValid(ev, browserCtx) {
-		return nil // Ignore this page.
-	}
 	session := b.conn.getSession(ev.SessionID)
 	if session == nil {
 		b.logger.Debugf("Browser:onAttachedToTarget",
 			"session closed before attachToTarget is handled. sid:%v tid:%v",
 			ev.SessionID, targetPage.TargetID)
 		return nil // ignore
+	}
+	if !b.isAttachedPageValid(ev, browserCtx) {
+		// Never ignore an attached target without detaching from it: the
+		// browser keeps the target paused until every attached client
+		// releases it, and detaching drops this client's hold.
+		detachSession(session)
+		return nil // Ignore this page.
 	}
 
 	var (

--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -321,10 +321,10 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) error {
 	}
 	p, err := NewPage(b.vuCtx, session, browserCtx, targetPage.TargetID, opener, isPage, b.logger)
 	if err != nil && b.isPageAttachmentErrorIgnorable(ev, session, err) {
-		if b.closing.Load() {
-			b.logger.Debugf("Browser:onAttachedToTarget", "new page failed; browser is closing: sid:%v", ev.SessionID)
-			detachSession(session)
-		}
+		// Always release: isPageAttachmentErrorIgnorable can also return
+		// true when only this VU's context ended, while the browser
+		// instance stays alive and shared with other VUs.
+		detachSession(session)
 		return nil // Ignore this page.
 	}
 	if err != nil {

--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -326,7 +326,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) error {
 	if err != nil && b.isPageAttachmentErrorIgnorable(ev, session, err) {
 		if b.closing.Load() {
 			b.logger.Debugf("Browser:onAttachedToTarget", "new page failed; browser is closing: sid:%v", ev.SessionID)
-			detachSession(b.browserCtx, session)
+			detachSession(session)
 		}
 		return nil // Ignore this page.
 	}
@@ -353,7 +353,7 @@ func (b *Browser) onAttachedToTarget(ev *target.EventAttachedToTarget) error {
 			)
 		}
 
-		detachSession(b.browserCtx, session)
+		detachSession(session)
 
 		return nil
 	}

--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -160,12 +160,16 @@ func (b *Browser) connect() error {
 		return fmt.Errorf("connecting to browser DevTools URL: %w", err)
 	}
 
-	// We don't need to lock this because `connect()` is called only in NewBrowser
-	b.defaultContext, err = NewBrowserContext(b.vuCtx, b, "", DefaultBrowserContextOptions(), b.logger)
+	defaultContext, err := NewBrowserContext(b.vuCtx, b, "", DefaultBrowserContextOptions(), b.logger)
 	if err != nil {
 		return fmt.Errorf("browser connect: %w", err)
 	}
-	b.runOnClose = append(b.runOnClose, b.defaultContext.cleanup)
+	// The connection's recvLoop reads defaultContext through
+	// connectionOnAttachedToTarget, so publish it under contextMu.
+	b.contextMu.Lock()
+	b.defaultContext = defaultContext
+	b.contextMu.Unlock()
+	b.runOnClose = append(b.runOnClose, defaultContext.cleanup)
 
 	return b.initEvents()
 }

--- a/internal/js/modules/k6/browser/common/browser_test.go
+++ b/internal/js/modules/k6/browser/common/browser_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/target"
 	"github.com/stretchr/testify/require"
@@ -239,6 +240,50 @@ func TestConnectionOnAttachedToTarget(t *testing.T) {
 			require.Equal(t, tt.want, b.connectionOnAttachedToTarget(ev))
 		})
 	}
+}
+
+// TestBrowserRejectedTarget ensures a target the connection accepts but the
+// browser rejects (isAttachedPageValid) is resumed and then detached from,
+// like the connection-level rejection in TestConnectionRejectedTarget.
+func TestBrowserRejectedTarget(t *testing.T) {
+	t.Parallel()
+
+	const rejectedSessionID = target.SessionID("session_id_0123456789")
+
+	wsURL, received := newAttachedToTargetServer(t,
+		attachedToTargetEvent(rejectedSessionID, "service_worker", ""),
+		300*time.Millisecond)
+
+	vuCtx, vuCancel := context.WithCancel(context.Background())
+	t.Cleanup(vuCancel)
+	b := newBrowser(context.Background(), vuCtx, vuCancel, nil, NewLocalBrowserOptions(), log.NewNullLogger())
+	var err error
+	b.defaultContext, err = NewBrowserContext(k6ext.WithVU(vuCtx, k6test.NewVU(t)), b, "", nil, nil)
+	require.NoError(t, err)
+
+	conn, err := NewConnection(
+		b.browserCtx, wsURL, log.NewNullLogger(), b.connectionOnAttachedToTarget,
+	)
+	require.NoError(t, err)
+	t.Cleanup(conn.Close)
+	b.conn = conn
+
+	evCh := make(chan Event)
+	conn.on(b.browserCtx, []string{cdproto.EventTargetAttachedToTarget}, evCh)
+
+	action := target.SetDiscoverTargets(true)
+	require.NoError(t, action.Do(cdp.WithExecutor(b.browserCtx, conn)))
+
+	select {
+	case event := <-evCh:
+		ev, ok := event.data.(*target.EventAttachedToTarget)
+		require.True(t, ok)
+		require.NoError(t, b.onAttachedToTarget(ev))
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the attached target event")
+	}
+
+	requireResumeThenDetach(t, received, rejectedSessionID)
 }
 
 type fakeConn struct {

--- a/internal/js/modules/k6/browser/common/browser_test.go
+++ b/internal/js/modules/k6/browser/common/browser_test.go
@@ -189,6 +189,58 @@ func TestBrowserNewPageInContext(t *testing.T) {
 	})
 }
 
+func TestConnectionOnAttachedToTarget(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ownContextID     cdp.BrowserContextID = "own"
+		foreignContextID cdp.BrowserContextID = "foreign"
+	)
+
+	newTestBrowser := func(t *testing.T, withOwnContext bool) *Browser {
+		t.Helper()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		b := newBrowser(context.Background(), ctx, cancel, nil, NewLocalBrowserOptions(), log.NewNullLogger())
+
+		var err error
+		b.defaultContext, err = NewBrowserContext(k6ext.WithVU(ctx, k6test.NewVU(t)), b, "", nil, nil)
+		require.NoError(t, err)
+		if withOwnContext {
+			b.context, err = NewBrowserContext(k6ext.WithVU(ctx, k6test.NewVU(t)), b, ownContextID, nil, nil)
+			require.NoError(t, err)
+		}
+
+		return b
+	}
+
+	tests := []struct {
+		name            string
+		withOwnContext  bool
+		targetContextID cdp.BrowserContextID
+		want            bool
+	}{
+		{"own_context_target", true, ownContextID, true},
+		{"foreign_target", true, foreignContextID, false},
+		{"foreign_target_without_own_context", false, foreignContextID, false},
+		{"default_context_target", false, "", true},
+		{"default_context_target_with_own_context", true, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			b := newTestBrowser(t, tt.withOwnContext)
+			ev := &target.EventAttachedToTarget{
+				TargetInfo: &target.Info{BrowserContextID: tt.targetContextID},
+			}
+			require.Equal(t, tt.want, b.connectionOnAttachedToTarget(ev))
+		})
+	}
+}
+
 type fakeConn struct {
 	connection
 	execute func(context.Context, string, any, any) error

--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -332,7 +332,36 @@ func (c *Connection) findTargetIDForLog(id target.SessionID) target.ID {
 	return s.targetID
 }
 
-//nolint:funlen,gocognit,cyclop
+// deliverToSession routes msg to session's readCh. It reports whether
+// recvLoop should stop reading from the connection entirely.
+//
+// getSession only holds the sessions lock for the lookup, so by the time
+// this runs, session may already be closed (e.g. by closeSession, which
+// can be called concurrently from any goroutine, not just recvLoop): its
+// readLoop may have already exited on its own done channel, leaving no
+// receiver on readCh. Without the <-session.done case, an unbuffered send
+// there would then block forever, since neither c.closeCh nor c.done fire
+// just because one session closed - stalling recvLoop, and with it every
+// other session on the connection.
+func (c *Connection) deliverToSession(session *Session, msg *cdproto.Message) (stop bool) {
+	select {
+	case session.readCh <- msg:
+	case <-session.done:
+		c.logger.Debugf("Connection:deliverToSession:<-session.done", "sid:%v tid:%v wsURL:%q",
+			session.id, session.targetID, c.wsURL)
+	case code := <-c.closeCh:
+		c.logger.Debugf("Connection:deliverToSession:<-c.closeCh", "sid:%v tid:%v wsURL:%v crashed:%t",
+			session.id, session.targetID, c.wsURL, session.crashed)
+		_ = c.close(code)
+	case <-c.done:
+		c.logger.Debugf("Connection:deliverToSession:<-c.done", "sid:%v tid:%v wsURL:%v crashed:%t",
+			session.id, session.targetID, c.wsURL, session.crashed)
+		return true
+	}
+	return false
+}
+
+//nolint:funlen,gocognit
 func (c *Connection) recvLoop() {
 	c.logger.Debugf("Connection:recvLoop", "wsURL:%q", c.wsURL)
 	for {
@@ -404,7 +433,6 @@ func (c *Connection) recvLoop() {
 
 		switch {
 		case msg.SessionID != "" && (msg.Method != "" || msg.ID != 0):
-			// TODO: possible data race - session can get removed after getting it here
 			session := c.getSession(msg.SessionID)
 			if session == nil {
 				continue
@@ -416,15 +444,7 @@ func (c *Connection) recvLoop() {
 				continue
 			}
 
-			select {
-			case session.readCh <- &msg:
-			case code := <-c.closeCh:
-				c.logger.Debugf("Connection:recvLoop:<-c.closeCh", "sid:%v tid:%v wsURL:%v crashed:%t",
-					session.id, session.targetID, c.wsURL, session.crashed)
-				_ = c.close(code)
-			case <-c.done:
-				c.logger.Debugf("Connection:recvLoop:<-c.done", "sid:%v tid:%v wsURL:%v crashed:%t",
-					session.id, session.targetID, c.wsURL, session.crashed)
+			if c.deliverToSession(session, &msg) {
 				return
 			}
 

--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -476,9 +476,17 @@ func (c *Connection) recvLoop() {
 // detached from. Best-effort: errors are not returned. Target.detachFromTarget
 // is browser-level: the session goes in the params, not the message's
 // session ID.
+//
+// The session is also closed locally here, rather than left for the
+// browser's own Target.detachedFromTarget event to reap: that event isn't
+// guaranteed to arrive (e.g. if the detach command itself errors), and
+// waiting for it would leak the session's goroutine and its entry in the
+// connection's sessions map until the whole connection closes.
 func detachSession(session *Session) {
 	go func() {
 		c := session.conn
+		defer c.closeSession(session.id, session.targetID)
+
 		ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
 		defer cancel()
 		_ = session.Execute(ctx, cdpruntime.CommandRunIfWaitingForDebugger, nil, nil)

--- a/internal/js/modules/k6/browser/common/connection.go
+++ b/internal/js/modules/k6/browser/common/connection.go
@@ -134,9 +134,12 @@ type Connection struct {
 	sessionsMu sync.RWMutex
 	sessions   map[target.SessionID]*Session
 
-	// onTargetAttachedToTarget is called when a new target is attached to the browser.
-	// Returning false will prevent the session from being created.
-	// If onTargetAttachedToTarget is nil, the session will be created.
+	// onTargetAttachedToTarget is called when a new target is attached to
+	// the browser. The target's session is registered before the call, so
+	// that the response to the release below can be routed back to it.
+	// Returning false releases the target: it is resumed and detached from
+	// instead of being adopted. If onTargetAttachedToTarget is nil, every
+	// target is adopted.
 	onTargetAttachedToTarget func(*target.EventAttachedToTarget) bool
 }
 
@@ -363,21 +366,21 @@ func (c *Connection) recvLoop() {
 			eva := ev.(*target.EventAttachedToTarget) //nolint:forcetypeassert
 			sid, tid := eva.SessionID, eva.TargetInfo.TargetID
 
-			if c.onTargetAttachedToTarget != nil {
-				// If onTargetAttachedToTarget is set, it will be called to determine
-				// if a session should be created for the target.
-				ok := c.onTargetAttachedToTarget(eva)
-				if !ok {
-					c.stopWaitingForDebugger(sid)
-					continue
-				}
-			}
-
 			c.sessionsMu.Lock()
 			session := NewSession(c.ctx, c, sid, tid, c.logger, c.msgIDGen)
 			c.logger.Debugf("Connection:recvLoop:EventAttachedToTarget", "sid:%v tid:%v wsURL:%q", sid, tid, c.wsURL)
 			c.sessions[sid] = session
 			c.sessionsMu.Unlock()
+
+			if c.onTargetAttachedToTarget != nil {
+				// If onTargetAttachedToTarget is set, it will be called to
+				// determine if the target should be adopted or released.
+				ok := c.onTargetAttachedToTarget(eva)
+				if !ok {
+					detachSession(session)
+					continue
+				}
+			}
 		} else if msg.Method == cdproto.EventTargetDetachedFromTarget {
 			ev, err := cdproto.UnmarshalMessage(&msg)
 			if err != nil {
@@ -445,29 +448,35 @@ func (c *Connection) recvLoop() {
 	}
 }
 
-// stopWaitingForDebugger tells the browser to stop waiting for the
-// debugger to attach to the page's session.
-//
-// Whether we're not sharing pages among browser contexts, Chromium
-// still does so (since we're auto-attaching all browser targets).
-// This means that if we don't stop waiting for the debugger, the
-// browser will wait for the debugger to attach to the new page
-// indefinitely, even if the page is not part of the browser context
-// we're using.
-//
-// We don't return an error because the browser might have already
-// closed the connection. In that case, handling the error would
-// be redundant. This operation is best-effort.
-func (c *Connection) stopWaitingForDebugger(sid target.SessionID) {
-	msg := &cdproto.Message{
-		ID:        c.msgIDGen.newID(),
-		SessionID: sid,
-		Method:    cdproto.MethodType(cdpruntime.CommandRunIfWaitingForDebugger),
-	}
-	err := c.send(c.ctx, msg, nil, nil)
-	if err != nil {
-		c.logger.Errorf("Connection:stopWaitingForDebugger", "sid:%v wsURL:%q, err:%v", sid, c.wsURL, err)
-	}
+// detachSession resumes a rejected target's session, awaits the response,
+// then detaches from it. Detaching alone should release the target, but the
+// browser has a bug where a detached target can stay paused, so the resume
+// must land first — the same workaround as Playwright's CRSession.detach
+// (crConnection.ts). The wait is bounded so an unresponsive target is still
+// detached from. Best-effort: errors are not returned. Target.detachFromTarget
+// is browser-level: the session goes in the params, not the message's
+// session ID.
+func detachSession(session *Session) {
+	go func() {
+		c := session.conn
+		ctx, cancel := context.WithTimeout(c.ctx, DefaultTimeout)
+		defer cancel()
+		_ = session.Execute(ctx, cdpruntime.CommandRunIfWaitingForDebugger, nil, nil)
+
+		buf, err := jsonv2.Marshal(&target.DetachFromTargetParams{SessionID: session.id}, defaultJSONV2Options)
+		if err != nil {
+			c.logger.Errorf("Connection:detachSession", "sid:%v wsURL:%q, err:%v", session.id, c.wsURL, err)
+			return
+		}
+		msg := &cdproto.Message{
+			ID:     c.msgIDGen.newID(),
+			Method: cdproto.MethodType(target.CommandDetachFromTarget),
+			Params: buf,
+		}
+		if err := c.send(c.ctx, msg, nil, nil); err != nil {
+			c.logger.Errorf("Connection:detachSession", "sid:%v wsURL:%q, err:%v", session.id, c.wsURL, err)
+		}
+	}()
 }
 
 func (c *Connection) send(

--- a/internal/js/modules/k6/browser/common/connection_test.go
+++ b/internal/js/modules/k6/browser/common/connection_test.go
@@ -228,6 +228,57 @@ func TestConnectionRejectedTarget(t *testing.T) {
 	requireResumeThenDetach(t, received, rejectedSessionID)
 }
 
+// TestConnectionRejectedTargetClosedLocallyOnDetachError ensures a rejected
+// target's session is closed locally even when the outgoing detach command
+// itself errors (as it can against a real browser). Waiting for the
+// browser's own Target.detachedFromTarget event to reap the session would
+// leak it whenever that event never arrives.
+func TestConnectionRejectedTargetClosedLocallyOnDetachError(t *testing.T) {
+	t.Parallel()
+
+	const rejectedSessionID = target.SessionID("session_id_0123456789")
+
+	received := make(chan cdproto.Message, 16)
+	handler := func(_ *websocket.Conn, msg *cdproto.Message, writeCh chan cdproto.Message, _ chan struct{}) {
+		if msg.Method == "" {
+			return
+		}
+		received <- *msg
+		switch msg.Method {
+		case cdproto.MethodType(cdproto.CommandTargetSetDiscoverTargets):
+			writeCh <- cdproto.Message{
+				Method: cdproto.EventTargetAttachedToTarget,
+				Params: jsontext.Value(attachedToTargetEvent(rejectedSessionID, "page", "browser_context_id_0123456789")),
+			}
+			writeCh <- cdproto.Message{ID: msg.ID, Result: jsontext.Value([]byte("{}"))}
+		case cdproto.MethodType(cdpruntime.CommandRunIfWaitingForDebugger):
+			writeCh <- cdproto.Message{ID: msg.ID, SessionID: msg.SessionID, Result: jsontext.Value([]byte("{}"))}
+		case cdproto.MethodType(target.CommandDetachFromTarget):
+			// Simulate the browser rejecting the detach itself.
+			writeCh <- cdproto.Message{ID: msg.ID, Error: &cdproto.Error{Message: "No session with given id"}}
+		}
+	}
+
+	server := ws.NewServer(t, ws.WithCDPHandler("/cdp", handler, nil))
+	u, err := url.Parse(server.ServerHTTP.URL)
+	require.NoError(t, err)
+	wsURL := fmt.Sprintf("ws://%s/cdp", u.Host)
+
+	ctx := context.Background()
+	rejectAll := func(*target.EventAttachedToTarget) bool { return false }
+	conn, err := NewConnection(ctx, wsURL, log.NewNullLogger(), rejectAll)
+	require.NoError(t, err)
+	t.Cleanup(conn.Close)
+
+	action := target.SetDiscoverTargets(true)
+	require.NoError(t, action.Do(cdp.WithExecutor(ctx, conn)))
+
+	require.Eventually(t, func() bool {
+		return conn.getSession(rejectedSessionID) == nil
+	}, 5*time.Second, 10*time.Millisecond,
+		"session should be closed locally even though the detach command errored")
+}
+
 // newTestConnection dials a minimal fake CDP server that acknowledges
 // every command with an empty success reply.
 func newTestConnection(t *testing.T) *Connection {

--- a/internal/js/modules/k6/browser/common/connection_test.go
+++ b/internal/js/modules/k6/browser/common/connection_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -225,6 +226,117 @@ func TestConnectionRejectedTarget(t *testing.T) {
 	require.NoError(t, action.Do(cdp.WithExecutor(ctx, conn)))
 
 	requireResumeThenDetach(t, received, rejectedSessionID)
+}
+
+// newTestConnection dials a minimal fake CDP server that acknowledges
+// every command with an empty success reply.
+func newTestConnection(t *testing.T) *Connection {
+	t.Helper()
+
+	handler := func(_ *websocket.Conn, msg *cdproto.Message, writeCh chan cdproto.Message, _ chan struct{}) {
+		writeCh <- cdproto.Message{ID: msg.ID, SessionID: msg.SessionID, Result: jsontext.Value([]byte("{}"))}
+	}
+	server := ws.NewServer(t, ws.WithCDPHandler("/cdp", handler, nil))
+	u, err := url.Parse(server.ServerHTTP.URL)
+	require.NoError(t, err)
+
+	conn, err := NewConnection(context.Background(), fmt.Sprintf("ws://%s/cdp", u.Host), log.NewNullLogger(), nil)
+	require.NoError(t, err)
+	t.Cleanup(conn.Close)
+
+	return conn
+}
+
+// TestConnectionDeliverToSessionAfterClose is a deterministic regression
+// test for a race in recvLoop's dispatch to a session's readCh: getSession
+// only holds the sessions lock for the map lookup, so a session obtained
+// this way can already be closed - by closeSession, callable from any
+// goroutine, not just recvLoop - by the time the dispatch actually runs.
+// Without the <-session.done case, delivering to an already-closed
+// session's readCh blocks forever: its readLoop has already exited, so
+// there is no reader left, and neither c.closeCh nor c.done fire just
+// because one session closed. That would stall recvLoop - the single
+// goroutine reading every message for the whole connection - along with
+// every other session sharing it.
+//
+// The session's readLoop is deliberately never started (done is closed by
+// hand instead of via NewSession + closeSession), so there is provably no
+// reader on readCh, ever - this removes any dependency on readLoop's own
+// exit timing and drives the exact interleaving deterministically, rather
+// than hoping to catch it.
+func TestConnectionDeliverToSessionAfterClose(t *testing.T) {
+	t.Parallel()
+
+	const sid = target.SessionID("session_id_0123456789")
+	const tid = target.ID("target_id_0123456789")
+
+	conn := newTestConnection(t)
+
+	session := &Session{
+		BaseEventEmitter: NewBaseEventEmitter(context.Background()),
+		conn:             conn,
+		id:               sid,
+		targetID:         tid,
+		readCh:           make(chan *cdproto.Message),
+		done:             make(chan struct{}),
+		msgIDGen:         conn.msgIDGen,
+		logger:           log.NewNullLogger(),
+	}
+	close(session.done) // no readLoop was ever started to close it itself
+
+	done := make(chan bool, 1)
+	go func() {
+		done <- conn.deliverToSession(session, &cdproto.Message{Method: "Test.event", SessionID: sid})
+	}()
+
+	select {
+	case stop := <-done:
+		require.False(t, stop, "delivering to a closed session must not signal a connection-level stop")
+	case <-time.After(2 * time.Second):
+		t.Fatal("deliverToSession blocked forever delivering to an already-closed session")
+	}
+}
+
+// TestConnectionCloseSessionConcurrent proves closeSession is safe to call
+// concurrently, and repeatedly, for the same session - the exact shape of
+// detachSession's own closeSession call racing the browser's genuine
+// Target.detachedFromTarget event arriving and being handled by recvLoop's
+// own closeSession call, or any other pair of callers. Under -race, a
+// data race here would fail the test; closeSession's own locking must
+// also make it safe to call twice - only the first caller may release the
+// session, every other caller must see it already gone.
+func TestConnectionCloseSessionConcurrent(t *testing.T) {
+	t.Parallel()
+
+	const sid = target.SessionID("session_id_0123456789")
+	const tid = target.ID("target_id_0123456789")
+	const callers = 50
+
+	conn := newTestConnection(t)
+
+	conn.sessionsMu.Lock()
+	conn.sessions[sid] = NewSession(context.Background(), conn, sid, tid, log.NewNullLogger(), conn.msgIDGen)
+	conn.sessionsMu.Unlock()
+
+	var wg sync.WaitGroup
+	results := make([]bool, callers)
+	for i := range callers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			results[i] = conn.closeSession(sid, tid)
+		}(i)
+	}
+	wg.Wait()
+
+	var released int
+	for _, ok := range results {
+		if ok {
+			released++
+		}
+	}
+	require.Equal(t, 1, released, "exactly one concurrent closeSession call should release the session")
+	require.Nil(t, conn.getSession(sid), "the session must be gone from the connection after closing")
 }
 
 func TestConnectionCreateSession(t *testing.T) {

--- a/internal/js/modules/k6/browser/common/connection_test.go
+++ b/internal/js/modules/k6/browser/common/connection_test.go
@@ -5,13 +5,16 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
+	"time"
 
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/log"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/tests/ws"
 
 	"github.com/chromedp/cdproto"
 	"github.com/chromedp/cdproto/cdp"
+	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/cdproto/target"
+	jsonv2 "github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
@@ -76,6 +79,152 @@ func TestConnectionSendRecv(t *testing.T) {
 			require.NoError(t, err)
 		}
 	})
+}
+
+// attachedToTargetEvent returns a Target.attachedToTarget event payload for
+// a paused target, as the browser sends when auto-attaching a new target.
+func attachedToTargetEvent(sessionID target.SessionID, targetType, browserContextID string) string {
+	return fmt.Sprintf(`
+	{
+		"sessionId": %q,
+		"targetInfo": {
+			"targetId": "target_id_0123456789",
+			"type": %q,
+			"title": "",
+			"url": "about:blank",
+			"attached": true,
+			"browserContextId": %q
+		},
+		"waitingForDebugger": true
+	}`, sessionID, targetType, browserContextID)
+}
+
+// resumeRespondedSentinel marks, in the received stream, the moment the
+// server wrote its response to Runtime.runIfWaitingForDebugger. Anything
+// the client sends after seeing that response arrives later in the stream.
+const resumeRespondedSentinel = cdproto.MethodType("test:resume-responded")
+
+// newAttachedToTargetServer starts a fake CDP websocket server that records
+// every command it receives and emits the given Target.attachedToTarget
+// event when the client sends Target.setDiscoverTargets. The response to
+// Runtime.runIfWaitingForDebugger is delayed by resumeDelay, and a
+// resumeRespondedSentinel is recorded when it is written.
+func newAttachedToTargetServer(
+	t *testing.T, attachedEvent string, resumeDelay time.Duration,
+) (string, chan cdproto.Message) {
+	t.Helper()
+
+	received := make(chan cdproto.Message, 16)
+	handler := func(conn *websocket.Conn, msg *cdproto.Message, writeCh chan cdproto.Message, done chan struct{}) {
+		if msg.Method == "" {
+			return
+		}
+		received <- *msg
+		switch msg.Method {
+		case cdproto.MethodType(cdproto.CommandTargetSetDiscoverTargets):
+			writeCh <- cdproto.Message{
+				Method: cdproto.EventTargetAttachedToTarget,
+				Params: jsontext.Value(attachedEvent),
+			}
+			writeCh <- cdproto.Message{
+				ID:     msg.ID,
+				Result: jsontext.Value([]byte("{}")),
+			}
+		case cdproto.MethodType(cdpruntime.CommandRunIfWaitingForDebugger):
+			response := cdproto.Message{
+				ID:        msg.ID,
+				SessionID: msg.SessionID,
+				Result:    jsontext.Value([]byte("{}")),
+			}
+			// Respond asynchronously so a delayed response does not also
+			// delay reading the messages the client sends in the meantime.
+			go func() {
+				select {
+				case <-time.After(resumeDelay):
+				case <-done:
+					return
+				}
+				received <- cdproto.Message{Method: resumeRespondedSentinel}
+				select {
+				case writeCh <- response:
+				case <-done:
+				}
+			}()
+		}
+	}
+
+	server := ws.NewServer(t, ws.WithCDPHandler("/cdp", handler, nil))
+	u, err := url.Parse(server.ServerHTTP.URL)
+	require.NoError(t, err)
+
+	return fmt.Sprintf("ws://%s/cdp", u.Host), received
+}
+
+// requireResumeThenDetach consumes the server-received messages until the
+// rejected target's session is detached from, asserting the client resumed
+// the target, awaited the server's response, and only then detached, with
+// both commands correctly addressed.
+func requireResumeThenDetach(t *testing.T, received <-chan cdproto.Message, sid target.SessionID) {
+	t.Helper()
+
+	timeout := time.After(5 * time.Second)
+	var sawResume, sawResponse bool
+	for {
+		select {
+		case msg := <-received:
+			switch msg.Method {
+			case cdproto.MethodType(cdpruntime.CommandRunIfWaitingForDebugger):
+				// The resume targets the paused session directly.
+				require.Equal(t, sid, msg.SessionID)
+				sawResume = true
+			case resumeRespondedSentinel:
+				sawResponse = true
+			case cdproto.MethodType(target.CommandDetachFromTarget):
+				// Target.detachFromTarget is a browser-level command: the
+				// session goes in the params, not in the message session ID.
+				require.Empty(t, msg.SessionID)
+				var params target.DetachFromTargetParams
+				require.NoError(t, jsonv2.Unmarshal(msg.Params, &params, defaultJSONV2Options))
+				require.Equal(t, sid, params.SessionID)
+				require.True(t, sawResume, "expected Runtime.runIfWaitingForDebugger before the detach")
+				require.True(t, sawResponse,
+					"expected the detach to be sent only after the resume response was written")
+				return
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for the rejected target to be released")
+		}
+	}
+}
+
+// TestConnectionRejectedTarget ensures a target rejected by the attach filter
+// is resumed and then detached from. The browser keeps a new target paused
+// until every client attached with waitForDebuggerOnStart releases it.
+// Detaching should be enough to release the hold, but the browser has a bug
+// where a detached target can stay paused, so the resume must come first —
+// the same workaround Playwright uses (crConnection.ts, CRSession.detach).
+// Wire order is not enough: only awaiting the response guarantees the
+// browser processed the resume before the detach, so the server delays the
+// resume response to catch a client that does not wait for it.
+func TestConnectionRejectedTarget(t *testing.T) {
+	t.Parallel()
+
+	const rejectedSessionID = target.SessionID("session_id_0123456789")
+
+	wsURL, received := newAttachedToTargetServer(t,
+		attachedToTargetEvent(rejectedSessionID, "page", "browser_context_id_0123456789"),
+		300*time.Millisecond)
+
+	ctx := context.Background()
+	rejectAll := func(*target.EventAttachedToTarget) bool { return false }
+	conn, err := NewConnection(ctx, wsURL, log.NewNullLogger(), rejectAll)
+	require.NoError(t, err)
+	t.Cleanup(conn.Close)
+
+	action := target.SetDiscoverTargets(true)
+	require.NoError(t, action.Do(cdp.WithExecutor(ctx, conn)))
+
+	requireResumeThenDetach(t, received, rejectedSessionID)
 }
 
 func TestConnectionCreateSession(t *testing.T) {

--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -969,7 +969,7 @@ func (fs *FrameSession) onAttachedToTarget(event *target.EventAttachedToTarget) 
 	default:
 		fs.logger.Debugf("FrameSession:onAttachedToTarget",
 			"unsupported target type %q sid:%v", ti.Type, session.ID())
-		detachSession(fs.teardownCtx, session)
+		detachSession(session)
 	}
 	if err == nil {
 		return
@@ -1020,7 +1020,7 @@ func (fs *FrameSession) attachIFrameToTarget(ti *target.Info, session *Session) 
 	if fs.page.isClosing() {
 		fs.logger.Debugf("FrameSession:attachIFrameToTarget",
 			"rejected frame; page is closing: tid=%v", ti.TargetID)
-		detachSession(fs.teardownCtx, session)
+		detachSession(session)
 		return nil
 	}
 
@@ -1059,7 +1059,7 @@ func (fs *FrameSession) attachIFrameToTarget(ti *target.Info, session *Session) 
 		if errors.Is(err, errPageClosing) {
 			fs.logger.Debugf("FrameSession:attachIFrameToTarget",
 				"rejected frame; page is closing: tid=%v", ti.TargetID)
-			detachSession(fs.teardownCtx, session)
+			detachSession(session)
 			return nil
 		}
 		return err
@@ -1073,7 +1073,7 @@ func (fs *FrameSession) attachWorkerToTarget(ti *target.Info, session *Session) 
 	if fs.page.isClosing() {
 		fs.logger.Debugf("FrameSession:attachWorkerToTarget",
 			"rejected worker; page is closing: tid=%v", ti.TargetID)
-		detachSession(fs.teardownCtx, session)
+		detachSession(session)
 		return nil
 	}
 
@@ -1287,12 +1287,4 @@ func (fs *FrameSession) executionContextForID(
 	}
 
 	return nil, fmt.Errorf("no execution context found for id: %v", executionContextID)
-}
-
-// detachSession unblocks a target waiting for debugger and detaches from it.
-// Prevents the browser from hanging on rejected targets during close
-func detachSession(ctx context.Context, session *Session) {
-	_ = session.ExecuteWithoutExpectationOnReply(ctx, cdpruntime.CommandRunIfWaitingForDebugger, nil, nil)
-	_ = session.ExecuteWithoutExpectationOnReply(ctx, target.CommandDetachFromTarget,
-		&target.DetachFromTargetParams{SessionID: session.id}, nil)
 }

--- a/internal/js/modules/k6/browser/tests/browser_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_test.go
@@ -351,6 +351,35 @@ func TestMultiConnectToSingleBrowser(t *testing.T) {
 	require.NoError(t, err, "failed to close page #2")
 }
 
+// TestContextlessConnectionDoesNotStallNavigation guards against connections
+// freezing each other's pages when they share a browser instance. Every new
+// page starts paused until all auto-attached connections resume it. A
+// connection that hadn't created its browser context yet used to claim other
+// connections' pages without ever releasing them, stalling their navigations
+// until it disconnected. The second connection here never creates a context,
+// which reproduces that state deterministically.
+func TestContextlessConnectionDoesNotStallNavigation(t *testing.T) {
+	t.Parallel()
+
+	tb := newTestBrowser(t)
+
+	b2, err := tb.browserType.Connect(context.Background(), tb.context(), tb.wsURL)
+	require.NoError(t, err)
+	t.Cleanup(b2.Close)
+
+	bctx, err := tb.NewContext(nil)
+	require.NoError(t, err)
+	p, err := bctx.NewPage()
+	require.NoError(t, err)
+
+	err = tb.awaitWithTimeout(10*time.Second, func() error {
+		opts := &common.FrameGotoOptions{Timeout: 10 * time.Second}
+		_, err := p.Goto("data:text/html,hello", opts)
+		return err
+	})
+	require.NoError(t, err)
+}
+
 func TestCloseContext(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What?

When multiple VUs share the same remote Chrome instance, each VU gets notified about every new page opened in that browser, including pages opened by other VUs. With this change, a VU only keeps hold of the pages it opened itself. A page that belongs to another VU is immediately released, so its owner can work with it right away.

Made up of these core changes:

* Fix a race issue.
* Ensure we not only resume (now awaited) but also detach from targets that are not part of the current VU's target (owned by another VU).
* Correct filtering of foreign targets.
* detach session of foreign target (don't just early return) if the target slips through to the second gate (isAttachedPageValid).

All of these help:

* prevent the blocking of the target which is owned by another VU.
* align the fix for all edge cases where this might happen.
* align with Playwright.

## Why?

When working with remote Chrome instances, let's say 2 of them, and a test that requires 50 VUs, we found that the browser module would indeed start all 50 VUs, but only 2 would be able to work with the Chrome browsers. All the others had to wait until a running iteration ended before one of them could take the freed spot, so the test effectively ran 2 VUs at a time instead of 50.

The cause: a new page always starts out paused, and it only starts running once every VU connected to that browser gives it the green light. A VU that was still setting up its own session would take hold of pages belonging to other VUs and never give that green light. Those pages stayed paused until the holding VU finished its iteration and disconnected.

This can only happen when VUs share a browser instance (remote browsers via `K6_BROWSER_WS_URL`). When every VU launches its own browser, which is what local runs do, nothing is shared, so this never showed up locally.

Playwright follows the same rule we adopt here: every target it gets attached to is either adopted and resumed ([crPage.ts#L549](https://github.com/microsoft/playwright/blob/2b1e2f67e84904b816d0ca0c8f2dcad5588d82e4/packages/playwright-core/src/server/chromium/crPage.ts#L549)), or resumed and detached from ([crConnection.ts#L176-L185](https://github.com/microsoft/playwright/blob/2b1e2f67e84904b816d0ca0c8f2dcad5588d82e4/packages/playwright-core/src/server/chromium/crConnection.ts#L176-L185), which notes that detaching alone should release a paused target but a backend bug makes the explicit resume necessary). No target is ever silently held, and this change applies the same rule at every place k6 declines a target.

The new test reproduces the freeze on master and passes in under a second with the fix.

Tested with `-race` on the browser packages, no new lint issues. Full `make check` not run yet (draft).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

Replaces #6276: same change rebuilt so the release mechanism (resume awaited, then detach) exists from the first commit, plus a regression test that the detach is only sent after the browser acknowledges the resume. Each commit builds, lints, and passes tests independently.
