### PR TITLE
Fix stale tc39 package path in docs

### DIFF
--- a/Dependencies.md
+++ b/Dependencies.md
@@ -94,4 +94,4 @@ It's preferable to make multiple PRs - in most cases you can split them in three
 
 Further splitting is recommended if PRs become too big.
 
-When updating Sobek it's recommended to run the tc39 tests in `js/tc39`. And if needed, update the breaking ones as explained in an [Introduction to a k6's TC39 testing](./js/tc39/README.md).
+When updating Sobek it's recommended to run the tc39 tests in `internal/js/tc39`. And if needed, update the breaking ones as explained in an [Introduction to a k6's TC39 testing](./internal/js/tc39/README.md).

--- a/internal/js/tc39/README.md
+++ b/internal/js/tc39/README.md
@@ -1,6 +1,6 @@
 # Introduction to a k6's TC39 testing
 
-`js/tc39` package tests k6 [Sobek](https://github.com/grafana/sobek) and the k6 Sobek+esbuild combo against the tc39 test suite.
+`internal/js/tc39` package tests k6 [Sobek](https://github.com/grafana/sobek) and the k6 Sobek+esbuild combo against the tc39 test suite.
 
 Ways to use it:
 1. run ./checkout.sh to checkout the last commit sha of [test262](https://github.com/tc39/test262)


### PR DESCRIPTION
## What?

`Dependencies.md` and `internal/js/tc39/README.md` still refer to the tc39 test package as `js/tc39`. The package lives in `internal/js/tc39`, so this PR updates both references.

This also fixes the link in `Dependencies.md`, which pointed to `./js/tc39/README.md` and therefore resolved to a file that does not exist.

## Why?

The package was moved under `internal/` in 7129195a ("chore: Move not publicly used APIs in internal package"), but these two documents were not updated.
`CONTRIBUTING.md` sends readers to `Dependencies.md` for the dependency update process, so the broken link sits on the path people are told to follow.

`CLAUDE.md` and `AGENTS.md` already use `internal/js/tc39/`.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

This is a documentation-only change, so no code comments or tests were added and `make check` does not apply. I verified that `internal/js/tc39/README.md` exists and that its title matches the link text in `Dependencies.md`.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

None.

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
