### PR TITLE
Add spec for single-run --once flag

### DIFF
--- a/openspec/changes/add-once-flag/.openspec.yaml
+++ b/openspec/changes/add-once-flag/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/add-once-flag/README.md
+++ b/openspec/changes/add-once-flag/README.md
@@ -1,0 +1,3 @@
+# add-once-flag
+
+Add --once flag for single-run execution mode

--- a/openspec/changes/add-once-flag/proposal.md
+++ b/openspec/changes/add-once-flag/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Running a script once with 1 virtual user and 1 iteration is how people smoke-test, end-to-end test, and functionally test with k6, but today that requires either editing the script's scenario configuration per environment or passing shortcut load flags that discard scenarios, ignore declared load, and break browser tests. Synthetic Monitoring needs this behavior for every check it runs and currently has no runtime enforcement at all, so k6 needs a built-in, guaranteed single-run mode.
+
+## What Changes
+
+- Add a `--once` command-line flag to `k6 run` and `k6 cloud run` that runs a script exactly once with 1 virtual user and 1 iteration, with no change to the script.
+- Accept `--once` for `k6 cloud run --local-execution` and for running an already-built archive; the archive-building command does not accept the flag, and passing it there fails as an unknown flag with a non-zero exit code.
+- Preserve the running scenario's exec target, its scenario options (browser options included), its environment variables, and its tags; discard its load-shaping fields (virtual users, iterations, duration, start time, maximum duration, time unit, stages, rate, graceful stop, graceful ramp-down, pre-allocated virtual users).
+- Run exactly one iteration on exactly one virtual user, with no ramping, whatever executor the script declared; the executor becomes shared-iterations.
+- Run the default function when the script declares no scenarios; run the one declared scenario when the script declares exactly one, including when that scenario targets the default function.
+- Fail with a non-zero exit code when the script declares two or more scenarios, naming the available scenarios.
+- Fail with a non-zero exit code when the script declares neither scenarios nor a default function, matching how k6 already behaves in that case.
+- Reject `--once` combined with any command-line flag that shapes load (virtual users, iterations, duration, stages), with an error naming the conflicting flag and a non-zero exit code.
+- Accept `--once` only as a command-line flag: neither an environment variable nor a configuration-file field turns single-run mode on, so a stray setting can never turn a real load test into a single run.
+- Keep the script's setup and teardown steps running exactly as they do without the flag.
+- Make declared load irrelevant whatever its source, whether it comes from script options, environment variables, or a configuration file: the run still ends at 1 virtual user and 1 iteration, while the scenario's non-load settings still apply.
+- Carry the resulting 1 virtual user / 1 iteration scenario into generated cloud archives, so a later re-run of that archive also runs once.
+
+## Capabilities
+
+### New Capabilities
+
+- once: A built-in single-run mode, turned on by the `--once` command-line flag, that runs a script exactly once with 1 virtual user and 1 iteration while preserving the scenario's configuration.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- The `run` and `cloud run` command-line surfaces, including local execution and archive execution, plus the archive command's flag set.
+- The scenario and executor configuration layer, where single-run mode replaces load shaping.
+- Cloud archive generation and later replay of those archives.
+- Browser test execution, which depends on scenario-level browser options surviving into the single run.
+- Error and exit-code reporting for rejected invocations.

--- a/openspec/changes/add-once-flag/proposal.md
+++ b/openspec/changes/add-once-flag/proposal.md
@@ -1,23 +1,23 @@
 ## Why
 
-Running a test once with 1 virtual user and 1 iteration is how people smoke-test, end-to-end test, and functionally test with k6. Today that needs either a per-environment edit to the script's scenario configuration, or a shortcut load flag. The shortcut flags replace every declared scenario with a generated `default` one, which drops `exec` targets, `env`, `tags`, and `options.browser`. Browser tests then fail with `browser not found in registry` and still exit 0, so CI and Synthetic Monitoring get no signal. Synthetic Monitoring needs a guaranteed single iteration on every check and has no runtime enforcement for it at all.
+Running a test once with 1 virtual user and 1 iteration is how people smoke-test, end-to-end test, and functionally test with k6. Today that needs either a per-environment edit to the script's scenario configuration, or a shortcut load flag. The shortcut flags replace every declared scenario with a generated `default` one, which drops `exec` targets, `env`, `tags`, and `options.browser`. A browser iteration can then fail with `browser not found in registry` while the process still exits 0, so CI and Synthetic Monitoring get no signal. Synthetic Monitoring needs a guaranteed single iteration on every check and has no runtime enforcement for it.
 
 ## What Changes
 
-- Add a `--once` command-line flag to `k6 run` and `k6 cloud run` that runs a test exactly once with 1 virtual user and 1 iteration, with no change to the script.
-- Accept it for `k6 cloud run --local-execution` and for running an already-built archive. Reject it on `k6 archive` and `k6 cloud upload`, the two commands that build an archive without running it, where it fails as an unknown flag with a non-zero exit code.
+- Add a bare `--once` command-line flag to `k6 run` and `k6 cloud run`. It configures one effective `shared-iterations` scenario with 1 virtual user and 1 iteration, with no change to the script.
+- Accept it only on those run commands, including `k6 cloud run --local-execution`, for script, archive, and standard-input sources they already support. Other commands reject it as unknown; `k6 archive` and `k6 cloud upload` are explicit regression cases.
 - Preserve the running scenario's name, `exec` target, `options` block including `options.browser`, `env`, and `tags`.
-- Discard the running scenario's load shaping: `executor`, `vus`, `iterations`, `duration`, `startTime`, `maxDuration`, `timeUnit`, `stages`, `rate`, `gracefulStop`, `gracefulRampDown`, `preAllocatedVUs`. The scenario ends up as `shared-iterations` with `vus: 1` and `iterations: 1`, carrying that executor's defaults for anything not preserved.
-- Run the `default` function when the test declares no scenarios. Run the one declared scenario when it declares exactly one, including when that scenario targets `default`.
-- Fail when the test declares two or more scenarios, saying that single-run mode runs only a single scenario, without listing them.
-- Fail when the test declares neither scenarios nor a `default` function, exactly as k6 already fails for such a test.
+- Discard every other scenario field, including its executor type and all load shaping. The scenario ends up as `shared-iterations` with `vus: 1`, `iterations: 1`, and the `shared-iterations` defaults for anything not preserved.
+- Run the `default` function when the effective configuration has no scenarios. Run its one scenario when it has exactly one, including when that scenario targets `default`.
+- Fail when the effective configuration has two or more scenarios, saying that single-run mode runs only a single scenario, without listing them.
+- Fail when the effective configuration has no scenario and the script has no `default` function, exactly as k6 already fails for such a test.
 - Reject `--once` combined with `--vus`, `--iterations`, `--duration`, or `--stage`, naming the conflicting flag.
-- Accept `--once` only from the command line: `K6_ONCE`, a bare `ONCE`, and a `once` configuration-file field all leave single-run mode off, so a stray setting can never turn a real load test into a single run. `--once` takes no value; `--once=false` leaves single-run mode off.
+- Keep single-run mode disabled by default and enable it only through bare `--once` on the current command line. A `once` script option, `K6_ONCE`, bare `ONCE`, or a `once` field in a configuration file or archive all leave it off. The flag has no scenario-selector form.
 - Keep `setup()` and `teardown()` behaving exactly as they do without the flag.
-- Carry the resulting 1 virtual user / 1 iteration scenario into the archives that `k6 cloud run` and `k6 cloud run --local-execution` upload, and keep those archives runnable, so a later re-run also runs once.
-- Reach 1 virtual user and 1 iteration whatever source declared the load, with no exception: script options, `K6_VUS`/`K6_ITERATIONS`/`K6_DURATION`/`K6_STAGES`, the JSON configuration file, or an archive's stored options. The running scenario's non-load configuration survives that. Only a load flag on the same command line is refused outright instead of overridden.
+- Carry the resulting 1 virtual user / 1 iteration scenario into the archives that `k6 cloud run` and `k6 cloud run --local-execution` upload. A later re-run also runs once when no other source supplies load.
+- Reach 1 virtual user and 1 iteration for load declared by any non-CLI source: script options, `K6_VUS`/`K6_ITERATIONS`/`K6_DURATION`/`K6_STAGES`, the JSON configuration file, or an archive's stored options. The running scenario's non-load configuration survives. A load flag on the same command line is refused instead of overridden.
 - Keep `thresholds` and every other non-scenario option untouched, so a threshold still fails the single run and sets the exit code.
-- Rewrite scenario configuration after configuration consolidation and change nothing else, so engine-level options such as `--paused` and `--execution-segment` keep their normal behavior.
+- Rewrite scenario configuration after configuration consolidation, clear the four top-level load shortcuts, and leave every other option unchanged. Engine-level options such as `--paused` and `--execution-segment` keep their normal behavior, so they can delay or scale the resulting single-run scenario.
 
 ## Non-goals
 
@@ -30,7 +30,7 @@ Running a test once with 1 virtual user and 1 iteration is how people smoke-test
 
 ### New Capabilities
 
-- once: A single-run mode, turned on by the `--once` command-line flag, that runs a test exactly once with 1 virtual user and 1 iteration while keeping the running scenario's identity and non-load configuration.
+- once: A single-run mode, turned on by the bare `--once` command-line flag, that configures one scenario with 1 virtual user and 1 iteration while keeping its identity and non-load configuration.
 
 ### Modified Capabilities
 
@@ -40,7 +40,7 @@ None.
 
 - The flag sets of `run` and `cloud run`, including local execution and archive execution. The flag cannot be added to the option flag set that `run`, `archive`, `cloud run`, and `cloud upload` share, because two of those must reject it.
 - Scenario and executor configuration, rewritten after consolidation.
-- How k6 merges configuration sources. `lib.Options.Apply` drops the whole `scenarios` map whenever a tier sets `vus`, `iterations`, `duration`, or `stages`, so neutralizing declared load without losing the scenario reaches into the merge every tier passes through. This is the largest and riskiest part of the change, and it is deliberate: without it a stray environment variable silently defeats the flag.
+- How k6 merges and derives execution options. `lib.Options.Apply` drops `scenarios` for a higher-tier `iterations`, `duration`, or `stages`; a lone `vus` can replace them during shortcut derivation. Neutralizing that load without losing the scenario reaches across this pipeline. This is the largest and riskiest part of the change, and it is deliberate: without it a stray environment variable silently defeats the flag.
 - Archive generation for both cloud paths, which today deliberately store pre-derivation options.
 - Browser test execution, which depends on the scenario's name and `options.browser` surviving into the run.
 - Error and exit-code reporting for rejected invocations.

--- a/openspec/changes/add-once-flag/proposal.md
+++ b/openspec/changes/add-once-flag/proposal.md
@@ -1,27 +1,36 @@
 ## Why
 
-Running a script once with 1 virtual user and 1 iteration is how people smoke-test, end-to-end test, and functionally test with k6, but today that requires either editing the script's scenario configuration per environment or passing shortcut load flags that discard scenarios, ignore declared load, and break browser tests. Synthetic Monitoring needs this behavior for every check it runs and currently has no runtime enforcement at all, so k6 needs a built-in, guaranteed single-run mode.
+Running a test once with 1 virtual user and 1 iteration is how people smoke-test, end-to-end test, and functionally test with k6. Today that needs either a per-environment edit to the script's scenario configuration, or a shortcut load flag. The shortcut flags replace every declared scenario with a generated `default` one, which drops `exec` targets, `env`, `tags`, and `options.browser`. Browser tests then fail with `browser not found in registry` and still exit 0, so CI and Synthetic Monitoring get no signal. Synthetic Monitoring needs a guaranteed single iteration on every check and has no runtime enforcement for it at all.
 
 ## What Changes
 
-- Add a `--once` command-line flag to `k6 run` and `k6 cloud run` that runs a script exactly once with 1 virtual user and 1 iteration, with no change to the script.
-- Accept `--once` for `k6 cloud run --local-execution` and for running an already-built archive; the archive-building command does not accept the flag, and passing it there fails as an unknown flag with a non-zero exit code.
-- Preserve the running scenario's exec target, its scenario options (browser options included), its environment variables, and its tags; discard its load-shaping fields (virtual users, iterations, duration, start time, maximum duration, time unit, stages, rate, graceful stop, graceful ramp-down, pre-allocated virtual users).
-- Run exactly one iteration on exactly one virtual user, with no ramping, whatever executor the script declared; the executor becomes shared-iterations.
-- Run the default function when the script declares no scenarios; run the one declared scenario when the script declares exactly one, including when that scenario targets the default function.
-- Fail with a non-zero exit code when the script declares two or more scenarios, naming the available scenarios.
-- Fail with a non-zero exit code when the script declares neither scenarios nor a default function, matching how k6 already behaves in that case.
-- Reject `--once` combined with any command-line flag that shapes load (virtual users, iterations, duration, stages), with an error naming the conflicting flag and a non-zero exit code.
-- Accept `--once` only as a command-line flag: neither an environment variable nor a configuration-file field turns single-run mode on, so a stray setting can never turn a real load test into a single run.
-- Keep the script's setup and teardown steps running exactly as they do without the flag.
-- Make declared load irrelevant whatever its source, whether it comes from script options, environment variables, or a configuration file: the run still ends at 1 virtual user and 1 iteration, while the scenario's non-load settings still apply.
-- Carry the resulting 1 virtual user / 1 iteration scenario into generated cloud archives, so a later re-run of that archive also runs once.
+- Add a `--once` command-line flag to `k6 run` and `k6 cloud run` that runs a test exactly once with 1 virtual user and 1 iteration, with no change to the script.
+- Accept it for `k6 cloud run --local-execution` and for running an already-built archive. Reject it on `k6 archive` and `k6 cloud upload`, the two commands that build an archive without running it, where it fails as an unknown flag with a non-zero exit code.
+- Preserve the running scenario's name, `exec` target, `options` block including `options.browser`, `env`, and `tags`.
+- Discard the running scenario's load shaping: `executor`, `vus`, `iterations`, `duration`, `startTime`, `maxDuration`, `timeUnit`, `stages`, `rate`, `gracefulStop`, `gracefulRampDown`, `preAllocatedVUs`. The scenario ends up as `shared-iterations` with `vus: 1` and `iterations: 1`, carrying that executor's defaults for anything not preserved.
+- Run the `default` function when the test declares no scenarios. Run the one declared scenario when it declares exactly one, including when that scenario targets `default`.
+- Fail when the test declares two or more scenarios, saying that single-run mode runs only a single scenario, without listing them.
+- Fail when the test declares neither scenarios nor a `default` function, exactly as k6 already fails for such a test.
+- Reject `--once` combined with `--vus`, `--iterations`, `--duration`, or `--stage`, naming the conflicting flag.
+- Accept `--once` only from the command line: `K6_ONCE`, a bare `ONCE`, and a `once` configuration-file field all leave single-run mode off, so a stray setting can never turn a real load test into a single run. `--once` takes no value; `--once=false` leaves single-run mode off.
+- Keep `setup()` and `teardown()` behaving exactly as they do without the flag.
+- Carry the resulting 1 virtual user / 1 iteration scenario into the archives that `k6 cloud run` and `k6 cloud run --local-execution` upload, and keep those archives runnable, so a later re-run also runs once.
+- Reach 1 virtual user and 1 iteration whatever source declared the load, with no exception: script options, `K6_VUS`/`K6_ITERATIONS`/`K6_DURATION`/`K6_STAGES`, the JSON configuration file, or an archive's stored options. The running scenario's non-load configuration survives that. Only a load flag on the same command line is refused outright instead of overridden.
+- Keep `thresholds` and every other non-scenario option untouched, so a threshold still fails the single run and sets the exit code.
+- Rewrite scenario configuration after configuration consolidation and change nothing else, so engine-level options such as `--paused` and `--execution-segment` keep their normal behavior.
+
+## Non-goals
+
+- Naming a scenario to run, as `--once=<name>`. That is a separate change.
+- Running every declared scenario once. That was considered and rejected, because a test with N scenarios would run N virtual users, defeating the goal.
+- Changing what shortcut flags do on their own, without `--once`.
+- Changing the end-of-test summary. A single run reports the same metrics as any other run.
 
 ## Capabilities
 
 ### New Capabilities
 
-- once: A built-in single-run mode, turned on by the `--once` command-line flag, that runs a script exactly once with 1 virtual user and 1 iteration while preserving the scenario's configuration.
+- once: A single-run mode, turned on by the `--once` command-line flag, that runs a test exactly once with 1 virtual user and 1 iteration while keeping the running scenario's identity and non-load configuration.
 
 ### Modified Capabilities
 
@@ -29,8 +38,9 @@ None.
 
 ## Impact
 
-- The `run` and `cloud run` command-line surfaces, including local execution and archive execution, plus the archive command's flag set.
-- The scenario and executor configuration layer, where single-run mode replaces load shaping.
-- Cloud archive generation and later replay of those archives.
-- Browser test execution, which depends on scenario-level browser options surviving into the single run.
+- The flag sets of `run` and `cloud run`, including local execution and archive execution. The flag cannot be added to the option flag set that `run`, `archive`, `cloud run`, and `cloud upload` share, because two of those must reject it.
+- Scenario and executor configuration, rewritten after consolidation.
+- How k6 merges configuration sources. `lib.Options.Apply` drops the whole `scenarios` map whenever a tier sets `vus`, `iterations`, `duration`, or `stages`, so neutralizing declared load without losing the scenario reaches into the merge every tier passes through. This is the largest and riskiest part of the change, and it is deliberate: without it a stray environment variable silently defeats the flag.
+- Archive generation for both cloud paths, which today deliberately store pre-derivation options.
+- Browser test execution, which depends on the scenario's name and `options.browser` surviving into the run.
 - Error and exit-code reporting for rejected invocations.

--- a/openspec/changes/add-once-flag/specs/once/spec.md
+++ b/openspec/changes/add-once-flag/specs/once/spec.md
@@ -1,154 +1,445 @@
 ## ADDED Requirements
 
-### Requirement: Single-run execution flag
+### Requirement: The `--once` flag and what it produces
 
-The system MUST provide a `--once` command-line flag that runs a script exactly one time with 1 virtual user and 1 iteration, without requiring any edit to the script. The run MUST perform exactly one iteration on exactly one virtual user, with no ramping, whatever executor the script declared, and the load declared in the script MUST NOT take effect. The scenario's executor MUST become shared-iterations. The system MUST NOT run more than one scenario in a single invocation under any circumstance. The flag MUST be accepted by `k6 run`, by `k6 cloud run`, by `k6 cloud run --local-execution`, and when running an already-built archive, and it MUST produce the same single-run behavior in each. The archive-building command MUST NOT accept the flag.
+The system MUST provide a `--once` command-line flag that runs a test exactly one time with 1 virtual user and 1 iteration, with no edit to the script.
 
-#### Scenario: Identical behavior across every accepted entry point
-- **GIVEN** a script whose single scenario declares 100 virtual users and 100 iterations under a ramping executor
-- **WHEN** the user runs it with `--once` under `k6 run`
-- **AND** separately under `k6 cloud run`
-- **AND** separately under `k6 cloud run --local-execution`
-- **AND** separately by running an already-built archive of that script with `--once`
-- **THEN** each invocation runs exactly one iteration on exactly one virtual user
-- **AND** each invocation uses the shared-iterations executor for that scenario
-- **AND** none of the declared load is applied
+Under single-run mode the scenario that runs MUST end up as a `shared-iterations` scenario with `vus: 1` and `iterations: 1`, whatever executor the test declared, and with no exception for any configuration source, flag, or option. The system MUST NOT run more than one scenario under single-run mode.
 
-#### Scenario: Archive building rejects the flag
-- **GIVEN** any script
-- **WHEN** the user passes `--once` to the archive-building command
-- **THEN** k6 reports an unknown flag error
+`--once` MUST be accepted by `k6 run`, `k6 cloud run`, `k6 cloud run --local-execution`, and by `k6 run` on an already-built archive. It MUST NOT be accepted by `k6 archive` or `k6 cloud upload`, the two commands that build an archive without running it.
+
+`--once` MUST take no value. As a boolean flag it also accepts `--once=true` and `--once=false`, and `--once=false` MUST leave single-run mode off, so the test runs its declared load. Any other value MUST be rejected as an invalid flag value and MUST NOT be read as a scenario name: naming a scenario to run is a separate, later change, and silently treating `--once=api` as a bare `--once` would run the wrong scenario.
+
+Note for whoever writes the tests: k6 prints the scenario description once, in the block before the run starts, and `--quiet` suppresses that block. The executed iteration count is a separate line, `N complete and 0 interrupted iterations`. Do not match the padded `iterations...........:` summary line — the dot run grows with the longest metric name in the test.
+
+#### Scenario: A 100 VU / 100 iteration scenario runs once
+- **GIVEN** `api.js`:
+  ```js
+  export const options = { scenarios: { api: {
+    executor: 'shared-iterations', exec: 'api', vus: 100, iterations: 100,
+  }}};
+  export function api() { console.log('api ran'); }
+  ```
+- **WHEN** the user runs `k6 run --once api.js`
+- **THEN** the pre-run scenario line reads `* api: 1 iterations shared among 1 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+- **AND** `api ran` is printed exactly once
+- **AND** the process exits with code 0
+
+#### Scenario: A ramping scenario becomes shared-iterations
+- **GIVEN** `ramp.js`:
+  ```js
+  export const options = { scenarios: { api: {
+    executor: 'ramping-vus', exec: 'api', startVUs: 10,
+    stages: [{ duration: '30s', target: 100 }], gracefulRampDown: '10s',
+  }}};
+  export function api() { console.log('api ran'); }
+  ```
+- **WHEN** the user runs `k6 run --once ramp.js`
+- **THEN** the pre-run scenario line reads `* api: 1 iterations shared among 1 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
+- **AND** it is no longer the ramping description `* api: Up to 100 looping VUs for 30s over 1 stages (gracefulRampDown: 10s, exec: api, gracefulStop: 30s)` that k6 prints without the flag
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+
+#### Scenario: Running an already-built archive
+- **GIVEN** an archive built with `k6 archive api.js -O api.tar`, whose stored options declare the 100 VU / 100 iteration `api` scenario
+- **WHEN** the user runs `k6 run --once api.tar`
+- **THEN** stdout contains `1 complete and 0 interrupted iterations`
+- **AND** `api ran` is printed exactly once
+
+#### Scenario: Local execution against the cloud
+- **GIVEN** `api.js`
+- **WHEN** the user runs `k6 cloud run --local-execution --once api.js`
+- **THEN** stdout contains `1 complete and 0 interrupted iterations`
+
+#### Scenario: Cloud execution
+- **GIVEN** `api.js`
+- **WHEN** the user runs `k6 cloud run --once api.js`
+- **THEN** the options k6 sends when it creates the cloud test run declare one scenario, named `api`, with `vus: 1` and `iterations: 1`
+
+#### Scenario: The archive-building commands reject the flag
+- **WHEN** the user runs `k6 archive --once api.js`
+- **AND** separately `k6 cloud upload --once api.js`
+- **THEN** each reports `unknown flag: --once`
+- **AND** each exits with a non-zero code
+
+#### Scenario: `--once=api` is not a scenario selector
+- **GIVEN** `multi.js`
+- **WHEN** the user runs `k6 run --once=api multi.js`
+- **THEN** k6 rejects the value as an invalid boolean, naming the `once` flag
+- **AND** the process exits with a non-zero code
+- **AND** it does not fall back to single-run mode and does not run any scenario
+
+#### Scenario: `--once=false` leaves the declared load alone
+- **GIVEN** `api.js`
+- **WHEN** the user runs `k6 run --once=false api.js`
+- **THEN** the pre-run scenario line reads `* api: 100 iterations shared among 100 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
+- **AND** stdout contains `100 complete and 0 interrupted iterations`
+
+### Requirement: The running scenario keeps its identity and its non-load configuration
+
+Single-run mode MUST preserve the running scenario's name, its `exec` target, its `options` block including `options.browser`, its `env`, and its `tags`.
+
+The name matters beyond display: it is a system tag on every metric the run emits, it is what `k6/execution` reports as `scenario.name`, and it is the key the browser module uses to find `options.browser`. A single-run scenario MUST NOT be renamed.
+
+#### Scenario: Name, exec target, env, and tags all survive
+- **GIVEN** `keep.js`:
+  ```js
+  import exec from 'k6/execution';
+  export const options = { scenarios: { api: {
+    executor: 'shared-iterations', exec: 'api', vus: 50, iterations: 50,
+    env: { URL: 'https://example.com' }, tags: { team: 'core' },
+  }}};
+  export function api() { console.log(`name=${exec.scenario.name} url=${__ENV.URL}`); }
+  export default function () { console.log('default ran'); }
+  ```
+- **WHEN** the user runs `k6 run --once --out json=out.json keep.js`
+- **THEN** `name=api url=https://example.com` is printed exactly once
+- **AND** `default ran` is not printed
+- **AND** every metric point in `out.json` carries the tags `scenario: api` and `team: core`
+
+### Requirement: Load-shaping configuration is discarded
+
+Single-run mode MUST discard the running scenario's load-shaping configuration: `executor`, `vus`, `iterations`, `duration`, `startTime`, `maxDuration`, `timeUnit`, `stages`, `rate`, `gracefulStop`, `gracefulRampDown`, `preAllocatedVUs`, and every other field belonging to the declared executor, such as `startVUs` and `maxVUs`.
+
+The list is not the mechanism. The resulting scenario MUST be a fresh `shared-iterations` configuration, so no field of the declared executor can survive by omission from the list. k6 rejects a scenario carrying a field its executor does not own, so an implementation that deletes only the listed fields produces a scenario k6 cannot load.
+
+Discarded means replaced, not merged: the resulting scenario carries the `shared-iterations` defaults for anything it does not preserve. A declared `maxDuration` or `gracefulStop` therefore does not carry over, and the single iteration runs under the default budget of 10 minutes with a 30 second graceful stop.
+
+#### Scenario: Arrival-rate shaping has no effect
+- **GIVEN** `rate.js`:
+  ```js
+  export const options = { scenarios: { api: {
+    executor: 'constant-arrival-rate', exec: 'api',
+    rate: 100, timeUnit: '1s', duration: '10m',
+    preAllocatedVUs: 50, maxVUs: 200, startTime: '30s',
+  }}};
+  export function api() { console.log('api ran'); }
+  ```
+- **WHEN** the user runs `k6 run --once rate.js`
+- **THEN** the pre-run scenario line reads `* api: 1 iterations shared among 1 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
+- **AND** `api ran` is printed within a second of start, not after the declared 30 second `startTime`
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+
+#### Scenario: A declared maximum duration and graceful stop do not carry over
+- **GIVEN** `budget.js`:
+  ```js
+  export const options = { scenarios: { api: {
+    executor: 'shared-iterations', exec: 'api', vus: 5, iterations: 5,
+    maxDuration: '1h', gracefulStop: '5m',
+  }}};
+  export function api() { console.log('api ran'); }
+  ```
+- **WHEN** the user runs `k6 run --once budget.js`
+- **THEN** the pre-run scenario line reads `* api: 1 iterations shared among 1 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
+- **AND** the pre-run header reads `1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):`, not the `1h5m30s` the declared values would give
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+
+### Requirement: A test with no scenarios runs its default function
+
+When a test declares no scenarios and exports a `default` function, single-run mode MUST run that function once, as a `shared-iterations` scenario named `default` with `vus: 1` and `iterations: 1`. Load the test declares outside a scenario MUST NOT take effect.
+
+#### Scenario: A default-only script runs once
+- **GIVEN** `plain.js`:
+  ```js
+  export const options = { vus: 50, duration: '30s' };
+  export default function () { console.log('default ran'); }
+  ```
+- **WHEN** the user runs `k6 run --once plain.js`
+- **THEN** the pre-run scenario line reads `* default: 1 iterations shared among 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)`
+- **AND** it is no longer the `* default: 50 looping VUs for 30s (gracefulStop: 30s)` that k6 prints without the flag
+- **AND** `default ran` is printed exactly once
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+
+### Requirement: One declared scenario is the one that runs
+
+When a test declares exactly one scenario, single-run mode MUST run that scenario, whatever it is named and wherever it was declared.
+
+If the scenario names an `exec` target, that target MUST run and the exported `default` function MUST NOT run, even when the script exports one. If the scenario names no `exec` target, or names `default`, then the `default` function MUST run, still under that scenario's preserved configuration. Such a scenario needs a `default` export: without one the run MUST fail.
+
+#### Scenario: A scenario with no exec target runs the default function
+- **GIVEN** `ui.js`:
+  ```js
+  export const options = { scenarios: { ui: {
+    executor: 'constant-vus', vus: 10, duration: '30s',
+    env: { BASE_URL: 'https://example.com' },
+  }}};
+  export default function () { console.log(`default ran url=${__ENV.BASE_URL}`); }
+  ```
+- **WHEN** the user runs `k6 run --once ui.js`
+- **THEN** `default ran url=https://example.com` is printed exactly once
+- **AND** the pre-run scenario line names the scenario `ui`, not `default`
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+
+#### Scenario: `exec: 'default'` behaves the same as no exec target
+- **GIVEN** `uiexec.js`, which is `ui.js` with `exec: 'default'` added to the `ui` scenario
+- **WHEN** the user runs `k6 run --once uiexec.js`
+- **THEN** `default ran url=https://example.com` is printed exactly once
+- **AND** the pre-run scenario line names the scenario `ui`
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+
+#### Scenario: A scenario needing the default function fails without one
+- **GIVEN** `nodefault.js`, which is `ui.js` with its `export default` replaced by `export function api() {}`, so the `ui` scenario still targets `default` but nothing exports it
+- **WHEN** the user runs `k6 run --once nodefault.js`
+- **THEN** standard error contains `executor ui: function 'default' not found in exports`
+- **AND** the process exits with a non-zero code
+- **AND** it is the same message and code that `k6 run nodefault.js` gives without the flag
+
+#### Scenario: The single scenario may come from a configuration file
+- **GIVEN** `plaindef.js`, which declares no scenarios and exports `default`
+- **AND** `cfg.json` containing exactly:
+  ```json
+  {"scenarios": {"api": {"executor": "shared-iterations", "vus": 7, "iterations": 9, "tags": {"team": "core"}}}}
+  ```
+- **WHEN** the user runs `k6 run --once -c cfg.json --out json=out.json plaindef.js`
+- **THEN** the pre-run scenario line names the scenario `api` and reads `1 iterations shared among 1 VUs`
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+- **AND** every metric point in `out.json` carries the tags `scenario: api` and `team: core`
+
+### Requirement: Declared load never takes effect, whatever declared it
+
+Single-run mode MUST reach 1 virtual user and 1 iteration whatever source declared the load, and the running scenario's non-load configuration MUST survive that. There is no exception. The sources are:
+
+- the script's `options`, both inside a scenario and at the top level
+- the environment variables `K6_VUS`, `K6_ITERATIONS`, `K6_DURATION`, and `K6_STAGES`
+- the JSON configuration file, whether named with `-c` or picked up from its default location
+- an archive's stored options, when `k6 run` is given an archive
+
+The command line is the one source that is refused outright rather than neutralized, because a load flag on the same command line as `--once` is a contradiction the user can see and fix. Every other source is silently overridden, because the user may not control it.
+
+This is the requirement with real weight behind it. k6 consolidates its sources before single-run mode acts, and any source that sets `vus`, `iterations`, `duration`, or `stages` throws the whole `scenarios` map away while consolidating, taking `exec`, `env`, `tags`, and `options.browser` with it. Today all four environment variables above turn the browser script below into `executor default: function 'default' not found in exports` with exit 104. Under `--once` that script MUST run once, with its scenario intact. Satisfying this reaches into how k6 merges configuration, and that is accepted: without it, a stray variable in a shell profile or a probe's environment silently defeats the flag, which is the failure this whole change exists to remove.
+
+#### Scenario: An environment variable cannot defeat single-run mode
+- **GIVEN** `envkeep.js`:
+  ```js
+  import exec from 'k6/execution';
+  export const options = { scenarios: { api: {
+    executor: 'shared-iterations', exec: 'api', vus: 50, iterations: 50,
+    env: { URL: 'https://example.com' }, tags: { team: 'core' },
+    options: { browser: { type: 'chromium' } },
+  }}};
+  export function api() { console.log(`name=${exec.scenario.name} url=${__ENV.URL}`); }
+  ```
+- **WHEN** the user runs `k6 run --once envkeep.js` with `K6_VUS=100` set
+- **AND** separately with `K6_ITERATIONS=100`
+- **AND** separately with `K6_DURATION=30s`
+- **AND** separately with `K6_STAGES=10s:5`
+- **THEN** each run prints `name=api url=https://example.com` exactly once
+- **AND** each pre-run scenario line names the scenario `api`, not `default`
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+- **AND** no warning contains `overrides scenarios configuration` or `overrode scenarios configuration entirely`
+- **AND** each run exits with code 0, where without `--once` all four exit 104 with `executor default: function 'default' not found in exports`
+
+#### Scenario: A configuration file cannot defeat single-run mode
+- **GIVEN** `envkeep.js` and `load.json` containing exactly `{"vus": 100, "iterations": 100}`
+- **WHEN** the user runs `k6 run --once -c load.json envkeep.js`
+- **THEN** `name=api url=https://example.com` is printed exactly once
+- **AND** the pre-run scenario line names the scenario `api`
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+
+#### Scenario: An archive's stored load cannot defeat single-run mode
+- **GIVEN** `load.tar`, an archive whose stored options carry both the `api` scenario and a top-level `iterations` value
+- **WHEN** the user runs `k6 run --once load.tar`
+- **THEN** stdout contains `1 complete and 0 interrupted iterations`
+- **AND** the run does not fail with a conflict between top-level options and `scenarios`
+
+### Requirement: Two or more scenarios are rejected
+
+When a test declares two or more scenarios, single-run mode MUST fail, because it cannot pick one of them or combine their configurations without ambiguity. It MUST NOT pick one, and MUST NOT run several.
+
+The error MUST be reported at error level and MUST contain `the --once flag can run only a single scenario`. It MUST be a single line, so one substring match works whatever the log format. It MUST NOT list the declared scenario names: Proposal 1's error carries no names, listing them is Proposal 2's affordance (`available scenarios: api, ui, ts`), and offering the list here implies a choice the flag does not accept.
+
+The rejection MUST happen before any iteration starts and before `setup()` runs. The script's init context still runs, because that is where k6 reads the scenario list from.
+
+#### Scenario: A three-scenario script is rejected before anything runs
+- **GIVEN** `multi.js`:
+  ```js
+  console.log('init ran');
+  export const options = { scenarios: {
+    zulu: { executor: 'shared-iterations', exec: 'zulu' },
+    xray: { executor: 'shared-iterations', exec: 'xray' },
+    kilo: { executor: 'shared-iterations', exec: 'kilo', options: { browser: { type: 'chromium' } } },
+  }};
+  export function setup() { console.log('setup ran'); }
+  export function zulu() { console.log('zulu ran'); }
+  export function xray() { console.log('xray ran'); }
+  export async function kilo() { const p = await browser.newPage(); await p.close(); }
+  ```
+  with `import { browser } from 'k6/browser';` at the top, so the browser scenario really would launch Chromium if it ran
+- **WHEN** the user runs `k6 run --once multi.js`
+- **THEN** standard error contains `the --once flag can run only a single scenario`
+- **AND** the message contains none of `zulu`, `xray`, or `kilo`
+- **AND** `setup ran`, `zulu ran`, and `xray ran` are all absent from the output
+- **AND** no Chromium process is started
+- **AND** `init ran` is present, because k6 reads the scenario list from the init context
 - **AND** the process exits with a non-zero code
 
-### Requirement: Scenario configuration is preserved and load shaping is discarded
-
-Single-run mode MUST preserve the running scenario's exec target, its scenario options including browser options, its environment variables, and its tags. Single-run mode MUST discard the scenario's load-shaping configuration: virtual users, iterations, duration, start time, maximum duration, time unit, stages, rate, graceful stop, graceful ramp-down, and pre-allocated virtual users.
-
-#### Scenario: Non-load configuration survives, load configuration does not
-- **GIVEN** a script with one scenario named `api` that sets an exec target, browser options, scenario environment variables, and tags
-- **AND** whose load is arrival-rate shaped, declaring a rate, a time unit, pre-allocated virtual users, a start time, and a maximum duration
-- **WHEN** the user runs it with `--once`
-- **THEN** the run uses that scenario's exec target, browser options, environment variables, and tags
-- **AND** exactly one iteration runs on exactly one virtual user
-- **AND** the rate, time unit, pre-allocated virtual users, start time, and maximum duration have no effect on the run
-
-### Requirement: Declared load never takes effect, whatever its source
-
-Under single-run mode, the scenario's load-shaping configuration MUST have no effect regardless of which configuration source it reaches the scenario from: script options, an environment variable, or a configuration file. The scenario's non-load configuration MUST still apply from whichever of those sources it reaches the scenario from.
-
-#### Scenario: Load supplied outside the script still runs once
-- **GIVEN** a script whose scenario takes its virtual user and iteration counts from an environment variable
-- **AND** whose scenario takes its tags from a configuration file
-- **WHEN** the user runs it with `--once`
-- **THEN** exactly one iteration runs on exactly one virtual user
-- **AND** the scenario's tags from the configuration file still apply
-
-### Requirement: Scripts without scenarios run the default function
-
-When a script declares no scenarios and exports a default function, single-run mode MUST run that default function once with 1 virtual user and 1 iteration, and any load the script declares at the top level MUST NOT take effect.
-
-#### Scenario: Default-only script runs once
-- **GIVEN** a script with no scenarios that exports a default function
-- **AND** declares 50 virtual users and a 30 second duration at the top level
-- **WHEN** the user runs it with `--once`
-- **THEN** the default function runs exactly one time on one virtual user
-- **AND** the declared virtual users and duration have no effect
-
-### Requirement: A single declared scenario is the one that runs
-
-When a script declares exactly one scenario, single-run mode MUST run that scenario once, using its configuration. If the scenario names an exec target, that target MUST run even when the script also exports a default function, and the default function MUST NOT run. If the scenario names no exec target, or names the default function as its target, the default function MUST run, still using that scenario's other configuration.
-
-#### Scenario: Named exec target wins over an exported default function
-- **GIVEN** a script that exports a default function
-- **AND** declares one scenario whose exec target is a different exported function
-- **WHEN** the user runs it with `--once`
-- **THEN** the scenario's exec target runs exactly once
-- **AND** the default function does not run even though the script exports it
-
-#### Scenario: Scenario without an exec target falls back to the default function
-- **GIVEN** a script with one scenario that names no exec target, or names the default function, and sets environment variables, tags, and browser options
-- **WHEN** the user runs it with `--once`
-- **THEN** the default function runs exactly once
-- **AND** it runs with that scenario's environment variables, tags, and browser options
-
-### Requirement: Multiple scenarios are rejected
-
-When a script declares two or more scenarios, single-run mode MUST fail, because it cannot choose which scenario to run or whose configuration to use without ambiguity. The system MUST NOT pick one of them, and MUST NOT run several of them together. The error MUST name the available scenarios. The rejection MUST happen before the script runs.
-
-#### Scenario: Multi-scenario script errors before anything runs
-- **GIVEN** a script declaring three scenarios
-- **WHEN** the user runs it with `--once` under `k6 run`
-- **AND** separately under `k6 cloud run`
-- **THEN** each invocation fails, naming the three scenario names
+#### Scenario: The same rejection under cloud run
+- **GIVEN** `multi.js`
+- **WHEN** the user runs `k6 cloud run --once multi.js`
+- **THEN** standard error contains `the --once flag can run only a single scenario`
+- **AND** k6 sends no request to create a cloud test run
 - **AND** the process exits with a non-zero code
 
-### Requirement: Scripts with no runnable entry point fail
+### Requirement: A test with nothing to run fails as it already does
 
-When a script declares neither scenarios nor a default function, single-run mode MUST fail with the same missing-default-function error k6 already reports for such a script today.
+When a test declares neither scenarios nor a `default` function, single-run mode MUST fail exactly as k6 fails for that same test without the flag: the same message and the same exit code.
 
 #### Scenario: Nothing to run
-- **GIVEN** a script with no scenarios and no exported default function
-- **WHEN** the user runs it with `--once`
-- **THEN** k6 reports the same missing-default-function error it reports for that script without the flag
+- **GIVEN** `noentry.js` containing only `export function api() {}`
+- **WHEN** the user runs `k6 run --once noentry.js`
+- **THEN** standard error contains `executor default: function 'default' not found in exports`
+- **AND** the message and the exit code are the same ones `k6 run noentry.js` gives without the flag
+
+### Requirement: Load-shaping command-line flags cannot be combined with `--once`
+
+`--vus`/`-u`, `--iterations`/`-i`, `--duration`/`-d`, and `--stage`/`-s` MUST each be rejected when passed together with `--once`, in their long and their short form alike. The rejection MUST happen before any iteration starts, even for a test single-run mode would otherwise accept, and the system MUST NOT resolve the ambiguity by preferring either flag.
+
+The error MUST name both flags. k6 has no existing "cannot be combined" wording, so this follows the flag-conflict phrasing k6 already uses for `--local-execution`: `the --once flag is not compatible with the --iterations flag`, written to standard error, with the same shape for `--vus`, `--duration`, and `--stage`. A test may match on the two flag names appearing in one error line rather than on the whole sentence.
+
+#### Scenario: `--iterations` is refused
+- **GIVEN** `api.js`, which single-run mode accepts on its own
+- **WHEN** the user runs `k6 run --once --iterations 10 api.js`
+- **THEN** standard error contains `the --once flag is not compatible with the --iterations flag`
+- **AND** `api ran` is not printed
 - **AND** the process exits with a non-zero code
 
-### Requirement: Load-shaping command-line flags cannot be combined with single-run mode
+#### Scenario: `--vus` is refused
+- **WHEN** the user runs `k6 run --once --vus 10 api.js`
+- **THEN** standard error contains `the --once flag is not compatible with the --vus flag`, `api ran` is not printed, and the process exits with a non-zero code
 
-The virtual-users flag, the iterations flag, the duration flag, and the stages flag MUST each be rejected when combined with `--once` on the same command line. The error MUST name the conflicting flag. The rejection MUST happen before the script runs, even when the script would otherwise be accepted by single-run mode. The system MUST NOT resolve the ambiguity by preferring one of the two flags.
+#### Scenario: `--duration` is refused
+- **WHEN** the user runs `k6 run --once --duration 30s api.js`
+- **THEN** standard error contains `the --once flag is not compatible with the --duration flag`, `api ran` is not printed, and the process exits with a non-zero code
 
-#### Scenario: Combination is refused even for an otherwise valid script
-- **GIVEN** a script with exactly one scenario, which single-run mode would accept on its own
-- **WHEN** the user runs it with `--once` together with the iterations flag
-- **AND** separately with `--once` together with the virtual-users flag
-- **AND** separately with `--once` together with the duration flag
-- **AND** separately with `--once` together with the stages flag
-- **AND** separately with each of those combinations under `k6 cloud run`
-- **THEN** each invocation reports that single-run mode cannot be combined with that flag
-- **AND** the script does not run
-- **AND** the process exits with a non-zero code
+#### Scenario: `--stage` is refused
+- **WHEN** the user runs `k6 run --once --stage 30s:10 api.js`
+- **THEN** standard error contains `the --once flag is not compatible with the --stage flag`, `api ran` is not printed, and the process exits with a non-zero code
 
-### Requirement: Browser tests run correctly under single-run mode
+#### Scenario: The short forms are refused too
+- **WHEN** the user runs `k6 run --once -i 10 api.js`
+- **AND** separately `k6 run --once -u 10 api.js`
+- **AND** separately `k6 run --once -d 30s api.js`
+- **AND** separately `k6 run --once -s 30s:10 api.js`
+- **THEN** each names the conflicting flag on standard error and exits with a non-zero code
 
-Because scenario-level browser options survive single-run mode, a browser script MUST run its browser steps successfully without the user editing the script or passing load-shaping flags. A browser MUST be launched only when the scenario that actually runs declares browser options.
+#### Scenario: The rejection also applies to cloud run
+- **WHEN** the user runs `k6 cloud run --once -i 10 api.js`
+- **THEN** standard error names the conflict, k6 sends no request to create a cloud test run, and the process exits with a non-zero code
 
-#### Scenario: Browser scenario runs once with its browser
-- **GIVEN** a script with one scenario that declares browser options and drives a page
-- **WHEN** the user runs it with `--once`
-- **THEN** the browser is launched and the scenario runs exactly one iteration on one virtual user
-- **AND** the run does not fail for a missing browser
+### Requirement: Browser tests run under single-run mode
 
-#### Scenario: No browser launches for a non-browser scenario
-- **GIVEN** a script with one scenario that declares no browser options
-- **WHEN** the user runs it with `--once`
-- **THEN** no browser is launched
+Because the running scenario keeps its name and its `options.browser` block, a browser test MUST run its browser steps under `--once` with no script edit and no load-shaping flag. This is the case that shortcut flags break today.
+
+A browser MUST be launched only when the running scenario declares `options.browser`.
+
+#### Scenario: A browser scenario runs once, with its browser
+- **GIVEN** `browser.js`:
+  ```js
+  import { browser } from 'k6/browser';
+  export const options = { scenarios: { ui: {
+    executor: 'shared-iterations', vus: 10, iterations: 10,
+    options: { browser: { type: 'chromium' } },
+  }}};
+  export default async function () {
+    const page = await browser.newPage();
+    try {
+      await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
+      console.log(`title=${await page.title()}`);
+    } finally { await page.close(); }
+  }
+  ```
+- **WHEN** the user runs `k6 run --once browser.js`
+- **THEN** the summary contains a `browser_web_vital_lcp` line, so a real browser drove a real page
+- **AND** `browser not found in registry` is absent from the output
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+
+#### Scenario: No browser launches when the scenario declares none
+- **GIVEN** `nobrowser.js`, which is `browser.js` with the `options.browser` block deleted
+- **WHEN** the user runs `k6 run --once nobrowser.js`
+- **THEN** no `browser_` metric appears in the summary
+- **AND** standard error contains `browser not found in registry`, exactly as it does for that script without the flag
 
 ### Requirement: Single-run mode is a command-line flag only
 
-Single-run mode MUST turn on only when `--once` appears on that invocation's command line. An environment variable named after the flag MUST NOT turn single-run mode on, and a configuration-file field named after the flag MUST NOT turn it on. In both cases the script MUST run with its declared load. This keeps a stray setting left in a shell profile or a shared configuration file from turning a real load test into a single run.
+Single-run mode MUST turn on only from `--once` on the invocation's own command line. No environment variable and no configuration-file field may turn it on. Concretely, `K6_ONCE`, a bare `ONCE`, and a `once` field in the JSON configuration file MUST all leave single-run mode off.
 
-#### Scenario: Environment variable and configuration file cannot turn on single-run mode
-- **GIVEN** a script whose scenario declares 100 virtual users and 100 iterations
-- **AND** an environment variable named after the `--once` flag is set
-- **AND** the configuration file contains a field named after the `--once` flag
-- **WHEN** the user runs the script without `--once` on the command line
-- **THEN** the script runs with its declared 100 virtual users and 100 iterations
+k6 decodes environment configuration with an empty prefix, so an unprefixed variable named after a configuration field reaches the decoder. Both spellings therefore have to be inert, not just the prefixed one. The point of the rule is that a setting left in a shell profile or a shared configuration file can never turn a real load test into a single run, where passing looks like success.
+
+#### Scenario: Neither environment variable turns it on
+- **GIVEN** `api.js`
+- **AND** `K6_ONCE=true` and `ONCE=true` are both set
+- **WHEN** the user runs `k6 run api.js`, with no `--once`
+- **THEN** the pre-run scenario line reads `* api: 100 iterations shared among 100 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
+- **AND** stdout contains `100 complete and 0 interrupted iterations`, so the declared load really ran
+- **AND** the process exits with code 0
+
+#### Scenario: The configuration file cannot turn it on
+- **GIVEN** `api.js` and `once.json` containing exactly `{"once": true}`
+- **WHEN** the user runs `k6 run -c once.json api.js`
+- **THEN** stdout contains `100 complete and 0 interrupted iterations`
+- **AND** the process exits with code 0
 
 ### Requirement: Setup and teardown are unaffected
 
-Single-run mode MUST change only the scenario configuration. The script's setup and teardown functions MUST behave exactly as they do without the flag, each running once around the single iteration.
+Single-run mode changes scenario configuration only. `setup()` and `teardown()` MUST behave exactly as they do without the flag on any invocation single-run mode accepts, including the flags that skip them.
 
-#### Scenario: Setup and teardown still run around the single iteration
-- **GIVEN** a script that exports setup and teardown functions
-- **WHEN** the user runs it with `--once`
-- **THEN** setup runs exactly once before the iteration
-- **AND** teardown runs exactly once after the iteration
+#### Scenario: Setup and teardown run once around the single iteration
+- **GIVEN** `lifecycle.js` exporting `setup()`, `teardown()`, and a `default` function, each printing a distinct line
+- **WHEN** the user runs `k6 run --once lifecycle.js`
+- **THEN** the output shows the setup line, then the default line, then the teardown line, in that order
+- **AND** each appears exactly once
+
+#### Scenario: The skip flags still skip
+- **GIVEN** `lifecycle.js`
+- **WHEN** the user runs `k6 run --once --no-setup --no-teardown lifecycle.js`
+- **THEN** neither the setup line nor the teardown line appears
+- **AND** the default line appears exactly once
 
 ### Requirement: Archives carry single-run mode forward
 
-An archive generated for a cloud run under single-run mode MUST contain the resulting 1 virtual user / 1 iteration scenario, so that re-running that archive later, including from the cloud interface, also runs exactly once.
+An archive that k6 builds for a cloud run started with `--once` MUST carry the resulting 1 virtual user / 1 iteration scenario, so a later run of that archive also runs once. This holds for the archive uploaded by `k6 cloud run` and for the archive uploaded by `k6 cloud run --local-execution`.
 
-#### Scenario: Re-running a generated archive still runs once
-- **GIVEN** a script whose scenario declares 100 virtual users and 100 iterations
-- **WHEN** the user starts a cloud run with `--once`
-- **AND** the archive produced for that run is run again later without the flag
-- **THEN** the later run also runs exactly one iteration on one virtual user
+The archive's stored options MUST hold the single-run scenario and nothing else that shapes load: the top-level `vus`, `iterations`, `duration`, and `stages` values MUST all be absent. This is absolute, not a preference. An archive built under `--once` describes a single run, so re-running it MUST give a single run even without the flag, and any leftover top-level load value breaks that: `iterations`, `duration`, or `stages` makes k6 refuse the archive outright, and `vus` is worse, because it silently discards the single-run scenario and runs that many virtual users while exiting 0.
+
+#### Scenario: Re-running the uploaded archive runs once
+- **GIVEN** `api.js`, whose scenario declares 100 virtual users and 100 iterations
+- **WHEN** the user starts `k6 cloud run --once api.js`
+- **AND** the archive k6 uploaded for that run is later run with `k6 run`, without `--once`
+- **THEN** the archive's `metadata.json` options have `vus`, `iterations`, `duration`, and `stages` all null
+- **AND** the later run's pre-run scenario line reads `* api: 1 iterations shared among 1 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
+- **AND** the later run prints no warning containing `overrides scenarios configuration`
+- **AND** the later run exits with code 0
+
+#### Scenario: The same holds for local execution
+- **GIVEN** `api.js`
+- **WHEN** the user starts `k6 cloud run --local-execution --once api.js`
+- **AND** the archive k6 uploaded for that run is later run with `k6 run`, without `--once`
+- **THEN** the later run's pre-run scenario line names the scenario `api` and reads `1 iterations shared among 1 VUs`
+- **AND** the later run exits with code 0
+
+### Requirement: Single-run mode leaves the engine's own options alone
+
+Single-run mode rewrites scenario configuration after k6 has consolidated its configuration sources, and changes nothing else. Options that act on the engine rather than on a scenario MUST keep their normal behavior, and single-run mode MUST NOT special-case them.
+
+So `--paused` still holds the run before its single iteration and releases it on resume. `--execution-segment` and `--execution-segment-sequence` still scale the resulting 1 virtual user / 1 iteration scenario exactly as they scale any such scenario, including down to no work for a segment that owns none. A segment that owns no work reports `0 complete and 0 interrupted iterations`; on current k6 such a run also logs a summary error and still exits 0, which is a pre-existing bug unrelated to this change.
+
+Options that are not scenario configuration MUST survive untouched. `thresholds` in particular MUST still be evaluated over the single iteration and MUST still set the exit code. That matters because a threshold is today the only way to make a single run fail on a failed check, which is what turns `--once` into a functional test. An implementation that replaced the whole options object rather than its `scenarios` field would drop the thresholds, and every single run would exit 0 -- the same silent success that makes broken browser tests look like passes.
+
+#### Scenario: A failing threshold still fails the single run
+- **GIVEN** `thresh.js`, which declares `thresholds: { checks: ['rate==1.0'] }`, one scenario with 50 virtual users and 50 iterations, and a body running one check that always fails
+- **WHEN** the user runs `k6 run --once thresh.js`
+- **THEN** standard error reports that the `checks` threshold was crossed
+- **AND** the process exits with code 99, the threshold-failure code
+- **AND** stdout contains `1 complete and 0 interrupted iterations`
+
+#### Scenario: A passing threshold leaves the single run green
+- **GIVEN** `thresh.js` with its check changed to always pass
+- **WHEN** the user runs `k6 run --once thresh.js`
+- **THEN** the process exits with code 0
+
+#### Scenario: `--paused` holds the single iteration until resumed
+- **GIVEN** `api.js`
+- **WHEN** the user runs `k6 run --once --paused --address localhost:6565 api.js`
+- **THEN** the progress output reports the run as `paused` and `api ran` is not printed
+- **AND** after a `PATCH /v1/status` sets `paused` to false, `api ran` is printed exactly once
+- **AND** stdout contains `1 complete and 0 interrupted iterations`

--- a/openspec/changes/add-once-flag/specs/once/spec.md
+++ b/openspec/changes/add-once-flag/specs/once/spec.md
@@ -1,445 +1,426 @@
 ## ADDED Requirements
 
-### Requirement: The `--once` flag and what it produces
+### Requirement: Bare `--once` enables single-run mode
 
-The system MUST provide a `--once` command-line flag that runs a test exactly one time with 1 virtual user and 1 iteration, with no edit to the script.
+`--once` MUST be disabled by default. Passing the bare `--once` flag MUST configure one effective `shared-iterations` scenario with `vus: 1` and `iterations: 1`, without requiring a script edit. This proposal defines no value form and no scenario selector for the flag.
 
-Under single-run mode the scenario that runs MUST end up as a `shared-iterations` scenario with `vus: 1` and `iterations: 1`, whatever executor the test declared, and with no exception for any configuration source, flag, or option. The system MUST NOT run more than one scenario under single-run mode.
+The 1 VU / 1 iteration guarantee describes the effective scenario configuration. Setup failure, iteration failure, timeout, interruption, pause, and execution segments MUST keep their normal behavior and can prevent one complete iteration.
 
-`--once` MUST be accepted by `k6 run`, `k6 cloud run`, `k6 cloud run --local-execution`, and by `k6 run` on an already-built archive. It MUST NOT be accepted by `k6 archive` or `k6 cloud upload`, the two commands that build an archive without running it.
+`--once` MUST be accepted only by `k6 run` and `k6 cloud run`, including `k6 cloud run --local-execution`, for script, archive, and standard-input sources those commands already support. Every other command MUST reject it as an unknown flag.
 
-`--once` MUST take no value. As a boolean flag it also accepts `--once=true` and `--once=false`, and `--once=false` MUST leave single-run mode off, so the test runs its declared load. Any other value MUST be rejected as an invalid flag value and MUST NOT be read as a scenario name: naming a scenario to run is a separate, later change, and silently treating `--once=api` as a bare `--once` would run the wrong scenario.
+#### Scenario: Supported entry points apply the same single-run configuration
 
-Note for whoever writes the tests: k6 prints the scenario description once, in the block before the run starts, and `--quiet` suppresses that block. The executed iteration count is a separate line, `N complete and 0 interrupted iterations`. Do not match the padded `iterations...........:` summary line — the dot run grows with the longest metric name in the test.
+- **GIVEN** `api.js` declares one `shared-iterations` scenario named `api`, with `exec: 'api'`, `vus: 4`, and `iterations: 4`, and its `api` function prints `API-RAN`
+- **AND** `api.tar` is an archive built from `api.js`
+- **WHEN** the user passes bare `--once` through each supported form:
 
-#### Scenario: A 100 VU / 100 iteration scenario runs once
-- **GIVEN** `api.js`:
-  ```js
-  export const options = { scenarios: { api: {
-    executor: 'shared-iterations', exec: 'api', vus: 100, iterations: 100,
-  }}};
-  export function api() { console.log('api ran'); }
-  ```
-- **WHEN** the user runs `k6 run --once api.js`
-- **THEN** the pre-run scenario line reads `* api: 1 iterations shared among 1 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
-- **AND** `api ran` is printed exactly once
-- **AND** the process exits with code 0
+  | Form | Input |
+  | --- | --- |
+  | `k6 run --once <input>` | `api.js`, `api.tar`, or `-` with either file supplied on standard input |
+  | `k6 cloud run --once <input>` | `api.js`, `api.tar`, or `-` with either file supplied on standard input |
+  | `k6 cloud run --local-execution --once <input>` | `api.js`, `api.tar`, or `-` with either file supplied on standard input |
 
-#### Scenario: A ramping scenario becomes shared-iterations
-- **GIVEN** `ramp.js`:
-  ```js
-  export const options = { scenarios: { api: {
-    executor: 'ramping-vus', exec: 'api', startVUs: 10,
-    stages: [{ duration: '30s', target: 100 }], gracefulRampDown: '10s',
-  }}};
-  export function api() { console.log('api ran'); }
-  ```
-- **WHEN** the user runs `k6 run --once ramp.js`
-- **THEN** the pre-run scenario line reads `* api: 1 iterations shared among 1 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
-- **AND** it is no longer the ramping description `* api: Up to 100 looping VUs for 30s over 1 stages (gracefulRampDown: 10s, exec: api, gracefulStop: 30s)` that k6 prints without the flag
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
+- **AND** path-based cases cover `--once` both before and after the input path
+- **THEN** each local execution lists `api` as `1 iterations shared among 1 VUs`
+- **AND** each local execution prints `API-RAN` once and reports `1 complete and 0 interrupted iterations`
+- **AND** each cloud upload or provisioning request contains one scenario named `api`, with `executor: shared-iterations`, `vus: 1`, `iterations: 1`, and `exec: api`
 
-#### Scenario: Running an already-built archive
-- **GIVEN** an archive built with `k6 archive api.js -O api.tar`, whose stored options declare the 100 VU / 100 iteration `api` scenario
-- **WHEN** the user runs `k6 run --once api.tar`
-- **THEN** stdout contains `1 complete and 0 interrupted iterations`
-- **AND** `api ran` is printed exactly once
+#### Scenario: Single-run mode stays disabled without the flag
 
-#### Scenario: Local execution against the cloud
 - **GIVEN** `api.js`
-- **WHEN** the user runs `k6 cloud run --local-execution --once api.js`
-- **THEN** stdout contains `1 complete and 0 interrupted iterations`
+- **WHEN** the user runs `k6 run api.js`
+- **THEN** k6 lists `api` as `4 iterations shared among 4 VUs`
+- **AND** the run reports `4 complete and 0 interrupted iterations`
 
-#### Scenario: Cloud execution
-- **GIVEN** `api.js`
-- **WHEN** the user runs `k6 cloud run --once api.js`
-- **THEN** the options k6 sends when it creates the cloud test run declare one scenario, named `api`, with `vus: 1` and `iterations: 1`
+#### Scenario: Commands that do not run a test reject the flag
 
-#### Scenario: The archive-building commands reject the flag
 - **WHEN** the user runs `k6 archive --once api.js`
-- **AND** separately `k6 cloud upload --once api.js`
-- **THEN** each reports `unknown flag: --once`
-- **AND** each exits with a non-zero code
+- **AND** separately runs `k6 cloud upload --once api.js`
+- **THEN** each command reports `unknown flag: --once`
+- **AND** each command exits with a non-zero code
 
 #### Scenario: `--once=api` is not a scenario selector
-- **GIVEN** `multi.js`
-- **WHEN** the user runs `k6 run --once=api multi.js`
-- **THEN** k6 rejects the value as an invalid boolean, naming the `once` flag
-- **AND** the process exits with a non-zero code
-- **AND** it does not fall back to single-run mode and does not run any scenario
 
-#### Scenario: `--once=false` leaves the declared load alone
-- **GIVEN** `api.js`
-- **WHEN** the user runs `k6 run --once=false api.js`
-- **THEN** the pre-run scenario line reads `* api: 100 iterations shared among 100 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
-- **AND** stdout contains `100 complete and 0 interrupted iterations`
+- **GIVEN** a valid test script
+- **WHEN** the user runs `k6 run --once=api script.js`
+- **THEN** k6 rejects the invocation as an invalid value for the `once` flag and exits with a non-zero code
+- **AND** no scenario iteration runs
 
-### Requirement: The running scenario keeps its identity and its non-load configuration
+### Requirement: The effective scenario is a fresh shared-iterations configuration
 
-Single-run mode MUST preserve the running scenario's name, its `exec` target, its `options` block including `options.browser`, its `env`, and its `tags`.
+Single-run mode MUST build a fresh `shared-iterations` scenario. It MUST preserve only the original scenario name, `exec`, `env`, `tags`, and `options`, then set `vus: 1` and `iterations: 1`.
 
-The name matters beyond display: it is a system tag on every metric the run emits, it is what `k6/execution` reports as `scenario.name`, and it is the key the browser module uses to find `options.browser`. A single-run scenario MUST NOT be renamed.
+It MUST discard the original `executor`, `vus`, `iterations`, `duration`, `startTime`, `maxDuration`, `timeUnit`, `stages`, `rate`, `startRate`, `gracefulStop`, `gracefulRampDown`, `preAllocatedVUs`, `startVUs`, `maxVUs`, and any other unpreserved scenario field. Discarded fields MUST NOT be copied and then deleted from a known list, because current and future executors can add fields.
 
-#### Scenario: Name, exec target, env, and tags all survive
+The fresh scenario MUST leave `maxDuration` and `gracefulStop` unset. They serialize as `null`, while `shared-iterations` applies its normal 10 minute and 30 second runtime defaults.
+
+#### Scenario: Every built-in executor becomes the same single-run scenario
+
+- **GIVEN** six scripts whose one `api` scenario uses the following valid configurations and whose `api` function prints its script-visible scenario configuration from `k6/execution`:
+
+  | Executor | Declared load |
+  | --- | --- |
+  | `shared-iterations` | `vus: 8`, `iterations: 20`, `maxDuration: '1h'`, `gracefulStop: '5m'` |
+  | `per-vu-iterations` | `vus: 8`, `iterations: 20`, `maxDuration: '1h'` |
+  | `constant-vus` | `vus: 8`, `duration: '30s'`, `startTime: '30s'` |
+  | `ramping-vus` | `startVUs: 8`, one stage, `gracefulRampDown: '10s'` |
+  | `constant-arrival-rate` | `rate: 100`, `timeUnit: '1s'`, `duration: '30s'`, `preAllocatedVUs: 10`, `maxVUs: 20` |
+  | `ramping-arrival-rate` | `startRate: 10`, `timeUnit: '1s'`, one stage, `preAllocatedVUs: 10`, `maxVUs: 20` |
+
+- **WHEN** the user runs each script with `k6 run --once`
+- **THEN** each script-visible scenario is named `api`, contains `executor: shared-iterations`, `vus: 1`, and `iterations: 1`, and has `startTime`, `maxDuration`, and `gracefulStop` set to `null`
+- **AND** each pre-run line shows `maxDuration: 10m0s` and `gracefulStop: 30s`, the run starts without the declared delay, and one iteration completes
+- **AND** no scenario contains a field that `shared-iterations` does not own or an original load-shaping value
+
+#### Scenario: Semantically invalid discarded load does not block the run
+
+- **GIVEN** a decodable `shared-iterations` scenario named `api` with `vus: 5` and `iterations: 1`, which is invalid without `--once` because it has more VUs than iterations
+- **WHEN** the user runs it with `k6 run --once`
+- **THEN** k6 validates the fresh 1 VU / 1 iteration scenario and runs it once
+- **BUT WHEN** a field cannot be decoded, the executor type is missing or unknown, the scenario contains an unknown field, or its preserved `exec` names a function that is not exported
+- **THEN** k6 fails while loading or validating the test as it normally does
+
+### Requirement: The scenario keeps its identity and non-load configuration
+
+Single-run mode MUST preserve the running scenario's name, `exec`, `env`, `tags`, and complete `options` block. Samples emitted during the scenario iteration MUST use the preserved scenario name and tags. Samples emitted by setup or teardown are outside that claim.
+
+#### Scenario: Name, exec, env, tags, options, and the script-visible configuration survive
+
 - **GIVEN** `keep.js`:
+
   ```js
   import exec from 'k6/execution';
-  export const options = { scenarios: { api: {
-    executor: 'shared-iterations', exec: 'api', vus: 50, iterations: 50,
-    env: { URL: 'https://example.com' }, tags: { team: 'core' },
-  }}};
-  export function api() { console.log(`name=${exec.scenario.name} url=${__ENV.URL}`); }
-  export default function () { console.log('default ran'); }
-  ```
-- **WHEN** the user runs `k6 run --once --out json=out.json keep.js`
-- **THEN** `name=api url=https://example.com` is printed exactly once
-- **AND** `default ran` is not printed
-- **AND** every metric point in `out.json` carries the tags `scenario: api` and `team: core`
 
-### Requirement: Load-shaping configuration is discarded
+  export const options = {
+    scenarios: {
+      api: {
+        executor: 'shared-iterations',
+        exec: 'api',
+        vus: 50,
+        iterations: 50,
+        env: { URL: 'https://example.com' },
+        tags: { team: 'core' },
+        options: { browser: { type: 'chromium' } },
+      },
+    },
+  };
 
-Single-run mode MUST discard the running scenario's load-shaping configuration: `executor`, `vus`, `iterations`, `duration`, `startTime`, `maxDuration`, `timeUnit`, `stages`, `rate`, `gracefulStop`, `gracefulRampDown`, `preAllocatedVUs`, and every other field belonging to the declared executor, such as `startVUs` and `maxVUs`.
-
-The list is not the mechanism. The resulting scenario MUST be a fresh `shared-iterations` configuration, so no field of the declared executor can survive by omission from the list. k6 rejects a scenario carrying a field its executor does not own, so an implementation that deletes only the listed fields produces a scenario k6 cannot load.
-
-Discarded means replaced, not merged: the resulting scenario carries the `shared-iterations` defaults for anything it does not preserve. A declared `maxDuration` or `gracefulStop` therefore does not carry over, and the single iteration runs under the default budget of 10 minutes with a 30 second graceful stop.
-
-#### Scenario: Arrival-rate shaping has no effect
-- **GIVEN** `rate.js`:
-  ```js
-  export const options = { scenarios: { api: {
-    executor: 'constant-arrival-rate', exec: 'api',
-    rate: 100, timeUnit: '1s', duration: '10m',
-    preAllocatedVUs: 50, maxVUs: 200, startTime: '30s',
-  }}};
-  export function api() { console.log('api ran'); }
-  ```
-- **WHEN** the user runs `k6 run --once rate.js`
-- **THEN** the pre-run scenario line reads `* api: 1 iterations shared among 1 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
-- **AND** `api ran` is printed within a second of start, not after the declared 30 second `startTime`
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
-
-#### Scenario: A declared maximum duration and graceful stop do not carry over
-- **GIVEN** `budget.js`:
-  ```js
-  export const options = { scenarios: { api: {
-    executor: 'shared-iterations', exec: 'api', vus: 5, iterations: 5,
-    maxDuration: '1h', gracefulStop: '5m',
-  }}};
-  export function api() { console.log('api ran'); }
-  ```
-- **WHEN** the user runs `k6 run --once budget.js`
-- **THEN** the pre-run scenario line reads `* api: 1 iterations shared among 1 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
-- **AND** the pre-run header reads `1 scenario, 1 max VUs, 10m30s max duration (incl. graceful stop):`, not the `1h5m30s` the declared values would give
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
-
-### Requirement: A test with no scenarios runs its default function
-
-When a test declares no scenarios and exports a `default` function, single-run mode MUST run that function once, as a `shared-iterations` scenario named `default` with `vus: 1` and `iterations: 1`. Load the test declares outside a scenario MUST NOT take effect.
-
-#### Scenario: A default-only script runs once
-- **GIVEN** `plain.js`:
-  ```js
-  export const options = { vus: 50, duration: '30s' };
-  export default function () { console.log('default ran'); }
-  ```
-- **WHEN** the user runs `k6 run --once plain.js`
-- **THEN** the pre-run scenario line reads `* default: 1 iterations shared among 1 VUs (maxDuration: 10m0s, gracefulStop: 30s)`
-- **AND** it is no longer the `* default: 50 looping VUs for 30s (gracefulStop: 30s)` that k6 prints without the flag
-- **AND** `default ran` is printed exactly once
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
-
-### Requirement: One declared scenario is the one that runs
-
-When a test declares exactly one scenario, single-run mode MUST run that scenario, whatever it is named and wherever it was declared.
-
-If the scenario names an `exec` target, that target MUST run and the exported `default` function MUST NOT run, even when the script exports one. If the scenario names no `exec` target, or names `default`, then the `default` function MUST run, still under that scenario's preserved configuration. Such a scenario needs a `default` export: without one the run MUST fail.
-
-#### Scenario: A scenario with no exec target runs the default function
-- **GIVEN** `ui.js`:
-  ```js
-  export const options = { scenarios: { ui: {
-    executor: 'constant-vus', vus: 10, duration: '30s',
-    env: { BASE_URL: 'https://example.com' },
-  }}};
-  export default function () { console.log(`default ran url=${__ENV.BASE_URL}`); }
-  ```
-- **WHEN** the user runs `k6 run --once ui.js`
-- **THEN** `default ran url=https://example.com` is printed exactly once
-- **AND** the pre-run scenario line names the scenario `ui`, not `default`
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
-
-#### Scenario: `exec: 'default'` behaves the same as no exec target
-- **GIVEN** `uiexec.js`, which is `ui.js` with `exec: 'default'` added to the `ui` scenario
-- **WHEN** the user runs `k6 run --once uiexec.js`
-- **THEN** `default ran url=https://example.com` is printed exactly once
-- **AND** the pre-run scenario line names the scenario `ui`
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
-
-#### Scenario: A scenario needing the default function fails without one
-- **GIVEN** `nodefault.js`, which is `ui.js` with its `export default` replaced by `export function api() {}`, so the `ui` scenario still targets `default` but nothing exports it
-- **WHEN** the user runs `k6 run --once nodefault.js`
-- **THEN** standard error contains `executor ui: function 'default' not found in exports`
-- **AND** the process exits with a non-zero code
-- **AND** it is the same message and code that `k6 run nodefault.js` gives without the flag
-
-#### Scenario: The single scenario may come from a configuration file
-- **GIVEN** `plaindef.js`, which declares no scenarios and exports `default`
-- **AND** `cfg.json` containing exactly:
-  ```json
-  {"scenarios": {"api": {"executor": "shared-iterations", "vus": 7, "iterations": 9, "tags": {"team": "core"}}}}
-  ```
-- **WHEN** the user runs `k6 run --once -c cfg.json --out json=out.json plaindef.js`
-- **THEN** the pre-run scenario line names the scenario `api` and reads `1 iterations shared among 1 VUs`
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
-- **AND** every metric point in `out.json` carries the tags `scenario: api` and `team: core`
-
-### Requirement: Declared load never takes effect, whatever declared it
-
-Single-run mode MUST reach 1 virtual user and 1 iteration whatever source declared the load, and the running scenario's non-load configuration MUST survive that. There is no exception. The sources are:
-
-- the script's `options`, both inside a scenario and at the top level
-- the environment variables `K6_VUS`, `K6_ITERATIONS`, `K6_DURATION`, and `K6_STAGES`
-- the JSON configuration file, whether named with `-c` or picked up from its default location
-- an archive's stored options, when `k6 run` is given an archive
-
-The command line is the one source that is refused outright rather than neutralized, because a load flag on the same command line as `--once` is a contradiction the user can see and fix. Every other source is silently overridden, because the user may not control it.
-
-This is the requirement with real weight behind it. k6 consolidates its sources before single-run mode acts, and any source that sets `vus`, `iterations`, `duration`, or `stages` throws the whole `scenarios` map away while consolidating, taking `exec`, `env`, `tags`, and `options.browser` with it. Today all four environment variables above turn the browser script below into `executor default: function 'default' not found in exports` with exit 104. Under `--once` that script MUST run once, with its scenario intact. Satisfying this reaches into how k6 merges configuration, and that is accepted: without it, a stray variable in a shell profile or a probe's environment silently defeats the flag, which is the failure this whole change exists to remove.
-
-#### Scenario: An environment variable cannot defeat single-run mode
-- **GIVEN** `envkeep.js`:
-  ```js
-  import exec from 'k6/execution';
-  export const options = { scenarios: { api: {
-    executor: 'shared-iterations', exec: 'api', vus: 50, iterations: 50,
-    env: { URL: 'https://example.com' }, tags: { team: 'core' },
-    options: { browser: { type: 'chromium' } },
-  }}};
-  export function api() { console.log(`name=${exec.scenario.name} url=${__ENV.URL}`); }
-  ```
-- **WHEN** the user runs `k6 run --once envkeep.js` with `K6_VUS=100` set
-- **AND** separately with `K6_ITERATIONS=100`
-- **AND** separately with `K6_DURATION=30s`
-- **AND** separately with `K6_STAGES=10s:5`
-- **THEN** each run prints `name=api url=https://example.com` exactly once
-- **AND** each pre-run scenario line names the scenario `api`, not `default`
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
-- **AND** no warning contains `overrides scenarios configuration` or `overrode scenarios configuration entirely`
-- **AND** each run exits with code 0, where without `--once` all four exit 104 with `executor default: function 'default' not found in exports`
-
-#### Scenario: A configuration file cannot defeat single-run mode
-- **GIVEN** `envkeep.js` and `load.json` containing exactly `{"vus": 100, "iterations": 100}`
-- **WHEN** the user runs `k6 run --once -c load.json envkeep.js`
-- **THEN** `name=api url=https://example.com` is printed exactly once
-- **AND** the pre-run scenario line names the scenario `api`
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
-
-#### Scenario: An archive's stored load cannot defeat single-run mode
-- **GIVEN** `load.tar`, an archive whose stored options carry both the `api` scenario and a top-level `iterations` value
-- **WHEN** the user runs `k6 run --once load.tar`
-- **THEN** stdout contains `1 complete and 0 interrupted iterations`
-- **AND** the run does not fail with a conflict between top-level options and `scenarios`
-
-### Requirement: Two or more scenarios are rejected
-
-When a test declares two or more scenarios, single-run mode MUST fail, because it cannot pick one of them or combine their configurations without ambiguity. It MUST NOT pick one, and MUST NOT run several.
-
-The error MUST be reported at error level and MUST contain `the --once flag can run only a single scenario`. It MUST be a single line, so one substring match works whatever the log format. It MUST NOT list the declared scenario names: Proposal 1's error carries no names, listing them is Proposal 2's affordance (`available scenarios: api, ui, ts`), and offering the list here implies a choice the flag does not accept.
-
-The rejection MUST happen before any iteration starts and before `setup()` runs. The script's init context still runs, because that is where k6 reads the scenario list from.
-
-#### Scenario: A three-scenario script is rejected before anything runs
-- **GIVEN** `multi.js`:
-  ```js
-  console.log('init ran');
-  export const options = { scenarios: {
-    zulu: { executor: 'shared-iterations', exec: 'zulu' },
-    xray: { executor: 'shared-iterations', exec: 'xray' },
-    kilo: { executor: 'shared-iterations', exec: 'kilo', options: { browser: { type: 'chromium' } } },
-  }};
-  export function setup() { console.log('setup ran'); }
-  export function zulu() { console.log('zulu ran'); }
-  export function xray() { console.log('xray ran'); }
-  export async function kilo() { const p = await browser.newPage(); await p.close(); }
-  ```
-  with `import { browser } from 'k6/browser';` at the top, so the browser scenario really would launch Chromium if it ran
-- **WHEN** the user runs `k6 run --once multi.js`
-- **THEN** standard error contains `the --once flag can run only a single scenario`
-- **AND** the message contains none of `zulu`, `xray`, or `kilo`
-- **AND** `setup ran`, `zulu ran`, and `xray ran` are all absent from the output
-- **AND** no Chromium process is started
-- **AND** `init ran` is present, because k6 reads the scenario list from the init context
-- **AND** the process exits with a non-zero code
-
-#### Scenario: The same rejection under cloud run
-- **GIVEN** `multi.js`
-- **WHEN** the user runs `k6 cloud run --once multi.js`
-- **THEN** standard error contains `the --once flag can run only a single scenario`
-- **AND** k6 sends no request to create a cloud test run
-- **AND** the process exits with a non-zero code
-
-### Requirement: A test with nothing to run fails as it already does
-
-When a test declares neither scenarios nor a `default` function, single-run mode MUST fail exactly as k6 fails for that same test without the flag: the same message and the same exit code.
-
-#### Scenario: Nothing to run
-- **GIVEN** `noentry.js` containing only `export function api() {}`
-- **WHEN** the user runs `k6 run --once noentry.js`
-- **THEN** standard error contains `executor default: function 'default' not found in exports`
-- **AND** the message and the exit code are the same ones `k6 run noentry.js` gives without the flag
-
-### Requirement: Load-shaping command-line flags cannot be combined with `--once`
-
-`--vus`/`-u`, `--iterations`/`-i`, `--duration`/`-d`, and `--stage`/`-s` MUST each be rejected when passed together with `--once`, in their long and their short form alike. The rejection MUST happen before any iteration starts, even for a test single-run mode would otherwise accept, and the system MUST NOT resolve the ambiguity by preferring either flag.
-
-The error MUST name both flags. k6 has no existing "cannot be combined" wording, so this follows the flag-conflict phrasing k6 already uses for `--local-execution`: `the --once flag is not compatible with the --iterations flag`, written to standard error, with the same shape for `--vus`, `--duration`, and `--stage`. A test may match on the two flag names appearing in one error line rather than on the whole sentence.
-
-#### Scenario: `--iterations` is refused
-- **GIVEN** `api.js`, which single-run mode accepts on its own
-- **WHEN** the user runs `k6 run --once --iterations 10 api.js`
-- **THEN** standard error contains `the --once flag is not compatible with the --iterations flag`
-- **AND** `api ran` is not printed
-- **AND** the process exits with a non-zero code
-
-#### Scenario: `--vus` is refused
-- **WHEN** the user runs `k6 run --once --vus 10 api.js`
-- **THEN** standard error contains `the --once flag is not compatible with the --vus flag`, `api ran` is not printed, and the process exits with a non-zero code
-
-#### Scenario: `--duration` is refused
-- **WHEN** the user runs `k6 run --once --duration 30s api.js`
-- **THEN** standard error contains `the --once flag is not compatible with the --duration flag`, `api ran` is not printed, and the process exits with a non-zero code
-
-#### Scenario: `--stage` is refused
-- **WHEN** the user runs `k6 run --once --stage 30s:10 api.js`
-- **THEN** standard error contains `the --once flag is not compatible with the --stage flag`, `api ran` is not printed, and the process exits with a non-zero code
-
-#### Scenario: The short forms are refused too
-- **WHEN** the user runs `k6 run --once -i 10 api.js`
-- **AND** separately `k6 run --once -u 10 api.js`
-- **AND** separately `k6 run --once -d 30s api.js`
-- **AND** separately `k6 run --once -s 30s:10 api.js`
-- **THEN** each names the conflicting flag on standard error and exits with a non-zero code
-
-#### Scenario: The rejection also applies to cloud run
-- **WHEN** the user runs `k6 cloud run --once -i 10 api.js`
-- **THEN** standard error names the conflict, k6 sends no request to create a cloud test run, and the process exits with a non-zero code
-
-### Requirement: Browser tests run under single-run mode
-
-Because the running scenario keeps its name and its `options.browser` block, a browser test MUST run its browser steps under `--once` with no script edit and no load-shaping flag. This is the case that shortcut flags break today.
-
-A browser MUST be launched only when the running scenario declares `options.browser`.
-
-#### Scenario: A browser scenario runs once, with its browser
-- **GIVEN** `browser.js`:
-  ```js
-  import { browser } from 'k6/browser';
-  export const options = { scenarios: { ui: {
-    executor: 'shared-iterations', vus: 10, iterations: 10,
-    options: { browser: { type: 'chromium' } },
-  }}};
-  export default async function () {
-    const page = await browser.newPage();
-    try {
-      await page.goto('https://test.k6.io/', { waitUntil: 'networkidle' });
-      console.log(`title=${await page.title()}`);
-    } finally { await page.close(); }
+  export function api() {
+    const scenario = exec.test.options.scenarios.api;
+    console.log(`name=${exec.scenario.name} exec=${scenario.exec} executor=${scenario.executor} vus=${scenario.vus} iterations=${scenario.iterations} url=${__ENV.URL} browser=${scenario.options.browser.type}`);
   }
+
+  export default function () { console.log('DEFAULT-RAN'); }
   ```
-- **WHEN** the user runs `k6 run --once browser.js`
-- **THEN** the summary contains a `browser_web_vital_lcp` line, so a real browser drove a real page
-- **AND** `browser not found in registry` is absent from the output
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
 
-#### Scenario: No browser launches when the scenario declares none
-- **GIVEN** `nobrowser.js`, which is `browser.js` with the `options.browser` block deleted
-- **WHEN** the user runs `k6 run --once nobrowser.js`
-- **THEN** no `browser_` metric appears in the summary
-- **AND** standard error contains `browser not found in registry`, exactly as it does for that script without the flag
+- **WHEN** the user runs `k6 run --once --out json=out.json keep.js`
+- **THEN** the log contains `name=api exec=api executor=shared-iterations vus=1 iterations=1 url=https://example.com browser=chromium` once
+- **AND** `DEFAULT-RAN` is absent
+- **AND** every `type: Point` entry emitted by the scenario iteration in `out.json` has `data.tags.scenario: api` and `data.tags.team: core`
 
-### Requirement: Single-run mode is a command-line flag only
+### Requirement: A test without scenarios runs its default function
 
-Single-run mode MUST turn on only from `--once` on the invocation's own command line. No environment variable and no configuration-file field may turn it on. Concretely, `K6_ONCE`, a bare `ONCE`, and a `once` field in the JSON configuration file MUST all leave single-run mode off.
+When the effective configuration contains no scenario and the script exports `default`, single-run mode MUST create a scenario named `default` with the single-run configuration. It MUST clear the top-level `vus`, `iterations`, `duration`, and `stages` fields before scenario derivation.
 
-k6 decodes environment configuration with an empty prefix, so an unprefixed variable named after a configuration field reaches the decoder. Both spellings therefore have to be inert, not just the prefixed one. The point of the rule is that a setting left in a shell profile or a shared configuration file can never turn a real load test into a single run, where passing looks like success.
+#### Scenario: Every no-scenario form runs the default function once
 
-#### Scenario: Neither environment variable turns it on
-- **GIVEN** `api.js`
-- **AND** `K6_ONCE=true` and `ONCE=true` are both set
-- **WHEN** the user runs `k6 run api.js`, with no `--once`
-- **THEN** the pre-run scenario line reads `* api: 100 iterations shared among 100 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
-- **AND** stdout contains `100 complete and 0 interrupted iterations`, so the declared load really ran
-- **AND** the process exits with code 0
+- **GIVEN** scripts that export a `default` function printing `DEFAULT-RAN` and use one of these option forms:
 
-#### Scenario: The configuration file cannot turn it on
-- **GIVEN** `api.js` and `once.json` containing exactly `{"once": true}`
-- **WHEN** the user runs `k6 run -c once.json api.js`
-- **THEN** stdout contains `100 complete and 0 interrupted iterations`
-- **AND** the process exits with code 0
+  | Form | Options |
+  | --- | --- |
+  | No options | no `options` export |
+  | Empty scenarios | `{ scenarios: {} }` |
+  | Null scenarios | `{ scenarios: null }` |
+  | Virtual-user shortcut | `{ vus: 8 }` |
+  | Duration shortcut | `{ vus: 8, duration: '30s' }` |
+  | Iteration shortcut | `{ vus: 8, iterations: 20 }` |
+  | Stage shortcut | `{ stages: [{ duration: '30s', target: 8 }] }` |
 
-### Requirement: Setup and teardown are unaffected
+- **WHEN** the user runs each script with `k6 run --once`
+- **THEN** k6 lists `default` as `1 iterations shared among 1 VUs`
+- **AND** `DEFAULT-RAN` appears once
+- **AND** the run reports `1 complete and 0 interrupted iterations`
+- **AND** no warning says that a top-level load option overrides `scenarios`
 
-Single-run mode changes scenario configuration only. `setup()` and `teardown()` MUST behave exactly as they do without the flag on any invocation single-run mode accepts, including the flags that skip them.
+### Requirement: A single declared scenario decides which function runs
 
-#### Scenario: Setup and teardown run once around the single iteration
-- **GIVEN** `lifecycle.js` exporting `setup()`, `teardown()`, and a `default` function, each printing a distinct line
+When the effective configuration contains one scenario, single-run mode MUST keep that scenario. A preserved non-empty `exec` value MUST select that exported function. A missing `exec` value or `exec: 'default'` MUST select the default function. The selected function MUST exist.
+
+#### Scenario: Missing exec and explicit default exec behave the same
+
+- **GIVEN** two versions of a script, each with one scenario named `ui` and `env: { URL: 'https://example.com' }`, declaring either no `exec` or `exec: 'default'`
+- **AND** each default function prints `DEFAULT-RAN url=<URL> exec=<effective exec>` from `k6/execution`
+- **WHEN** the user runs each script with `k6 run --once`
+- **THEN** each run lists a scenario named `ui`, not `default`
+- **AND** the missing-exec case prints `DEFAULT-RAN url=https://example.com exec=null` once
+- **AND** the explicit case prints `DEFAULT-RAN url=https://example.com exec=default` once
+
+#### Scenario: A required function that is not exported still fails
+
+- **GIVEN** these fixtures:
+
+  | Configuration | Exports | Required error text |
+  | --- | --- | --- |
+  | No scenarios | only `api` | `executor default: function 'default' not found in exports` |
+  | One scenario named `ui`, with no `exec` | only `api` | `executor ui: function 'default' not found in exports` |
+  | One scenario named `ui`, with `exec: 'target'` | only `api` | `executor ui: function 'target' not found in exports` |
+  | One scenario named `ui`, with `exec: ''` | `default` | `exec value cannot be empty` |
+  | One scenario whose name is empty | `default` | `scenario name can't be empty` |
+  | Empty script | none | `no exported functions in script` |
+
+- **WHEN** the user runs each fixture with `k6 run --once`
+- **THEN** each invocation reports its required text and exits with a non-zero code
+- **AND** no scenario iteration runs
+
+### Requirement: Non-CLI load cannot remove the scenario
+
+Single-run mode MUST ignore top-level `vus`, `iterations`, `duration`, and `stages` from the script, environment, JSON configuration, and stored archive options. Those values MUST NOT remove or rename an effective scenario and MUST NOT cause a conflict with it.
+
+The source still MUST be syntactically valid. Single-run mode does not suppress script, environment, configuration-file, or archive decoding errors.
+
+Scenario declarations from different sources MUST keep normal scenario-to-scenario precedence. The presence of `--once` changes only how top-level load fields affect those scenarios. Without `--once`, existing configuration precedence MUST remain unchanged.
+
+#### Scenario: A named scenario survives load from every non-CLI source
+
+- **GIVEN** each case supplies one complete `api` scenario with the `exec`, env, tags, and `options.browser` from `keep.js`; `api` prints those effective values, and a default function prints `FALLBACK-RAN`
+- **WHEN** the user runs each input with `--once` under its source case:
+
+  | Scenario source and input | Later or colocated load |
+  | --- | --- |
+  | Script | top-level `vus: 50` in the same script |
+  | Script | each of `K6_VUS=50`, `K6_ITERATIONS=50`, `K6_DURATION=30s`, and `K6_STAGES=30s:50` in separate runs |
+  | Explicit JSON config; the script exports `api` but no options | the same config sets top-level `vus` and `iterations` |
+  | Default JSON config; the script exports `api` but no options | the same config sets top-level `duration` |
+  | Script, while an explicit JSON config declares a different scenario | no top-level load; the script's `api` scenario wins wholesale |
+  | Explicit JSON config | the script sets top-level `iterations: 50` |
+  | Stored archive options | the same archive stores top-level `vus: 50` |
+  | Stored archive options | `K6_DURATION=30s` is set when running the archive |
+
+- **THEN** every run keeps the `api` scenario and prints its preserved `exec`, env, tags, and `options.browser`
+- **AND** every effective scenario has `executor: shared-iterations`, `vus: 1`, and `iterations: 1`
+- **AND** `FALLBACK-RAN` is absent
+- **AND** no warning says that top-level load removed `scenarios`; the normal scenario-to-scenario override warning remains in the config-versus-script case
+
+#### Scenario: Normal configuration precedence is unchanged without `--once`
+
+- **GIVEN** the script-declared `api` scenario and fallback default function from the matrix above
+- **WHEN** the user runs it without `--once` and with `K6_ITERATIONS=2`
+- **THEN** existing k6 behavior applies: the environment load replaces the scenario, the fallback default function runs twice, and k6 reports the existing override warning
+
+### Requirement: Two or more effective scenarios are rejected
+
+When the effective configuration contains two or more scenarios, single-run mode MUST fail before setup, VU initialization, browser launch, or any cloud request. Init context still runs because k6 evaluates it to read the options.
+
+The error MUST contain `the --once flag can run only a single scenario` and MUST NOT list the declared scenario names.
+
+#### Scenario: The boundary case of exactly two scenarios is rejected through every run path
+
+- **GIVEN** `multi.js` prints `INIT-RAN` in init context, declares scenarios named `zulu` and `xray`, defines setup and both scenario functions with distinct markers, and makes `xray` a browser scenario that calls the browser API
+- **AND** `multi.tar` is an archive built from `multi.js`
+- **AND** `K6_BROWSER_EXECUTABLE_PATH` names a nonexistent executable
+- **WHEN** the user invokes each applicable path:
+
+  | Path | Input |
+  | --- | --- |
+  | `k6 run --once` | `multi.js` |
+  | `k6 run --once` | `multi.tar` |
+  | `k6 cloud run --once` | `multi.js` or `multi.tar` |
+  | `k6 cloud run --local-execution --once` | `multi.js` or `multi.tar` |
+
+- **THEN** each invocation reports the required error and exits with a non-zero code
+- **AND** the error contains neither `zulu` nor `xray`
+- **AND** `INIT-RAN` is present, while setup and body markers are absent
+- **AND** no browser executable lookup occurs
+- **AND** no request reaches a cloud API
+
+#### Scenario: Higher-tier load cannot hide multiple scenarios
+
+- **GIVEN** `multi.js`
+- **WHEN** the user runs `K6_ITERATIONS=3 k6 run --once multi.js`
+- **THEN** k6 reports the same multi-scenario error
+- **AND** no scenario iteration runs
+
+### Requirement: CLI load flags conflict with `--once`
+
+An enabled `--once` MUST reject `--vus`/`-u`, `--iterations`/`-i`, `--duration`/`-d`, and `--stage`/`-s` when the user passes both on the same command line. The single-line error MUST contain `the --once flag is not compatible with the --<name> flag`, using the conflicting flag's long name. This direct command-line error MUST take precedence over errors that require loading the test. An explicitly passed zero still counts as a conflict; a malformed flag value can fail earlier during flag parsing.
+
+#### Scenario: Every long and short load flag is rejected
+
+- **GIVEN** `api.js`, which `--once` accepts on its own
+- **WHEN** the user runs `k6 run --once <added flag> api.js` for each row:
+
+  | Added flag | Required text in the error |
+  | --- | --- |
+  | `--vus 1` or `-u 2` | `the --once flag is not compatible with the --vus flag` |
+  | `--iterations 2` or `-i 2` | `the --once flag is not compatible with the --iterations flag` |
+  | `--duration 2s` or `-d 2s` | `the --once flag is not compatible with the --duration flag` |
+  | `--stage 2s:2` or `-s 2s:2` | `the --once flag is not compatible with the --stage flag` |
+
+- **THEN** every invocation exits with a non-zero code before a scenario iteration runs
+- **AND** the error contains the required text
+
+#### Scenario: The direct flag conflict wins before input loading
+
+- **GIVEN** `broken.js` has invalid JavaScript syntax
+- **WHEN** the user runs `k6 run --once -i 0 api.js`
+- **AND** separately runs `k6 run --once -i 2 broken.js`
+- **AND** separately runs `k6 cloud run --once -i 2 broken.js`
+- **AND** separately runs `k6 cloud run --local-execution --once -i 2 broken.js`
+- **AND** separately runs `k6 run --once -i 2 multi.js`
+- **THEN** every error contains `the --once flag is not compatible with the --iterations flag`
+- **AND** the multi-scenario case does not report the multi-scenario failure
+- **AND** the invalid-script cases do not report the syntax error
+- **AND** no request reaches a cloud API
+
+### Requirement: Browser configuration survives single-run mode
+
+Single-run mode MUST preserve `options.browser` on a declared scenario and MUST keep the scenario name used to find that configuration. It MUST NOT add browser configuration to a scenario that did not declare it.
+
+#### Scenario: A browser scenario survives an environment load override
+
+- **GIVEN** a controlled local HTTP fixture that responds with HTTP 200 and the title `once fixture`
+- **AND** `browser.js` declares one `shared-iterations` scenario named `ui`, with `exec: 'ui'`, 10 VUs, 10 iterations, and `options.browser.type: chromium`
+- **AND** `ui` opens the fixture and prints its response status and page title
+- **WHEN** the user runs `K6_ITERATIONS=50 k6 run --once browser.js`
+- **THEN** `status=200 title=once fixture` appears once
+- **AND** the summary reports a non-zero `browser_data_received` value
+- **AND** `browser not found in registry` is absent
+- **AND** the run reports `1 complete and 0 interrupted iterations`
+
+#### Scenario: Cloud paths receive the preserved browser scenario
+
+- **GIVEN** `browser.js` and `K6_ITERATIONS=50`
+- **WHEN** the user runs it with `k6 cloud run --once`
+- **AND** separately with `k6 cloud run --local-execution --once`
+- **THEN** the remote uploaded archive contains one scenario named `ui`, with `exec: ui`, `executor: shared-iterations`, `vus: 1`, `iterations: 1`, and `options.browser.type: chromium`
+- **AND** the local-execution provisioning options and uploaded archive contain the same scenario
+- **AND** local execution prints `status=200 title=once fixture` once and reports a non-zero `browser_data_received` value
+
+#### Scenario: Single-run mode does not invent browser options
+
+- **GIVEN** one test with a scenario named `ui` that calls the browser API without declaring `options.browser`
+- **AND** another test that declares no scenarios and calls the browser API from `default`
+- **AND** `K6_BROWSER_EXECUTABLE_PATH` names a nonexistent executable
+- **WHEN** the user runs each test with `k6 run --once`
+- **THEN** each run reports `browser not found in registry`
+- **AND** neither run reports an error from looking up or launching the nonexistent executable
+- **AND** each run exits with code 0, unchanged from the same test without `--once`
+
+### Requirement: Single-run mode is CLI-only
+
+Only the bare flag on the current invocation may enable single-run mode. An exported script option, `K6_ONCE`, `ONCE`, a JSON configuration field, or an archive option named `once` MUST be inert. Single-run mode MUST NOT become a `Config` or `lib.Options` field, and archives created for a single run MUST carry the behavior through their scenario configuration instead of a stored flag.
+
+#### Scenario: Non-CLI sources cannot enable single-run mode
+
+- **GIVEN** `api.js` normally runs four iterations
+- **WHEN** the user runs it without `--once` under each case:
+
+  | Source | Value |
+  | --- | --- |
+  | Exported script options | `once: true` |
+  | Environment | `K6_ONCE=true` |
+  | Environment | `ONCE=true` |
+  | Explicit JSON config | `{"once": true}` passed with `-c` |
+  | Default JSON config | `{"once": true}` at the default config path |
+  | Archive metadata | `"once": true` in the stored options |
+
+- **THEN** every run reports four complete iterations
+- **AND** no run uses the single-run configuration
+- **AND** the script-options case warns that `once` is an unknown exported option
+
+### Requirement: Setup and teardown keep normal behavior
+
+Single-run mode MUST preserve setup and teardown execution, their data flow, their timeouts, and the existing options that skip them.
+
+#### Scenario: Setup data reaches the selected function and teardown
+
+- **GIVEN** `lifecycle.js` declares one `shared-iterations` scenario named `api`, with `exec: 'api'`, 50 VUs, and 50 iterations
+- **AND** setup prints `SETUP-RAN` and returns `{ token: 'abc' }`
+- **AND** `api(data)` prints `API-RAN token=abc`
+- **AND** teardown prints `TEARDOWN-RAN token=abc`
+- **AND** an exported default function prints `DEFAULT-RAN`
 - **WHEN** the user runs `k6 run --once lifecycle.js`
-- **THEN** the output shows the setup line, then the default line, then the teardown line, in that order
-- **AND** each appears exactly once
+- **THEN** the log shows `SETUP-RAN`, `API-RAN token=abc`, and `TEARDOWN-RAN token=abc` once each and in that order
+- **AND** `DEFAULT-RAN` is absent
+- **AND** the run reports one complete iteration
 
-#### Scenario: The skip flags still skip
-- **GIVEN** `lifecycle.js`
-- **WHEN** the user runs `k6 run --once --no-setup --no-teardown lifecycle.js`
-- **THEN** neither the setup line nor the teardown line appears
-- **AND** the default line appears exactly once
+#### Scenario: Existing skip controls still skip their lifecycle functions
 
-### Requirement: Archives carry single-run mode forward
+- **GIVEN** a lifecycle fixture whose VU function and teardown do not read setup data
+- **WHEN** the user runs it with `k6 run --once` under each case:
 
-An archive that k6 builds for a cloud run started with `--once` MUST carry the resulting 1 virtual user / 1 iteration scenario, so a later run of that archive also runs once. This holds for the archive uploaded by `k6 cloud run` and for the archive uploaded by `k6 cloud run --local-execution`.
+  | Source | Skip values |
+  | --- | --- |
+  | Command line | `--no-setup --no-teardown` |
+  | Environment | `K6_NO_SETUP=true K6_NO_TEARDOWN=true` |
+  | Script options | `noSetup: true, noTeardown: true` |
+  | JSON config | `noSetup: true, noTeardown: true` |
 
-The archive's stored options MUST hold the single-run scenario and nothing else that shapes load: the top-level `vus`, `iterations`, `duration`, and `stages` values MUST all be absent. This is absolute, not a preference. An archive built under `--once` describes a single run, so re-running it MUST give a single run even without the flag, and any leftover top-level load value breaks that: `iterations`, `duration`, or `stages` makes k6 refuse the archive outright, and `vus` is worse, because it silently discards the single-run scenario and runs that many virtual users while exiting 0.
+- **THEN** neither lifecycle marker appears
+- **AND** the selected VU function runs once, no script exception is reported, and the process exits successfully
 
-#### Scenario: Re-running the uploaded archive runs once
-- **GIVEN** `api.js`, whose scenario declares 100 virtual users and 100 iterations
-- **WHEN** the user starts `k6 cloud run --once api.js`
-- **AND** the archive k6 uploaded for that run is later run with `k6 run`, without `--once`
-- **THEN** the archive's `metadata.json` options have `vus`, `iterations`, `duration`, and `stages` all null
-- **AND** the later run's pre-run scenario line reads `* api: 1 iterations shared among 1 VUs (maxDuration: 10m0s, exec: api, gracefulStop: 30s)`
-- **AND** the later run prints no warning containing `overrides scenarios configuration`
-- **AND** the later run exits with code 0
+### Requirement: Cloud archives carry the single-run scenario
 
-#### Scenario: The same holds for local execution
-- **GIVEN** `api.js`
-- **WHEN** the user starts `k6 cloud run --local-execution --once api.js`
-- **AND** the archive k6 uploaded for that run is later run with `k6 run`, without `--once`
-- **THEN** the later run's pre-run scenario line names the scenario `api` and reads `1 iterations shared among 1 VUs`
-- **AND** the later run exits with code 0
+An archive uploaded by `k6 cloud run --once` or `k6 cloud run --local-execution --once` MUST store the single-run scenario and its preserved configuration. Its top-level `vus`, `iterations`, `duration`, and `stages` fields MUST be unset and serialize as `null`. Its options MUST NOT contain a `once` key.
 
-### Requirement: Single-run mode leaves the engine's own options alone
+Running the captured archive without `--once` MUST run once when no command-line, environment, explicit JSON config, or default JSON config supplies load. With `--no-archive-upload`, local execution MUST still use the single-run provisioning options, but no archive exists to carry forward.
 
-Single-run mode rewrites scenario configuration after k6 has consolidated its configuration sources, and changes nothing else. Options that act on the engine rather than on a scenario MUST keep their normal behavior, and single-run mode MUST NOT special-case them.
+#### Scenario: Both cloud archive paths store a clean, runnable scenario
 
-So `--paused` still holds the run before its single iteration and releases it on resume. `--execution-segment` and `--execution-segment-sequence` still scale the resulting 1 virtual user / 1 iteration scenario exactly as they scale any such scenario, including down to no work for a segment that owns none. A segment that owns no work reports `0 complete and 0 interrupted iterations`; on current k6 such a run also logs a summary error and still exits 0, which is a pre-existing bug unrelated to this change.
+- **GIVEN** `archive.js` declares both top-level `vus: 50` and `duration: '30s'`
+- **AND** it declares one `ramping-arrival-rate` scenario named `api`, with `exec: 'api'`, env, tags, `options.browser`, `startRate`, `timeUnit`, one valid stage, `preAllocatedVUs`, and `maxVUs`
+- **WHEN** the user runs `k6 cloud run --once archive.js`
+- **AND** separately runs `k6 cloud run --local-execution --once archive.js`
+- **THEN** the managed create request's `script` part and the local path's presigned upload each contain an archive whose `metadata.json.options` has `vus`, `iterations`, `duration`, and `stages` set to `null`
+- **AND** each `metadata.json.options` has no `once` key
+- **AND** each archive stores exactly one `api` scenario with `exec`, env, tags, and `options.browser` preserved
+- **AND** that scenario has `executor: shared-iterations`, `vus: 1`, and `iterations: 1`; `startTime`, `maxDuration`, and `gracefulStop` are `null`, and fields owned only by the old executor are absent
+- **AND** the managed path's `POST /cloud/v6/validate_options` body contains the same clean options
+- **AND** running either archive with `k6 run`, without `--once` or load from another source, lists `api` with `maxDuration: 10m0s` and `gracefulStop: 30s`, runs it once, and prints no override warning
+- **AND** the local-execution provisioning request describes the same scenario with `max_vus: 1` and `total_duration: 630`
 
-Options that are not scenario configuration MUST survive untouched. `thresholds` in particular MUST still be evaluated over the single iteration and MUST still set the exit code. That matters because a threshold is today the only way to make a single run fail on a failed check, which is what turns `--once` into a functional test. An implementation that replaced the whole options object rather than its `scenarios` field would drop the thresholds, and every single run would exit 0 -- the same silent success that makes broken browser tests look like passes.
+#### Scenario: Cloud archives store the synthesized default scenario
+
+- **GIVEN** `plain.js` exports a default function that prints `DEFAULT-RAN`, and its options declare top-level `vus: 50` and `duration: '30s'`
+- **WHEN** the user runs it separately with `k6 cloud run --once` and `k6 cloud run --local-execution --once`
+- **THEN** each uploaded archive has the four top-level load fields set to `null` and one `default` `shared-iterations` scenario with `vus: 1` and `iterations: 1`
+- **AND** local execution prints `DEFAULT-RAN` once
+- **AND** running either archive with `k6 run`, without load from another source, prints `DEFAULT-RAN` once and reports one complete iteration
+
+#### Scenario: Local execution can omit the archive without changing its run
+
+- **GIVEN** `archive.js`
+- **WHEN** the user runs `k6 cloud run --local-execution --no-archive-upload --once archive.js`
+- **AND** separately runs it with `K6_NO_ARCHIVE_UPLOAD=true` instead of `--no-archive-upload`
+- **THEN** the start-local-execution request contains the single-run scenario and `archive_size: null`
+- **AND** no request is made to a presigned archive-upload URL
+- **AND** local execution runs `api` once
+
+### Requirement: Non-scenario options keep normal behavior
+
+Apart from replacing the effective scenario and clearing the four top-level load fields, single-run mode MUST leave every consolidated option unchanged. Thresholds MUST still decide the process exit code. Pause and execution-segment options MUST still act on the resulting single-run scenario.
 
 #### Scenario: A failing threshold still fails the single run
-- **GIVEN** `thresh.js`, which declares `thresholds: { checks: ['rate==1.0'] }`, one scenario with 50 virtual users and 50 iterations, and a body running one check that always fails
-- **WHEN** the user runs `k6 run --once thresh.js`
-- **THEN** standard error reports that the `checks` threshold was crossed
-- **AND** the process exits with code 99, the threshold-failure code
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
 
-#### Scenario: A passing threshold leaves the single run green
-- **GIVEN** `thresh.js` with its check changed to always pass
-- **WHEN** the user runs `k6 run --once thresh.js`
-- **THEN** the process exits with code 0
+- **GIVEN** a test with one 50 VU / 50 iteration scenario, a check that always fails, and `thresholds: { checks: ['rate==1.0'] }`
+- **WHEN** the user runs `k6 run --once threshold.js`
+- **THEN** the test performs one iteration
+- **AND** k6 reports that the `checks` threshold was crossed
+- **AND** the process exits with the threshold-failure code
 
-#### Scenario: `--paused` holds the single iteration until resumed
+#### Scenario: Pause holds the iteration until the user resumes it
+
+- **GIVEN** `api.js` and a free REST API address
+- **WHEN** the user runs `k6 run --once --paused --address <address> api.js`
+- **THEN** `GET /v1/status` reports `paused: true` and status `4`, while `API-RAN` is absent
+- **AND WHEN** the user sends `PATCH /v1/status` with `{"data":{"type":"status","id":"default","attributes":{"paused":false}}}` and receives HTTP 200
+- **THEN** `API-RAN` appears once and the run reports one complete iteration
+
+#### Scenario: Execution segments retain their existing scaling behavior
+
 - **GIVEN** `api.js`
-- **WHEN** the user runs `k6 run --once --paused --address localhost:6565 api.js`
-- **THEN** the progress output reports the run as `paused` and `api ran` is not printed
-- **AND** after a `PATCH /v1/status` sets `paused` to false, `api ran` is printed exactly once
-- **AND** stdout contains `1 complete and 0 interrupted iterations`
+- **WHEN** the user runs `k6 run --once --execution-segment 0:1/2 --execution-segment-sequence 0,1/2,1 api.js`
+- **THEN** `API-RAN` appears once and the run reports one complete iteration
+- **BUT WHEN** the user runs `k6 run --once --execution-segment 1/2:1 --execution-segment-sequence 0,1/2,1 api.js`
+- **THEN** `API-RAN` is absent and k6 reports zero VUs and zero complete iterations
+- **AND** the process exits with code 0, even if k6 also logs its existing `failed to handle the end-of-test summary` error

--- a/openspec/changes/add-once-flag/specs/once/spec.md
+++ b/openspec/changes/add-once-flag/specs/once/spec.md
@@ -1,0 +1,154 @@
+## ADDED Requirements
+
+### Requirement: Single-run execution flag
+
+The system MUST provide a `--once` command-line flag that runs a script exactly one time with 1 virtual user and 1 iteration, without requiring any edit to the script. The run MUST perform exactly one iteration on exactly one virtual user, with no ramping, whatever executor the script declared, and the load declared in the script MUST NOT take effect. The scenario's executor MUST become shared-iterations. The system MUST NOT run more than one scenario in a single invocation under any circumstance. The flag MUST be accepted by `k6 run`, by `k6 cloud run`, by `k6 cloud run --local-execution`, and when running an already-built archive, and it MUST produce the same single-run behavior in each. The archive-building command MUST NOT accept the flag.
+
+#### Scenario: Identical behavior across every accepted entry point
+- **GIVEN** a script whose single scenario declares 100 virtual users and 100 iterations under a ramping executor
+- **WHEN** the user runs it with `--once` under `k6 run`
+- **AND** separately under `k6 cloud run`
+- **AND** separately under `k6 cloud run --local-execution`
+- **AND** separately by running an already-built archive of that script with `--once`
+- **THEN** each invocation runs exactly one iteration on exactly one virtual user
+- **AND** each invocation uses the shared-iterations executor for that scenario
+- **AND** none of the declared load is applied
+
+#### Scenario: Archive building rejects the flag
+- **GIVEN** any script
+- **WHEN** the user passes `--once` to the archive-building command
+- **THEN** k6 reports an unknown flag error
+- **AND** the process exits with a non-zero code
+
+### Requirement: Scenario configuration is preserved and load shaping is discarded
+
+Single-run mode MUST preserve the running scenario's exec target, its scenario options including browser options, its environment variables, and its tags. Single-run mode MUST discard the scenario's load-shaping configuration: virtual users, iterations, duration, start time, maximum duration, time unit, stages, rate, graceful stop, graceful ramp-down, and pre-allocated virtual users.
+
+#### Scenario: Non-load configuration survives, load configuration does not
+- **GIVEN** a script with one scenario named `api` that sets an exec target, browser options, scenario environment variables, and tags
+- **AND** whose load is arrival-rate shaped, declaring a rate, a time unit, pre-allocated virtual users, a start time, and a maximum duration
+- **WHEN** the user runs it with `--once`
+- **THEN** the run uses that scenario's exec target, browser options, environment variables, and tags
+- **AND** exactly one iteration runs on exactly one virtual user
+- **AND** the rate, time unit, pre-allocated virtual users, start time, and maximum duration have no effect on the run
+
+### Requirement: Declared load never takes effect, whatever its source
+
+Under single-run mode, the scenario's load-shaping configuration MUST have no effect regardless of which configuration source it reaches the scenario from: script options, an environment variable, or a configuration file. The scenario's non-load configuration MUST still apply from whichever of those sources it reaches the scenario from.
+
+#### Scenario: Load supplied outside the script still runs once
+- **GIVEN** a script whose scenario takes its virtual user and iteration counts from an environment variable
+- **AND** whose scenario takes its tags from a configuration file
+- **WHEN** the user runs it with `--once`
+- **THEN** exactly one iteration runs on exactly one virtual user
+- **AND** the scenario's tags from the configuration file still apply
+
+### Requirement: Scripts without scenarios run the default function
+
+When a script declares no scenarios and exports a default function, single-run mode MUST run that default function once with 1 virtual user and 1 iteration, and any load the script declares at the top level MUST NOT take effect.
+
+#### Scenario: Default-only script runs once
+- **GIVEN** a script with no scenarios that exports a default function
+- **AND** declares 50 virtual users and a 30 second duration at the top level
+- **WHEN** the user runs it with `--once`
+- **THEN** the default function runs exactly one time on one virtual user
+- **AND** the declared virtual users and duration have no effect
+
+### Requirement: A single declared scenario is the one that runs
+
+When a script declares exactly one scenario, single-run mode MUST run that scenario once, using its configuration. If the scenario names an exec target, that target MUST run even when the script also exports a default function, and the default function MUST NOT run. If the scenario names no exec target, or names the default function as its target, the default function MUST run, still using that scenario's other configuration.
+
+#### Scenario: Named exec target wins over an exported default function
+- **GIVEN** a script that exports a default function
+- **AND** declares one scenario whose exec target is a different exported function
+- **WHEN** the user runs it with `--once`
+- **THEN** the scenario's exec target runs exactly once
+- **AND** the default function does not run even though the script exports it
+
+#### Scenario: Scenario without an exec target falls back to the default function
+- **GIVEN** a script with one scenario that names no exec target, or names the default function, and sets environment variables, tags, and browser options
+- **WHEN** the user runs it with `--once`
+- **THEN** the default function runs exactly once
+- **AND** it runs with that scenario's environment variables, tags, and browser options
+
+### Requirement: Multiple scenarios are rejected
+
+When a script declares two or more scenarios, single-run mode MUST fail, because it cannot choose which scenario to run or whose configuration to use without ambiguity. The system MUST NOT pick one of them, and MUST NOT run several of them together. The error MUST name the available scenarios. The rejection MUST happen before the script runs.
+
+#### Scenario: Multi-scenario script errors before anything runs
+- **GIVEN** a script declaring three scenarios
+- **WHEN** the user runs it with `--once` under `k6 run`
+- **AND** separately under `k6 cloud run`
+- **THEN** each invocation fails, naming the three scenario names
+- **AND** the process exits with a non-zero code
+
+### Requirement: Scripts with no runnable entry point fail
+
+When a script declares neither scenarios nor a default function, single-run mode MUST fail with the same missing-default-function error k6 already reports for such a script today.
+
+#### Scenario: Nothing to run
+- **GIVEN** a script with no scenarios and no exported default function
+- **WHEN** the user runs it with `--once`
+- **THEN** k6 reports the same missing-default-function error it reports for that script without the flag
+- **AND** the process exits with a non-zero code
+
+### Requirement: Load-shaping command-line flags cannot be combined with single-run mode
+
+The virtual-users flag, the iterations flag, the duration flag, and the stages flag MUST each be rejected when combined with `--once` on the same command line. The error MUST name the conflicting flag. The rejection MUST happen before the script runs, even when the script would otherwise be accepted by single-run mode. The system MUST NOT resolve the ambiguity by preferring one of the two flags.
+
+#### Scenario: Combination is refused even for an otherwise valid script
+- **GIVEN** a script with exactly one scenario, which single-run mode would accept on its own
+- **WHEN** the user runs it with `--once` together with the iterations flag
+- **AND** separately with `--once` together with the virtual-users flag
+- **AND** separately with `--once` together with the duration flag
+- **AND** separately with `--once` together with the stages flag
+- **AND** separately with each of those combinations under `k6 cloud run`
+- **THEN** each invocation reports that single-run mode cannot be combined with that flag
+- **AND** the script does not run
+- **AND** the process exits with a non-zero code
+
+### Requirement: Browser tests run correctly under single-run mode
+
+Because scenario-level browser options survive single-run mode, a browser script MUST run its browser steps successfully without the user editing the script or passing load-shaping flags. A browser MUST be launched only when the scenario that actually runs declares browser options.
+
+#### Scenario: Browser scenario runs once with its browser
+- **GIVEN** a script with one scenario that declares browser options and drives a page
+- **WHEN** the user runs it with `--once`
+- **THEN** the browser is launched and the scenario runs exactly one iteration on one virtual user
+- **AND** the run does not fail for a missing browser
+
+#### Scenario: No browser launches for a non-browser scenario
+- **GIVEN** a script with one scenario that declares no browser options
+- **WHEN** the user runs it with `--once`
+- **THEN** no browser is launched
+
+### Requirement: Single-run mode is a command-line flag only
+
+Single-run mode MUST turn on only when `--once` appears on that invocation's command line. An environment variable named after the flag MUST NOT turn single-run mode on, and a configuration-file field named after the flag MUST NOT turn it on. In both cases the script MUST run with its declared load. This keeps a stray setting left in a shell profile or a shared configuration file from turning a real load test into a single run.
+
+#### Scenario: Environment variable and configuration file cannot turn on single-run mode
+- **GIVEN** a script whose scenario declares 100 virtual users and 100 iterations
+- **AND** an environment variable named after the `--once` flag is set
+- **AND** the configuration file contains a field named after the `--once` flag
+- **WHEN** the user runs the script without `--once` on the command line
+- **THEN** the script runs with its declared 100 virtual users and 100 iterations
+
+### Requirement: Setup and teardown are unaffected
+
+Single-run mode MUST change only the scenario configuration. The script's setup and teardown functions MUST behave exactly as they do without the flag, each running once around the single iteration.
+
+#### Scenario: Setup and teardown still run around the single iteration
+- **GIVEN** a script that exports setup and teardown functions
+- **WHEN** the user runs it with `--once`
+- **THEN** setup runs exactly once before the iteration
+- **AND** teardown runs exactly once after the iteration
+
+### Requirement: Archives carry single-run mode forward
+
+An archive generated for a cloud run under single-run mode MUST contain the resulting 1 virtual user / 1 iteration scenario, so that re-running that archive later, including from the cloud interface, also runs exactly once.
+
+#### Scenario: Re-running a generated archive still runs once
+- **GIVEN** a script whose scenario declares 100 virtual users and 100 iterations
+- **WHEN** the user starts a cloud run with `--once`
+- **AND** the archive produced for that run is run again later without the flag
+- **THEN** the later run also runs exactly one iteration on one virtual user


### PR DESCRIPTION
## Why

Smoke, e2e, and functional testing with k6 today needs either per-environment script edits or shortcut load flags that discard scenarios, ignore declared load, and break browser tests. Synthetic Monitoring needs guaranteed single-iteration runs on every check and has no runtime enforcement for that today.

## What this adds

An [OpenSpec](https://github.com/Fission-AI/OpenSpec) proposal and spec (spec only, no implementation) for a built-in `--once` flag: runs a script exactly once with 1 VU and 1 iteration, keeps the running scenario's non-load configuration (exec target, browser options, env vars, tags), and discards load shaping regardless of where it's declared.

Validated with `openspec validate add-once-flag --strict`.