### PR TITLE
Show k6 cloud login hint on invalid Cloud API token

### DIFF
--- a/cloudapi/errors.go
+++ b/cloudapi/errors.go
@@ -71,5 +71,9 @@ func (e ResponseError) Error() string {
 		msg = fmt.Sprintf("(%s) %s", code, msg)
 	}
 
+	if e.Response != nil && e.Response.StatusCode == http.StatusUnauthorized {
+		msg += ". Run `k6 cloud login` to refresh your token"
+	}
+
 	return msg
 }

--- a/cloudapi/errors_test.go
+++ b/cloudapi/errors_test.go
@@ -36,6 +36,12 @@ func TestErrorResponse_Error(t *testing.T) {
 
 	expected := "(E123) " + msg1 + "\n " + msg2 + "\n field1: error1, error2"
 	assert.Equal(t, expected, errResp.Error())
+
+	unauth := ResponseError{
+		Response: &http.Response{StatusCode: http.StatusUnauthorized},
+		Message:  "Invalid token",
+	}
+	assert.Equal(t, "(401) Invalid token. Run `k6 cloud login` to refresh your token", unauth.Error())
 }
 
 func TestCheckResponse(t *testing.T) {

--- a/internal/cloudapi/httperr/httperr.go
+++ b/internal/cloudapi/httperr/httperr.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	// ErrNotAuthenticated maps HTTP 401.
-	ErrNotAuthenticated = errors.New("failed to authenticate with k6 Cloud")
+	ErrNotAuthenticated = errors.New("failed to authenticate with k6 Cloud. Run `k6 cloud login` to refresh your token")
 	// ErrNotAuthorized maps HTTP 403.
 	ErrNotAuthorized = errors.New("not allowed to upload result to k6 Cloud")
 )

--- a/internal/cloudapi/v6/errors.go
+++ b/internal/cloudapi/v6/errors.go
@@ -54,5 +54,9 @@ func (e ResponseError) Error() string {
 		msg = fmt.Sprintf("(%s) %s", code, msg)
 	}
 
+	if e.Response != nil && e.Response.StatusCode == http.StatusUnauthorized {
+		msg += ". Run `k6 cloud login` to refresh your token"
+	}
+
 	return msg
 }

--- a/internal/cloudapi/v6/errors_test.go
+++ b/internal/cloudapi/v6/errors_test.go
@@ -66,6 +66,17 @@ func TestResponseError_Error(t *testing.T) {
 			},
 			expected: "(400/error) bad request",
 		},
+		{
+			name: "unauthorized 401 includes login hint",
+			respErr: ResponseError{
+				Response: &http.Response{StatusCode: http.StatusUnauthorized},
+				APIError: k6cloud.ErrorApiModel{
+					Message: "Invalid token",
+					Code:    "error",
+				},
+			},
+			expected: "(401/error) Invalid token. Run `k6 cloud login` to refresh your token",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- Cloud API 401 responses now include a recovery hint pointing at `k6 cloud login`.
- Covers the parsed v6 `ResponseError` path (the `(401/error) Invalid token` case), the legacy cloud API error type, and the unclassified 401 fallback in `httperr`.

Closes #5874

## Test plan
- [ ] `go test ./internal/cloudapi/v6/ ./cloudapi/`
- [ ] Run `k6 cloud run script.js` with an expired/invalid token and confirm the error tells you to run `k6 cloud login`
