### PR TITLE
Fix stale module paths in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ make grpc-server-run
 
 **JavaScript Runtime**: `internal/js/` and `js/`
 - `internal/js/`: Core JavaScript execution engine using Sobek (Goja fork)
-- `js/modules/`: Built-in k6 modules (http, browser, crypto, etc.)
+- `js/modules/`: Built-in k6 modules (http, html)
 - `js/common/`: Shared JavaScript runtime utilities
 
 **Load Testing Core**: `lib/`
@@ -184,7 +184,7 @@ git log
 ## Common File Locations
 
 **CLI Commands**: `internal/cmd/` (run.go, cloud.go, etc.)
-**HTTP Module**: `js/modules/k6/http/` and `internal/js/modules/k6/http/`  
+**HTTP Module**: `js/modules/k6/http/`  
 **Browser Module**: `internal/js/modules/k6/browser/`
 **Metrics**: `metrics/` package for metric definitions
 **Examples**: `examples/` directory with various test script examples


### PR DESCRIPTION
## What?

`AGENTS.md` references two module paths that don't exist in the repository:

- `internal/js/modules/k6/http/` — the HTTP module lives in `js/modules/k6/http/` only (listed under "Common File Locations")
- `js/modules/` is described as containing "http, browser, crypto, etc." — it actually contains only `http` and `html`. Most built-in k6 modules (browser, crypto, grpc, websockets, ...) live in `internal/js/modules/k6/`, which the file already lists correctly in the "Module System" section, so the two sections contradicted each other.

## Verification

Checked every path mentioned in `AGENTS.md` against the working tree — all others are correct. Only these two claims were stale.
