### PR TITLE
Add `--scenario` to select scenarios in the script by name

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -207,6 +207,22 @@ func readEnvConfig(envMap map[string]string) (Config, error) {
 	return conf, err
 }
 
+// readConfigLayers reads file and environment options before merging them.
+func readConfigLayers(gs *state.GlobalState) (Config, Config, error) {
+	fileConf, err := readDiskConfig(gs)
+	if err != nil {
+		err = fmt.Errorf("failed to load the configuration file from the local file system: %w", err)
+		return Config{}, Config{}, errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
+	}
+
+	envConf, err := readEnvConfig(gs.Env)
+	if err != nil {
+		return Config{}, Config{}, errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
+	}
+
+	return fileConf, envConf, nil
+}
+
 // getConsolidatedConfig assemble the final consolidated configuration from all of the different sources:
 // - start with the CLI-provided options to get shadowed (non-Valid) defaults in there
 // - add the global file config options
@@ -217,30 +233,8 @@ func readEnvConfig(envMap map[string]string) (Config, error) {
 // TODO: add better validation, more explicit default values and improve consistency between formats
 // TODO: accumulate all errors and differentiate between the layers?
 func getConsolidatedConfig(
-	gs *state.GlobalState, cliConf Config, runnerOpts lib.Options, flags *features.Flags,
+	gs *state.GlobalState, cliConf, fileConf, envConf Config, runnerOpts lib.Options, flags *features.Flags,
 ) (Config, error) {
-	fileConf, err := readDiskConfig(gs)
-	if err != nil {
-		err = fmt.Errorf("failed to load the configuration file from the local file system: %w", err)
-		return Config{}, errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
-	}
-
-	envConf, err := readEnvConfig(gs.Env)
-	if err != nil {
-		return Config{}, errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
-	}
-
-	// Lower layers drop their shortcuts before the merge; getOptions rejects the CLI ones.
-	if cliConf.once {
-		if err := dropOnceShortcuts(gs.Logger, map[string]*lib.Options{
-			"config":      &fileConf.Options,
-			"script":      &runnerOpts,
-			"environment": &envConf.Options,
-		}); err != nil {
-			return Config{}, err
-		}
-	}
-
 	conf := cliConf.Apply(fileConf)
 
 	warnOnShortHandOverride(conf.Options, runnerOpts, "script", gs.Logger)
@@ -268,7 +262,7 @@ func getConsolidatedConfig(
 	// for CLI flags in cmd.getOptions, in case other configuration sources
 	// (e.g. env vars) overrode our default value. This is not done in
 	// lib.Options.Validate to avoid circular imports.
-	if _, err = metrics.GetResolversForTrendColumns(conf.SummaryTrendStats); err != nil {
+	if _, err := metrics.GetResolversForTrendColumns(conf.SummaryTrendStats); err != nil {
 		return Config{}, err
 	}
 

--- a/internal/cmd/config_consolidation_test.go
+++ b/internal/cmd/config_consolidation_test.go
@@ -608,7 +608,11 @@ func runTestCase(t *testing.T, testCase configConsolidationTestCase, subCmd stri
 	if testCase.options.runner != nil {
 		opts = *testCase.options.runner
 	}
-	consolidatedConfig, err := getConsolidatedConfig(ts.GlobalState, cliConf, opts, testCase.options.features)
+	var consolidatedConfig Config
+	fileConf, envConf, err := readConfigLayers(ts.GlobalState)
+	if err == nil {
+		consolidatedConfig, err = getConsolidatedConfig(ts.GlobalState, cliConf, fileConf, envConf, opts, testCase.options.features)
+	}
 	if testCase.expected.consolidationError {
 		require.Error(t, err)
 		return

--- a/internal/cmd/once_test.go
+++ b/internal/cmd/once_test.go
@@ -144,7 +144,14 @@ func TestGetConsolidatedConfigOnceDropsLowerLayerShortcuts(t *testing.T) {
 		ExecutionSegment: segment,
 	}
 
-	conf, err := getConsolidatedConfig(ts.GlobalState, Config{once: true}, runnerOpts, nil)
+	fileConf, envConf, err := readConfigLayers(ts.GlobalState)
+	require.NoError(t, err)
+	require.NoError(t, dropOnceShortcuts(ts.Logger, map[string]*lib.Options{
+		"config":      &fileConf.Options,
+		"script":      &runnerOpts,
+		"environment": &envConf.Options,
+	}))
+	conf, err := getConsolidatedConfig(ts.GlobalState, Config{}, fileConf, envConf, runnerOpts, nil)
 	require.NoError(t, err)
 
 	assert.False(t, conf.VUs.Valid)
@@ -168,7 +175,14 @@ func TestOncePreservesScenarioAcrossLayers(t *testing.T) {
 
 	runnerOpts := lib.Options{Duration: types.NullDurationFrom(time.Second)}
 
-	conf, err := getConsolidatedConfig(ts.GlobalState, Config{once: true}, runnerOpts, nil)
+	fileConf, envConf, err := readConfigLayers(ts.GlobalState)
+	require.NoError(t, err)
+	require.NoError(t, dropOnceShortcuts(ts.Logger, map[string]*lib.Options{
+		"config":      &fileConf.Options,
+		"script":      &runnerOpts,
+		"environment": &envConf.Options,
+	}))
+	conf, err := getConsolidatedConfig(ts.GlobalState, Config{}, fileConf, envConf, runnerOpts, nil)
 	require.NoError(t, err)
 
 	opts, err := applyOnce(conf.Options)

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -25,6 +25,7 @@ func optionFlagSet() *pflag.FlagSet {
 	flags.SortFlags = false
 
 	flags.Bool("once", false, "run the test with 1 VU and 1 iteration")
+	flags.StringSlice("scenario", nil, "run scenarios by name (comma-separated)")
 	flags.Int64P("vus", "u", 1, "number of virtual users")
 	flags.DurationP("duration", "d", 0, "test duration limit")
 	flags.Int64P("iterations", "i", 0, "script total iteration limit (among all VUs)")
@@ -81,6 +82,9 @@ func optionFlagSet() *pflag.FlagSet {
 //nolint:funlen,gocognit,cyclop // this needs breaking up but probably should wait for croconf
 func getOptions(flags *pflag.FlagSet) (lib.Options, error) {
 	if err := checkOnceConflicts(flags); err != nil {
+		return lib.Options{}, err
+	}
+	if err := checkScenarioConflicts(flags); err != nil {
 		return lib.Options{}, err
 	}
 

--- a/internal/cmd/scenarios.go
+++ b/internal/cmd/scenarios.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/pflag"
+
+	"go.k6.io/k6/v2/errext"
+	"go.k6.io/k6/v2/errext/exitcodes"
+	"go.k6.io/k6/v2/lib"
+)
+
+func checkScenarioConflicts(flags *pflag.FlagSet) error {
+	if !flags.Changed("scenario") {
+		return nil
+	}
+	for _, name := range []string{"vus", "duration", "iterations", "stage"} {
+		if flags.Changed(name) {
+			return errext.WithExitCodeIfNone(
+				fmt.Errorf("--scenario cannot be combined with --%s", name), exitcodes.InvalidConfig)
+		}
+	}
+	return nil
+}
+
+func dropScenarioShortcuts(logger logrus.FieldLogger, layers map[string]*lib.Options) error {
+	var unset lib.Options
+	for _, name := range []string{"config", "script", "environment"} {
+		opts, ok := layers[name]
+		if !ok {
+			return fmt.Errorf("missing %q layer", name)
+		}
+
+		var dropped []string
+		if opts.VUs.Valid {
+			dropped = append(dropped, "vus")
+		}
+		if opts.Duration.Valid {
+			dropped = append(dropped, "duration")
+		}
+		if opts.Iterations.Valid {
+			dropped = append(dropped, "iterations")
+		}
+		if opts.Stages != nil {
+			dropped = append(dropped, "stages")
+		}
+		opts.VUs = unset.VUs
+		opts.Duration = unset.Duration
+		opts.Iterations = unset.Iterations
+		opts.Stages = unset.Stages
+		if len(dropped) > 0 {
+			logger.Warnf("--scenario overrode %s in %q configuration", strings.Join(dropped, ", "), name)
+		}
+	}
+	return nil
+}
+
+func selectScenarios(opts lib.Options, names []string) (lib.Options, error) {
+	for _, name := range names {
+		if _, ok := opts.Scenarios[name]; ok {
+			continue
+		}
+
+		available := strings.Join(slices.Sorted(maps.Keys(opts.Scenarios)), ", ")
+		err := fmt.Errorf("scenario %q not found; available scenarios: %s", name, available)
+		if len(opts.Scenarios) == 0 {
+			err = fmt.Errorf("scenario %q not found; the script does not have any named scenario", name)
+		}
+
+		return opts, errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
+	}
+
+	opts.Scenarios = maps.Clone(opts.Scenarios)
+	maps.DeleteFunc(opts.Scenarios, func(name string, _ lib.ExecutorConfig) bool {
+		return !slices.Contains(names, name)
+	})
+
+	return opts, nil
+}

--- a/internal/cmd/scenarios.go
+++ b/internal/cmd/scenarios.go
@@ -61,8 +61,10 @@ func dropScenarioShortcuts(logger logrus.FieldLogger, layers map[string]*lib.Opt
 }
 
 func selectScenarios(opts lib.Options, names []string) (lib.Options, error) {
+	selected := make(lib.ScenarioConfigs, len(names))
 	for _, name := range names {
-		if _, ok := opts.Scenarios[name]; ok {
+		if sc, ok := opts.Scenarios[name]; ok {
+			selected[name] = sc
 			continue
 		}
 
@@ -75,10 +77,7 @@ func selectScenarios(opts lib.Options, names []string) (lib.Options, error) {
 		return opts, errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
 	}
 
-	opts.Scenarios = maps.Clone(opts.Scenarios)
-	maps.DeleteFunc(opts.Scenarios, func(name string, _ lib.ExecutorConfig) bool {
-		return !slices.Contains(names, name)
-	})
+	opts.Scenarios = selected
 
 	return opts, nil
 }

--- a/internal/cmd/scenarios.go
+++ b/internal/cmd/scenarios.go
@@ -12,6 +12,7 @@ import (
 	"go.k6.io/k6/v2/errext"
 	"go.k6.io/k6/v2/errext/exitcodes"
 	"go.k6.io/k6/v2/lib"
+	"go.k6.io/k6/v2/metrics"
 )
 
 func checkScenarioConflicts(flags *pflag.FlagSet) error {
@@ -80,4 +81,36 @@ func selectScenarios(opts lib.Options, names []string) (lib.Options, error) {
 	})
 
 	return opts, nil
+}
+
+func dropScenarioThresholds(logger logrus.FieldLogger, opts *lib.Options, configured lib.ScenarioConfigs) {
+	opts.Thresholds = maps.Clone(opts.Thresholds)
+	var dropped []string
+	for metricName := range opts.Thresholds {
+		_, tags, err := metrics.ParseMetricName(metricName)
+		if err != nil {
+			// Only --no-thresholds permits malformed filters past threshold validation.
+			continue
+		}
+		// Match AddSubmetric's normalization and last-value-wins handling of repeated tags.
+		for _, tag := range slices.Backward(tags) {
+			key, value, _ := strings.Cut(tag, ":")
+			if strings.Trim(strings.TrimSpace(key), `"'`) != "scenario" {
+				continue
+			}
+			name := strings.Trim(strings.TrimSpace(value), `"'`)
+			_, exists := configured[name]
+			_, selected := opts.Scenarios[name]
+			if exists && !selected {
+				delete(opts.Thresholds, metricName)
+				dropped = append(dropped, metricName)
+			}
+			break
+		}
+	}
+	if len(dropped) > 0 {
+		slices.Sort(dropped)
+		logger.Warnf("--scenario skipped thresholds for excluded scenarios: %s; "+
+			"these thresholds remain skipped even if another scenario emits matching tags", strings.Join(dropped, "; "))
+	}
 }

--- a/internal/cmd/scenarios_test.go
+++ b/internal/cmd/scenarios_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v3"
+
+	"go.k6.io/k6/v2/errext"
+	"go.k6.io/k6/v2/errext/exitcodes"
+	"go.k6.io/k6/v2/lib"
+	"go.k6.io/k6/v2/lib/executor"
+	"go.k6.io/k6/v2/lib/types"
+)
+
+func TestSelectScenarios(t *testing.T) {
+	t.Parallel()
+
+	ui := executor.NewConstantVUsConfig("ui")
+	ui.VUs = null.IntFrom(7)
+	ui.Duration = types.NullDurationFrom(30 * time.Second)
+	ui.Exec = null.StringFrom("uiFn")
+	ui.Env = map[string]string{"GREETING": "hi"}
+	ui.Tags = map[string]string{"team": "core"}
+	ui.Options = &lib.ScenarioOptions{Browser: map[string]any{"type": "chromium"}}
+
+	api := executor.NewConstantVUsConfig("api")
+
+	all := lib.ScenarioConfigs{"ui": ui, "api": api, "db": executor.NewConstantVUsConfig("db")}
+
+	for _, tt := range []struct {
+		name    string
+		names   []string
+		want    lib.ScenarioConfigs
+		wantErr string
+	}{
+		{
+			name:  "selects and preserves",
+			names: []string{"ui", "api"},
+			want:  lib.ScenarioConfigs{"ui": ui, "api": api},
+		},
+		{
+			name:    "unknown name lists available",
+			names:   []string{"ui", "gone"},
+			wantErr: `scenario "gone" not found; available scenarios: api, db, ui`,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := selectScenarios(lib.Options{Scenarios: all}, tt.names)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				var ec errext.HasExitCode
+				require.ErrorAs(t, err, &ec)
+				assert.Equal(t, exitcodes.InvalidConfig, ec.ExitCode())
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, res.Scenarios)
+		})
+	}
+
+	_, err := selectScenarios(lib.Options{}, []string{"default"})
+	require.EqualError(t, err, `scenario "default" not found; the script does not have any named scenario`)
+}
+
+func TestGetOptionsScenarioShortcuts(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		flag, value string
+		allowed     bool
+	}{
+		{"vus", "2", false},
+		{"duration", "1s", false},
+		{"iterations", "2", false},
+		{"stage", "1s:2", false},
+		{"execution-segment", "0:1/2", true},
+		{"execution-segment-sequence", "0,1/2,1", true},
+	} {
+		t.Run(tt.flag, func(t *testing.T) {
+			t.Parallel()
+			flags := optionFlagSet()
+			require.NoError(t, flags.Parse([]string{"--scenario", "ui", "--" + tt.flag, tt.value}))
+			_, err := getOptions(flags)
+			if tt.allowed {
+				require.NoError(t, err)
+				return
+			}
+			require.EqualError(t, err, "--scenario cannot be combined with --"+tt.flag)
+			var ec errext.HasExitCode
+			require.ErrorAs(t, err, &ec)
+			assert.Equal(t, exitcodes.InvalidConfig, ec.ExitCode())
+		})
+	}
+}

--- a/internal/cmd/scenarios_test.go
+++ b/internal/cmd/scenarios_test.go
@@ -1,18 +1,24 @@
 package cmd
 
 import (
+	"maps"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
 
 	"go.k6.io/k6/v2/errext"
 	"go.k6.io/k6/v2/errext/exitcodes"
+	"go.k6.io/k6/v2/internal/lib/testutils"
 	"go.k6.io/k6/v2/lib"
 	"go.k6.io/k6/v2/lib/executor"
 	"go.k6.io/k6/v2/lib/types"
+	"go.k6.io/k6/v2/metrics"
 )
 
 func TestSelectScenarios(t *testing.T) {
@@ -97,4 +103,33 @@ func TestGetOptionsScenarioShortcuts(t *testing.T) {
 			assert.Equal(t, exitcodes.InvalidConfig, ec.ExitCode())
 		})
 	}
+}
+
+func TestDropScenarioThresholds(t *testing.T) {
+	t.Parallel()
+
+	kept := []string{
+		"iterations", "iterations{name:scenario:api}", "iterations{scenario:ui}",
+		"iterations{scenario:unknown}", "iterations{scenario:api,scenario:ui}",
+		"iterations{scenario:api",
+	}
+	dropped := []string{
+		"iterations{ 'scenario' : 'api', name:login}",
+		"iterations{scenario:api}", "iterations{scenario:ui,scenario:api}",
+	}
+	thresholds := make(map[string]metrics.Thresholds)
+	for _, name := range slices.Concat(kept, dropped) {
+		thresholds[name] = metrics.NewThresholds([]string{"count>0"})
+	}
+	opts := lib.Options{Scenarios: lib.ScenarioConfigs{"ui": nil}, Thresholds: thresholds}
+	logger, hook := testutils.NewLoggerWithHook(t, logrus.WarnLevel)
+	dropScenarioThresholds(logger, &opts, lib.ScenarioConfigs{"ui": nil, "api": nil})
+
+	assert.ElementsMatch(t, kept, slices.Collect(maps.Keys(opts.Thresholds)))
+	assert.Len(t, thresholds, len(kept)+len(dropped))
+	assert.Equal(t, []string{"--scenario skipped thresholds for excluded scenarios: " +
+		strings.Join(dropped, "; ") + "; these thresholds remain skipped even if another scenario emits matching tags"}, hook.Lines())
+
+	dropScenarioThresholds(logger, &opts, opts.Scenarios)
+	assert.Empty(t, hook.Lines())
 }

--- a/internal/cmd/scenarios_test.go
+++ b/internal/cmd/scenarios_test.go
@@ -36,41 +36,18 @@ func TestSelectScenarios(t *testing.T) {
 
 	all := lib.ScenarioConfigs{"ui": ui, "api": api, "db": executor.NewConstantVUsConfig("db")}
 
-	for _, tt := range []struct {
-		name    string
-		names   []string
-		want    lib.ScenarioConfigs
-		wantErr string
-	}{
-		{
-			name:  "selects and preserves",
-			names: []string{"ui", "api"},
-			want:  lib.ScenarioConfigs{"ui": ui, "api": api},
-		},
-		{
-			name:    "unknown name lists available",
-			names:   []string{"ui", "gone"},
-			wantErr: `scenario "gone" not found; available scenarios: api, db, ui`,
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+	res, err := selectScenarios(lib.Options{Scenarios: all}, []string{"ui", "api"})
+	require.NoError(t, err)
+	assert.Equal(t, lib.ScenarioConfigs{"ui": ui, "api": api}, res.Scenarios)
+	assert.Len(t, all, 3)
 
-			res, err := selectScenarios(lib.Options{Scenarios: all}, tt.names)
-			if tt.wantErr != "" {
-				require.EqualError(t, err, tt.wantErr)
-				var ec errext.HasExitCode
-				require.ErrorAs(t, err, &ec)
-				assert.Equal(t, exitcodes.InvalidConfig, ec.ExitCode())
-				return
-			}
+	_, err = selectScenarios(lib.Options{Scenarios: all}, []string{"ui", "gone"})
+	require.EqualError(t, err, `scenario "gone" not found; available scenarios: api, db, ui`)
+	var ec errext.HasExitCode
+	require.ErrorAs(t, err, &ec)
+	assert.Equal(t, exitcodes.InvalidConfig, ec.ExitCode())
 
-			require.NoError(t, err)
-			assert.Equal(t, tt.want, res.Scenarios)
-		})
-	}
-
-	_, err := selectScenarios(lib.Options{}, []string{"default"})
+	_, err = selectScenarios(lib.Options{}, []string{"default"})
 	require.EqualError(t, err, `scenario "default" not found; the script does not have any named scenario`)
 }
 

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -585,6 +585,7 @@ func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 		return nil, err
 	}
 
+	configuredScenarios := consolidatedConfig.Scenarios
 	if scenarioNames != nil {
 		consolidatedConfig.Options, err = selectScenarios(consolidatedConfig.Options, scenarioNames)
 		if err != nil {
@@ -619,6 +620,10 @@ func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 				return nil, errext.WithExitCodeIfNone(err, exitcodes.InvalidConfig)
 			}
 		}
+	}
+
+	if scenarioNames != nil {
+		dropScenarioThresholds(gs.Logger, &consolidatedConfig.Options, configuredScenarios)
 	}
 
 	derivedConfig, err := deriveAndValidateConfig(consolidatedConfig, lt.initRunner.IsExecutable, gs.Logger)

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -585,18 +585,20 @@ func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 		return nil, err
 	}
 
-	if cliConfig.once {
-		if err = rejectAmbiguousOnce(consolidatedConfig.Scenarios); err != nil {
-			return nil, err
-		}
-		if consolidatedConfig.Options, err = applyOnce(consolidatedConfig.Options); err != nil {
+	if scenarioNames != nil {
+		consolidatedConfig.Options, err = selectScenarios(consolidatedConfig.Options, scenarioNames)
+		if err != nil {
 			return nil, err
 		}
 	}
 
-	if scenarioNames != nil {
-		consolidatedConfig.Options, err = selectScenarios(consolidatedConfig.Options, scenarioNames)
-		if err != nil {
+	if cliConfig.once && scenarioNames == nil {
+		if err = rejectAmbiguousOnce(consolidatedConfig.Scenarios); err != nil {
+			return nil, err
+		}
+	}
+	if cliConfig.once {
+		if consolidatedConfig.Options, err = applyOnce(consolidatedConfig.Options); err != nil {
 			return nil, err
 		}
 	}

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -545,6 +545,20 @@ func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 		cliConfig.once = getNullBool(cmd.Flags(), "once").Bool
 	}
 
+	var scenarioNames []string
+	if cmd.Flags().Changed("scenario") {
+		var err error
+		scenarioNames, err = cmd.Flags().GetStringSlice("scenario")
+		if err != nil {
+			return nil, err
+		}
+		if len(scenarioNames) == 0 {
+			return nil, errext.WithExitCodeIfNone(
+				errors.New("--scenario requires at least one scenario name"),
+				exitcodes.InvalidConfig)
+		}
+	}
+
 	gs.Logger.Debug("Consolidating config layers...")
 	fileConf, envConf, err := readConfigLayers(gs)
 	if err != nil {
@@ -552,14 +566,18 @@ func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 	}
 	runnerOpts := lt.initRunner.GetOptions()
 	// Lower layers drop their shortcuts before the merge; getOptions rejects the CLI ones.
+	layers := map[string]*lib.Options{
+		"config":      &fileConf.Options,
+		"script":      &runnerOpts,
+		"environment": &envConf.Options,
+	}
 	if cliConfig.once {
-		if err := dropOnceShortcuts(gs.Logger, map[string]*lib.Options{
-			"config":      &fileConf.Options,
-			"script":      &runnerOpts,
-			"environment": &envConf.Options,
-		}); err != nil {
-			return nil, err
-		}
+		err = dropOnceShortcuts(gs.Logger, layers)
+	} else if scenarioNames != nil {
+		err = dropScenarioShortcuts(gs.Logger, layers)
+	}
+	if err != nil {
+		return nil, err
 	}
 	consolidatedConfig, err := getConsolidatedConfig(
 		gs, cliConfig, fileConf, envConf, runnerOpts, lt.preInitState.FeatureFlags)
@@ -572,6 +590,13 @@ func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 			return nil, err
 		}
 		if consolidatedConfig.Options, err = applyOnce(consolidatedConfig.Options); err != nil {
+			return nil, err
+		}
+	}
+
+	if scenarioNames != nil {
+		consolidatedConfig.Options, err = selectScenarios(consolidatedConfig.Options, scenarioNames)
+		if err != nil {
 			return nil, err
 		}
 	}

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -546,8 +546,23 @@ func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 	}
 
 	gs.Logger.Debug("Consolidating config layers...")
+	fileConf, envConf, err := readConfigLayers(gs)
+	if err != nil {
+		return nil, err
+	}
+	runnerOpts := lt.initRunner.GetOptions()
+	// Lower layers drop their shortcuts before the merge; getOptions rejects the CLI ones.
+	if cliConfig.once {
+		if err := dropOnceShortcuts(gs.Logger, map[string]*lib.Options{
+			"config":      &fileConf.Options,
+			"script":      &runnerOpts,
+			"environment": &envConf.Options,
+		}); err != nil {
+			return nil, err
+		}
+	}
 	consolidatedConfig, err := getConsolidatedConfig(
-		gs, cliConfig, lt.initRunner.GetOptions(), lt.preInitState.FeatureFlags)
+		gs, cliConfig, fileConf, envConf, runnerOpts, lt.preInitState.FeatureFlags)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/test_load.go
+++ b/internal/cmd/test_load.go
@@ -529,6 +529,7 @@ func detectTestType(data []byte) string {
 	return testTypeJS
 }
 
+//nolint:funlen // Keep CLI feature ordering together.
 func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 	gs *state.GlobalState, cmd *cobra.Command,
 	cliConfGetter func(flags *pflag.FlagSet) (Config, error), // TODO: obviate
@@ -586,17 +587,14 @@ func (lt *loadedTest) consolidateDeriveAndValidateConfig(
 	}
 
 	configuredScenarios := consolidatedConfig.Scenarios
-	if scenarioNames != nil {
+	switch {
+	case scenarioNames != nil:
 		consolidatedConfig.Options, err = selectScenarios(consolidatedConfig.Options, scenarioNames)
-		if err != nil {
-			return nil, err
-		}
+	case cliConfig.once:
+		err = rejectAmbiguousOnce(consolidatedConfig.Scenarios)
 	}
-
-	if cliConfig.once && scenarioNames == nil {
-		if err = rejectAmbiguousOnce(consolidatedConfig.Scenarios); err != nil {
-			return nil, err
-		}
+	if err != nil {
+		return nil, err
 	}
 	if cliConfig.once {
 		if consolidatedConfig.Options, err = applyOnce(consolidatedConfig.Options); err != nil {

--- a/internal/cmd/tests/cmd_scenarios_test.go
+++ b/internal/cmd/tests/cmd_scenarios_test.go
@@ -1,0 +1,119 @@
+package tests
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v3"
+
+	"go.k6.io/k6/v2/errext/exitcodes"
+	"go.k6.io/k6/v2/internal/cmd"
+	"go.k6.io/k6/v2/lib"
+	"go.k6.io/k6/v2/lib/executor"
+	"go.k6.io/k6/v2/lib/fsext"
+)
+
+const scenariosScript = `
+	import exec from 'k6/execution';
+	export const options = {
+		cloud: { name: 'pick', projectID: 123456 },
+		vus: 1, duration: '1ms', iterations: 1, stages: [],
+		thresholds: { 'iterations{scenario:db}': ['count==0'] },
+		scenarios: {
+			ui:  { executor: 'per-vu-iterations', vus: 2, iterations: 1 },
+			api: { executor: 'shared-iterations', vus: 1, iterations: 2 },
+			db:  { executor: 'shared-iterations', vus: 1, iterations: 1 }
+		}
+	};
+	export default function() { console.log('ran ' + exec.scenario.name); }
+`
+
+func TestScenariosFilterArchive(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		tar  func(t *testing.T) []byte
+	}{
+		{
+			name: "local archive",
+			tar: func(t *testing.T) []byte {
+				return buildArchive(t, scenariosScript, "--scenario", "ui,api")
+			},
+		},
+		{
+			name: "cloud run",
+			tar: func(t *testing.T) []byte {
+				_, data := uploadAndCaptureArchive(t,
+					[]string{"k6", "cloud", "run", "--scenario", "ui,api", "test.js"}, nil, scenariosScript)
+				return data
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tarData := tt.tar(t)
+			arc, err := lib.ReadArchive(bytes.NewReader(tarData))
+			require.NoError(t, err)
+
+			require.Len(t, arc.Options.Scenarios, 2)
+			assert.NotContains(t, arc.Options.Scenarios, "db")
+
+			ui, ok := arc.Options.Scenarios["ui"].(executor.PerVUIterationsConfig)
+			require.True(t, ok)
+			assert.Equal(t, null.IntFrom(2), ui.VUs)
+			assert.Equal(t, null.IntFrom(1), ui.Iterations)
+			assert.Contains(t, arc.Options.Thresholds, "iterations{scenario:db}")
+			assert.False(t, arc.Options.VUs.Valid)
+			assert.False(t, arc.Options.Duration.Valid)
+			assert.False(t, arc.Options.Iterations.Valid)
+			assert.Nil(t, arc.Options.Stages)
+
+			ts := NewGlobalTestState(t)
+			tarPath := filepath.Join(ts.Cwd, "archive.tar")
+			require.NoError(t, fsext.WriteFile(ts.FS, tarPath, tarData, 0o644))
+			ts.CmdArgs = []string{"k6", "run", "--log-output=stdout", tarPath}
+			cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+			stdout := ts.Stdout.String()
+			assert.Equal(t, 2, strings.Count(stdout, "ran ui"))
+			assert.Equal(t, 2, strings.Count(stdout, "ran api"))
+			assert.NotContains(t, stdout, "ran db")
+			assert.NotContains(t, stdout, "ran default")
+		})
+	}
+}
+
+func TestRunScenarios(t *testing.T) {
+	t.Parallel()
+
+	ts := getSingleFileTestState(t, scenariosScript,
+		[]string{"--log-output=stdout", "--log-format=raw", "--scenario", "api"}, 0)
+	ts.Env["K6_ITERATIONS"] = "1"
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	assert.Equal(t, 2, strings.Count(stdout, "ran api"))
+	assert.NotContains(t, stdout, "ran ui")
+	assert.NotContains(t, stdout, "ran db")
+	assert.NotContains(t, stdout, "ran default")
+	assert.Contains(t, stdout, `--scenario overrode vus, duration, iterations, stages in "script" configuration`)
+	assert.Contains(t, stdout, `--scenario overrode iterations in "environment" configuration`)
+}
+
+func TestRunRejectsEmptyScenarios(t *testing.T) {
+	t.Parallel()
+
+	ts := getSingleFileTestState(t, scenariosScript,
+		[]string{"--log-output=stdout", "--scenario="}, exitcodes.InvalidConfig)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	assert.Contains(t, stdout, "requires at least one scenario name")
+	assert.NotContains(t, stdout, "ran ")
+}

--- a/internal/cmd/tests/cmd_scenarios_test.go
+++ b/internal/cmd/tests/cmd_scenarios_test.go
@@ -39,29 +39,20 @@ const scenariosScript = `
 func TestScenariosFilterArchive(t *testing.T) {
 	t.Parallel()
 
-	for _, tt := range []struct {
-		name string
-		tar  func(t *testing.T) []byte
-	}{
-		{
-			name: "local archive",
-			tar: func(t *testing.T) []byte {
-				return buildArchive(t, scenariosScript, "--scenario", "ui,api")
-			},
+	for name, build := range map[string]func(*testing.T) []byte{
+		"local archive": func(t *testing.T) []byte {
+			return buildArchive(t, scenariosScript, "--scenario", "ui,api")
 		},
-		{
-			name: "cloud run",
-			tar: func(t *testing.T) []byte {
-				_, data := uploadAndCaptureArchive(t,
-					[]string{"k6", "cloud", "run", "--scenario", "ui,api", "test.js"}, nil, scenariosScript)
-				return data
-			},
+		"cloud run": func(t *testing.T) []byte {
+			_, data := uploadAndCaptureArchive(t,
+				[]string{"k6", "cloud", "run", "--scenario", "ui,api", "test.js"}, nil, scenariosScript)
+			return data
 		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			tarData := tt.tar(t)
+			tarData := build(t)
 			arc, err := lib.ReadArchive(bytes.NewReader(tarData))
 			require.NoError(t, err)
 
@@ -121,17 +112,14 @@ func TestScenarioThresholdValidation(t *testing.T) {
 
 	script := strings.Replace(scenariosScript,
 		"'iterations{scenario:db}': ['count>0']", "'iterations{scenario:db}': ['invalid']", 1)
-	for _, tt := range []struct {
-		noThresholds string
-		exitCode     exitcodes.ExitCode
-	}{
-		{"false", exitcodes.InvalidConfig},
-		{"true", 0},
+	for noThresholds, exitCode := range map[string]exitcodes.ExitCode{
+		"false": exitcodes.InvalidConfig,
+		"true":  0,
 	} {
-		t.Run(tt.noThresholds, func(t *testing.T) {
+		t.Run(noThresholds, func(t *testing.T) {
 			t.Parallel()
 			ts := getSingleFileTestState(t, script,
-				[]string{"--scenario", "api", "--no-thresholds=" + tt.noThresholds}, tt.exitCode)
+				[]string{"--scenario", "api", "--no-thresholds=" + noThresholds}, exitCode)
 			cmd.ExecuteWithGlobalState(ts.GlobalState)
 		})
 	}

--- a/internal/cmd/tests/cmd_scenarios_test.go
+++ b/internal/cmd/tests/cmd_scenarios_test.go
@@ -106,6 +106,19 @@ func TestRunScenarios(t *testing.T) {
 	assert.Contains(t, stdout, `--scenario overrode iterations in "environment" configuration`)
 }
 
+func TestRunScenariosOnce(t *testing.T) {
+	t.Parallel()
+
+	ts := getSingleFileTestState(t, scenariosScript,
+		[]string{"--log-output=stdout", "--scenario", "ui,api", "--once"}, 0)
+	cmd.ExecuteWithGlobalState(ts.GlobalState)
+
+	stdout := ts.Stdout.String()
+	assert.Equal(t, 1, strings.Count(stdout, "ran ui"))
+	assert.Equal(t, 1, strings.Count(stdout, "ran api"))
+	assert.NotContains(t, stdout, "ran db")
+}
+
 func TestRunRejectsEmptyScenarios(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/tests/cmd_scenarios_test.go
+++ b/internal/cmd/tests/cmd_scenarios_test.go
@@ -22,7 +22,11 @@ const scenariosScript = `
 	export const options = {
 		cloud: { name: 'pick', projectID: 123456 },
 		vus: 1, duration: '1ms', iterations: 1, stages: [],
-		thresholds: { 'iterations{scenario:db}': ['count==0'] },
+		thresholds: {
+			iterations: ['count>0'],
+			'iterations{scenario:api}': ['count>0'],
+			'iterations{scenario:db}': ['count>0']
+		},
 		scenarios: {
 			ui:  { executor: 'per-vu-iterations', vus: 2, iterations: 1 },
 			api: { executor: 'shared-iterations', vus: 1, iterations: 2 },
@@ -68,7 +72,9 @@ func TestScenariosFilterArchive(t *testing.T) {
 			require.True(t, ok)
 			assert.Equal(t, null.IntFrom(2), ui.VUs)
 			assert.Equal(t, null.IntFrom(1), ui.Iterations)
-			assert.Contains(t, arc.Options.Thresholds, "iterations{scenario:db}")
+			assert.NotContains(t, arc.Options.Thresholds, "iterations{scenario:db}")
+			assert.Contains(t, arc.Options.Thresholds, "iterations")
+			assert.Contains(t, arc.Options.Thresholds, "iterations{scenario:api}")
 			assert.False(t, arc.Options.VUs.Valid)
 			assert.False(t, arc.Options.Duration.Valid)
 			assert.False(t, arc.Options.Iterations.Valid)
@@ -85,6 +91,7 @@ func TestScenariosFilterArchive(t *testing.T) {
 			assert.Equal(t, 2, strings.Count(stdout, "ran api"))
 			assert.NotContains(t, stdout, "ran db")
 			assert.NotContains(t, stdout, "ran default")
+			assert.NotContains(t, stdout, "--scenario skipped thresholds")
 		})
 	}
 }
@@ -104,6 +111,30 @@ func TestRunScenarios(t *testing.T) {
 	assert.NotContains(t, stdout, "ran default")
 	assert.Contains(t, stdout, `--scenario overrode vus, duration, iterations, stages in "script" configuration`)
 	assert.Contains(t, stdout, `--scenario overrode iterations in "environment" configuration`)
+	assert.Contains(t, stdout, "--scenario skipped thresholds for excluded scenarios: iterations{scenario:db}; "+
+		"these thresholds remain skipped even if another scenario emits matching tags")
+	assert.Equal(t, 1, strings.Count(stdout, "--scenario skipped thresholds"))
+}
+
+func TestScenarioThresholdValidation(t *testing.T) {
+	t.Parallel()
+
+	script := strings.Replace(scenariosScript,
+		"'iterations{scenario:db}': ['count>0']", "'iterations{scenario:db}': ['invalid']", 1)
+	for _, tt := range []struct {
+		noThresholds string
+		exitCode     exitcodes.ExitCode
+	}{
+		{"false", exitcodes.InvalidConfig},
+		{"true", 0},
+	} {
+		t.Run(tt.noThresholds, func(t *testing.T) {
+			t.Parallel()
+			ts := getSingleFileTestState(t, script,
+				[]string{"--scenario", "api", "--no-thresholds=" + tt.noThresholds}, tt.exitCode)
+			cmd.ExecuteWithGlobalState(ts.GlobalState)
+		})
+	}
 }
 
 func TestRunScenariosOnce(t *testing.T) {


### PR DESCRIPTION
## What?

Adds `--scenario` to select which named scenarios in the script run.

## Why?

Lets you run scenarios without changing the script or adding environment-variable plumbing.

## How does it work?

> [!NOTE]
> Tested with `cloud run` on real cloud runs ✅ 

Given this script:

```javascript
import { check } from 'k6';
import { Counter } from 'k6/metrics';

const hits = new Counter('hits');

export const options = {
  scenarios: {
    ui: { executor: 'shared-iterations', vus: 1, iterations: 2, exec: 'ui' },
    api: { executor: 'per-vu-iterations', vus: 2, iterations: 1, exec: 'api' },
  },
  thresholds: {
    checks: ['rate==1'],
    'hits{scenario:api}': ['count>0'],
    'iterations{scenario:api}': ['count>0'],
  },
};

// These modes demonstrate different configurations using the same script.
if (__ENV.MODE === 'default') {
  options.scenarios.default = { executor: 'shared-iterations', vus: 1, iterations: 1 };
}
if (__ENV.MODE === 'no-scenarios') {
  delete options.scenarios;
  options.thresholds = { checks: ['rate==1'] };
}

export function ui() {
  check(true, { 'ui ran': Boolean });
  hits.add(1, { scenario: 'api' }); // A sample tag can differ from the scenario that ran.
  console.log('ran ui');
}

export function api() {
  check(true, { 'api ran': Boolean });
  hits.add(1);
  console.log('ran api');
}

export default function () {
  check(true, { 'default ran': Boolean });
  console.log('ran default');
}
```

The optional `MODE` branches let the commands below add a named `default` or remove all named scenarios.

### Select one scenario

The scenario keeps its configured executor and load:

```console
$ k6 run --scenario=ui script.js

     * ui: 2 iterations shared among 1 VUs
```

### Select multiple scenarios

```console
$ k6 run --scenario=ui,api script.js

     * api: 1 iterations for each of 2 VUs
     * ui: 2 iterations shared among 1 VUs
```

### Handle load shortcuts

CLI `--vus`, `--duration`, `--iterations`, and `--stage` conflict with selection because they can replace configured scenarios:

```console
$ k6 run --scenario=ui --vus=2 script.js
ERRO[0000] --scenario cannot be combined with --vus
```

Selection warns and ignores their top-level equivalents from the script, config files, or environment variables:

```console
$ K6_VUS=2 k6 run --scenario=ui script.js
WARN[0000] --scenario overrode vus in "environment" configuration

     * ui: 2 iterations shared among 1 VUs
```

Settings inside each selected scenario and other global options keep their usual behavior.

### Keep thresholds for the selected workload

Selection skips thresholds tagged for configured scenarios you didn't select and prints a warning. Global thresholds and filters without a `scenario` tag stay active, as do thresholds tagged for selected or unconfigured scenarios.

Selecting `ui` keeps the global checks threshold and skips the api-tagged ones:

```console
$ k6 run --scenario=ui script.js
WARN[0000] --scenario skipped thresholds for excluded scenarios: hits{scenario:api}; iterations{scenario:api}; these thresholds remain skipped even if another scenario emits matching tags

    checks
    ✓ 'rate==1' rate=100.00%
```

Selecting both scenarios keeps all three thresholds:

```console
$ k6 run --scenario=ui,api script.js

    checks
    ✓ 'rate==1' rate=100.00%

    hits{scenario:api}
    ✓ 'count>0' count=4

    iterations{scenario:api}
    ✓ 'count>0' count=2
```

`ui` emits `hits` tagged `scenario:api`, so skipping that threshold also skips an assertion on samples `ui` produced. Combining selection with `--once` uses the same threshold rule.

### Use selection across commands

```console
$ k6 run --scenario=ui script.js
$ k6 cloud run --scenario=ui script.js
$ k6 cloud run --local-execution --scenario=ui script.js
$ k6 archive --scenario=ui -O test.tar script.js
```

The archive keeps the selected scenarios with their effective settings and remaining thresholds:

```console
$ tar -xOf test.tar metadata.json | jq '.options | {scenarios: (.scenarios | keys), thresholds: (.thresholds | keys)}'
{
  "scenarios": [
    "ui"
  ],
  "thresholds": [
    "checks"
  ]
}
```

Replay uses that saved configuration without needing `--scenario` again or repeating the threshold-removal warning:

```console
$ k6 run test.tar

     * ui: 2 iterations shared among 1 VUs
```

### Select a default scenario

A default export alone does not define a named scenario:

```console
$ k6 run --scenario=default script.js
ERRO[0000] scenario "default" not found; available scenarios: api, ui
```

`MODE=default` adds an explicitly configured `scenarios.default`, which selection can pick:

```console
$ k6 run -e MODE=default --scenario=default script.js

     * default: 1 iterations shared among 1 VUs
```

`MODE=no-scenarios` removes the named scenarios and their tagged thresholds, leaving the global checks threshold. An ordinary run uses the default export:

```console
$ k6 run -e MODE=no-scenarios script.js

     * default: 1 iterations for each of 1 VUs
```

Selection still requires a configured name:

```console
$ k6 run -e MODE=no-scenarios --scenario=default script.js
ERRO[0000] scenario "default" not found; the script does not have any named scenario
```

### Invalid selections

A missing scenario reports the available names:

```console
$ k6 run --scenario=missing script.js
ERRO[0000] scenario "missing" not found; available scenarios: api, ui
```

An empty selection fails before execution:

```console
$ k6 run --scenario= script.js
ERRO[0000] --scenario requires at least one scenario name
```

## Composition with `--once`

`--scenario` picks the scenarios, then `--once` runs each selected scenario once.

### Bare `--once`

Its existing multi-scenario error remains unchanged:

```console
$ k6 run --once script.js
ERRO[0000] --once can run only with a single scenario, but got: api, ui
```

### Select one scenario and run it once

```console
$ k6 run --scenario=ui --once script.js

     * ui: 1 iterations shared among 1 VUs
```

### Select multiple scenarios and run each once

```console
$ k6 run --scenario=ui,api --once script.js

     * api: 1 iterations shared among 1 VUs
     * ui: 1 iterations shared among 1 VUs
```

### Select without changing the load

Without `--once`, the selected scenario keeps its original configuration:

```console
$ k6 run --scenario=ui script.js

     * ui: 2 iterations shared among 1 VUs
```

## Related PR(s)/Issue(s)

- Closes #5792
- Closes #2780
- Builds on #6338
- Related to #5791
- Part of #5732
