### PR TITLE
Fix sending duration with HTTPS proxies

### DIFF
--- a/lib/netext/httpext/tracer.go
+++ b/lib/netext/httpext/tracer.go
@@ -343,21 +343,10 @@ func (t *Tracer) Done() *Trail {
 	if tlsHandshakeDone != 0 && tlsHandshakeStart != 0 {
 		trail.TLSHandshaking = time.Duration(tlsHandshakeDone - tlsHandshakeStart)
 	}
+	if gotConn != 0 && wroteRequest > gotConn {
+		trail.Sending = time.Duration(wroteRequest - gotConn)
+	}
 	if wroteRequest != 0 {
-		switch {
-		case tlsHandshakeDone != 0:
-			// If the request was sent over TLS, we need to use
-			// TLS Handshake Done time to calculate sending duration
-			trail.Sending = time.Duration(wroteRequest - tlsHandshakeDone)
-		case connectDone != 0:
-			// Otherwise, use the end of the normal connection
-			trail.Sending = time.Duration(wroteRequest - connectDone)
-		default:
-			// Finally, this handles the strange HTTP/2 case where the GotConn() hook
-			// gets called first, but with Reused=false
-			trail.Sending = time.Duration(wroteRequest - gotConn)
-		}
-
 		if gotFirstResponseByte != 0 {
 			// We started receiving at least some response back
 

--- a/lib/netext/httpext/tracer_test.go
+++ b/lib/netext/httpext/tracer_test.go
@@ -236,8 +236,30 @@ func TestTracerNegativeHttpSendingValues(t *testing.T) {
 		builtinMetrics := metrics.RegisterBuiltinMetrics(registry)
 		trail.SaveSamples(builtinMetrics, &metrics.TagsAndMeta{Tags: registry.RootTagSet()})
 
-		require.True(t, trail.Sending > 0)
+		require.GreaterOrEqual(t, trail.Sending, time.Duration(0))
 	}
+}
+
+func TestTracerSendingStartsAtGotConn(t *testing.T) {
+	t.Parallel()
+
+	const interval = time.Millisecond
+	getConn := time.Now().Add(-5 * interval).UnixNano()
+	// With an HTTPS proxy and target, k6 keeps the first TLS handshake completion,
+	// which occurs before the target connection is available and GotConn() is called.
+	firstTLSHandshakeDone := getConn + int64(interval)
+	tracer := &Tracer{
+		getConn:              getConn,
+		tlsHandshakeDone:     firstTLSHandshakeDone,
+		gotConn:              firstTLSHandshakeDone + int64(2*interval),
+		wroteRequest:         firstTLSHandshakeDone + int64(3*interval),
+		gotFirstResponseByte: firstTLSHandshakeDone + int64(4*interval),
+	}
+
+	trail := tracer.Done()
+	assert.Equal(t, 3*interval, trail.Blocked)
+	assert.Equal(t, interval, trail.Sending)
+	assert.Equal(t, trail.EndTime.Sub(time.Unix(0, getConn)), trail.Blocked+trail.Duration)
 }
 
 func TestTracerError(t *testing.T) {


### PR DESCRIPTION
## What?

Fixes request timing metrics when an HTTPS proxy is used with an HTTPS target. `Sending` is now calculated from `GotConn` to `WroteRequest`, preventing it from overlapping with `Blocked`.

Unavailable or out-of-order timestamps produce a zero `Sending` duration.

A deterministic regression test covers the double-TLS event ordering. The existing negative-sending test also accepts zero for platforms with coarse clock resolution.

## Why?

When both the proxy connection and upstream connection use TLS, the previous `Sending` start time could be recorded before `GotConn`. This caused `Sending` to include time already accounted for by `Blocked`, producing incorrect request timing metrics.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [ ] I have run linter and tests locally (`make check`) and all pass.

Targeted lint, vet, tests, and build checks passed. The race-enabled test could not run because the local Windows C compiler does not support 64-bit builds.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

Closes #6317