### PR TITLE
Fix getRandomValues element width, input validation, and quota basis

### DIFF
--- a/internal/js/modules/k6/webcrypto/cmd_run_test.go
+++ b/internal/js/modules/k6/webcrypto/cmd_run_test.go
@@ -99,8 +99,137 @@ func TestExamplesInputOutput(t *testing.T) {
 	}
 }
 
-func getFiles(t *testing.T, path string) []string {
-	t.Helper()
+// TestGetRandomValuesBehavior verifies the element-width, input-validation and
+// quota behavior of crypto.getRandomValues (#6318, #6320).
+func TestGetRandomValuesBehavior(t *testing.T) {
+	t.Parallel()
+
+	const script = `
+function assertThrowsTypeError(value, label) {
+    try {
+        crypto.getRandomValues(value);
+    } catch (error) {
+        if (error.name !== "TypeError") {
+            throw new Error(label + " threw " + error.name + " instead of TypeError");
+        }
+        return;
+    }
+    throw new Error(label + " was accepted");
+}
+
+function assertThrowsWebCryptoError(value, expectedErrorName, label) {
+    try {
+        crypto.getRandomValues(value);
+    } catch (error) {
+        if (!String(error.message).includes(expectedErrorName)) {
+            throw new Error(label + " threw " + error.name + ": " + error.message);
+        }
+        return;
+    }
+    throw new Error(label + " was accepted");
+}
+
+export default function () {
+    // Every element of a wide view must carry its full width of random bits
+    // (#6318): across 1000 * 8 uint32 draws, all fitting in 8 bits is
+    // impossible in practice unless only one byte per element is random.
+    let max32 = 0;
+    for (let i = 0; i < 1000; i++) {
+        const a = new Uint32Array(8);
+        crypto.getRandomValues(a);
+        for (const v of a) {
+            if (v > 0xffffffff || v < 0) {
+                throw new Error("Uint32Array element out of range: " + v);
+            }
+            max32 = Math.max(max32, v);
+        }
+    }
+    if (max32 <= 255) {
+        throw new Error("Uint32Array values only carry 8 random bits: max was " + max32);
+    }
+
+    let sawWide16 = false;
+    for (let i = 0; i < 200; i++) {
+        const a = new Uint16Array(16);
+        crypto.getRandomValues(a);
+        for (const v of a) {
+            if (v > 0xffff || v < 0) {
+                throw new Error("Uint16Array element out of range: " + v);
+            }
+            if (v > 255) {
+                sawWide16 = true;
+            }
+        }
+    }
+    if (!sawWide16) {
+        throw new Error("Uint16Array values only carry 8 random bits");
+    }
+
+    // 8-bit views keep their ranges.
+    const i8 = new Int8Array(64);
+    crypto.getRandomValues(i8);
+    for (const v of i8) {
+        if (v < -128 || v > 127) {
+            throw new Error("Int8Array element out of range: " + v);
+        }
+    }
+    const u8 = new Uint8Array(64);
+    crypto.getRandomValues(u8);
+    for (const v of u8) {
+        if (v < 0 || v > 255) {
+            throw new Error("Uint8Array element out of range: " + v);
+        }
+    }
+    const clamped = new Uint8ClampedArray(64);
+    crypto.getRandomValues(clamped);
+    for (const v of clamped) {
+        if (v < 0 || v > 255) {
+            throw new Error("Uint8ClampedArray element out of range: " + v);
+        }
+    }
+    if (crypto.getRandomValues(u8) !== u8) {
+        throw new Error("getRandomValues must return the view it filled");
+    }
+
+    // A missing argument and an unsupported value throw catchable errors
+    // instead of taking the process down (#6320).
+    assertThrowsTypeError(undefined, "missing argument");
+    assertThrowsTypeError(null, "null argument");
+    assertThrowsWebCryptoError({}, "TypeMismatchError", "plain object");
+    assertThrowsWebCryptoError(" Uint8Array", "TypeMismatchError", "string");
+    assertThrowsWebCryptoError(new Float64Array(4), "TypeMismatchError", "Float64Array");
+
+    // Overridden JS-visible properties are not trusted: the real view length
+    // is used and the call neither crashes nor throws (#6320).
+    const overridden = new Uint8Array(4);
+    Object.defineProperty(overridden, "length", { value: -1 });
+    crypto.getRandomValues(overridden);
+    for (let i = 0; i < 4; i++) {
+        if (typeof overridden[i] !== "number") {
+            throw new Error("element " + i + " was not filled after length override");
+        }
+    }
+
+    // The quota is on the view's byteLength (#6318): exactly 65536 bytes is
+    // allowed, anything above it throws a catchable QuotaExceededError.
+    crypto.getRandomValues(new Uint8Array(65536));
+    assertThrowsWebCryptoError(new Uint8Array(65537), "QuotaExceededError", "65537 Uint8 bytes");
+    assertThrowsWebCryptoError(new Uint32Array(16385), "QuotaExceededError", "16385 Uint32 elements");
+
+    console.log("getRandomValues behavior ok, widest uint32 seen: " + max32);
+}
+`
+	ts := getSingleFileTestState(t, script, []string{"-v", "--log-output=stdout"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	assert.Contains(t, stdout, "getRandomValues behavior ok")
+	assert.NotContains(t, stdout, "Uncaught")
+	assert.NotContains(t, stdout, "panic")
+	assert.Empty(t, ts.Stderr.String())
+}
+
+func getFiles(t *testing.T, path string) []string {	t.Helper()
 
 	result := []string{}
 

--- a/internal/js/modules/k6/webcrypto/crypto.go
+++ b/internal/js/modules/k6/webcrypto/crypto.go
@@ -2,8 +2,8 @@ package webcrypto
 
 import (
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
-	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/grafana/sobek"
@@ -36,60 +36,52 @@ type Crypto struct {
 //
 // [specification]: https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
 func (c *Crypto) GetRandomValues(typedArray sobek.Value) sobek.Value {
-	acceptedTypes := []JSType{
-		Int8ArrayConstructor,
-		Uint8ArrayConstructor,
-		Uint8ClampedArrayConstructor,
-		Int16ArrayConstructor,
-		Uint16ArrayConstructor,
-		Int32ArrayConstructor,
-		Uint32ArrayConstructor,
-	}
+	rt := c.vu.Runtime()
 
 	// 1.
-	if !IsInstanceOf(c.vu.Runtime(), typedArray, acceptedTypes...) {
-		common.Throw(c.vu.Runtime(), NewError(TypeMismatchError, "typedArray parameter isn't a TypedArray instance"))
+	// A missing, null or undefined argument used to reach the constructor
+	// lookup below and take the whole process down with a nil pointer
+	// dereference. Browsers and Node throw a TypeError the script can
+	// catch instead (#6320).
+	if common.IsNullish(typedArray) {
+		panic(rt.NewTypeError("typedArray parameter is missing, null or undefined"))
 	}
 
 	// 2.
-	// Obtain the length of the typed array, and throw a QuotaExceededError if
-	// it's too big, as specified in the [spec's] 10.2.1.2 paragraph.
-	// [spec]: https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
-	obj := typedArray.ToObject(c.vu.Runtime())
-	objLength, ok := obj.Get("length").ToNumber().Export().(int64)
-	if !ok {
-		common.Throw(c.vu.Runtime(), NewError(TypeMismatchError, "typedArray parameter isn't a TypedArray instance"))
-	}
-
-	if objLength > maxRandomValuesLength {
-		common.Throw(
-			c.vu.Runtime(),
-			NewError(
-				QuotaExceededError,
-				fmt.Sprintf("typedArray parameter is too big; maximum length is %d", maxRandomValuesLength),
-			),
-		)
-	}
-
-	// 3.
-	// Create a buffer of a matching size and fill
-	// it with random values.
+	// Identify and fill the view through its Go-side representation rather
+	// than its JS-visible properties. Exporting one of the IntegerArray
+	// types yields a slice aliasing the view's storage, so writing through
+	// it updates the JS array in place, and every element receives as many
+	// random bits as its width allows (#6318). Because the element count
+	// and width come from the view itself, overridden properties such as
+	// `length` or `constructor` can neither crash the process nor change
+	// how many bytes are written (#6320).
 	//
-	// We use crypto/rand.Read() here as it will use /dev/urandom or
-	// an equivalent on Unix-like systems, and CryptGenRandom()
-	// on Windows. This is the recommended way to generate random
-	// by the specification.
-	randomValues := make([]byte, objLength)
-	_, err := rand.Read(randomValues)
-	if err != nil {
-		common.Throw(c.vu.Runtime(), err)
-	}
-
-	for i := range objLength {
-		err := obj.Set(strconv.FormatInt(i, 10), randomValues[i])
-		if err != nil {
-			common.Throw(c.vu.Runtime(), err)
-		}
+	// The quota is specified on the view's byteLength, not its element
+	// count ([spec's] 10.2.1.2 paragraph): a Uint32Array(65536) asks for
+	// 256 KiB of randomness and is rejected the same way it is in browsers.
+	// [spec]: https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
+	switch view := typedArray.Export().(type) {
+	case []byte: // Uint8Array, Uint8ClampedArray
+		c.throwIfViewTooLong(rt, len(view), 1)
+		fillRandomBytes(view)
+	case []int8: // Int8Array
+		c.throwIfViewTooLong(rt, len(view), 1)
+		fillRandomBytes(view)
+	case []int16: // Int16Array
+		c.throwIfViewTooLong(rt, len(view), 2)
+		scatterRandomInt16s(view)
+	case []uint16: // Uint16Array
+		c.throwIfViewTooLong(rt, len(view), 2)
+		scatterRandomUint16s(view)
+	case []int32: // Int32Array
+		c.throwIfViewTooLong(rt, len(view), 4)
+		scatterRandomInt32s(view)
+	case []uint32: // Uint32Array
+		c.throwIfViewTooLong(rt, len(view), 4)
+		scatterRandomUint32s(view)
+	default:
+		common.Throw(rt, NewError(TypeMismatchError, "typedArray parameter isn't a TypedArray instance"))
 	}
 
 	// Although the input array has been modified in place,
@@ -97,7 +89,74 @@ func (c *Crypto) GetRandomValues(typedArray sobek.Value) sobek.Value {
 	return typedArray
 }
 
-// MaxRandomValues is the maximum number of random values that can be generated
+// throwIfViewTooLong enforces the spec's 65536-byte quota on getRandomValues
+// input views, throwing a QuotaExceededError the script can catch.
+func (c *Crypto) throwIfViewTooLong(rt *sobek.Runtime, elements, elementSize int) {
+	if elements*elementSize > maxRandomValuesLength {
+		common.Throw(
+			rt,
+			NewError(
+				QuotaExceededError,
+				fmt.Sprintf(
+					"typedArray parameter is too big; maximum length is %d bytes",
+					maxRandomValuesLength,
+				),
+			),
+		)
+	}
+}
+
+// fillRandomBytes overwrites an 8-bit view's storage with fresh random bytes.
+// Signedness is irrelevant at this width: the bits are copied verbatim.
+func fillRandomBytes[E ~int8 | ~uint8](view []E) {
+	buf := make([]byte, len(view))
+	_, _ = rand.Read(buf)
+	for i, b := range buf {
+		view[i] = E(b)
+	}
+}
+
+// scatterRandomInt16s fills each 16-bit element with 16 fresh random bits.
+// The byte order used to assemble elements is an implementation detail: it is
+// only required to be consistent, since the result is uniformly random either
+// way.
+func scatterRandomInt16s(view []int16) {
+	buf := make([]byte, 2*len(view))
+	_, _ = rand.Read(buf)
+	for i := range view {
+		view[i] = int16(binary.LittleEndian.Uint16(buf[2*i:]))
+	}
+}
+
+// scatterRandomUint16s fills each 16-bit element with 16 fresh random bits.
+func scatterRandomUint16s(view []uint16) {
+	buf := make([]byte, 2*len(view))
+	_, _ = rand.Read(buf)
+	for i := range view {
+		view[i] = binary.LittleEndian.Uint16(buf[2*i:])
+	}
+}
+
+// scatterRandomInt32s fills each 32-bit element with 32 fresh random bits.
+func scatterRandomInt32s(view []int32) {
+	buf := make([]byte, 4*len(view))
+	_, _ = rand.Read(buf)
+	for i := range view {
+		view[i] = int32(binary.LittleEndian.Uint32(buf[4*i:]))
+	}
+}
+
+// scatterRandomUint32s fills each 32-bit element with 32 fresh random bits.
+func scatterRandomUint32s(view []uint32) {
+	buf := make([]byte, 4*len(view))
+	_, _ = rand.Read(buf)
+	for i := range view {
+		view[i] = binary.LittleEndian.Uint32(buf[4*i:])
+	}
+}
+
+// MaxRandomValues is the maximum number of random bytes that can be requested
+// from a single getRandomValues call.
 const maxRandomValuesLength = 65536
 
 // RandomUUID returns a [RFC4122] compliant v4 UUID string.


### PR DESCRIPTION
## What?

`crypto.getRandomValues()` fills 16- and 32-bit views with only 8 random bits per element, and two ordinary input mistakes crash the whole k6 process instead of throwing a catchable error.

Closes #6318
Closes #6320

## Why?

Three defects shared one root cause — the implementation read the view through its **JS-visible properties**:

- it wrote one random *byte* per element via `obj.Set(i, randomValues[i])`, so a `Uint32Array` element carried 8 of its 32 bits (#6318);
- `IsInstanceOf` did `v.ToObject(rt).Get("constructor")`, and a missing/undefined argument makes that a nil-pointer SIGSEGV (#6320);
- the element count came from the JS `length` property, so `Object.defineProperty(a, "length", { value: -1 })` reached `make([]byte, -1)` -> `makeslice: len out of range` (#6320).

The quota was also checked against the element count, while the spec's [10.2.1.2 paragraph](https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues) bounds the view's **byteLength** at 65536 — so `Uint32Array(65536)` asked for 256 KiB of randomness and passed.

## How?

Fill the view through its Go-side representation instead of its JS surface. Exporting one of the spec's IntegerArray types from sobek yields a slice **aliasing** the view's storage, so:

- each element is assembled from as many fresh random bits as its width (2/4 bytes via `encoding/binary`); writes land in the JS array in place, with no per-element `obj.Set` round-trip;
- the element count and width come from the view itself, so overridden `length`/`constructor` properties neither crash nor change how many bytes are written — matching browsers, which read internal slots and simply ignore the override;
- the 65536 quota is enforced on `byteLength` (`elements x elementSize`), matching browsers: `Uint8Array(65536)` passes, `Uint8Array(65537)` and `Uint32Array(16385)` throw a catchable `QuotaExceededError`;
- a missing, null or undefined argument throws a real `TypeError` (`rt.NewTypeError`, the same pattern `internal/js/modules/k6/execution` and `k6/data` use), catchable in `try`/`catch`.

`Uint8Array`/`Uint8ClampedArray`/`Int8Array` behavior is unchanged apart from the quota basis (they were already one byte per element); non-IntegerArray inputs (plain objects, strings, `Float64Array`, ...) keep throwing `TypeMismatchError` as before.

## Testing

`TestGetRandomValuesBehavior` in `internal/js/modules/k6/webcrypto/cmd_run_test.go` runs end-to-end through the k6 runner (same harness #6278 uses) and asserts:

- across 1000x8 `Uint32Array` draws the maximum exceeds 255 and every value stays in range; `Uint16Array` likewise exceeds 255; `Int8Array`/`Uint8Array`/`Uint8ClampedArray` keep their ranges; the view is returned;
- missing and `null` arguments throw `TypeError`; a plain object, a string and a `Float64Array` throw `TypeMismatchError`;
- the `length: -1` override neither crashes nor throws — the real 4 bytes are filled;
- exactly 65536 bytes is accepted; 65537 bytes and 16385x4 bytes throw `QuotaExceededError`.

**Differential**: on `master` the test fails with `Uint32Array values only carry 8 random bits: max was 255` (the exact #6318 report); with this branch it passes. `go test ./internal/js/modules/k6/webcrypto/` green, `go vet` clean. (Note `gofmt -l` flags 24 files in this package on a Windows CRLF checkout of `master` too — pre-existing, unrelated.)

Follow-up: #6319 (algorithm params like `iv` are read after the call returns) takes a different path (`subtle.encrypt`'s params structs) and will be a separate PR.