### PR TITLE
httpext: close digest response body on read errors

### DIFF
--- a/lib/netext/httpext/digest_transport.go
+++ b/lib/netext/httpext/digest_transport.go
@@ -37,10 +37,10 @@ func (t digestTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	respBody, err := io.ReadAll(noAuthResponse.Body)
+	_ = noAuthResponse.Body.Close()
 	if err != nil {
 		return nil, err
 	}
-	_ = noAuthResponse.Body.Close()
 
 	// Calculate the Authorization header
 	// TODO: determine if we actually need the body, since I'm not sure that's

--- a/lib/netext/httpext/digest_transport_test.go
+++ b/lib/netext/httpext/digest_transport_test.go
@@ -1,0 +1,56 @@
+package httpext
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type failingReadCloser struct {
+	err    error
+	closed bool
+}
+
+func (b *failingReadCloser) Read(_ []byte) (int, error) {
+	return 0, b.err
+}
+
+func (b *failingReadCloser) Close() error {
+	b.closed = true
+	return nil
+}
+
+type staticResponseTransport struct {
+	response *http.Response
+}
+
+func (t staticResponseTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	return t.response, nil
+}
+
+func TestDigestTransportClosesUnauthorizedResponseBodyOnReadError(t *testing.T) {
+	t.Parallel()
+
+	readErr := errors.New("read failed")
+	body := &failingReadCloser{err: readErr}
+	transport := digestTransport{
+		originalTransport: staticResponseTransport{
+			response: &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       body,
+			},
+		},
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://user:password@example.com", nil)
+	require.NoError(t, err)
+
+	// The response must be nil when reading the challenge body fails.
+	response, err := transport.RoundTrip(req) //nolint:bodyclose
+
+	require.ErrorIs(t, err, readErr)
+	assert.Nil(t, response)
+	assert.True(t, body.closed)
+}


### PR DESCRIPTION
## What?

<!-- A short (or detailed) description of what this PR does. -->

Close the initial digest authentication response body immediately after the attempt to read it, including when reading the body fails.

Add a regression test using a 401 response body that returns a read error.


## Why?

<!-- A short (or detailed) explanation of why these changes are made and needed. -->


The initial 401 response is consumed internally and is not returned to the caller. The digest transport therefore owns its body and must close it on all return paths.

Previously, a failure from `io.ReadAll` returned before `Body.Close` was called, leaking the response body.


## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

<!-- - <https://github.com/grafana/...> -->

<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

Closes https://github.com/grafana/k6/issues/6354


<!-- Thanks for your contribution! 🙏🏼 -->
