### PR TITLE
Export constants for ReadyState in websockets module

### DIFF
--- a/internal/js/modules/k6/websockets/websockets.go
+++ b/internal/js/modules/k6/websockets/websockets.go
@@ -29,8 +29,9 @@ type RootModule struct{}
 
 // WebSocketsAPI is the k6 extension implementing the websocket API as defined in https://websockets.spec.whatwg.org
 type WebSocketsAPI struct { //nolint:revive
-	vu              modules.VU
-	blobConstructor sobek.Value
+	vu                   modules.VU
+	blobConstructor      sobek.Value
+	webSocketConstructor sobek.Value
 }
 
 var _ modules.Module = &RootModule{}
@@ -42,17 +43,23 @@ func New() *RootModule {
 
 // NewModuleInstance returns a new instance of the module
 func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
-	return &WebSocketsAPI{
-		vu: vu,
-	}
+	api := &WebSocketsAPI{vu: vu}
+
+	rt := vu.Runtime()
+	api.blobConstructor = rt.ToValue(api.blob)
+
+	wsConstructor := rt.ToValue(api.websocket).(*sobek.Object)
+	defineReadyStateProperties(rt, wsConstructor)
+	api.webSocketConstructor = wsConstructor
+
+	return api
 }
 
 // Exports implements the modules.Instance interface's Exports
 func (r *WebSocketsAPI) Exports() modules.Exports {
-	r.blobConstructor = r.vu.Runtime().ToValue(r.blob)
 	return modules.Exports{
 		Named: map[string]any{
-			"WebSocket": r.websocket,
+			"WebSocket": r.webSocketConstructor,
 			"Blob":      r.blobConstructor,
 		},
 	}
@@ -256,6 +263,16 @@ func defineWebsocket(rt *sobek.Runtime, w *webSocket) {
 	setOn("onclose", w.eventListeners.getType(events.CLOSE))
 	setOn("onping", w.eventListeners.getType(events.PING))
 	setOn("onpong", w.eventListeners.getType(events.PONG))
+
+	defineReadyStateProperties(rt, w.obj)
+}
+
+// the spec defines constants for the ready state on both the constructor and actual instances
+func defineReadyStateProperties(rt *sobek.Runtime, target *sobek.Object) {
+	must(rt, target.DefineDataProperty("OPEN", rt.ToValue(uint(OPEN)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+	must(rt, target.DefineDataProperty("CLOSED", rt.ToValue(uint(CLOSED)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+	must(rt, target.DefineDataProperty("CLOSING", rt.ToValue(uint(CLOSING)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+	must(rt, target.DefineDataProperty("CONNECTING", rt.ToValue(uint(CONNECTING)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
 }
 
 type message struct {
@@ -834,7 +851,7 @@ func (w *webSocket) connectionClosedWithError(err error) error {
 	return w.callEventListeners(events.CLOSE)
 }
 
-// newEvent return an event implementing "implements" https://dom.spec.whatwg.org/#event
+// newEvent returns an event implementing "implements" https://dom.spec.whatwg.org/#event
 // needs to be called on the event loop
 // TODO: move to events
 func (w *webSocket) newEvent(eventType string, t time.Time, funcOptions ...func(*sobek.Object)) *sobek.Object {

--- a/internal/js/modules/k6/websockets/websockets.go
+++ b/internal/js/modules/k6/websockets/websockets.go
@@ -48,7 +48,11 @@ func (r *RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	rt := vu.Runtime()
 	api.blobConstructor = rt.ToValue(api.blob)
 
-	wsConstructor := rt.ToValue(api.websocket).(*sobek.Object)
+	wsConstructor, ok := rt.ToValue(api.websocket).(*sobek.Object)
+	if !ok {
+		common.Throw(rt, errors.New("websocket constructor is not a sobek.Object"))
+	}
+
 	defineReadyStateProperties(rt, wsConstructor)
 	api.webSocketConstructor = wsConstructor
 
@@ -269,10 +273,14 @@ func defineWebsocket(rt *sobek.Runtime, w *webSocket) {
 
 // the spec defines constants for the ready state on both the constructor and actual instances
 func defineReadyStateProperties(rt *sobek.Runtime, target *sobek.Object) {
-	must(rt, target.DefineDataProperty("OPEN", rt.ToValue(uint(OPEN)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
-	must(rt, target.DefineDataProperty("CLOSED", rt.ToValue(uint(CLOSED)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
-	must(rt, target.DefineDataProperty("CLOSING", rt.ToValue(uint(CLOSING)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
-	must(rt, target.DefineDataProperty("CONNECTING", rt.ToValue(uint(CONNECTING)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+	must(rt, target.DefineDataProperty(
+		"OPEN", rt.ToValue(uint(OPEN)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+	must(rt, target.DefineDataProperty(
+		"CLOSED", rt.ToValue(uint(CLOSED)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+	must(rt, target.DefineDataProperty(
+		"CLOSING", rt.ToValue(uint(CLOSING)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
+	must(rt, target.DefineDataProperty(
+		"CONNECTING", rt.ToValue(uint(CONNECTING)), sobek.FLAG_FALSE, sobek.FLAG_FALSE, sobek.FLAG_TRUE))
 }
 
 type message struct {

--- a/internal/js/modules/k6/websockets/websockets_test.go
+++ b/internal/js/modules/k6/websockets/websockets_test.go
@@ -276,11 +276,11 @@ func TestReadyState(t *testing.T) {
 	_, err := ts.runtime.RunOnEventLoop(ts.tb.Replacer.Replace(`
 		var ws = new WebSocket("WSBIN_URL/ws-echo")
 		ws.addEventListener("open", () => {
-			if (ws.readyState != 1){
+			if (ws.readyState != WebSocket.OPEN){
 				throw new Error("Expected ready state 1 got "+ ws.readyState)
 			}
 			ws.addEventListener("close", () => {
-				if (ws.readyState != 3){
+				if (ws.readyState != WebSocket.CLOSED){
 					throw new Error("Expected ready state 3 got "+ ws.readyState)
 				}
 
@@ -288,7 +288,7 @@ func TestReadyState(t *testing.T) {
 			ws.send("something")
 			ws.close()
 		})
-		if (ws.readyState != 0){
+		if (ws.readyState != WebSocket.CONNECTING){
 			throw new Error("Expected ready state 0 got "+ ws.readyState)
 		}
 	`))
@@ -1590,7 +1590,7 @@ func TestReadyStateSwitch(t *testing.T) {
 		var ws = new WebSocket("WSBIN_URL/ws-echo")
 		try {
 			switch (ws.readyState) {
-				case 0:
+				case WebSocket.CONNECTING:
 					break;
 				default:
 					throw "ws.readyState doesn't get correct value in switch"


### PR DESCRIPTION
## What?

Exports constants for the `ReadyState` values on both `WebSocket` constructor and instances following the [spec](https://websockets.spec.whatwg.org/#the-websocket-interface).

## Why?
Replaces the previously, wrongly advertised (by the typedefs) enum.
Aligns our implementation with what user are used to from the browser.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

PR in grafana/k6-DefinitelyTyped: https://github.com/grafana/k6-DefinitelyTyped/pull/120

Issue was also described in #4540
