### PR TITLE
Fix browser panic runtime race

### DIFF
--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -698,6 +698,7 @@ func (fs *FrameSession) onExecutionContextCreated(event *cdpruntime.EventExecuti
 	}
 	if err := json.Unmarshal(auxData, &i); err != nil {
 		k6ext.Panicf(fs.ctx, "unmarshaling executionContextCreated event JSON: %w", err)
+		return
 	}
 
 	frame, ok := fs.manager.getFrameByID(i.FrameID)
@@ -797,6 +798,7 @@ func (fs *FrameSession) onFrameNavigated(frame *cdp.Frame, initial bool) {
 	if err != nil {
 		k6ext.Panicf(fs.ctx, "handling frameNavigated event to %q: %w",
 			frame.URL+frame.URLFragment, err)
+		return
 	}
 
 	// Only create a navigation span once from here, since a new page navigating
@@ -1102,6 +1104,7 @@ func (fs *FrameSession) onTargetCrashed() {
 	s, ok := fs.session.(*Session)
 	if !ok {
 		k6ext.Panicf(fs.ctx, "unexpected type %T", fs.session)
+		return
 	}
 	s.markAsCrashed()
 }

--- a/internal/js/modules/k6/browser/k6ext/panic.go
+++ b/internal/js/modules/k6/browser/k6ext/panic.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/sobek"
 
 	"go.k6.io/k6/v2/errext"
-	k6common "go.k6.io/k6/v2/js/common"
 )
 
 // Abortf will shutdown the whole test run. This should
@@ -26,13 +25,12 @@ func Abortf(ctx context.Context, format string, a ...any) {
 	sharedPanic(ctx, failFunc, a...)
 }
 
-// Panicf will cause a panic with the given error which will stop
-// the current iteration. Before panicking, it will find the
+// Panicf will interrupt the runtime with the given error which will stop
+// the current iteration. Before interrupting, it will find the
 // browser process from the context and kill it if it still exists.
-// TODO: test.
 func Panicf(ctx context.Context, format string, a ...any) {
 	failFunc := func(rt *sobek.Runtime, a ...any) {
-		k6common.Throw(rt, BrowserError(fmt.Errorf(format, a...)))
+		rt.Interrupt(BrowserError(fmt.Errorf(format, a...)))
 	}
 	sharedPanic(ctx, failFunc, a...)
 }

--- a/internal/js/modules/k6/browser/k6ext/panic_test.go
+++ b/internal/js/modules/k6/browser/k6ext/panic_test.go
@@ -1,0 +1,46 @@
+package k6ext
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	k6common "go.k6.io/k6/v2/js/common"
+	k6modulestest "go.k6.io/k6/v2/js/modulestest"
+)
+
+func TestPanicfInterruptsRuntimeFromAnotherGoroutine(t *testing.T) {
+	testRT := k6modulestest.NewRuntime(t)
+	ctx := WithVU(context.Background(), testRT.VU)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	require.NoError(t, testRT.VU.Runtime().GlobalObject().Set("waitForPanic", func() {
+		close(started)
+		<-release
+	}))
+
+	runErr := make(chan error, 1)
+	go func() {
+		runErr <- testRT.EventLoop.Start(func() error {
+			_, err := testRT.VU.Runtime().RunString("waitForPanic();")
+			return err
+		})
+	}()
+
+	<-started
+	panicReturned := make(chan struct{})
+	go func() {
+		defer func() {
+			_ = recover()
+			close(panicReturned)
+		}()
+		Panicf(ctx, "browser event failed")
+	}()
+	<-panicReturned
+	close(release)
+
+	err := <-runErr
+	require.EqualError(t, k6common.UnwrapSobekInterruptedError(err), "browser event failed")
+}


### PR DESCRIPTION
## What?

Replace the browser error path's direct Sobek throw with `Runtime.Interrupt`,
which is safe to invoke from background browser event goroutines. Event handlers
that previously relied on `Panicf` not returning now return explicitly.

Add a regression test that blocks the event loop, calls `Panicf` from another
goroutine, and verifies that the runtime receives the browser error without a
race.

## Why?

`Panicf` can run in CDP and browser-event goroutines. Calling `js/common.Throw`
there constructs and panics with a Sobek value from outside the event-loop
goroutine, producing the race reported in #5534. Sobek's interruption API is
designed for this cross-goroutine boundary.

## Validation

- `go test -race -run '^TestPanicfInterruptsRuntimeFromAnotherGoroutine$' -count=20 ./internal/js/modules/k6/browser/k6ext`
- `go test -race ./internal/js/modules/k6/browser/k6ext`
- `go test ./internal/js/modules/k6/browser/common`
- `go test ./internal/js/modules/k6/browser/... -run '^$'`
- `go vet ./internal/js/modules/k6/browser/k6ext ./internal/js/modules/k6/browser/common`
- `make lint`
- real Chrome under `-race`: the three tests named in #5534 passed once, then five consecutive times with package parallelism capped
- the two unrelated browser tests that timed out in an uncapped local `make tests` run passed when rerun in isolation under `-race`

The repository-wide race run passes all non-browser packages and the changed
browser packages locally. The browser E2E package itself remains non-green on
this macOS host under full parallel load because unrelated lifecycle tests time
out and an existing asynchronous test logger races with `testing.T` teardown;
neither path intersects this change.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

Fixes #5534
