### PR TITLE
Feature/improve invalid token error

### DIFF
--- a/internal/cloudapi/v6/client.go
+++ b/internal/cloudapi/v6/client.go
@@ -102,7 +102,9 @@ func CheckResponse(r *http.Response, err error) error {
 	}
 
 	if r.StatusCode == http.StatusUnauthorized {
-		return errext.WithHint(respErr, "Run `k6 cloud login` to authenticate")
+		return errext.WithHint(respErr,
+			"Authenticate by running `k6 cloud login` "+
+				"or verify the active Grafana Cloud token (K6_CLOUD_TOKEN, options.cloud.token)")
 	}
 	return respErr
 }

--- a/internal/cloudapi/v6/client.go
+++ b/internal/cloudapi/v6/client.go
@@ -11,6 +11,7 @@ import (
 
 	k6cloud "github.com/grafana/k6-cloud-openapi-client-go/k6"
 	"github.com/sirupsen/logrus"
+	"go.k6.io/k6/v2/errext"
 	"go.k6.io/k6/v2/internal/cloudapi/clientcfg"
 	"go.k6.io/k6/v2/internal/cloudapi/httperr"
 )
@@ -82,18 +83,26 @@ func CheckResponse(r *http.Response, err error) error {
 		return err
 	}
 
+	var respErr error
 	var payload ResponseError
 	if err := json.Unmarshal(data, &payload); err != nil {
 		if classified := httperr.ClassifyStatus(r.StatusCode); classified != nil {
-			return classified
+			respErr = classified
+		} else {
+			respErr = fmt.Errorf(
+				"unexpected HTTP error from %s: %d %s",
+				r.Request.URL,
+				r.StatusCode,
+				http.StatusText(r.StatusCode),
+			)
 		}
-		return fmt.Errorf(
-			"unexpected HTTP error from %s: %d %s",
-			r.Request.URL,
-			r.StatusCode,
-			http.StatusText(r.StatusCode),
-		)
+	} else {
+		payload.Response = r
+		respErr = payload
 	}
-	payload.Response = r
-	return payload
+
+	if r.StatusCode == http.StatusUnauthorized {
+		return errext.WithHint(respErr, "Run `k6 cloud login` to authenticate")
+	}
+	return respErr
 }

--- a/internal/cloudapi/v6/v6test/server.go
+++ b/internal/cloudapi/v6/v6test/server.go
@@ -61,8 +61,8 @@ type Config struct {
 
 	// ErrorStatus, when non-zero, makes every request fail with this HTTP
 	// status and the real k6 Cloud API's error body for it, instead of
-	// the endpoint's normal canned response. For testing how the CLI
-	// handles a failing API call (e.g. an invalid/expired token, a 5xx).
+	// the endpoint's normal canned response. Requires the value to be present
+	// in the forcedErrorMessages map or will panic
 	ErrorStatus int
 }
 

--- a/internal/cloudapi/v6/v6test/server.go
+++ b/internal/cloudapi/v6/v6test/server.go
@@ -58,6 +58,12 @@ type Config struct {
 
 	// LoadZones is the load zone list returned by the load-zones endpoint.
 	LoadZones []cloudapi.LoadZone
+
+	// ErrorStatus, when non-zero, makes every request fail with this HTTP
+	// status and the real k6 Cloud API's error body for it, instead of
+	// the endpoint's normal canned response. For testing how the CLI
+	// handles a failing API call (e.g. an invalid/expired token, a 5xx).
+	ErrorStatus int
 }
 
 // NewServer creates a test server that serves v6 API endpoints.
@@ -94,11 +100,45 @@ func NewServer(t *testing.T, cfg Config) *Server {
 		s.handleAbortTestRun,
 	)
 
-	srv := httptest.NewServer(mux)
+	var handler http.Handler = mux
+	if cfg.ErrorStatus != 0 {
+		handler = forcedErrorHandler(cfg.ErrorStatus)
+	}
+
+	srv := httptest.NewServer(handler)
 	s.Server = srv
 	t.Cleanup(srv.Close)
 
 	return s
+}
+
+// forcedErrorMessages mirrors the real k6 Cloud API's error body for each
+// status this mock can simulate via Config.ErrorStatus. Confirmed against
+// the live v6 API (2026-08-24): a validate_options call with an
+// invalid/expired token returns exactly this 401 body.
+var forcedErrorMessages = map[int]string{
+	http.StatusUnauthorized: "Invalid token",
+}
+
+// forcedErrorHandler short-circuits every request with the given status and
+// its real error body, regardless of route.
+func forcedErrorHandler(status int) http.Handler {
+	msg, ok := forcedErrorMessages[status]
+	if !ok {
+		panic(fmt.Sprintf("v6test: no error body registered for status %d", status))
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		var body struct {
+			Error struct {
+				Message string `json:"message"`
+				Code    string `json:"code"`
+			} `json:"error"`
+		}
+		body.Error.Message = msg
+		body.Error.Code = "error"
+		writeJSON(w, status, body)
+	})
 }
 
 func (s *Server) handleListProjects(w http.ResponseWriter, _ *http.Request) {

--- a/internal/cloudapi/v6/v6test/server.go
+++ b/internal/cloudapi/v6/v6test/server.go
@@ -112,32 +112,21 @@ func NewServer(t *testing.T, cfg Config) *Server {
 	return s
 }
 
-// forcedErrorMessages mirrors the real k6 Cloud API's error body for each
-// status this mock can simulate via Config.ErrorStatus. Confirmed against
-// the live v6 API (2026-08-24): a validate_options call with an
-// invalid/expired token returns exactly this 401 body.
-var forcedErrorMessages = map[int]string{
-	http.StatusUnauthorized: "Invalid token",
-}
-
 // forcedErrorHandler short-circuits every request with the given status and
 // its real error body, regardless of route.
 func forcedErrorHandler(status int) http.Handler {
+	forcedErrorMessages := map[int]string{
+		http.StatusUnauthorized: "Invalid token",
+	}
+
 	msg, ok := forcedErrorMessages[status]
 	if !ok {
 		panic(fmt.Sprintf("v6test: no error body registered for status %d", status))
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		var body struct {
-			Error struct {
-				Message string `json:"message"`
-				Code    string `json:"code"`
-			} `json:"error"`
-		}
-		body.Error.Message = msg
-		body.Error.Code = "error"
-		writeJSON(w, status, body)
+		res := k6cloud.NewErrorResponseApiModel(*k6cloud.NewErrorApiModel(msg, "error"))
+		writeJSON(w, status, res)
 	})
 }
 

--- a/internal/cmd/cloud_login.go
+++ b/internal/cmd/cloud_login.go
@@ -271,7 +271,6 @@ func authenticateUserToken(
 			"Authentication failed as provided token or stack might not be valid."+
 				" Learn more: https://grafana.com/docs/grafana-cloud/testing/k6/author-run/tokens-and-cli-authentication."+
 				" Server error for details: %w",
-
 			err)
 	}
 	config.StackURL = null.StringFrom(stackURL)

--- a/internal/cmd/tests/cmd_cloud_test.go
+++ b/internal/cmd/tests/cmd_cloud_test.go
@@ -55,7 +55,7 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		stdout := ts.Stdout.String()
 		t.Log(stdout)
 		assert.Contains(t, stdout, `Invalid token`, "the real API error message should still be shown")
-		assert.Contains(t, stdout, "hint=\"Run `k6 cloud login` to authenticate\"",
+		assert.Contains(t, stdout, "hint=\"Authenticate by running `k6 cloud login` or verify the active Grafana Cloud token (K6_CLOUD_TOKEN, options.cloud.token)\"",
 			"a 401 should come with a recovery hint pointing at `k6 cloud login`")
 	})
 

--- a/internal/cmd/tests/cmd_cloud_test.go
+++ b/internal/cmd/tests/cmd_cloud_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"go.k6.io/k6/v2/errext/exitcodes"
 	cloudapiv6 "go.k6.io/k6/v2/internal/cloudapi/v6"
 	"go.k6.io/k6/v2/internal/cloudapi/v6/v6test"
 	"go.k6.io/k6/v2/internal/cmd"
@@ -31,24 +32,12 @@ func TestCloudNoArgsShowsHelp(t *testing.T) {
 type setupCommandFunc func(cliFlags []string) []string
 
 func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
-	//t.Run("TestCloudUserNotAuthenticated", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
-	//	delete(ts.Env, "K6_CLOUD_TOKEN")
-	//	ts.ExpectedExitCode = -1 // TODO: use a more specific exit code?
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.Contains(t, stdout, `access token not configured`)
-	//})
-
-	t.Run("TestCloudInvalidToken", func(t *testing.T) {
+	t.Run("TestCloudUserNotAuthenticated", func(t *testing.T) {
 		t.Parallel()
 
-		ts := getSimpleCloudTestStateWithError(t, nil, setupCmd, nil, nil, 401)
-		ts.ExpectedExitCode = -1
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+		delete(ts.Env, "K6_CLOUD_TOKEN")
+		ts.ExpectedExitCode = -1 // TODO: use a more specific exit code?
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()
@@ -56,176 +45,190 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		assert.Contains(t, stdout, `access token not configured`)
 	})
 
-	//t.Run("TestCloudStackNotConfigured", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
-	//	delete(ts.Env, "K6_CLOUD_STACK_ID")
-	//	ts.ExpectedExitCode = -1
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.Contains(t, stdout, `stack ID not configured`)
-	//})
-	//
-	//// TODO: Remove after we remove K6_CLOUD_HOST_V6.
-	//t.Run("TestCloudV6ClientUsesV6Host", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
-	//	ts.Env["K6_CLOUD_HOST"] = "http://wrong-host"
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	require.NotContains(t, stdout, "wrong-host", "v6 client should use K6_CLOUD_HOST_V6, not K6_CLOUD_HOST")
-	//})
-	//
-	//t.Run("TestCloudLoggedInWithScriptToken", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	script := `
-	//	export let options = {
-	//		cloud: {
-	//			token: "asdf",
-	//			name: "my load test",
-	//			projectID: 124,
-	//			note: 124,
-	//		}
-	//	};
-	//	export default function() {};
-	//`
-	//
-	//	ts := getSimpleCloudTestState(t, []byte(script), setupCmd, nil, nil)
-	//	delete(ts.Env, "K6_CLOUD_TOKEN")
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.NotContains(t, stdout, `not logged in`)
-	//	assert.Contains(t, stdout, `execution: cloud`)
-	//	assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
-	//	assert.Contains(t, stdout, `test status: Finished`)
-	//})
-	//
-	//t.Run("TestCloudExitOnRunning", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"},
-	//		v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.Contains(t, stdout, `execution: cloud`)
-	//	assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
-	//	assert.Contains(t, stdout, `test status: Running`)
-	//})
-	//
-	//t.Run("TestCloudExitOnRunningEnv", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	// Same as TestCloudExitOnRunning, but driven by the environment
-	//	// variable instead of the CLI flag. Without the override taking
-	//	// effect, the command would keep polling the mock server forever,
-	//	// since its progress is always "Running".
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--log-output=stdout"},
-	//		v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
-	//	ts.Env["K6_EXIT_ON_RUNNING"] = "true"
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.Contains(t, stdout, `execution: cloud`)
-	//	assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
-	//	assert.Contains(t, stdout, `test status: Running`)
-	//})
-	//
-	//t.Run("TestCloudExitOnRunningFlagOverridesEnv", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	// An explicitly set CLI flag takes precedence over the environment
-	//	// variable. If the "false" from the environment won instead, the
-	//	// command would poll the always-"Running" mock server forever.
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"},
-	//		v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
-	//	ts.Env["K6_EXIT_ON_RUNNING"] = "false"
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.Contains(t, stdout, `test status: Running`)
-	//})
-	//
-	//t.Run("TestCloudExitOnRunningInvalidEnv", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
-	//	ts.Env["K6_EXIT_ON_RUNNING"] = "invalid"
-	//	ts.ExpectedExitCode = -1
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.Contains(t, stdout, `parsing K6_EXIT_ON_RUNNING returned an error`)
-	//})
-	//
-	//t.Run("TestCloudURLFromStartResponse", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	// v6 returns the run URL in the start response (no ConfigOverride).
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.Contains(t, stdout, "execution: cloud")
-	//	assert.Contains(t, stdout, "output: https://stack.grafana.com/a/k6-app/runs/123")
-	//	assert.Contains(t, stdout, `test status: Finished`)
-	//})
-	//
-	//t.Run("TestCloudThresholdsHaveFailed", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
-	//		v6test.Progress(cloudapiv6.StatusCompleted, cloudapiv6.ResultFailed))
-	//	ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
-	//
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.Contains(t, stdout, `Thresholds have been crossed`)
-	//})
-	//
-	//t.Run("TestCloudAbortedThreshold", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
-	//		v6test.Progress(cloudapiv6.StatusAborted, cloudapiv6.ResultFailed))
-	//	ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
-	//
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.Contains(t, stdout, `Thresholds have been crossed`)
-	//})
-	//
-	//t.Run("TestCloudAbortedByUser", func(t *testing.T) {
-	//	t.Parallel()
-	//
-	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
-	//		v6test.AbortedByUserProgress("user@example.com"))
-	//	ts.ExpectedExitCode = int(exitcodes.CloudTestRunFailed)
-	//
-	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
-	//
-	//	stdout := ts.Stdout.String()
-	//	t.Log(stdout)
-	//	assert.Contains(t, stdout, `test status: Aborted (by user)`)
-	//})
+	t.Run("TestCloudInvalidToken", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestStateWithError(t, nil, setupCmd, nil, nil, http.StatusUnauthorized)
+		ts.ExpectedExitCode = -1
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `Invalid token`, "the real API error message should still be shown")
+		assert.Contains(t, stdout, "hint=\"Run `k6 cloud login` to authenticate\"",
+			"a 401 should come with a recovery hint pointing at `k6 cloud login`")
+	})
+
+	t.Run("TestCloudStackNotConfigured", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+		delete(ts.Env, "K6_CLOUD_STACK_ID")
+		ts.ExpectedExitCode = -1
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `stack ID not configured`)
+	})
+
+	// TODO: Remove after we remove K6_CLOUD_HOST_V6.
+	t.Run("TestCloudV6ClientUsesV6Host", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+		ts.Env["K6_CLOUD_HOST"] = "http://wrong-host"
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		require.NotContains(t, stdout, "wrong-host", "v6 client should use K6_CLOUD_HOST_V6, not K6_CLOUD_HOST")
+	})
+
+	t.Run("TestCloudLoggedInWithScriptToken", func(t *testing.T) {
+		t.Parallel()
+
+		script := `
+		export let options = {
+			cloud: {
+				token: "asdf",
+				name: "my load test",
+				projectID: 124,
+				note: 124,
+			}
+		};
+		export default function() {};
+	`
+
+		ts := getSimpleCloudTestState(t, []byte(script), setupCmd, nil, nil)
+		delete(ts.Env, "K6_CLOUD_TOKEN")
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.NotContains(t, stdout, `not logged in`)
+		assert.Contains(t, stdout, `execution: cloud`)
+		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
+		assert.Contains(t, stdout, `test status: Finished`)
+	})
+
+	t.Run("TestCloudExitOnRunning", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"},
+			v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `execution: cloud`)
+		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
+		assert.Contains(t, stdout, `test status: Running`)
+	})
+
+	t.Run("TestCloudExitOnRunningEnv", func(t *testing.T) {
+		t.Parallel()
+
+		// Same as TestCloudExitOnRunning, but driven by the environment
+		// variable instead of the CLI flag. Without the override taking
+		// effect, the command would keep polling the mock server forever,
+		// since its progress is always "Running".
+		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--log-output=stdout"},
+			v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
+		ts.Env["K6_EXIT_ON_RUNNING"] = "true"
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `execution: cloud`)
+		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
+		assert.Contains(t, stdout, `test status: Running`)
+	})
+
+	t.Run("TestCloudExitOnRunningFlagOverridesEnv", func(t *testing.T) {
+		t.Parallel()
+
+		// An explicitly set CLI flag takes precedence over the environment
+		// variable. If the "false" from the environment won instead, the
+		// command would poll the always-"Running" mock server forever.
+		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"},
+			v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
+		ts.Env["K6_EXIT_ON_RUNNING"] = "false"
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `test status: Running`)
+	})
+
+	t.Run("TestCloudExitOnRunningInvalidEnv", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+		ts.Env["K6_EXIT_ON_RUNNING"] = "invalid"
+		ts.ExpectedExitCode = -1
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `parsing K6_EXIT_ON_RUNNING returned an error`)
+	})
+
+	t.Run("TestCloudURLFromStartResponse", func(t *testing.T) {
+		t.Parallel()
+
+		// v6 returns the run URL in the start response (no ConfigOverride).
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, "execution: cloud")
+		assert.Contains(t, stdout, "output: https://stack.grafana.com/a/k6-app/runs/123")
+		assert.Contains(t, stdout, `test status: Finished`)
+	})
+
+	t.Run("TestCloudThresholdsHaveFailed", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
+			v6test.Progress(cloudapiv6.StatusCompleted, cloudapiv6.ResultFailed))
+		ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `Thresholds have been crossed`)
+	})
+
+	t.Run("TestCloudAbortedThreshold", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
+			v6test.Progress(cloudapiv6.StatusAborted, cloudapiv6.ResultFailed))
+		ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `Thresholds have been crossed`)
+	})
+
+	t.Run("TestCloudAbortedByUser", func(t *testing.T) {
+		t.Parallel()
+
+		ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
+			v6test.AbortedByUserProgress("user@example.com"))
+		ts.ExpectedExitCode = int(exitcodes.CloudTestRunFailed)
+
+		cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+		stdout := ts.Stdout.String()
+		t.Log(stdout)
+		assert.Contains(t, stdout, `test status: Aborted (by user)`)
+	})
 }
 
 func cloudTestStartSimple(tb testing.TB, testRunID int) http.Handler {

--- a/internal/cmd/tests/cmd_cloud_test.go
+++ b/internal/cmd/tests/cmd_cloud_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"go.k6.io/k6/v2/errext/exitcodes"
 	cloudapiv6 "go.k6.io/k6/v2/internal/cloudapi/v6"
 	"go.k6.io/k6/v2/internal/cloudapi/v6/v6test"
 	"go.k6.io/k6/v2/internal/cmd"
@@ -32,12 +31,24 @@ func TestCloudNoArgsShowsHelp(t *testing.T) {
 type setupCommandFunc func(cliFlags []string) []string
 
 func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
-	t.Run("TestCloudUserNotAuthenticated", func(t *testing.T) {
+	//t.Run("TestCloudUserNotAuthenticated", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+	//	delete(ts.Env, "K6_CLOUD_TOKEN")
+	//	ts.ExpectedExitCode = -1 // TODO: use a more specific exit code?
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.Contains(t, stdout, `access token not configured`)
+	//})
+
+	t.Run("TestCloudInvalidToken", func(t *testing.T) {
 		t.Parallel()
 
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
-		delete(ts.Env, "K6_CLOUD_TOKEN")
-		ts.ExpectedExitCode = -1 // TODO: use a more specific exit code?
+		ts := getSimpleCloudTestStateWithError(t, nil, setupCmd, nil, nil, 401)
+		ts.ExpectedExitCode = -1
 		cmd.ExecuteWithGlobalState(ts.GlobalState)
 
 		stdout := ts.Stdout.String()
@@ -45,176 +56,176 @@ func runCloudTests(t *testing.T, setupCmd setupCommandFunc) {
 		assert.Contains(t, stdout, `access token not configured`)
 	})
 
-	t.Run("TestCloudStackNotConfigured", func(t *testing.T) {
-		t.Parallel()
-
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
-		delete(ts.Env, "K6_CLOUD_STACK_ID")
-		ts.ExpectedExitCode = -1
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, `stack ID not configured`)
-	})
-
-	// TODO: Remove after we remove K6_CLOUD_HOST_V6.
-	t.Run("TestCloudV6ClientUsesV6Host", func(t *testing.T) {
-		t.Parallel()
-
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
-		ts.Env["K6_CLOUD_HOST"] = "http://wrong-host"
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		require.NotContains(t, stdout, "wrong-host", "v6 client should use K6_CLOUD_HOST_V6, not K6_CLOUD_HOST")
-	})
-
-	t.Run("TestCloudLoggedInWithScriptToken", func(t *testing.T) {
-		t.Parallel()
-
-		script := `
-		export let options = {
-			cloud: {
-				token: "asdf",
-				name: "my load test",
-				projectID: 124,
-				note: 124,
-			}
-		};
-		export default function() {};
-	`
-
-		ts := getSimpleCloudTestState(t, []byte(script), setupCmd, nil, nil)
-		delete(ts.Env, "K6_CLOUD_TOKEN")
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.NotContains(t, stdout, `not logged in`)
-		assert.Contains(t, stdout, `execution: cloud`)
-		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
-		assert.Contains(t, stdout, `test status: Finished`)
-	})
-
-	t.Run("TestCloudExitOnRunning", func(t *testing.T) {
-		t.Parallel()
-
-		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"},
-			v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, `execution: cloud`)
-		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
-		assert.Contains(t, stdout, `test status: Running`)
-	})
-
-	t.Run("TestCloudExitOnRunningEnv", func(t *testing.T) {
-		t.Parallel()
-
-		// Same as TestCloudExitOnRunning, but driven by the environment
-		// variable instead of the CLI flag. Without the override taking
-		// effect, the command would keep polling the mock server forever,
-		// since its progress is always "Running".
-		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--log-output=stdout"},
-			v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
-		ts.Env["K6_EXIT_ON_RUNNING"] = "true"
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, `execution: cloud`)
-		assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
-		assert.Contains(t, stdout, `test status: Running`)
-	})
-
-	t.Run("TestCloudExitOnRunningFlagOverridesEnv", func(t *testing.T) {
-		t.Parallel()
-
-		// An explicitly set CLI flag takes precedence over the environment
-		// variable. If the "false" from the environment won instead, the
-		// command would poll the always-"Running" mock server forever.
-		ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"},
-			v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
-		ts.Env["K6_EXIT_ON_RUNNING"] = "false"
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, `test status: Running`)
-	})
-
-	t.Run("TestCloudExitOnRunningInvalidEnv", func(t *testing.T) {
-		t.Parallel()
-
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
-		ts.Env["K6_EXIT_ON_RUNNING"] = "invalid"
-		ts.ExpectedExitCode = -1
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, `parsing K6_EXIT_ON_RUNNING returned an error`)
-	})
-
-	t.Run("TestCloudURLFromStartResponse", func(t *testing.T) {
-		t.Parallel()
-
-		// v6 returns the run URL in the start response (no ConfigOverride).
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, "execution: cloud")
-		assert.Contains(t, stdout, "output: https://stack.grafana.com/a/k6-app/runs/123")
-		assert.Contains(t, stdout, `test status: Finished`)
-	})
-
-	t.Run("TestCloudThresholdsHaveFailed", func(t *testing.T) {
-		t.Parallel()
-
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
-			v6test.Progress(cloudapiv6.StatusCompleted, cloudapiv6.ResultFailed))
-		ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
-
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, `Thresholds have been crossed`)
-	})
-
-	t.Run("TestCloudAbortedThreshold", func(t *testing.T) {
-		t.Parallel()
-
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
-			v6test.Progress(cloudapiv6.StatusAborted, cloudapiv6.ResultFailed))
-		ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
-
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, `Thresholds have been crossed`)
-	})
-
-	t.Run("TestCloudAbortedByUser", func(t *testing.T) {
-		t.Parallel()
-
-		ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
-			v6test.AbortedByUserProgress("user@example.com"))
-		ts.ExpectedExitCode = int(exitcodes.CloudTestRunFailed)
-
-		cmd.ExecuteWithGlobalState(ts.GlobalState)
-
-		stdout := ts.Stdout.String()
-		t.Log(stdout)
-		assert.Contains(t, stdout, `test status: Aborted (by user)`)
-	})
+	//t.Run("TestCloudStackNotConfigured", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+	//	delete(ts.Env, "K6_CLOUD_STACK_ID")
+	//	ts.ExpectedExitCode = -1
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.Contains(t, stdout, `stack ID not configured`)
+	//})
+	//
+	//// TODO: Remove after we remove K6_CLOUD_HOST_V6.
+	//t.Run("TestCloudV6ClientUsesV6Host", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+	//	ts.Env["K6_CLOUD_HOST"] = "http://wrong-host"
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	require.NotContains(t, stdout, "wrong-host", "v6 client should use K6_CLOUD_HOST_V6, not K6_CLOUD_HOST")
+	//})
+	//
+	//t.Run("TestCloudLoggedInWithScriptToken", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	script := `
+	//	export let options = {
+	//		cloud: {
+	//			token: "asdf",
+	//			name: "my load test",
+	//			projectID: 124,
+	//			note: 124,
+	//		}
+	//	};
+	//	export default function() {};
+	//`
+	//
+	//	ts := getSimpleCloudTestState(t, []byte(script), setupCmd, nil, nil)
+	//	delete(ts.Env, "K6_CLOUD_TOKEN")
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.NotContains(t, stdout, `not logged in`)
+	//	assert.Contains(t, stdout, `execution: cloud`)
+	//	assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
+	//	assert.Contains(t, stdout, `test status: Finished`)
+	//})
+	//
+	//t.Run("TestCloudExitOnRunning", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"},
+	//		v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.Contains(t, stdout, `execution: cloud`)
+	//	assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
+	//	assert.Contains(t, stdout, `test status: Running`)
+	//})
+	//
+	//t.Run("TestCloudExitOnRunningEnv", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	// Same as TestCloudExitOnRunning, but driven by the environment
+	//	// variable instead of the CLI flag. Without the override taking
+	//	// effect, the command would keep polling the mock server forever,
+	//	// since its progress is always "Running".
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--log-output=stdout"},
+	//		v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
+	//	ts.Env["K6_EXIT_ON_RUNNING"] = "true"
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.Contains(t, stdout, `execution: cloud`)
+	//	assert.Contains(t, stdout, `output: https://stack.grafana.com/a/k6-app/runs/123`)
+	//	assert.Contains(t, stdout, `test status: Running`)
+	//})
+	//
+	//t.Run("TestCloudExitOnRunningFlagOverridesEnv", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	// An explicitly set CLI flag takes precedence over the environment
+	//	// variable. If the "false" from the environment won instead, the
+	//	// command would poll the always-"Running" mock server forever.
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, []string{"--exit-on-running", "--log-output=stdout"},
+	//		v6test.Progress(cloudapiv6.StatusRunning, v6test.ResultNone))
+	//	ts.Env["K6_EXIT_ON_RUNNING"] = "false"
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.Contains(t, stdout, `test status: Running`)
+	//})
+	//
+	//t.Run("TestCloudExitOnRunningInvalidEnv", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+	//	ts.Env["K6_EXIT_ON_RUNNING"] = "invalid"
+	//	ts.ExpectedExitCode = -1
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.Contains(t, stdout, `parsing K6_EXIT_ON_RUNNING returned an error`)
+	//})
+	//
+	//t.Run("TestCloudURLFromStartResponse", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	// v6 returns the run URL in the start response (no ConfigOverride).
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil, nil)
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.Contains(t, stdout, "execution: cloud")
+	//	assert.Contains(t, stdout, "output: https://stack.grafana.com/a/k6-app/runs/123")
+	//	assert.Contains(t, stdout, `test status: Finished`)
+	//})
+	//
+	//t.Run("TestCloudThresholdsHaveFailed", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
+	//		v6test.Progress(cloudapiv6.StatusCompleted, cloudapiv6.ResultFailed))
+	//	ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
+	//
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.Contains(t, stdout, `Thresholds have been crossed`)
+	//})
+	//
+	//t.Run("TestCloudAbortedThreshold", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
+	//		v6test.Progress(cloudapiv6.StatusAborted, cloudapiv6.ResultFailed))
+	//	ts.ExpectedExitCode = int(exitcodes.ThresholdsHaveFailed)
+	//
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.Contains(t, stdout, `Thresholds have been crossed`)
+	//})
+	//
+	//t.Run("TestCloudAbortedByUser", func(t *testing.T) {
+	//	t.Parallel()
+	//
+	//	ts := getSimpleCloudTestState(t, nil, setupCmd, nil,
+	//		v6test.AbortedByUserProgress("user@example.com"))
+	//	ts.ExpectedExitCode = int(exitcodes.CloudTestRunFailed)
+	//
+	//	cmd.ExecuteWithGlobalState(ts.GlobalState)
+	//
+	//	stdout := ts.Stdout.String()
+	//	t.Log(stdout)
+	//	assert.Contains(t, stdout, `test status: Aborted (by user)`)
+	//})
 }
 
 func cloudTestStartSimple(tb testing.TB, testRunID int) http.Handler {
@@ -232,7 +243,21 @@ func cloudTestStartSimple(tb testing.TB, testRunID int) http.Handler {
 	})
 }
 
-func getSimpleCloudTestState(t *testing.T, script []byte, setupCmd setupCommandFunc, cliFlags []string, progressCallback func() *cloudapiv6.TestProgress) *GlobalTestState {
+func getSimpleCloudTestState(
+	t *testing.T, script []byte, setupCmd setupCommandFunc, cliFlags []string,
+	progressCallback func() *cloudapiv6.TestProgress,
+) *GlobalTestState {
+	return getSimpleCloudTestStateWithError(t, script, setupCmd, cliFlags, progressCallback, 0)
+}
+
+// getSimpleCloudTestStateWithError is getSimpleCloudTestState plus the
+// ability to make the mock v6 API fail every request with errorStatus (e.g.
+// http.StatusUnauthorized), for testing how the CLI surfaces a failing
+// cloud API call to the user.
+func getSimpleCloudTestStateWithError(
+	t *testing.T, script []byte, setupCmd setupCommandFunc, cliFlags []string,
+	progressCallback func() *cloudapiv6.TestProgress, errorStatus int,
+) *GlobalTestState {
 	if script == nil {
 		script = []byte("export let options = { cloud: { projectID: 1 } };\nexport default function() {}")
 	}
@@ -243,6 +268,7 @@ func getSimpleCloudTestState(t *testing.T, script []byte, setupCmd setupCommandF
 
 	srv := v6test.NewServer(t, v6test.Config{
 		ProgressCallback: progressCallback,
+		ErrorStatus:      errorStatus,
 	})
 
 	ts := NewGlobalTestState(t)


### PR DESCRIPTION
## What?
- Adds a hint to the error output when a cloud request failed with 401 in the v6 client:
<img width="884" height="224" alt="image" src="https://github.com/user-attachments/assets/b93abba0-a7b1-4f1e-9491-c0502f760581" />

- Adjusted v6 test server with ability to return errors to enable testing.

### Tradeoffs
Hint is also visible when cloud login fails (redundant). Accepted for simplicity.
<img width="863" height="327" alt="image" src="https://github.com/user-attachments/assets/22ff649b-70b7-4d8c-b197-d3194391d5dc" />

## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Related PR(s)/Issue(s)

Closes #5874 
