### PR TITLE
fix: resolve 32-bit overflow issues

### DIFF
--- a/internal/dashboard/sse.go
+++ b/internal/dashboard/sse.go
@@ -80,7 +80,7 @@ func (emitter *eventEmitter) onEvent(name string, data any) {
 	var retry []byte
 
 	if name == stopEvent {
-		retry = []byte(strconv.Itoa(maxSafeInteger))
+		retry = []byte(strconv.FormatInt(int64(maxSafeInteger), 10))
 	}
 
 	id := strconv.FormatInt(emitter.id.Add(1), 10)

--- a/internal/output/prometheusrw/remote/client.go
+++ b/internal/output/prometheusrw/remote/client.go
@@ -128,7 +128,7 @@ func newWriteRequestBody(series []*prompb.TimeSeries) ([]byte, error) {
 	}
 	if snappy.MaxEncodedLen(len(b)) < 0 {
 		return nil, fmt.Errorf("the protobuf message is too large to be handled by Snappy encoder; "+
-			"size: %d, limit: %d", len(b), math.MaxUint32)
+			"size: %d, limit: %d", len(b), uint64(math.MaxUint32))
 	}
 	return snappy.Encode(nil, b), nil
 }

--- a/output/cloud/expv2/metrics_client.go
+++ b/output/cloud/expv2/metrics_client.go
@@ -101,7 +101,7 @@ func newRequestBody(data *pbcloud.MetricSet) ([]byte, error) {
 	// https://pkg.go.dev/github.com/klauspost/compress/snappy#NewBufferedWriter
 	if snappy.MaxEncodedLen(len(b)) < 0 {
 		return nil, fmt.Errorf("the Protobuf message is too large to be handled by Snappy encoder; "+
-			"size: %d, limit: %d", len(b), 0xffffffff)
+			"size: %d, limit: %d", len(b), uint64(0xffffffff))
 	}
 	return snappy.Encode(nil, b), nil
 }


### PR DESCRIPTION
- Use strconv.FormatInt with int64 cast for maxSafeInteger
- Explicitly cast uint32 limits to uint64 in error formatting

## What?

fix: resolve 32-bit overflow issues

## Why?

Without this fixes, this app failed build in 32bit machine (either arm or x86)

## Checklist

<!-- 
If you haven't read the contributing guidelines https://github.com/grafana/k6/blob/master/CONTRIBUTING.md 
and code of conduct https://github.com/grafana/k6/blob/master/CODE_OF_CONDUCT.md yet, please do so
-->

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

<!-- - [ ] Any other relevant item -->

## Related PR(s)/Issue(s)

termux/termux-packages#31576
<!-- Does it close an issue? -->

<!-- Closes #ISSUE-ID -->

<!-- Thanks for your contribution! 🙏🏼 -->
