### PR TITLE
Fix cleared timer callbacks and connecting WebSocket hangs

### DIFF
--- a/internal/js/modules/k6/websockets/websockets.go
+++ b/internal/js/modules/k6/websockets/websockets.go
@@ -95,8 +95,14 @@ type webSocket struct {
 	obj            *sobek.Object // the object that is given to js to interact with the WebSocket
 	started        time.Time
 
-	done         chan struct{}
-	writeQueueCh chan message
+	done          chan struct{}
+	writeQueueCh  chan message
+	connectCancel context.CancelFunc
+
+	connectionMu sync.Mutex
+	// pendingConnection and publishing conn are guarded by connectionMu. Once connected, it also
+	// orders successful writes before events for data that the peer can only send after that write.
+	pendingConnection net.Conn
 
 	eventListeners *eventListeners
 
@@ -145,6 +151,7 @@ func (r *WebSocketsAPI) websocket(c sobek.ConstructorCall) *sobek.Object {
 		}
 	}
 
+	connectionCtx, connectCancel := context.WithCancel(r.vu.Context())
 	w := &webSocket{
 		vu:              r.vu,
 		blobConstructor: r.blobConstructor,
@@ -154,6 +161,7 @@ func (r *WebSocketsAPI) websocket(c sobek.ConstructorCall) *sobek.Object {
 		builtinMetrics:  r.vu.State().BuiltinMetrics,
 		done:            make(chan struct{}),
 		writeQueueCh:    make(chan message),
+		connectCancel:   connectCancel,
 		eventListeners:  newEventListeners(),
 		obj:             rt.NewObject(),
 		tagsAndMeta:     params.tagsAndMeta,
@@ -164,7 +172,7 @@ func (r *WebSocketsAPI) websocket(c sobek.ConstructorCall) *sobek.Object {
 	// Maybe have this after the goroutine below ?!?
 	defineWebsocket(rt, w)
 
-	go w.establishConnection(params)
+	go w.establishConnection(connectionCtx, params)
 	return w.obj
 }
 
@@ -290,34 +298,19 @@ type message struct {
 }
 
 // documented https://websockets.spec.whatwg.org/#concept-websocket-establish
-func (w *webSocket) establishConnection(params *wsParams) {
+func (w *webSocket) establishConnection(ctx context.Context, params *wsParams) {
+	defer w.connectCancel()
+
 	state := w.vu.State()
 	w.started = time.Now()
-	var tlsConfig *tls.Config
-	if state.TLSConfig != nil {
-		tlsConfig = state.TLSConfig.Clone()
-		tlsConfig.NextProtos = []string{"http/1.1"}
-	}
-	// technically we have to do a fetch request here, so ... uh do normal one ;)
-	wsd := websocket.Dialer{
-		HandshakeTimeout: time.Second * 60, // TODO configurable
-		// Pass a custom net.DialContext function to websocket.Dialer that will substitute
-		// the underlying net.Conn with our own tracked netext.Conn
-		NetDialContext:    state.Dialer.DialContext,
-		Proxy:             http.ProxyFromEnvironment,
-		TLSClientConfig:   tlsConfig,
-		EnableCompression: params.enableCompression,
-		Subprotocols:      params.subprocotols,
-	}
-
-	// this is needed because of how interfaces work and that wsd.Jar is http.Cookiejar
-	if params.cookieJar != nil {
-		wsd.Jar = params.cookieJar
-	}
-
-	ctx := w.vu.Context()
+	handshakeDone := make(chan struct{})
+	go w.closePendingConnectionOnContextDone(ctx, handshakeDone)
 	start := time.Now()
-	conn, httpResponse, connErr := wsd.DialContext(ctx, w.url.String(), params.headers)
+	conn, httpResponse, connErr := w.dial(ctx, params)
+	w.connectionMu.Lock()
+	w.pendingConnection = nil
+	w.connectionMu.Unlock()
+	close(handshakeDone)
 	connectionEnd := time.Now()
 	connectionDuration := metrics.D(connectionEnd.Sub(start))
 
@@ -341,10 +334,8 @@ func (w *webSocket) establishConnection(params *wsParams) {
 		w.extensions = httpResponse.Header.Values("Sec-WebSocket-Extensions")
 		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagSubproto, w.protocol)
 	}
-	w.conn = conn
-
 	nameTagValue, nameTagManuallySet := params.tagsAndMeta.Tags.Get(metrics.TagName.String())
-	// After k6 v0.41.0, the `name` and `url` tags have the exact same values:
+	// After k6 v0.41.0, the name and URL tags have the same values.
 	if nameTagManuallySet {
 		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagURL, nameTagValue)
 	} else {
@@ -352,7 +343,8 @@ func (w *webSocket) establishConnection(params *wsParams) {
 		w.tagsAndMeta.SetSystemTagOrMetaIfEnabled(systemTags, metrics.TagName, w.url.String())
 	}
 
-	w.emitConnectionMetrics(ctx, start, connectionDuration)
+	//nolint:contextcheck // Handshake cancellation must not suppress connection metrics.
+	w.emitConnectionMetrics(w.vu.Context(), start, connectionDuration)
 	if connErr != nil {
 		// Pass the error to the user script before exiting immediately
 		w.tq.Queue(func() error {
@@ -361,10 +353,86 @@ func (w *webSocket) establishConnection(params *wsParams) {
 		w.tq.Close()
 		return
 	}
+
+	w.connectionMu.Lock()
+	if ctx.Err() != nil {
+		w.connectionMu.Unlock()
+		_ = conn.Close()
+		w.tq.Queue(func() error {
+			return w.connectionClosedWithError(ctx.Err())
+		})
+		w.tq.Close()
+		return
+	}
+	w.conn = conn
+	//nolint:contextcheck // An established connection is governed by the longer-lived VU context.
 	go w.loop()
+	w.connectionMu.Unlock()
 	w.tq.Queue(func() error {
 		return w.connectionConnected()
 	})
+}
+
+func (w *webSocket) dial(ctx context.Context, params *wsParams) (*websocket.Conn, *http.Response, error) {
+	state := w.vu.State()
+	var tlsConfig *tls.Config
+	if state.TLSConfig != nil {
+		tlsConfig = state.TLSConfig.Clone()
+		tlsConfig.NextProtos = []string{"http/1.1"}
+	}
+	// technically we have to do a fetch request here, so ... uh do normal one ;)
+	wsd := websocket.Dialer{
+		HandshakeTimeout: time.Second * 60, // TODO configurable
+		// Pass a custom net.DialContext function to websocket.Dialer that will substitute
+		// the underlying net.Conn with our own tracked netext.Conn
+		NetDialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			conn, err := state.Dialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+
+			w.connectionMu.Lock()
+			if ctx.Err() != nil {
+				w.connectionMu.Unlock()
+				_ = conn.Close()
+				return nil, ctx.Err()
+			}
+			w.pendingConnection = conn
+			w.connectionMu.Unlock()
+
+			return conn, nil
+		},
+		Proxy:             http.ProxyFromEnvironment,
+		TLSClientConfig:   tlsConfig,
+		EnableCompression: params.enableCompression,
+		Subprotocols:      params.subprocotols,
+	}
+
+	// this is needed because of how interfaces work and that wsd.Jar is http.Cookiejar
+	if params.cookieJar != nil {
+		wsd.Jar = params.cookieJar
+	}
+
+	return wsd.DialContext(ctx, w.url.String(), params.headers)
+}
+
+func (w *webSocket) closePendingConnectionOnContextDone(ctx context.Context, handshakeDone <-chan struct{}) {
+	select {
+	case <-ctx.Done():
+	case <-handshakeDone:
+		return
+	}
+	w.closePendingConnection()
+}
+
+func (w *webSocket) closePendingConnection() {
+	w.connectionMu.Lock()
+	conn := w.pendingConnection
+	w.pendingConnection = nil
+	w.connectionMu.Unlock()
+	if conn != nil {
+		_ = conn.Close()
+	}
 }
 
 // emitConnectionMetrics emits the metrics for a websocket connection.
@@ -417,8 +485,8 @@ func (w *webSocket) loop() {
 		return nil
 	})
 
-	ctx := w.vu.Context()
 	wg := new(sync.WaitGroup)
+	ctx := w.vu.Context()
 
 	defer func() {
 		metrics.PushIfNotDone(ctx, w.vu.State().Samples, metrics.Sample{
@@ -535,11 +603,15 @@ func (w *webSocket) readPump(wg *sync.WaitGroup) {
 	for {
 		messageType, data, err := w.conn.ReadMessage()
 		if err == nil {
+			// An immediate peer response can arrive before WriteMessage() returns. Wait for the
+			// writer to queue its bufferedAmount update before queuing the corresponding event.
+			w.connectionMu.Lock()
 			w.queueMessage(&message{
 				mtype: messageType,
 				data:  data,
 				t:     time.Now(),
 			})
+			w.connectionMu.Unlock()
 			continue
 		}
 
@@ -584,6 +656,10 @@ func (w *webSocket) writePump(wg *sync.WaitGroup) {
 				}
 				size := len(msg.data)
 
+				// Lock before writing because the peer can respond while WriteMessage() is still
+				// returning. Keep the lock through Queue() so readPump cannot queue that response
+				// ahead of the bufferedAmount update on the JavaScript event loop.
+				w.connectionMu.Lock()
 				err := func() error {
 					if msg.mtype != websocket.PingMessage {
 						return w.conn.WriteMessage(msg.mtype, msg.data)
@@ -592,6 +668,15 @@ func (w *webSocket) writePump(wg *sync.WaitGroup) {
 					// WriteControl is concurrently okay
 					return w.conn.WriteControl(msg.mtype, msg.data, msg.t.Add(writeWait))
 				}()
+				if err == nil {
+					// This from the specification needs to happen like that instead of with
+					// atomics or locks outside of the event loop.
+					w.tq.Queue(func() error {
+						w.bufferedAmount -= size
+						return nil
+					})
+				}
+				w.connectionMu.Unlock()
 				if err != nil {
 					w.tq.Queue(func() error {
 						_ = w.conn.Close() // TODO fix
@@ -600,12 +685,6 @@ func (w *webSocket) writePump(wg *sync.WaitGroup) {
 					})
 					return
 				}
-				// This from the specification needs to happen like that instead of with
-				// atomics or locks outside of the event loop
-				w.tq.Queue(func() error {
-					w.bufferedAmount -= size
-					return nil
-				})
 
 				metrics.PushIfNotDone(ctx, samplesOutput, metrics.Sample{
 					TimeSeries: metrics.TimeSeries{
@@ -790,10 +869,6 @@ func isValidCloseReason(reason string) bool {
 }
 
 func (w *webSocket) close(code int, reason string) error {
-	if w.readyState == CLOSED || w.readyState == CLOSING {
-		return nil
-	}
-
 	if code != 0 && !isValidClientCloseCode(code) {
 		return fmt.Errorf(
 			"InvalidAccessError: Failed to execute 'close' on 'WebSocket': "+
@@ -807,13 +882,32 @@ func (w *webSocket) close(code int, reason string) error {
 			`SyntaxError: Failed to execute 'close' on 'WebSocket': The message must not be greater than 123 bytes`,
 		)
 	}
-
+	if w.readyState == CLOSED || w.readyState == CLOSING {
+		return nil
+	}
 	if code == 0 {
 		code = websocket.CloseNormalClosure
 	}
 
+	wasConnecting := w.readyState == CONNECTING
 	w.readyState = CLOSING
-	w.closeCode = code
+	if wasConnecting {
+		w.connectionMu.Lock()
+		w.connectCancel()
+		pendingConnection := w.pendingConnection
+		w.pendingConnection = nil
+		connectionEstablished := w.conn != nil
+		w.connectionMu.Unlock()
+
+		if pendingConnection != nil {
+			_ = pendingConnection.Close()
+		}
+		if !connectionEstablished {
+			return nil
+		}
+	} else {
+		w.closeCode = code
+	}
 
 	w.writeQueueCh <- message{
 		mtype: websocket.CloseMessage,

--- a/internal/js/modules/k6/websockets/websockets_test.go
+++ b/internal/js/modules/k6/websockets/websockets_test.go
@@ -223,6 +223,44 @@ func TestBasic(t *testing.T) {
 	assertSessionMetricsEmitted(t, samples, "", sr("WSBIN_URL/ws-echo"), http.StatusSwitchingProtocols, "")
 }
 
+func TestClearedExpiredTimerDoesNotCloseConnectingWebSocket(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestState(t)
+	requestStarted := make(chan struct{})
+	ts.tb.Mux.HandleFunc("/ws-delayed-failure", func(w http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		time.Sleep(250 * time.Millisecond)
+		http.Error(w, "handshake failed", http.StatusBadRequest)
+	})
+
+	require.NoError(t, ts.runtime.VU.RuntimeField.Set("waitForRequest", func() { <-requestStarted }))
+	require.NoError(t, ts.runtime.VU.RuntimeField.Set("sleep20", func() { time.Sleep(20 * time.Millisecond) }))
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := ts.runtime.RunOnEventLoop(ts.tb.Replacer.Replace(`
+			const ws = new WebSocket("WSBIN_URL/ws-delayed-failure");
+			ws.onerror = () => {};
+
+			setTimeout(() => ws.close(), 1000);
+			const canceledTimer = setTimeout(() => {}, 10);
+
+			waitForRequest();
+			sleep20();
+			clearTimeout(canceledTimer);
+		`))
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("event loop did not finish after clearing the expired timer")
+	}
+}
+
 func TestBasicSendBlob(t *testing.T) {
 	t.Parallel()
 	ts := newTestState(t)

--- a/internal/js/modules/k6/websockets/websockets_test.go
+++ b/internal/js/modules/k6/websockets/websockets_test.go
@@ -202,6 +202,25 @@ func (ts *testState) addHandler(uri string, upgrader *websocket.Upgrader, messag
 	}))
 }
 
+func runOnEventLoopWithTimeout(t *testing.T, runtime *modulestest.Runtime, code string) error {
+	t.Helper()
+
+	result := make(chan error, 1)
+	go func() {
+		_, err := runtime.RunOnEventLoop(code)
+		result <- err
+	}()
+
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(3 * time.Second):
+		runtime.CancelContext()
+		t.Fatal("event loop did not finish")
+		return nil
+	}
+}
+
 type testMessage struct {
 	kind int
 	data []byte
@@ -235,29 +254,130 @@ func TestClearedExpiredTimerDoesNotCloseConnectingWebSocket(t *testing.T) {
 	})
 
 	require.NoError(t, ts.runtime.VU.RuntimeField.Set("waitForRequest", func() { <-requestStarted }))
-	require.NoError(t, ts.runtime.VU.RuntimeField.Set("sleep20", func() { time.Sleep(20 * time.Millisecond) }))
+	require.NoError(t, ts.runtime.VU.RuntimeField.Set("sleep", time.Sleep))
 
-	result := make(chan error, 1)
-	go func() {
-		_, err := ts.runtime.RunOnEventLoop(ts.tb.Replacer.Replace(`
+	err := runOnEventLoopWithTimeout(t, ts.runtime, ts.tb.Replacer.Replace(`
 			const ws = new WebSocket("WSBIN_URL/ws-delayed-failure");
-			ws.onerror = () => {};
+			ws.onerror = () => call("error");
 
-			setTimeout(() => ws.close(), 1000);
+			setTimeout(() => {
+				call("close timer");
+				ws.close();
+			}, 1000);
 			const canceledTimer = setTimeout(() => {}, 10);
 
 			waitForRequest();
-			sleep20();
+			sleep(20_000_000);
 			clearTimeout(canceledTimer);
 		`))
-		result <- err
-	}()
+	require.NoError(t, err)
+	require.Equal(t, []string{"error", "close timer"}, ts.callRecorder.Recorded())
+}
+
+func TestCloseWhileConnectingCancelsHandshake(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestState(t)
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	ts.tb.Mux.HandleFunc("/ws-pending-handshake", func(_ http.ResponseWriter, req *http.Request) {
+		close(requestStarted)
+		<-req.Context().Done()
+		close(requestCanceled)
+	})
+
+	require.NoError(t, ts.runtime.VU.RuntimeField.Set("waitForRequest", func() { <-requestStarted }))
+	err := runOnEventLoopWithTimeout(t, ts.runtime, ts.tb.Replacer.Replace(`
+		const ws = new WebSocket("WSBIN_URL/ws-pending-handshake");
+		ws.onerror = () => call("error:" + ws.readyState);
+		ws.onclose = () => call("close:" + ws.readyState);
+
+		waitForRequest();
+		call("before:" + ws.readyState);
+		ws.close();
+		call("after:" + ws.readyState);
+	`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"before:0", "after:2", "error:3", "close:3"}, ts.callRecorder.Recorded())
 
 	select {
-	case err := <-result:
-		require.NoError(t, err)
-	case <-time.After(3 * time.Second):
-		t.Fatal("event loop did not finish after clearing the expired timer")
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("WebSocket handshake was not canceled")
+	}
+}
+
+func TestCloseWhileHandshakeBecomesEstablished(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestState(t)
+	upgraded := make(chan struct{})
+	serverDone := make(chan struct{})
+	ts.tb.Mux.HandleFunc("/ws-close-during-upgrade", func(w http.ResponseWriter, req *http.Request) {
+		conn, err := (&websocket.Upgrader{}).Upgrade(w, req, w.Header())
+		if err != nil {
+			ts.errors <- fmt.Errorf("cannot upgrade request: %w", err)
+			return
+		}
+		close(upgraded)
+		defer close(serverDone)
+		defer func() { _ = conn.Close() }()
+		for {
+			if _, _, err = conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	require.NoError(t, ts.runtime.VU.RuntimeField.Set("waitForUpgrade", func() { <-upgraded }))
+	require.NoError(t, ts.runtime.VU.RuntimeField.Set("sleep", time.Sleep))
+	err := runOnEventLoopWithTimeout(t, ts.runtime, ts.tb.Replacer.Replace(`
+		const ws = new WebSocket("WSBIN_URL/ws-close-during-upgrade");
+		ws.onopen = () => call("open");
+		ws.onerror = () => call("error:" + ws.readyState);
+		ws.onclose = () => call("close:" + ws.readyState);
+
+		waitForUpgrade();
+		sleep(20_000_000);
+		call("before:" + ws.readyState);
+		ws.close();
+		call("after:" + ws.readyState);
+	`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"before:0", "after:2", "close:3"}, ts.callRecorder.Recorded())
+
+	select {
+	case <-serverDone:
+	case <-time.After(time.Second):
+		t.Fatal("established WebSocket connection was not closed")
+	}
+}
+
+func TestContextCancelWhileConnectingCancelsHandshake(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestState(t)
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	ts.tb.Mux.HandleFunc("/ws-canceled-context", func(_ http.ResponseWriter, req *http.Request) {
+		close(requestStarted)
+		<-req.Context().Done()
+		close(requestCanceled)
+	})
+
+	require.NoError(t, ts.runtime.VU.RuntimeField.Set("waitForRequest", func() { <-requestStarted }))
+	require.NoError(t, ts.runtime.VU.RuntimeField.Set("cancel", ts.runtime.CancelContext))
+	err := runOnEventLoopWithTimeout(t, ts.runtime, ts.tb.Replacer.Replace(`
+		new WebSocket("WSBIN_URL/ws-canceled-context");
+		waitForRequest();
+		cancel();
+	`))
+	require.NoError(t, err)
+
+	select {
+	case <-requestCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("WebSocket handshake survived VU context cancellation")
 	}
 }
 
@@ -1606,7 +1726,7 @@ func testArrayBufferViewBufferedAmount(t *testing.T, viewName string) {
 			if (ws.bufferedAmount != sent.byteLength) {
 				throw new Error("Expected " + sent.byteLength + " bufferedAmount got " + ws.bufferedAmount);
 			}
-			ws.onmessage = async (e) => {
+			ws.onmessage = (e) => {
 				if (ws.bufferedAmount != 0) {
 					throw new Error("Expected 0 bufferedAmount got " + ws.bufferedAmount);
 				}
@@ -1718,6 +1838,30 @@ func TestCloseWithReasonTooLong(t *testing.T) {
 	require.ErrorContains(t, err, "SyntaxError: Failed to execute 'close' on 'WebSocket': The message must not be greater than 123 bytes")
 	samples := metrics.GetBufferedSamples(ts.samples)
 	assertSessionMetricsEmitted(t, samples, "", sr("WSBIN_URL/ws-echo"), http.StatusSwitchingProtocols, "")
+}
+
+func TestCloseValidatesArgumentsWhenClosed(t *testing.T) {
+	t.Parallel()
+
+	ts := newTestState(t)
+	_, err := ts.runtime.RunOnEventLoop(ts.tb.Replacer.Replace(`
+		const ws = new WebSocket("WSBIN_URL/ws-echo");
+		ws.onopen = () => ws.close();
+		ws.onclose = () => {
+			try {
+				ws.close(1001);
+			} catch (_) {
+				call("invalid code");
+			}
+			try {
+				ws.close(1000, "a really really long reason about why we are closing this connection, which is clearly over the top and too long, long enough to be longer than the allowed amount of 123 bytes");
+			} catch (_) {
+				call("invalid reason");
+			}
+		};
+	`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"invalid code", "invalid reason"}, ts.callRecorder.Recorded())
 }
 
 func TestRemoteCloseWithCodeAndReason(t *testing.T) {

--- a/internal/js/tc55/timers/timers.go
+++ b/internal/js/tc55/timers/timers.go
@@ -20,7 +20,7 @@ type timers struct {
 
 	timerIDCounter uint64
 
-	timers map[uint64]time.Time
+	timers map[uint64]*timer
 	// Maybe in the future if this moves to core it will be expanded to have multiple queues
 	queue *timerQueue
 
@@ -46,7 +46,7 @@ func SetupGlobally(vu modules.VU) error {
 func newTimers(vu modules.VU) *timers {
 	return &timers{
 		vu:     vu,
-		timers: make(map[uint64]time.Time),
+		timers: make(map[uint64]*timer),
 		queue:  new(timerQueue),
 	}
 }
@@ -138,40 +138,22 @@ func (e *timers) timerInitialization(
 		common.Throw(e.vu.Runtime(), fmt.Errorf("%s's callback isn't a callable function", name))
 	}
 
-	task := func() error {
-		// Specification 8.1: If id does not exist in global's map of active timers, then abort these steps.
-		if _, exist := e.timers[id]; !exist {
-			return nil
-		}
-
-		err := e.call(callback, args)
-
-		if _, exist := e.timers[id]; !exist { // 8.4
-			return err
-		}
-
-		if repeat {
-			e.timerInitialization(callback, timeout, args, repeat, id)
-		} else {
-			delete(e.timers, id)
-		}
-
-		return err
-	}
-
-	e.runAfterTimeout(&timer{
+	t := &timer{
 		id:          id,
-		task:        task,
 		nextTrigger: time.Now().Add(time.Duration(timeout * float64(time.Millisecond))),
 		name:        name,
-	})
+	}
+	t.task = func() error {
+		return e.runTask(t, callback, timeout, args, repeat)
+	}
+	e.runAfterTimeout(t)
 }
 
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#run-steps-after-a-timeout
 // Notes: this just takes timers as makes the implementation way easier and we do not currently need
 // most of the functionality provided
 func (e *timers) runAfterTimeout(t *timer) {
-	e.timers[t.id] = t.nextTrigger
+	e.timers[t.id] = t
 
 	// as we have only one orderingId we have one queue
 	index := e.queue.add(t)
@@ -183,13 +165,23 @@ func (e *timers) runAfterTimeout(t *timer) {
 	e.setupTaskTimeout()
 }
 
-func (e *timers) runFirstTask() error {
-	t := e.queue.pop()
-	if t == nil {
-		return nil // everything was cleared
+func (e *timers) runTask(
+	t *timer, callback sobek.Callable, timeout float64, args []sobek.Value, repeat bool,
+) error {
+	if e.timers[t.id] != t {
+		return nil // the timer was cleared after its task was queued
 	}
+	e.queue.remove(t.id)
 
-	err := t.task()
+	err := e.call(callback, args)
+
+	if e.timers[t.id] == t {
+		if repeat {
+			e.timerInitialization(callback, timeout, args, repeat, t.id)
+		} else {
+			delete(e.timers, t.id)
+		}
+	}
 
 	if e.queue.length() > 0 {
 		e.setupTaskTimeout()
@@ -202,14 +194,15 @@ func (e *timers) runFirstTask() error {
 
 func (e *timers) setupTaskTimeout() {
 	e.queue.stopTimer()
-	delay := -time.Since(e.timers[e.queue.first().id])
+	t := e.queue.first()
+	delay := -time.Since(t.nextTrigger)
 	if e.taskQueue == nil {
 		e.taskQueue = taskqueue.New(e.vu.RegisterCallback)
 		e.setupTaskQueueCloserOnIterationEnd()
 	}
 	q := e.taskQueue
 	e.queue.head = time.AfterFunc(delay, func() {
-		q.Queue(e.runFirstTask)
+		q.Queue(t.task)
 	})
 }
 
@@ -264,7 +257,7 @@ func (e *timers) setupTaskQueueCloserOnIterationEnd() {
 			})
 			q.Close()
 		case <-ch:
-			e.timers = make(map[uint64]time.Time)
+			e.timers = make(map[uint64]*timer)
 			e.queue.stopTimer()
 			e.queue = new(timerQueue)
 			e.taskQueue = nil
@@ -313,16 +306,6 @@ func (tq *timerQueue) remove(id uint64) {
 	tq.queue = slices.DeleteFunc(tq.queue, func(t *timer) bool {
 		return id == t.id
 	})
-}
-
-func (tq *timerQueue) pop() *timer {
-	length := len(tq.queue)
-	if length == 0 {
-		return nil
-	}
-	t := tq.queue[0]
-	tq.queue = slices.Delete(tq.queue, 0, 1)
-	return t
 }
 
 func (tq *timerQueue) length() int {

--- a/internal/js/tc55/timers/timers_test.go
+++ b/internal/js/tc55/timers/timers_test.go
@@ -225,3 +225,125 @@ func TestClearFirstTimeoutWhenMultiple(t *testing.T) {
 		require.GreaterOrEqual(t, log[0].Sub(start), time.Second)
 	})
 }
+
+func TestClearExpiredFirstTimerBeforeItsTaskRuns(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{
+			name: "clear timeout with clearTimeout",
+			script: `
+				var canceledTimer = setTimeout(() => {}, 10);
+				sleep(20_000_000);
+				clearTimeout(canceledTimer);
+			`,
+		},
+		{
+			name: "clear timeout with clearInterval",
+			script: `
+				var canceledTimer = setTimeout(() => {}, 10);
+				sleep(20_000_000);
+				clearInterval(canceledTimer);
+			`,
+		},
+		{
+			name: "clear interval with clearTimeout",
+			script: `
+				var canceledTimer = setInterval(() => {}, 10);
+				sleep(20_000_000);
+				clearTimeout(canceledTimer);
+			`,
+		},
+		{
+			name: "clear interval with clearInterval",
+			script: `
+				var canceledTimer = setInterval(() => {}, 10);
+				sleep(20_000_000);
+				clearInterval(canceledTimer);
+			`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			synctest.Test(t, func(t *testing.T) {
+				runtime := newRuntime(t)
+				rt := runtime.VU.Runtime()
+				var firedAt time.Time
+
+				require.NoError(t, rt.Set("sleep", time.Sleep))
+				require.NoError(t, rt.Set("record", func() { firedAt = time.Now() }))
+
+				for i := range 1000 {
+					firedAt = time.Time{}
+					start := time.Now()
+					_, err := runtime.RunOnEventLoop("setTimeout(record, 1000);" + test.script)
+					require.NoErrorf(t, err, "iteration %d", i)
+					require.Falsef(t, firedAt.IsZero(), "iteration %d", i)
+					require.GreaterOrEqualf(t, firedAt.Sub(start), time.Second, "iteration %d", i)
+				}
+			})
+		})
+	}
+}
+
+func TestClearExpiredOnlyTimerBeforeItsTaskRuns(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runtime := newRuntime(t)
+		rt := runtime.VU.Runtime()
+
+		require.NoError(t, rt.Set("sleep", time.Sleep))
+
+		for i := range 1000 {
+			_, err := runtime.RunOnEventLoop(`
+				var canceledTimer = setTimeout(() => {
+					throw new Error("canceled timer ran");
+				}, 10);
+				sleep(20_000_000);
+				clearTimeout(canceledTimer);
+			`)
+			require.NoErrorf(t, err, "iteration %d", i)
+		}
+	})
+}
+
+func TestClearedExpiredTimerDoesNotRunNewTimersEarly(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		runtime := newRuntime(t)
+		rt := runtime.VU.Runtime()
+		type call struct {
+			name    string
+			firedAt time.Time
+		}
+		var calls []call
+
+		require.NoError(t, rt.Set("sleep", time.Sleep))
+		require.NoError(t, rt.Set("record", func(name string) {
+			calls = append(calls, call{name: name, firedAt: time.Now()})
+		}))
+
+		for i := range 1000 {
+			calls = calls[:0]
+			start := time.Now()
+			_, err := runtime.RunOnEventLoop(`
+				var canceledTimer = setTimeout(() => record("canceled"), 10);
+				sleep(20_000_000);
+				clearTimeout(canceledTimer);
+				setTimeout(record, 100, "first");
+				setTimeout(record, 200, "second");
+			`)
+			require.NoErrorf(t, err, "iteration %d", i)
+			require.Lenf(t, calls, 2, "iteration %d", i)
+			require.Equalf(t, "first", calls[0].name, "iteration %d", i)
+			require.Equalf(t, "second", calls[1].name, "iteration %d", i)
+			require.GreaterOrEqualf(t, calls[0].firedAt.Sub(start), 100*time.Millisecond, "iteration %d", i)
+			require.GreaterOrEqualf(t, calls[1].firedAt.Sub(start), 200*time.Millisecond, "iteration %d", i)
+		}
+	})
+}


### PR DESCRIPTION
## What?

This PR fixes a timer race where clearing an expired timer could cause a later timeout or interval to execute prematurely.

Queued timer tasks now retain the identity of the timer that created them. If that timer has been cleared before its event-loop task runs, the task becomes a no-op instead of executing the new head of the timer queue.

It also fixes the resulting WebSocket/VU hang:

- Closing a WebSocket while it is `CONNECTING` cancels the handshake and closes its pending transport.
- Connection publication and cancellation are coordinated so `close()` only queues a close frame after the socket writer exists.
- Established sockets continue to use the longer-lived VU context.
- The normal unbuffered write path is preserved.
- Successful writes are ordered before causally dependent inbound events so `onmessage` observes the updated `bufferedAmount`.
- Close arguments are validated before state-based no-op handling.

Tests cover the timer race repeatedly, replacement task queues, pending and concurrently completed WebSocket handshakes, VU cancellation, state transitions, close validation, and `bufferedAmount` ordering.

## Why?

Timer callbacks were queued as a generic operation that ran the first active timer. This allowed the following sequence:

1. A timer expired and queued an event-loop task.
2. JavaScript cleared that timer before the task ran.
3. A later timer became the queue head.
4. The stale task executed that later timer prematurely.

Previous timer changes fixed adjacent cases:

- [05ee9051a](https://github.com/grafana/k6/commit/05ee9051af9e92307d2c01932ced619608353fc2) introduced sorted timer ordering.
- [df2c3dfb3](https://github.com/grafana/k6/commit/df2c3dfb3cc69be46bc9b6356d068284d0cf884b) rearmed the head after clearing a timer before its Go timer fired.

Neither handled a timer whose event-loop task had already been queued.

The race could prematurely execute a callback that called `WebSocket.close()` while the socket was still connecting. Previously, `close()` synchronously sent to an unbuffered write queue, but the writer pump did not exist until the HTTP upgrade completed. A stalled or failed handshake could therefore block the event loop and prevent the VU from finishing.

Stress testing also exposed an ordering race where an echoed message could be queued before the event-loop task that decreased `bufferedAmount`. The write and inbound-event paths are now ordered while keeping the actual state update on the JavaScript event loop.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [x] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_


## Related PR(s)/Issue(s)

Related timer work:

- [Update to xk6-timers v0.2.2—fix timer ordering](https://github.com/grafana/k6/commit/05ee9051af9e92307d2c01932ced619608353fc2)
- [Fix clearing the first timer running the next timer](https://github.com/grafana/k6/commit/df2c3dfb3cc69be46bc9b6356d068284d0cf884b)

Related WebSocket work:

- [Correct WebSocket `readyState` exposure](https://github.com/grafana/k6/commit/7e82c3dfc585e7652ea125456c6b0c5003ef2502)
- [Add close code and reason handling (#5376)](https://github.com/grafana/k6/commit/15c30ca20f56d80500d841c70f715a5d0ab37993)
- [Fix shutdown deadlock in ping and pong handlers (#5905)](https://github.com/grafana/k6/commit/d838f20be08e158c526e3c1c44c5024e903a2a17)
- [Avoid VU hangs after write failures](https://github.com/grafana/k6/commit/133cd81384e13aa9a8ff9f70473ae6340e595d41) (complementary work not in this branch's ancestry)
