### PR TITLE
fix(http): keep double quotes in request cookie values

### DIFF
--- a/js/modules/k6/http/request_test.go
+++ b/js/modules/k6/http/request_test.go
@@ -690,6 +690,32 @@ func TestRequest(t *testing.T) {
 				assertRequestMetricsEmitted(t, metrics.GetBufferedSamples(samples), "GET", sr("HTTPBIN_URL/cookies"), 200, "")
 			})
 
+			t.Run("doubleQuotes", func(t *testing.T) {
+				// The endpoint echoes back the raw Cookie header, since go-httpbin
+				// parses cookies with net/http and would drop the double quotes
+				// before we get a chance to see them.
+				tb.Mux.HandleFunc("/echo-cookie-header", http.HandlerFunc(
+					func(w http.ResponseWriter, r *http.Request) {
+						_, _ = w.Write([]byte(r.Header.Get("Cookie")))
+					}))
+
+				cookieJar, err := cookiejar.New(nil)
+				assert.NoError(t, err)
+				state.CookieJar = cookieJar
+				_, err = rt.RunString(sr(`
+				var jar = http.cookieJar();
+				jar.set("HTTPBIN_URL/echo-cookie-header", "fromJar", '{"a":1}');
+				var jarCookies = jar.cookiesForURL("HTTPBIN_URL/echo-cookie-header");
+				if (jarCookies.fromJar[0] != '{"a":1}') { throw new Error("wrong cookie value in jar: " + jarCookies.fromJar[0]); }
+
+				var res = http.request("GET", "HTTPBIN_URL/echo-cookie-header", null, { cookies: { fromParams: '"' } });
+				if (res.body.indexOf('fromJar={"a":1}') == -1) { throw new Error("wrong jar cookie sent: " + res.body); }
+				if (res.body.indexOf('fromParams="') == -1) { throw new Error("wrong param cookie sent: " + res.body); }
+				`))
+				assert.NoError(t, err)
+				assertRequestMetricsEmitted(t, metrics.GetBufferedSamples(samples), "GET", sr("HTTPBIN_URL/echo-cookie-header"), 200, "")
+			})
+
 			t.Run("redirect", func(t *testing.T) {
 				t.Run("set cookie after redirect", func(t *testing.T) {
 					// TODO figure out a way to remove this ?

--- a/lib/netext/httpext/request.go
+++ b/lib/netext/httpext/request.go
@@ -349,14 +349,64 @@ func MakeRequest(ctx context.Context, state *lib.State, preq *ParsedHTTPRequest)
 func SetRequestCookies(req *http.Request, jar *cookiejar.Jar, reqCookies map[string]*HTTPRequestCookie) {
 	replacedCookies := make(map[string]struct{})
 	for key, reqCookie := range reqCookies {
-		req.AddCookie(&http.Cookie{Name: key, Value: reqCookie.Value})
+		addRequestCookie(req, key, reqCookie.Value)
 		if reqCookie.Replace {
 			replacedCookies[key] = struct{}{}
 		}
 	}
 	for _, c := range jar.Cookies(req.URL) {
 		if _, ok := replacedCookies[c.Name]; !ok {
-			req.AddCookie(&http.Cookie{Name: c.Name, Value: c.Value})
+			addRequestCookie(req, c.Name, c.Value)
 		}
 	}
+}
+
+// cookieNameSanitizer mirrors what net/http does with cookie names: CR and LF
+// would end the header, so they are replaced instead of being sent.
+var cookieNameSanitizer = strings.NewReplacer("\n", "-", "\r", "-") //nolint:gochecknoglobals
+
+// addRequestCookie appends a name/value pair to the Cookie header of req, the
+// way (*http.Request).AddCookie() does, but with k6's own value sanitization.
+func addRequestCookie(req *http.Request, name, value string) {
+	cookie := cookieNameSanitizer.Replace(name) + "=" + sanitizeCookieValue(value)
+	if current := req.Header.Get("Cookie"); current != "" {
+		req.Header.Set("Cookie", current+"; "+cookie)
+	} else {
+		req.Header.Set("Cookie", cookie)
+	}
+}
+
+// sanitizeCookieValue prepares a cookie value to be sent in a Cookie header.
+//
+// Unlike net/http, k6 keeps double quotes and backslashes in the value, as
+// browsers do. RFC 6265 leaves them out of cookie-octet, but servers read a
+// cookie value as everything up to the next ";" (RFC 6265 section 5.2), so
+// sending them is unambiguous, while dropping them silently corrupts values
+// like a JSON document. Non-ASCII bytes are passed through as well. Only bytes
+// that would change the meaning of the header are removed: control characters,
+// which include the CR and LF that would allow header injection, and ";",
+// which would let a value forge extra cookies.
+//
+// A value containing a space or a comma is wrapped in the double-quoted form
+// allowed by RFC 6265 section 4.1.1, unless it is already wrapped, because
+// those bytes are otherwise rejected by strict servers.
+func sanitizeCookieValue(value string) string {
+	var sanitized strings.Builder
+	sanitized.Grow(len(value))
+	for i := range len(value) {
+		if b := value[i]; b >= 0x20 && b != 0x7f && b != ';' {
+			sanitized.WriteByte(b)
+		}
+	}
+	value = sanitized.String()
+
+	if strings.ContainsAny(value, " ,") && !isQuoted(value) {
+		return `"` + value + `"`
+	}
+	return value
+}
+
+// isQuoted reports whether the value is already wrapped in double quotes.
+func isQuoted(value string) bool {
+	return len(value) > 1 && strings.HasPrefix(value, `"`) && strings.HasSuffix(value, `"`)
 }

--- a/lib/netext/httpext/request_test.go
+++ b/lib/netext/httpext/request_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
 	"runtime"
@@ -590,4 +591,64 @@ func TestMakeRequestRPSLimit(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
+}
+
+func TestSetRequestCookies(t *testing.T) {
+	t.Parallel()
+
+	testCases := map[string]struct {
+		value  string
+		expect string
+	}{
+		"plain":              {`value`, `k=value`},
+		"double quote":       {`"`, `k="`},
+		"inner double quote": {`a"b`, `k=a"b`},
+		"quoted value":       {`"quoted"`, `k="quoted"`},
+		"json":               {`{"a":1}`, `k={"a":1}`},
+		"escaped json":       {`{"a":"sa\"y"}`, `k={"a":"sa\"y"}`},
+		"space":              {`a b`, `k="a b"`},
+		"comma":              {`a,b`, `k="a,b"`},
+		"quotes and space":   {`{"a": 1}`, `k="{"a": 1}"`},
+		"already quoted":     {`"a b"`, `k="a b"`},
+		"non-ascii":          {"héllo", "k=héllo"},
+		"semicolon dropped":  {`a;b=c`, `k=ab=c`},
+		"newline dropped":    {"a\r\nb", `k=ab`},
+		"empty":              {``, `k=`},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			jar, err := cookiejar.New(nil)
+			require.NoError(t, err)
+			req, err := http.NewRequestWithContext(
+				context.Background(), http.MethodGet, "https://example.com/", nil)
+			require.NoError(t, err)
+
+			SetRequestCookies(req, jar, map[string]*HTTPRequestCookie{
+				"k": {Name: "k", Value: tc.value},
+			})
+			assert.Equal(t, tc.expect, req.Header.Get("Cookie"))
+		})
+	}
+}
+
+func TestSetRequestCookiesFromJar(t *testing.T) {
+	t.Parallel()
+
+	jar, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	u, err := url.Parse("https://example.com/")
+	require.NoError(t, err)
+	jar.SetCookies(u, []*http.Cookie{{Name: "k", Value: `a"b`}})
+
+	// The jar itself must round-trip the value unchanged.
+	require.Len(t, jar.Cookies(u), 1)
+	assert.Equal(t, `a"b`, jar.Cookies(u)[0].Value)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, u.String(), nil)
+	require.NoError(t, err)
+	SetRequestCookies(req, jar, nil)
+	assert.Equal(t, `k=a"b`, req.Header.Get("Cookie"))
 }


### PR DESCRIPTION
## What?

`SetRequestCookies()` now serializes the `Cookie` request header itself instead of calling `(*http.Request).AddCookie()`, so a cookie value is sent as the script provided it.

Documented semantics:

- Double quotes, backslashes and non-ASCII bytes are kept verbatim, as browsers send them. RFC 6265 leaves them out of `cookie-octet`, but servers read a cookie value as everything up to the next `;` (RFC 6265 §5.2), so sending them is unambiguous.
- Only bytes that would change the meaning of the header are removed: control characters, including the CR and LF that would allow header injection, and `;`, which would let a value forge extra cookies.
- A value containing a space or a comma is still wrapped in the double-quoted form of RFC 6265 §4.1.1 (unchanged behaviour), unless it is already wrapped.

Not changed: the receiving side. `net/http` discards an entire `Set-Cookie` header whose value contains a double quote before k6 can see it; fixing that would mean reimplementing Set-Cookie parsing, so it is left out of this PR.

## Why?

`net/http` strips `"` and `\` from `Cookie.Value` and logs

net/http: invalid byte '"' in Cookie.Value; dropping invalid bytes


directly to stderr through the stdlib `log` package. A cookie set with `jar.set()` or the `cookies` request param was therefore silently corrupted — `{"a":1}` went out as `{a:1}` and `"` went out as an empty value — and the warning could not be silenced or tied to a VU.

Reproducer from the issue:

```js
import http from 'k6/http';

export default function () {
  const resp = http.get('https://httpbingo.org/cookies', { cookies: { test: '"' } });
  console.log(resp.body);
}
```

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

Closes #711