### PR TITLE
Snapshot BufferSource algorithm params when the call is made

### DIFF
--- a/internal/js/modules/k6/webcrypto/cmd_run_test.go
+++ b/internal/js/modules/k6/webcrypto/cmd_run_test.go
@@ -99,6 +99,114 @@ func TestExamplesInputOutput(t *testing.T) {
 	}
 }
 
+
+// TestAlgorithmParamsSnapshot verifies that BufferSource algorithm parameters
+// (iv, counter, additionalData, label, salt) are copied when the call is made,
+// not read after the returned promise settles (#6319).
+func TestAlgorithmParamsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	const script = `
+const hex = (b) => Array.from(new Uint8Array(b), (x) => x.toString(16).padStart(2, "0")).join("");
+
+async function importAesKey(name, usages) {
+    return await crypto.subtle.importKey(
+        "raw", new Uint8Array(16).fill(7), { name }, false, usages,
+    );
+}
+
+export default async function () {
+    const data = new Uint8Array([1, 2, 3, 4]);
+
+    // The exact shape of #6319: mutating the iv while the promise is pending
+    // must not change the ciphertext — the all-zero iv snapshot must win.
+    const key = await importAesKey("AES-GCM", ["encrypt"]);
+    const iv = new Uint8Array(12);
+    const pending = crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, data);
+    iv.fill(0xff);
+    const mutatedIvResult = hex(await pending);
+    const zeroIvResult = hex(await crypto.subtle.encrypt(
+        { name: "AES-GCM", iv: new Uint8Array(12) }, key, data,
+    ));
+    if (mutatedIvResult !== zeroIvResult) {
+        throw new Error("encrypt used the mutated iv, not the snapshot");
+    }
+
+    // Same property for AES-GCM additionalData.
+    const aad = new Uint8Array(8);
+    const aadPending = crypto.subtle.encrypt(
+        { name: "AES-GCM", iv: new Uint8Array(12), additionalData: aad }, key, data,
+    );
+    aad.fill(0xee);
+    const mutatedAadResult = hex(await aadPending);
+    const zeroAadResult = hex(await crypto.subtle.encrypt(
+        { name: "AES-GCM", iv: new Uint8Array(12), additionalData: new Uint8Array(8) }, key, data,
+    ));
+    if (mutatedAadResult !== zeroAadResult) {
+        throw new Error("encrypt used the mutated additionalData, not the snapshot");
+    }
+
+    // Same property for the AES-CTR counter.
+    const counterKey = await importAesKey("AES-CTR", ["encrypt"]);
+    const counter = new Uint8Array(16);
+    const counterPending = crypto.subtle.encrypt(
+        { name: "AES-CTR", counter, length: 64 }, counterKey, new Uint8Array([5, 6]),
+    );
+    counter.fill(0xab);
+    const counterMutated = hex(await counterPending);
+    const counterControl = hex(await crypto.subtle.encrypt(
+        { name: "AES-CTR", counter: new Uint8Array(16), length: 64 }, counterKey, new Uint8Array([5, 6]),
+    ));
+    if (counterMutated !== counterControl) {
+        throw new Error("AES-CTR used the mutated counter, not the snapshot");
+    }
+
+    // Reusing the same buffers across calls must re-snapshot: after the
+    // buffers change, the next call uses the new bytes, not the first
+    // call's snapshot.
+    const sharedIv = new Uint8Array(12);
+    const sharedAlgorithm = { name: "AES-GCM", iv: sharedIv };
+    const firstShared = hex(await crypto.subtle.encrypt(sharedAlgorithm, key, data));
+    sharedIv.fill(0x5a);
+    const secondShared = hex(await crypto.subtle.encrypt(sharedAlgorithm, key, data));
+    const sharedControl = hex(await crypto.subtle.encrypt(
+        { name: "AES-GCM", iv: new Uint8Array(12).fill(0x5a) }, key, data,
+    ));
+    if (secondShared !== sharedControl || secondShared === firstShared) {
+        throw new Error("a reused iv buffer was not re-snapshotted");
+    }
+
+    // PBKDF2's salt is derived against later, in the callback goroutine.
+    const baseKey = await crypto.subtle.importKey(
+        "raw", new Uint8Array(16).fill(3), { name: "PBKDF2" }, false, ["deriveBits"],
+    );
+    const salt = new Uint8Array(16);
+    const saltPending = crypto.subtle.deriveBits(
+        { name: "PBKDF2", hash: "SHA-256", iterations: 1000, salt }, baseKey, 128,
+    );
+    salt.fill(0xff);
+    const saltMutated = hex(await saltPending);
+    const saltControl = hex(await crypto.subtle.deriveBits(
+        { name: "PBKDF2", hash: "SHA-256", iterations: 1000, salt: new Uint8Array(16) },
+        baseKey, 128,
+    ));
+    if (saltMutated !== saltControl) {
+        throw new Error("deriveBits used the mutated salt, not the snapshot");
+    }
+
+    console.log("algorithm params snapshot ok");
+}
+`
+	ts := getSingleFileTestState(t, script, []string{"-v", "--log-output=stdout"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	assert.Contains(t, stdout, "algorithm params snapshot ok")
+	assert.NotContains(t, stdout, "Uncaught")
+	assert.NotContains(t, stdout, "panic")
+	assert.Empty(t, ts.Stderr.String())
+}
+
 func getFiles(t *testing.T, path string) []string {
 	t.Helper()
 

--- a/internal/js/modules/k6/webcrypto/encryption.go
+++ b/internal/js/modules/k6/webcrypto/encryption.go
@@ -1,6 +1,7 @@
 package webcrypto
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 
@@ -56,5 +57,31 @@ func newEncryptDecrypter(
 		return nil, NewError(SyntaxError, errMsg)
 	}
 
+	// The BufferSource fields above (iv, counter, additionalData, label)
+	// alias the script's view or buffer after ExportTo, and the encrypter
+	// reads them later, in the callback goroutine — after the synchronous
+	// call has already returned its promise. Snapshot them now so a script
+	// reusing or mutating the buffer while the promise is pending cannot
+	// change (or race with) the bytes actually used, as the specification's
+	// "get a copy of the bytes" steps require (#6319).
+	snapshotParams(ed)
+
 	return ed, nil
+}
+
+// snapshotParams replaces every BufferSource field of the encrypt/decrypt
+// algorithm parameters with a copy, detaching the parameters from any storage
+// the script can still reach.
+func snapshotParams(ed EncryptDecrypter) {
+	switch p := ed.(type) {
+	case *AESCBCParams:
+		p.Iv = bytes.Clone(p.Iv)
+	case *AESCTRParams:
+		p.Counter = bytes.Clone(p.Counter)
+	case *AESGCMParams:
+		p.Iv = bytes.Clone(p.Iv)
+		p.AdditionalData = bytes.Clone(p.AdditionalData)
+	case *RSAOaepParams:
+		p.Label = bytes.Clone(p.Label)
+	}
 }

--- a/internal/js/modules/k6/webcrypto/pbkdf2.go
+++ b/internal/js/modules/k6/webcrypto/pbkdf2.go
@@ -1,6 +1,7 @@
 package webcrypto
 
 import (
+	"bytes"
 	"crypto/pbkdf2"
 
 	"github.com/grafana/sobek"
@@ -95,6 +96,13 @@ func newPBKDF2DeriveParams(rt *sobek.Runtime, normalized Algorithm, params sobek
 	if err != nil {
 		return nil, err
 	}
+
+	// ToBytes returns a slice aliasing the script's view or buffer, and the
+	// derivation runs later, in the callback goroutine — after the call has
+	// already returned its promise. Snapshot the salt so mutating or reusing
+	// the buffer while the promise is pending cannot change (or race with)
+	// the bytes actually used (#6319).
+	byteSalt = bytes.Clone(byteSalt)
 
 	return &PBKDF2Params{
 		Name:       normalized.Name,


### PR DESCRIPTION
## What?

`crypto.subtle.encrypt()` (and friends) read the `iv` — and `counter`, `additionalData`, `label`, and PBKDF2's `salt` — **after** the call has returned, so editing or reusing the buffer while the promise is pending changes (or races with) the bytes actually used.

Closes #6319

## Why?

`newEncryptDecrypter` fills the params structs (`AESCBCParams.Iv`, `AESCTRParams.Counter`, `AESGCMParams.Iv`/`AdditionalData`, `RSAOaepParams.Label`) with `rt.ExportTo`, which for a typed array view produces a Go slice **aliasing** the view's storage, not a copy. The encrypter then reads those fields in the callback goroutine, after `Encrypt()` has already returned its promise. So with the issue's repro:

```js
const iv = new Uint8Array(12);
const pending = crypto.subtle.encrypt({ name: "AES-GCM", iv }, key, data);
iv.fill(0xff);            // still reachable — and read late
await pending;            // ciphertext matches the 0xff iv, not the all-zero iv
```

PBKDF2's salt takes the same route: `common.ToBytes(salt.Export())` returns the aliased slice (or `ArrayBuffer.Bytes()`, which is also the underlying storage), and `pbkdf2.Key` runs later in the callback goroutine. The `data`/keyData arguments were already copied at call time (`exportArrayBuffer`); the algorithm parameters were left out, exactly as #6319 notes.

## How?

Clone every BufferSource field at the moment the parameters are interpreted, which is when `newEncryptDecrypter` runs synchronously inside the call:

- `newEncryptDecrypter`: after `rt.ExportTo`, `snapshotParams(ed)` replaces each field with `bytes.Clone(...)`;
- `newPBKDF2DeriveParams`: `byteSalt = bytes.Clone(byteSalt)` after `ToBytes`.

Each call therefore uses a copy of the bytes **as of when it was made**, which is what the spec's "get a copy of the bytes held by the [parameter]" steps require. Reusing a buffer across calls keeps working — each call re-snapshots.

## Testing

`TestAlgorithmParamsSnapshot` (same end-to-end runner harness as #6278):

- the exact #6319 repro: a pending `encrypt` whose `iv` is mutated before the first `await` must produce the all-zero-`iv` ciphertext;
- the same property for AES-GCM `additionalData` and the AES-CTR `counter`;
- a reused `iv` buffer is re-snapshotted per call: after mutating it, the next call's ciphertext matches a fresh buffer filled with the new bytes (and differs from the first call's);
- PBKDF2 `deriveBits` with a `salt` mutated while pending matches the all-zero-salt result.

**Differential**: on `master` the test fails with `encrypt used the mutated iv, not the snapshot` (the exact #6319 symptom); with this branch it passes. Full `go test ./internal/js/modules/k6/webcrypto/` green, `go vet` clean.

Companion to #6323 (getRandomValues width/validation) — different code path, no overlap.