### PR TITLE
fix(js): error out when setup()'s promise never settles

### DIFF
--- a/internal/js/runner.go
+++ b/internal/js/runner.go
@@ -667,6 +667,10 @@ func (r *Runner) runPart(
 		return nil, deadlineError
 	}
 
+	if v == nil && err == nil {
+		return nil, fmt.Errorf("%s() did not finish: it is still awaiting an operation that never completed", name)
+	}
+
 	return v, err
 }
 

--- a/internal/js/runner_test.go
+++ b/internal/js/runner_test.go
@@ -507,6 +507,28 @@ func TestSetupDataPromise(t *testing.T) {
 	};`)
 }
 
+// TestSetupDataPendingPromise checks that a setup() whose promise never settles is reported as an
+// error rather than crashing k6.
+func TestSetupDataPendingPromise(t *testing.T) {
+	t.Parallel()
+	r, err := getSimpleRunner(t, "/script.js", `
+	exports.options = { setupTimeout: "1s", teardownTimeout: "1s" };
+	exports.setup = async function() {
+		// Nothing that could ever settle this promise is registered with the event loop, so the
+		// loop runs dry with setup() still awaiting it. setupTimeout does not save us: there is no
+		// pending callback keeping the loop alive until the deadline, so it returns immediately.
+		await new Promise(function() {});
+		return {"data": "correct"};
+	}
+	exports.default = function() {};`)
+	require.NoError(t, err)
+
+	err = r.Setup(t.Context(), make(chan metrics.SampleContainer, 100))
+	require.Error(t, err, "a setup() that never finishes must be reported as an error")
+	require.Contains(t, err.Error(), "setup()")
+	require.Contains(t, err.Error(), "did not finish")
+}
+
 func TestRunnerIntegrationImports(t *testing.T) {
 	t.Parallel()
 	t.Run("Modules", func(t *testing.T) {


### PR DESCRIPTION
## What?

Prevents a panic from occurring during `setup()`.

## Why?

The panic can occur when a promise in a `setup()` function never settles.

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

n/a - I just saw this in an internal repo of mine.

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
