### PR TITLE
feat(js): propagate metric context through promise reactions

### DIFF
--- a/examples/async_metric_context.js
+++ b/examples/async_metric_context.js
@@ -1,0 +1,63 @@
+// Run with:
+// k6 run --features async-metric-context examples/async_metric_context.js
+
+import { check } from 'k6';
+import exec from 'k6/execution';
+import { Counter } from 'k6/metrics';
+
+const callbackPhases = new Counter('callback_phases');
+
+export const options = {
+  iterations: 1,
+  thresholds: {
+    callback_phases: ['count == 6'],
+    checks: ['rate == 1'],
+  },
+};
+
+function setContext(owner, phase) {
+  exec.vu.metrics.tags.owner = owner;
+  exec.vu.metrics.tags.phase = phase;
+  exec.vu.metrics.metadata.trace = owner;
+  exec.vu.metrics.metadata.step = phase;
+}
+
+function contextMatches(owner, phase) {
+  return exec.vu.metrics.tags.owner === owner
+    && exec.vu.metrics.tags.phase === phase
+    && exec.vu.metrics.metadata.trace === owner
+    && exec.vu.metrics.metadata.step === phase;
+}
+
+export default async function () {
+  let releaseAlpha;
+  let releaseBeta;
+  const alphaGate = new Promise(resolve => { releaseAlpha = resolve; });
+  const betaGate = new Promise(resolve => { releaseBeta = resolve; });
+
+  const register = (owner, gate) => {
+    setContext(owner, 'registered');
+    return gate.then(async () => {
+      for (const phase of ['first', 'second', 'third']) {
+        setContext(owner, phase);
+        await Promise.resolve();
+        callbackPhases.add(1);
+        check(null, {
+          [`${owner}:${phase} kept its context`]: () => contextMatches(owner, phase),
+        });
+      }
+    });
+  };
+
+  const alpha = register('alpha', alphaGate);
+  const beta = register('beta', betaGate);
+
+  setContext('root', 'waiting');
+  releaseBeta();
+  releaseAlpha();
+  await Promise.all([alpha, beta]);
+
+  check(null, {
+    'the awaiting context was restored': () => contextMatches('root', 'waiting'),
+  });
+}

--- a/internal/cmd/tests/cmd_run_async_context_test.go
+++ b/internal/cmd/tests/cmd_run_async_context_test.go
@@ -1,0 +1,58 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/lib/fsext"
+)
+
+func TestRunAsyncMetricContextWithoutK6Module(t *testing.T) {
+	t.Parallel()
+
+	script := `
+		import exec from 'k6/execution';
+		import { Counter } from 'k6/metrics';
+
+		const callbackPhases = new Counter('callback_phases');
+		const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+		export default function () {
+			let release;
+			const gate = new Promise(resolve => { release = resolve; });
+			exec.vu.metrics.tags.owner = 'registered';
+			exec.vu.metrics.metadata.trace = 'registered';
+			const pending = gate.then(async () => {
+				for (const phase of ['first', 'second', 'third']) {
+					exec.vu.metrics.tags.phase = phase;
+					exec.vu.metrics.metadata.step = phase;
+					if (phase === 'second') {
+						await delay(0);
+					} else {
+						await Promise.resolve();
+					}
+					callbackPhases.add(1, {phase_name: phase});
+				}
+			});
+			exec.vu.metrics.tags.owner = 'root';
+			exec.vu.metrics.metadata.trace = 'root';
+			release();
+			return pending;
+		}
+	`
+
+	ts := getSingleFileTestState(t, script,
+		[]string{"--features", "async-metric-context", "--out", "json=results.json", "--summary-mode=disabled"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	results, err := fsext.ReadFile(ts.FS, "results.json")
+	require.NoError(t, err)
+	for _, phase := range []string{"first", "second", "third"} {
+		assert.Equal(t, []float64{1}, getSampleValuesWithMetadata(t, results, "callback_phases", map[string]string{
+			"owner": "registered", "phase": phase, "phase_name": phase,
+		}, map[string]string{"trace": "registered", "step": phase}))
+	}
+}

--- a/internal/cmd/tests/cmd_run_test.go
+++ b/internal/cmd/tests/cmd_run_test.go
@@ -1603,14 +1603,23 @@ func TestMetricTagAndSetupDataIsolation(t *testing.T) {
 }
 
 func getSampleValues(t *testing.T, jsonOutput []byte, metric string, tags map[string]string) []float64 {
+	return getSampleValuesWithMetadata(t, jsonOutput, metric, tags, nil)
+}
+
+func getSampleValuesWithMetadata(
+	t *testing.T, jsonOutput []byte, metric string, tags, metadata map[string]string,
+) []float64 {
 	jsonLines := bytes.Split(jsonOutput, []byte("\n"))
 	result := []float64{}
 
-	tagsMatch := func(rawTags any) bool {
-		sampleTags, ok := rawTags.(map[string]any)
+	valuesMatch := func(rawValues any, expected map[string]string) bool {
+		if len(expected) == 0 {
+			return true
+		}
+		sampleValues, ok := rawValues.(map[string]any)
 		require.True(t, ok)
-		for k, v := range tags {
-			rv, sok := sampleTags[k]
+		for k, v := range expected {
+			rv, sok := sampleValues[k]
 			if !sok {
 				return false
 			}
@@ -1642,7 +1651,7 @@ func getSampleValues(t *testing.T, jsonOutput []byte, metric string, tags map[st
 		sampleData, ok := line["data"].(map[string]any)
 		require.True(t, ok)
 
-		if !tagsMatch(sampleData["tags"]) {
+		if !valuesMatch(sampleData["tags"], tags) || !valuesMatch(sampleData["metadata"], metadata) {
 			continue
 		}
 

--- a/internal/features/features.go
+++ b/internal/features/features.go
@@ -41,11 +41,12 @@ func (l Lifecycle) String() string {
 
 // Flags declares every feature flag as a tagged bool field.
 type Flags struct {
-	NativeHistograms bool `lifecycle:"experimental" help:"Use native histograms for trend metrics"`
-	MergeRunTags     bool `lifecycle:"experimental" help:"Merge run tags across config layers instead of replacing"`
-	FreezeEnv        bool `lifecycle:"experimental" help:"Freeze __ENV object to prevent modifications from JS code"`
-	_                noCopy
-	activated        []string
+	NativeHistograms   bool `lifecycle:"experimental" help:"Use native histograms for trend metrics"`
+	MergeRunTags       bool `lifecycle:"experimental" help:"Merge run tags across config layers instead of replacing"`
+	FreezeEnv          bool `lifecycle:"experimental" help:"Freeze __ENV object to prevent modifications from JS code"`
+	AsyncMetricContext bool `lifecycle:"experimental" help:"Propagate metric context through asynchronous operations"`
+	_                  noCopy
+	activated          []string
 }
 
 // Activated returns a copy of the sorted canonical names of active features.

--- a/internal/js/bundle.go
+++ b/internal/js/bundle.go
@@ -266,6 +266,9 @@ func (b *Bundle) Instantiate(ctx context.Context, vuID uint64) (*BundleInstance,
 			local:  event.NewEventSystem(100, b.preInitState.Logger),
 		},
 	}
+	if b.preInitState.FeatureFlags != nil && b.preInitState.FeatureFlags.AsyncMetricContext {
+		vuImpl.runtime.SetAsyncContextTracker(common.NewMetricContextTracker(vuImpl.State))
+	}
 	vuImpl.eventLoop = eventloop.New(vuImpl)
 	bi, err := b.instantiate(vuImpl, vuID)
 	if err != nil {

--- a/internal/js/runner.go
+++ b/internal/js/runner.go
@@ -247,6 +247,7 @@ func (r *Runner) newVU(
 		Samples:        vu.Samples,
 		Tags:           lib.NewVUStateTags(vu.Runner.RunTags),
 		BuiltinMetrics: r.preInitState.BuiltinMetrics,
+		FeatureFlags:   r.preInitState.FeatureFlags,
 		TracerProvider: r.preInitState.TracerProvider,
 		Usage:          r.preInitState.Usage,
 		TestStatus:     r.preInitState.TestStatus,

--- a/js/common/metriccontext.go
+++ b/js/common/metriccontext.go
@@ -1,0 +1,117 @@
+package common
+
+import (
+	"github.com/grafana/sobek"
+
+	"go.k6.io/k6/v2/lib"
+	"go.k6.io/k6/v2/metrics"
+)
+
+// metricContextTracker propagates metric context through promise reactions, including await
+// continuations. Promise reactions do not nest and run on the event-loop goroutine.
+type metricContextTracker struct {
+	state   func() *lib.State
+	restore func()
+}
+
+// CapturedMetricContext is an immutable registration-time metric context. Its zero value is a
+// disabled context, so callers don't need separate feature-flag or nil-state branches.
+type CapturedMetricContext struct {
+	state       *lib.State
+	tagsAndMeta metrics.TagsAndMeta
+}
+
+var _ sobek.AsyncContextTracker = (*metricContextTracker)(nil)
+
+// NewMetricContextTracker returns an async-context tracker backed by the current VU state.
+func NewMetricContextTracker(state func() *lib.State) sobek.AsyncContextTracker {
+	return &metricContextTracker{state: state}
+}
+
+// Grab captures the metric context when a promise reaction is created.
+func (t *metricContextTracker) Grab() any {
+	state := t.state()
+	if state == nil || state.Tags == nil {
+		return nil
+	}
+	return state.Tags.GetCurrentValues()
+}
+
+// Resumed applies the context captured for a promise reaction.
+func (t *metricContextTracker) Resumed(trackingObject any) {
+	captured, ok := trackingObject.(metrics.TagsAndMeta)
+	state := t.state()
+	if !ok || state == nil || state.Tags == nil {
+		t.restore = nil
+		return
+	}
+	t.restore = ApplyMetricContext(state, captured)
+}
+
+// Exited restores the context that was active before the promise reaction ran.
+func (t *metricContextTracker) Exited() {
+	if t.restore != nil {
+		t.restore()
+		t.restore = nil
+	}
+}
+
+// AsyncMetricContextEnabled reports whether asynchronous metric-context propagation is enabled.
+func AsyncMetricContextEnabled(state *lib.State) bool {
+	return state != nil && state.FeatureFlags != nil && state.FeatureFlags.AsyncMetricContext
+}
+
+// CaptureMetricContext captures the current tags and metadata for work that will run outside
+// Sobek's promise machinery.
+func CaptureMetricContext(state *lib.State) CapturedMetricContext {
+	if !AsyncMetricContextEnabled(state) || state.Tags == nil {
+		return CapturedMetricContext{}
+	}
+	return CapturedMetricContext{state: state, tagsAndMeta: state.Tags.GetCurrentValues()}
+}
+
+// Enter installs a clone of the captured context and returns a function that restores the context
+// it interrupted. Entering a disabled context is a no-op.
+func (c CapturedMetricContext) Enter() (restore func()) {
+	if c.state == nil {
+		return func() {}
+	}
+	return ApplyMetricContext(c.state, c.tagsAndMeta)
+}
+
+// RunWithMetricContext executes fn under captured and supports callbacks that return a value.
+func RunWithMetricContext[T any](captured CapturedMetricContext, fn func() (T, error)) (T, error) {
+	if captured.state == nil {
+		return fn()
+	}
+	restore := captured.Enter()
+	defer restore()
+	return fn()
+}
+
+// WrapSobekCallable captures invocation under c while preserving the callable's arguments and
+// return value.
+func (c CapturedMetricContext) WrapSobekCallable(fn sobek.Callable) sobek.Callable {
+	if fn == nil || c.state == nil {
+		return fn
+	}
+	return func(this sobek.Value, args ...sobek.Value) (sobek.Value, error) {
+		return RunWithMetricContext(c, func() (sobek.Value, error) {
+			return fn(this, args...)
+		})
+	}
+}
+
+// ApplyMetricContext replaces the current tags and metadata until the returned function restores
+// them. Both assignments clone metadata so mutations cannot change a reusable captured snapshot.
+func ApplyMetricContext(state *lib.State, captured metrics.TagsAndMeta) (restore func()) {
+	previous := state.Tags.GetCurrentValues()
+	state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
+		*tagsAndMeta = captured.Clone()
+	})
+	return func() {
+		state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
+			*tagsAndMeta = previous
+		})
+	}
+}

--- a/js/common/metriccontext_test.go
+++ b/js/common/metriccontext_test.go
@@ -1,0 +1,131 @@
+package common
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"go.k6.io/k6/v2/internal/features"
+	"go.k6.io/k6/v2/lib"
+	"go.k6.io/k6/v2/metrics"
+)
+
+func newMetricContextState(enabled bool) *lib.State {
+	registry := metrics.NewRegistry()
+	return &lib.State{
+		FeatureFlags: &features.Flags{AsyncMetricContext: enabled},
+		Tags: lib.NewVUStateTags(
+			registry.RootTagSet().WithTagsFromMap(map[string]string{"group": lib.RootGroupPath}),
+		),
+	}
+}
+
+func setMetricContext(state *lib.State, group, phase, trace string) {
+	state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
+		tagsAndMeta.SetTag("group", group)
+		tagsAndMeta.SetTag("phase", phase)
+		tagsAndMeta.SetMetadata("trace", trace)
+	})
+}
+
+func requireMetricContext(t *testing.T, state *lib.State, group, phase, trace string) {
+	t.Helper()
+	current := state.Tags.GetCurrentValues()
+	actualGroup, _ := current.Tags.Get("group")
+	actualPhase, _ := current.Tags.Get("phase")
+	require.Equal(t, group, actualGroup)
+	require.Equal(t, phase, actualPhase)
+	require.Equal(t, trace, current.Metadata["trace"])
+}
+
+func TestCapturedMetricContext(t *testing.T) {
+	t.Parallel()
+
+	state := newMetricContextState(true)
+	setMetricContext(state, "::registered", "registered", "registered")
+	captured := CaptureMetricContext(state)
+	setMetricContext(state, "::active", "active", "active")
+
+	restore := captured.Enter()
+	requireMetricContext(t, state, "::registered", "registered", "registered")
+	setMetricContext(state, "::callback", "callback", "callback")
+	restore()
+	requireMetricContext(t, state, "::active", "active", "active")
+
+	// A reusable snapshot must not retain mutations from its previous invocation.
+	restore = captured.Enter()
+	requireMetricContext(t, state, "::registered", "registered", "registered")
+	restore()
+}
+
+func TestCapturedMetricContextDisabled(t *testing.T) {
+	t.Parallel()
+
+	state := newMetricContextState(false)
+	setMetricContext(state, "::registered", "registered", "registered")
+	captured := CaptureMetricContext(state)
+	setMetricContext(state, "::active", "active", "active")
+
+	restore := captured.Enter()
+	requireMetricContext(t, state, "::active", "active", "active")
+	setMetricContext(state, "::callback", "callback", "callback")
+	restore()
+	requireMetricContext(t, state, "::callback", "callback", "callback")
+}
+
+func TestRunWithMetricContext(t *testing.T) {
+	t.Parallel()
+
+	state := newMetricContextState(true)
+	setMetricContext(state, "::registered", "registered", "registered")
+	captured := CaptureMetricContext(state)
+	setMetricContext(state, "::active", "active", "active")
+
+	value, err := RunWithMetricContext(captured, func() (string, error) {
+		requireMetricContext(t, state, "::registered", "registered", "registered")
+		setMetricContext(state, "::callback", "callback", "callback")
+		return "result", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, "result", value)
+	requireMetricContext(t, state, "::active", "active", "active")
+}
+
+func TestMetricContextTracker(t *testing.T) {
+	t.Parallel()
+
+	state := newMetricContextState(true)
+	tracker := NewMetricContextTracker(func() *lib.State { return state })
+	setMetricContext(state, "::registered", "registered", "registered")
+	captured := tracker.Grab()
+	setMetricContext(state, "::active", "active", "active")
+
+	tracker.Resumed(captured)
+	requireMetricContext(t, state, "::registered", "registered", "registered")
+	setMetricContext(state, "::callback", "callback", "callback")
+	tracker.Exited()
+	requireMetricContext(t, state, "::active", "active", "active")
+}
+
+func BenchmarkCapturedMetricContext(b *testing.B) {
+	for _, metadataEntries := range []int{0, 4} {
+		b.Run(strconv.Itoa(metadataEntries)+"_metadata", func(b *testing.B) {
+			state := newMetricContextState(true)
+			state.Tags.Modify(func(tagsAndMeta *metrics.TagsAndMeta) {
+				tagsAndMeta.SetTag("phase", "registered")
+				for i := range metadataEntries {
+					tagsAndMeta.SetMetadata(string(rune('a'+i)), "value")
+				}
+			})
+			captured := CaptureMetricContext(state)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				restore := captured.Enter()
+				restore()
+			}
+		})
+	}
+}

--- a/lib/vu_state.go
+++ b/lib/vu_state.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/time/rate"
 
+	"go.k6.io/k6/v2/internal/features"
 	"go.k6.io/k6/v2/internal/usage"
 	"go.k6.io/k6/v2/metrics"
 )
@@ -49,6 +50,7 @@ type State struct {
 	// TestPreInitState. The Samples channel might also benefit from that...
 	Options        Options
 	BuiltinMetrics *metrics.BuiltinMetrics
+	FeatureFlags   *features.Flags
 
 	// Logger instance for every VU.
 	Logger logrus.FieldLogger


### PR DESCRIPTION
## What?

> **Stack 1 of 6**
>
> Base: `master`
>
> Head: `feature/async-context`
>
> The next PR will target this branch and add async `group()` support.

This PR adds the opt-in, experimental `async-metric-context` feature and the runtime foundation used
by the rest of the stack. When enabled, tags and metadata behave as async-local metric context across
Sobek Promise reactions, including `await` continuations and `.then()`, `.catch()`, and `.finally()`
handlers.

The implementation:

- installs a Sobek `AsyncContextTracker` when each VU runtime is created, before setup, teardown, or
  iteration code can queue Promise reactions;
- captures the complete `TagsAndMeta` value when a reaction is registered;
- applies a cloned snapshot while that reaction runs and restores the interrupted context when it
  exits;
- adds common capture, apply, and callback-wrapping helpers for module callbacks that enter
  JavaScript outside Sobek's Promise machinery;
- makes feature flags available from the VU state; and
- keeps the entire path disabled unless `async-metric-context` is enabled through `--features`,
  `K6_FEATURES`, or the JSON features configuration.

The example demonstrates two interleaved Promise chains mutating tags and metadata independently
across several `await` boundaries.

The context-application microbenchmark measured
84.60 ns/op, 32 B/op, and one allocation without metadata, and 480.0 ns/op, 704 B/op, and five
allocations with four metadata entries, over five one-second runs with `GOMAXPROCS=1`.

## Why?

k6 currently stores the active metric tags and metadata as mutable VU state. That works while
JavaScript is synchronous, but a Promise continuation runs after the stack that registered it has
returned. By then, another group or callback may have changed the VU's live context, so metrics are
attributed according to incidental scheduling rather than the logical operation that created the
continuation.

This is broader than the `group` system tag described in #2728. User tags and metadata have the same
lifetime problem, and later PRs need the same semantics for timers and protocol callbacks. Providing
one complete metric-context abstraction avoids implementing subtly different group-only behavior in
each module.

It is feature-gated because isolating
callback-local tag and metadata mutations changes the current global-mutation behavior, and every
Promise reaction gains snapshot/apply work while the feature is enabled.

Alternatives considered:

- The earlier #2863 approach attached tracker state directly to `group()`. That was narrower, did not
  generally cover ordinary Promise reactions, and could not serve other async APIs.
- Propagating only the `group` tag would be cheaper, but would leave custom tags and metadata
  timing-dependent and require a second mechanism later.
- Wrapping Promise-producing APIs one by one would miss user-created Promise chains and `await`
  continuations.
- Exposing the TC39 Async Context proposal directly remains a possible future direction. This PR uses
  Sobek's internal tracker to provide metric-context semantics; it does not add a public JavaScript
  `AsyncContext` API or claim full conformance with that proposal.

## Checklist

<!--
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _TBD for the complete experimental stack_
- [ ] I have updated or added an issue to the
  [k6-documentation](https://github.com/grafana/k6-docs): _TBD after the experimental behavior is
  approved_
- [x] I have updated or added an issue to the
  [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6):
  _not applicable; this foundation adds no JavaScript API surface_

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

- [`group` doesn't work with async calls well (#2728)](https://github.com/grafana/k6/issues/2728)
- [Try to use Sobek's `AsyncContextTracker` for async groups
  (#3392)](https://github.com/grafana/k6/issues/3392)
- [Design doc for supporting async code in groups (#5435), now
  closed](https://github.com/grafana/k6/issues/5435)
- [Implement AsyncContext via the TC39 standard for async groups
  (#5673)](https://github.com/grafana/k6/issues/5673)
- Earlier implementation attempt: [#2863](https://github.com/grafana/k6/pull/2863)

This foundation does not close the issues by itself. The following PRs apply it to `group()`, timers,
WebSocket listeners, gRPC listeners, and browser callbacks and metrics.

<!-- Thanks for your contribution! 🙏🏼 -->
