### PR TITLE
Shut down TracerProvider after the Exit event is handled

### DIFF
--- a/internal/cmd/run.go
+++ b/internal/cmd/run.go
@@ -73,6 +73,18 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 	globalCtx, globalCancel := context.WithCancel(c.gs.Ctx)
 	defer globalCancel()
 
+	// shutdownTracerProvider is set once the tracer provider is created below.
+	// It must run after the Exit event has been emitted and handled (e.g. by
+	// the browser module ending any open spans), but before globalCtx is
+	// cancelled by globalCancel above, since it derives its own timeout from
+	// globalCtx.
+	var shutdownTracerProvider func()
+	defer func() {
+		if shutdownTracerProvider != nil {
+			shutdownTracerProvider()
+		}
+	}()
+
 	// lingerCtx is cancelled by Ctrl+C, and is used to wait for that event when
 	// k6 was started with the --linger option.
 	lingerCtx, lingerCancel := context.WithCancel(globalCtx)
@@ -119,7 +131,7 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 	if err = c.setupTracerProvider(globalCtx, test); err != nil {
 		return err
 	}
-	waitTracesFlushed := func() {
+	shutdownTracerProvider = func() {
 		ctx, cancel := context.WithTimeout(globalCtx, waitForTracerProviderStopTimeout)
 		defer cancel()
 		if tpErr := test.preInitState.TracerProvider.Shutdown(ctx); tpErr != nil {
@@ -377,24 +389,10 @@ func (c *cmdRun) run(cmd *cobra.Command, args []string) (err error) {
 	}
 
 	defer func() {
-		logger.Debug("Waiting for metrics and traces processing to finish...")
+		logger.Debug("Waiting for metrics processing to finish...")
 		close(samples)
-
-		ww := [...]func(){
-			waitOutputsFlushed,
-			waitTracesFlushed,
-		}
-		var wg sync.WaitGroup
-		wg.Add(len(ww))
-		for _, w := range ww {
-			go func() {
-				w()
-				wg.Done()
-			}()
-		}
-		wg.Wait()
-
-		logger.Debug("Metrics and traces processing finished!")
+		waitOutputsFlushed()
+		logger.Debug("Metrics processing finished!")
 	}()
 
 	printExecutionDescription(

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -713,7 +713,7 @@ func TestSetupTeardownThresholds(t *testing.T) {
 	assert.True(t, testutils.LogContains(logMsgs, logrus.DebugLevel, "Running thresholds on 4 metrics..."))
 	assert.True(t, testutils.LogContains(logMsgs, logrus.DebugLevel, "Finalizing thresholds..."))
 	assert.True(t, testutils.LogContains(logMsgs, logrus.DebugLevel, "Metrics emission of VUs and VUsMax metrics stopped"))
-	assert.True(t, testutils.LogContains(logMsgs, logrus.DebugLevel, "Metrics and traces processing finished!"))
+	assert.True(t, testutils.LogContains(logMsgs, logrus.DebugLevel, "Metrics processing finished!"))
 }
 
 func TestThresholdsFailed(t *testing.T) {
@@ -797,7 +797,7 @@ func TestAbortedByThreshold(t *testing.T) {
 	assert.Contains(t, stdOut, "iterations\n    ✗ 'count == 1'")
 	assert.Contains(t, stdOut, `teardown() called`)
 	assert.Contains(t, stdOut, `level=debug msg="Metrics emission of VUs and VUsMax metrics stopped"`)
-	assert.Contains(t, stdOut, `level=debug msg="Metrics and traces processing finished!"`)
+	assert.Contains(t, stdOut, `level=debug msg="Metrics processing finished!"`)
 	assert.Contains(t, stdOut, `level=debug msg="Sending test finished" output=cloud ref=111 run_status=8 tainted=true`)
 }
 
@@ -859,7 +859,7 @@ func TestAbortedByUserWithGoodThresholds(t *testing.T) {
       ✓ 'count == 1' count=1`)
 	assert.Contains(t, stdout, `Stopping k6 in response to signal`)
 	assert.Contains(t, stdout, `level=debug msg="Metrics emission of VUs and VUsMax metrics stopped"`)
-	assert.Contains(t, stdout, `level=debug msg="Metrics and traces processing finished!"`)
+	assert.Contains(t, stdout, `level=debug msg="Metrics processing finished!"`)
 	assert.Contains(t, stdout, `level=debug msg="Sending test finished" output=cloud ref=111 run_status=5 tainted=false`)
 }
 
@@ -983,7 +983,7 @@ func TestAbortedByUserWithRestAPI(t *testing.T) {
 	assert.Contains(t, stdout, `PATCH /v1/status`)
 	assert.Contains(t, stdout, `level=error msg="test run stopped from REST API`)
 	assert.Contains(t, stdout, `level=debug msg="Metrics emission of VUs and VUsMax metrics stopped"`)
-	assert.Contains(t, stdout, `level=debug msg="Metrics and traces processing finished!"`)
+	assert.Contains(t, stdout, `level=debug msg="Metrics processing finished!"`)
 	assert.Contains(t, stdout, `level=debug msg="Sending test finished" output=cloud ref=111 run_status=5 tainted=false`)
 	assert.NotContains(t, stdout, `Running thresholds`)
 	assert.NotContains(t, stdout, `Finalizing thresholds`)
@@ -1273,7 +1273,7 @@ func testAbortedByScriptError(t *testing.T, script string, runTest func(*testing
 	stdout := ts.Stdout.String()
 	t.Log(stdout)
 	assert.Contains(t, stdout, `level=debug msg="Metrics emission of VUs and VUsMax metrics stopped"`)
-	assert.Contains(t, stdout, `level=debug msg="Metrics and traces processing finished!"`)
+	assert.Contains(t, stdout, `level=debug msg="Metrics processing finished!"`)
 	assert.Contains(t, stdout, `level=debug msg="Everything has finished, exiting k6 with an error!"`)
 	assert.Contains(t, stdout, `level=debug msg="Sending test finished" output=cloud ref=111 run_status=7 tainted=false`)
 	return ts
@@ -1418,7 +1418,7 @@ func testAbortedByScriptTestAbort(t *testing.T, script string, runTest func(*tes
 	assert.Contains(t, stdout, "test aborted: foo")
 	assert.Contains(t, stdout, `level=debug msg="Sending test finished" output=cloud ref=111 run_status=5 tainted=false`)
 	assert.Contains(t, stdout, `level=debug msg="Metrics emission of VUs and VUsMax metrics stopped"`)
-	assert.Contains(t, stdout, `level=debug msg="Metrics and traces processing finished!"`)
+	assert.Contains(t, stdout, `level=debug msg="Metrics processing finished!"`)
 	assert.Contains(t, stdout, "bogus summary")
 }
 


### PR DESCRIPTION
TracerProvider.Shutdown ran in a defer registered after the Exit event's emit-and-wait defer, so LIFO ordering made it execute first. This meant the browser module's Exit handler, which ends any open spans in reaction to event.Exit, was ending them after the tracer's exporter had already been torn down, silently dropping those spans.

Move the tracer provider shutdown into its own nil-safe hook that is deferred right after globalCancel, so it runs after the Exit event has been emitted and awaited (and after ExitData.Error has been finalized by threshold handling), but before globalCtx is cancelled. Drop the now-unnecessary WaitGroup used to run the traces and outputs flush concurrently, since only outputs flushing remains there.

## What?

Move the tracer provider shutdown into its own nil-safe hook that is deferred right after globalCancel, so it runs after the Exit event has been emitted and awaited (and after ExitData.Error has been finalized by threshold handling), but before globalCtx is cancelled. Drop the now-unnecessary WaitGroup used to run the traces and outputs flush concurrently, since only outputs flushing remains there.

## Why?

TracerProvider.Shutdown ran in a defer registered after the Exit event's emit-and-wait defer, so LIFO ordering made it execute first. This meant the browser module's Exit handler, which ends any open spans in reaction to event.Exit, was ending them after the tracer's exporter had already been torn down, silently dropping those spans.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
