### PR TITLE
feat(browser): add connectOverCDP options and http(s) endpoint resolution

### DIFF
--- a/internal/js/modules/k6/browser/browser/chromium_mapping.go
+++ b/internal/js/modules/k6/browser/browser/chromium_mapping.go
@@ -2,6 +2,7 @@ package browser
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/grafana/sobek"
 
@@ -12,7 +13,14 @@ import (
 // mapChromium maps the Chromium browser type API to the JS module.
 func mapChromium(vu moduleVU, bt *chromium.BrowserType) mapping {
 	return mapping{
-		"connectOverCDP": func(wsEndpoint string) *sobek.Promise {
+		"connectOverCDP": func(endpoint string, opts sobek.Value) (*sobek.Promise, error) {
+			// Parse the optional options argument on the JS thread, before the
+			// promise callback runs on a background goroutine.
+			cdpOpts, err := parseConnectOverCDPOptions(vu.Runtime(), opts)
+			if err != nil {
+				return nil, err
+			}
+
 			return promise(vu, func() (any, error) {
 				iter := vu.State().Iteration
 
@@ -23,7 +31,7 @@ func mapChromium(vu moduleVU, bt *chromium.BrowserType) mapping {
 
 				// Link the connection to the iteration trace and connect.
 				tracedCtx := vu.startConnectTrace(vu.Context(), iter)
-				b, err := connBT.ConnectOverCDP(tracedCtx, wsEndpoint)
+				b, err := connBT.ConnectOverCDP(tracedCtx, endpoint, cdpOpts)
 				if err != nil {
 					return nil, fmt.Errorf("connecting to Chromium over CDP: %w", err)
 				}
@@ -34,7 +42,27 @@ func mapChromium(vu moduleVU, bt *chromium.BrowserType) mapping {
 				return mapBrowser(vu, func() (*common.Browser, error) {
 					return b, nil
 				}), nil
-			})
+			}), nil
 		},
 	}
+}
+
+// parseConnectOverCDPOptions parses the optional trailing options argument of
+// chromium.connectOverCDP (e.g. { timeout }) into chromium.ConnectOverCDPOptions.
+// A nil, undefined or null value yields the zero options.
+func parseConnectOverCDPOptions(rt *sobek.Runtime, opts sobek.Value) (chromium.ConnectOverCDPOptions, error) {
+	var o chromium.ConnectOverCDPOptions
+	if opts == nil || sobek.IsUndefined(opts) || sobek.IsNull(opts) {
+		return o, nil
+	}
+
+	obj := opts.ToObject(rt)
+	for _, k := range obj.Keys() {
+		switch k {
+		case "timeout":
+			o.Timeout = time.Duration(obj.Get(k).ToInteger()) * time.Millisecond
+		}
+	}
+
+	return o, nil
 }

--- a/internal/js/modules/k6/browser/browser/chromium_mapping_test.go
+++ b/internal/js/modules/k6/browser/browser/chromium_mapping_test.go
@@ -1,0 +1,40 @@
+package browser
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/sobek"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestParseConnectOverCDPOptions checks that the optional trailing options
+// argument of chromium.connectOverCDP is parsed correctly.
+func TestParseConnectOverCDPOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil", func(t *testing.T) {
+		t.Parallel()
+		o, err := parseConnectOverCDPOptions(sobek.New(), nil)
+		require.NoError(t, err)
+		assert.Zero(t, o.Timeout)
+	})
+
+	t.Run("undefined", func(t *testing.T) {
+		t.Parallel()
+		o, err := parseConnectOverCDPOptions(sobek.New(), sobek.Undefined())
+		require.NoError(t, err)
+		assert.Zero(t, o.Timeout)
+	})
+
+	t.Run("timeout in ms", func(t *testing.T) {
+		t.Parallel()
+		rt := sobek.New()
+		obj := rt.NewObject()
+		require.NoError(t, obj.Set("timeout", 5000))
+		o, err := parseConnectOverCDPOptions(rt, obj)
+		require.NoError(t, err)
+		assert.Equal(t, 5*time.Second, o.Timeout)
+	})
+}

--- a/internal/js/modules/k6/browser/chromium/browser_type.go
+++ b/internal/js/modules/k6/browser/chromium/browser_type.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/rand" // nosemgrep: math-random-used // This is used to generate id for easier debugging
+	"net/http"
 	"net/url"
 	"os/exec"
 	"path/filepath"
@@ -112,20 +113,28 @@ func (b *BrowserType) initContext(ctx context.Context) context.Context {
 	return ctx
 }
 
+// ConnectOverCDPOptions holds the optional settings for ConnectOverCDP,
+// mirroring the trailing options argument of Playwright's connectOverCDP.
+type ConnectOverCDPOptions struct {
+	// Timeout, when greater than zero, overrides the env-derived connect
+	// timeout (K6_BROWSER_TIMEOUT) for this call.
+	Timeout time.Duration
+}
+
 // ConnectOverCDP attaches the k6 browser to an existing, user-managed browser
 // over CDP, without requiring scenario browser options.
+//
+// The endpoint may be a ws:// or wss:// CDP WebSocket URL, or an http(s):// URL
+// pointing at the browser's debugging endpoint; in the latter case the
+// browser-level WebSocket URL is resolved from /json/version, mirroring
+// Playwright's connectOverCDP.
 //
 // The passed context must be the context the caller wants to control both the
 // connection and the browser lifetime; when it is canceled (iteration ends),
 // the connection is torn down.
-func (b *BrowserType) ConnectOverCDP(ctx context.Context, wsEndpoint string) (*common.Browser, error) {
-	// Validate wsEndpoint up front so an empty or malformed value
-	// fails fast with a clear error, instead of a confusing lower-level
-	// connection error.
-	if err := validateWSEndpoint(wsEndpoint); err != nil {
-		return nil, err
-	}
-
+func (b *BrowserType) ConnectOverCDP(
+	ctx context.Context, endpoint string, opts ConnectOverCDPOptions,
+) (*common.Browser, error) {
 	// Parse browser options from the environment (K6_BROWSER_TIMEOUT,
 	// K6_BROWSER_DEBUG, the log category filter, ...) like Connect does. Pass a
 	// fixed chromium type instead of scenario options: connectOverCDP works
@@ -133,6 +142,23 @@ func (b *BrowserType) ConnectOverCDP(ctx context.Context, wsEndpoint string) (*c
 	ctx, browserOpts, logger, err := b.init(ctx, true, map[string]any{"type": "chromium"})
 	if err != nil {
 		return nil, fmt.Errorf("initializing browser type: %w", err)
+	}
+
+	// A per-call timeout overrides the env-derived connect timeout.
+	if opts.Timeout > 0 {
+		browserOpts.Timeout = opts.Timeout
+	}
+
+	// Resolve the endpoint to a CDP WebSocket URL (an http(s) endpoint is
+	// resolved via /json/version), then validate it up front so an empty or
+	// malformed value fails fast with a clear error instead of a confusing
+	// lower-level connection error.
+	wsEndpoint, err := resolveCDPWSEndpoint(ctx, endpoint, browserOpts.Timeout)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateWSEndpoint(wsEndpoint); err != nil {
+		return nil, err
 	}
 
 	bp, err := b.connect(ctx, ctx, wsEndpoint, browserOpts, logger)
@@ -145,6 +171,77 @@ func (b *BrowserType) ConnectOverCDP(ctx context.Context, wsEndpoint string) (*c
 	}
 
 	return bp, nil
+}
+
+// resolveCDPWSEndpoint returns a CDP WebSocket URL for the given endpoint.
+//
+// A ws:// or wss:// endpoint is returned unchanged. An http(s):// endpoint is
+// treated as the browser's debugging endpoint: the browser-level WebSocket URL
+// is fetched from {endpoint}/json/version (the "webSocketDebuggerUrl" field),
+// mirroring Playwright. This is convenient because that WS URL embeds a
+// per-launch GUID users would otherwise have to discover themselves.
+func resolveCDPWSEndpoint(ctx context.Context, endpoint string, timeout time.Duration) (string, error) {
+	if strings.TrimSpace(endpoint) == "" {
+		return "", errors.New("CDP endpoint cannot be empty")
+	}
+
+	u, err := url.Parse(strings.TrimSpace(endpoint))
+	if err != nil {
+		return "", fmt.Errorf("invalid CDP endpoint %q: %w", endpoint, err)
+	}
+
+	switch u.Scheme {
+	case "ws", "wss":
+		return endpoint, nil
+	case "http", "https":
+		return fetchWSDebuggerURL(ctx, u, timeout)
+	default:
+		return "", fmt.Errorf(
+			"invalid CDP endpoint %q: scheme must be ws, wss, http or https, got %q", endpoint, u.Scheme,
+		)
+	}
+}
+
+// fetchWSDebuggerURL fetches {endpoint}/json/version and returns the
+// webSocketDebuggerUrl reported by the browser.
+func fetchWSDebuggerURL(ctx context.Context, endpoint *url.URL, timeout time.Duration) (string, error) {
+	versionURL := *endpoint
+	versionURL.Path = strings.TrimRight(endpoint.Path, "/") + "/json/version"
+
+	if timeout <= 0 {
+		timeout = common.DefaultTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, versionURL.String(), nil)
+	if err != nil {
+		return "", fmt.Errorf("building CDP version request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetching CDP version from %q: %w", versionURL.String(), err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf(
+			"fetching CDP version from %q: unexpected status %s", versionURL.String(), resp.Status,
+		)
+	}
+
+	var payload struct {
+		WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decoding CDP version from %q: %w", versionURL.String(), err)
+	}
+	if payload.WebSocketDebuggerURL == "" {
+		return "", fmt.Errorf("no webSocketDebuggerUrl in CDP version response from %q", versionURL.String())
+	}
+
+	return payload.WebSocketDebuggerURL, nil
 }
 
 // validateWSEndpoint returns an error if wsEndpoint is not a usable CDP

--- a/internal/js/modules/k6/browser/chromium/browser_type_test.go
+++ b/internal/js/modules/k6/browser/chromium/browser_type_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"io/fs"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"sort"
 	"testing"
+	"time"
 
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/common"
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/env"
@@ -382,4 +385,80 @@ func TestParseArgs(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestResolveCDPWSEndpoint pins the connectOverCDP endpoint resolution: ws/wss
+// endpoints pass through unchanged, while an http(s) endpoint is resolved to the
+// browser-level WebSocket URL via /json/version (mirroring Playwright).
+func TestResolveCDPWSEndpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ws passthrough", func(t *testing.T) {
+		t.Parallel()
+		got, err := resolveCDPWSEndpoint(context.Background(), "ws://localhost:9222/devtools/browser/abc", 0)
+		require.NoError(t, err)
+		assert.Equal(t, "ws://localhost:9222/devtools/browser/abc", got)
+	})
+
+	t.Run("wss passthrough", func(t *testing.T) {
+		t.Parallel()
+		got, err := resolveCDPWSEndpoint(context.Background(), "wss://example.com/x", 0)
+		require.NoError(t, err)
+		assert.Equal(t, "wss://example.com/x", got)
+	})
+
+	t.Run("http resolves via /json/version", func(t *testing.T) {
+		t.Parallel()
+		const wsURL = "ws://127.0.0.1:9222/devtools/browser/2f3a"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/json/version", r.URL.Path)
+			_, _ = w.Write([]byte(`{"webSocketDebuggerUrl":"` + wsURL + `"}`))
+		}))
+		defer srv.Close()
+
+		got, err := resolveCDPWSEndpoint(context.Background(), srv.URL, time.Second)
+		require.NoError(t, err)
+		assert.Equal(t, wsURL, got)
+	})
+
+	t.Run("http with base path", func(t *testing.T) {
+		t.Parallel()
+		const wsURL = "ws://127.0.0.1:9222/devtools/browser/base"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "/cdp/json/version", r.URL.Path)
+			_, _ = w.Write([]byte(`{"webSocketDebuggerUrl":"` + wsURL + `"}`))
+		}))
+		defer srv.Close()
+
+		got, err := resolveCDPWSEndpoint(context.Background(), srv.URL+"/cdp", time.Second)
+		require.NoError(t, err)
+		assert.Equal(t, wsURL, got)
+	})
+
+	t.Run("errors", func(t *testing.T) {
+		t.Parallel()
+
+		srvEmpty := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer srvEmpty.Close()
+
+		srvBadStatus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srvBadStatus.Close()
+
+		cases := map[string]string{
+			"empty":              "",
+			"blank":              "   ",
+			"unsupported scheme": "ftp://localhost:9222",
+			"missing scheme":     "localhost:9222",
+			"no ws url in json":  srvEmpty.URL,
+			"bad status":         srvBadStatus.URL,
+		}
+		for name, endpoint := range cases {
+			_, err := resolveCDPWSEndpoint(context.Background(), endpoint, time.Second)
+			require.Errorf(t, err, "endpoint %q (%s) should be rejected", endpoint, name)
+		}
+	})
 }

--- a/internal/js/modules/k6/browser/tests/browser_type_test.go
+++ b/internal/js/modules/k6/browser/tests/browser_type_test.go
@@ -41,7 +41,7 @@ func TestBrowserTypeConnectOverCDP(t *testing.T) {
 	bt := chromium.NewBrowserType(vu)
 	vu.ActivateVU()
 
-	b, err := bt.ConnectOverCDP(context.Background(), tb.wsURL)
+	b, err := bt.ConnectOverCDP(context.Background(), tb.wsURL, chromium.ConnectOverCDPOptions{})
 	require.NoError(t, err)
 	t.Cleanup(b.Close)
 
@@ -59,12 +59,12 @@ func TestBrowserTypeConnectOverCDPValidation(t *testing.T) {
 	vu.ActivateVU()
 
 	for _, wsEndpoint := range []string{
-		"",                      // empty (e.g. an undefined value or failed lookup)
-		"   ",                   // blank
-		"http://localhost:9222", // wrong scheme
-		"localhost:9222",        // missing ws/wss scheme
+		"",                     // empty (e.g. an undefined value or failed lookup)
+		"   ",                  // blank
+		"ftp://localhost:9222", // unsupported scheme
+		"localhost:9222",       // missing scheme
 	} {
-		_, err := bt.ConnectOverCDP(context.Background(), wsEndpoint)
+		_, err := bt.ConnectOverCDP(context.Background(), wsEndpoint, chromium.ConnectOverCDPOptions{})
 		require.Errorf(t, err, "endpoint %q should be rejected", wsEndpoint)
 	}
 }
@@ -80,7 +80,7 @@ func TestChromiumConnectOverCDPAppliesBrowserTimeout(t *testing.T) {
 	bt := chromium.NewBrowserType(vu)
 	vu.ActivateVU()
 
-	b, err := bt.ConnectOverCDP(context.Background(), tb.wsURL)
+	b, err := bt.ConnectOverCDP(context.Background(), tb.wsURL, chromium.ConnectOverCDPOptions{})
 	require.NoError(t, err)
 	t.Cleanup(b.Close)
 


### PR DESCRIPTION
Addresses #6179 (partially — `headers` deferred, see below).

Brings `chromium.connectOverCDP` closer to Playwright's `browserType.connectOverCDP()` with two additive, backwards-compatible changes.

### 1. Optional `options` argument with `timeout`
A per-call `timeout` that overrides the env-derived connect timeout (`K6_BROWSER_TIMEOUT`). The existing string-only signature keeps working.

```js
const browser = await chromium.connectOverCDP('ws://localhost:9222/devtools/browser/<id>', { timeout: 5000 });
```

### 2. Accept an `http(s)://` endpoint
When given an `http(s)://` endpoint, the browser-level WebSocket URL is resolved from `{endpoint}/json/version` (`webSocketDebuggerUrl`), mirroring Playwright. This is convenient because that WS URL embeds a per-launch GUID users would otherwise have to discover themselves. `ws://` / `wss://` endpoints are passed through unchanged.

```js
const browser = await chromium.connectOverCDP('http://localhost:9222');
```

### Deferred
Custom connect `headers` (the other half of parity item 1) are intentionally left for a follow-up, since sending headers on the CDP upgrade request needs threading an `http.Header` through the connection dialer — happy to do that separately.

### Tests
- `resolveCDPWSEndpoint` — ws/wss passthrough, http(s) resolution via `/json/version` (including a base path), and error cases (empty, unsupported scheme, missing `webSocketDebuggerUrl`, non-200).
- `parseConnectOverCDPOptions` — nil/undefined and `timeout` parsing.

I raised the proposed scope in #6179 first — feedback welcome!
