### PR TITLE
Record build origin in anonymous usage reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ WORKDIR $GOPATH/src/go.k6.io/k6
 COPY . .
 ARG TARGETOS TARGETARCH
 RUN apk --no-cache add git=~2
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath -o /usr/bin/k6
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -trimpath \
+    -ldflags "-X go.k6.io/k6/v2/internal/build.BuildOrigin=release" -o /usr/bin/k6
 
 # Runtime stage
 FROM alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b as release

--- a/build-release.sh
+++ b/build-release.sh
@@ -15,7 +15,9 @@ build() {
     local ALIAS="$1" SUFFIX="${2}"  # Any other arguments are passed to the go build command as env vars
     local NAME="k6-${VERSION}-${ALIAS}"
 
-    local BUILD_ARGS=(-o "${OUT_DIR}/${NAME}/k6${SUFFIX}" -trimpath)
+    # -X marks the binary, and so the packages built from it, as an official build.
+    local BUILD_ARGS=(-o "${OUT_DIR}/${NAME}/k6${SUFFIX}" -trimpath
+        -ldflags "-X go.k6.io/k6/v2/internal/build.BuildOrigin=release")
 
     local PACKAGE_FORMATS
     IFS="," read -ra PACKAGE_FORMATS <<< "${3}"

--- a/internal/build/version.go
+++ b/internal/build/version.go
@@ -4,3 +4,7 @@ package build
 // Version contains the current version of k6
 // represented using Semantic Versioning expression.
 const Version = "2.2.0"
+
+// BuildOrigin records how this binary was built, e.g. "release", and a build command sets it with
+// -ldflags "-X go.k6.io/k6/v2/internal/build.BuildOrigin=release".
+var BuildOrigin string //nolint:gochecknoglobals // the Go linker can only set a package-level variable

--- a/internal/cmd/report.go
+++ b/internal/cmd/report.go
@@ -49,6 +49,9 @@ func addEnvironmentInfo(m map[string]any, lookupEnv func(string) (string, bool))
 	m["goos"] = runtime.GOOS
 	m["goarch"] = runtime.GOARCH
 	m["is_ci"] = isCI(lookupEnv)
+	if build.BuildOrigin != "" {
+		m["build_origin"] = build.BuildOrigin
+	}
 }
 
 // createReport assembles the anonymous usage report for a run from its

--- a/internal/cmd/report_test.go
+++ b/internal/cmd/report_test.go
@@ -107,3 +107,48 @@ func TestCreateReport(t *testing.T) {
 		assert.EqualValues(t, true, m["is_ci"])
 	})
 }
+
+//nolint:paralleltest // swaps the package-global build.BuildOrigin, so the subtests must run serially.
+func TestCreateReportBuildOrigin(t *testing.T) {
+	logger := testutils.NewLogger(t)
+	opts, err := executor.DeriveScenariosFromShortcuts(lib.Options{
+		VUs:        null.IntFrom(1),
+		Iterations: null.IntFrom(1),
+	}, logger)
+	require.NoError(t, err)
+
+	newScheduler := func() *execution.Scheduler {
+		s, err := execution.NewScheduler(&lib.TestRunState{
+			TestPreInitState: &lib.TestPreInitState{
+				Logger:    logger,
+				LookupEnv: func(string) (string, bool) { return "", false },
+			},
+			Options: opts,
+		}, local.NewController())
+		require.NoError(t, err)
+		return s
+	}
+
+	noCatalog := func() map[string]struct{} { return nil }
+
+	t.Run("empty origin omits the field", func(t *testing.T) {
+		original := build.BuildOrigin
+		build.BuildOrigin = ""
+		t.Cleanup(func() { build.BuildOrigin = original })
+
+		m := createReport(usage.New(), newScheduler(), noCatalog)
+
+		_, ok := m["build_origin"]
+		assert.False(t, ok)
+	})
+
+	t.Run("recorded origin appears in the report", func(t *testing.T) {
+		original := build.BuildOrigin
+		build.BuildOrigin = "release"
+		t.Cleanup(func() { build.BuildOrigin = original })
+
+		m := createReport(usage.New(), newScheduler(), noCatalog)
+
+		assert.Equal(t, "release", m["build_origin"])
+	})
+}


### PR DESCRIPTION
## What?

Adds a `build_origin` field to the anonymous usage report and stamps official k6 release binaries with `release`.

See grafana/k6#6111 for details.

## Why?

Distinguishes k6 releases, xk6 builds, and provisioned binaries, since xk6 and provisioning otherwise report identical build information. This is one repo of a multi-repo change; k6foundry, xk6, k6build, and k6-docs carry the rest.

## Related PR(s)/Issue(s)

- #6111
- grafana/xk6#592
- grafana/k6build#379
- grafana/k6foundry#130
- grafana/k6-docs#2307
