### PR TITLE
Add v2.3.0 release notes

### DIFF
--- a/release notes/v2.3.0.md
+++ b/release notes/v2.3.0.md
@@ -1,0 +1,47 @@
+k6 `v2.3.0` is here 🎉! This release includes:
+
+- (_optional_) `<highlight of breaking changes>`
+- `<Summary of new features>` (_one or multiple bullets_)
+
+## Breaking changes
+
+- `#pr`, `<small_break_1>`
+- `#pr`, `<small_break_2>`
+
+### (_optional h3_) `<big_breaking_change>` `#pr`
+
+## New features
+
+_optional intro here_
+
+### `<big_feature_1>` `#pr`
+
+_what, why, and what this means for the user_
+
+### `<big_feature_n>` `#pr`
+
+_what, why, and what this means for the user_
+
+## UX improvements and enhancements
+
+_Format as `<number> <present_verb> <object>. <credit>`_:
+
+- _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
+- `#pr` `<description>`
+- `#pr` `<description>`
+
+## Bug fixes
+
+_Format as `<number> <present_verb> <object>. <credit>`_:
+
+- _`#111` Fixes race condition in runtime_
+
+## Maintenance and internal improvements
+
+_Format as `<number> <present_verb> <object>. <credit>`_:
+
+- _`#2770` Refactors parts of the JS module._
+
+## _Optional_ Roadmap
+
+_Discussion of future plans_

--- a/release notes/v2.3.0.md
+++ b/release notes/v2.3.0.md
@@ -79,6 +79,10 @@ if (socket.readyState === WebSocket.OPEN) {
 
 ## Bug fixes
 
+- [#5922](https://github.com/grafana/k6/pull/5922) Stops the test with an error when a ramping-VU scenario cannot start a VU, instead of silently stopping the scenario and reporting success. Thanks, @HwangRock!
+- [#6163](https://github.com/grafana/k6/pull/6163) Preserves Web Vitals from intermediate pages when a browser test navigates several times in the same tab, so results include those pages as well as the last one.
+- [#6355](https://github.com/grafana/k6/pull/6355) Prevents a response-body leak when reading a digest authentication challenge fails. Thanks, @cuishuang!
+
 - [#5949](https://github.com/grafana/k6/pull/5949) Supports sending metrics to InfluxDB behind a reverse proxy with a URL path prefix, such as `https://host/influxdb/database`. Thanks, @o6ivp!
 - [#6235](https://github.com/grafana/k6/pull/6235) Uses forward slashes in remote screenshot paths on Windows. Thanks, @adarshsm!
 - [#6238](https://github.com/grafana/k6/pull/6238) Sends `null` and `undefined` form fields as empty values instead of the string `<nil>`, and warns when a nested object cannot be encoded as a form field. Thanks, @djedi-knight!
@@ -96,10 +100,10 @@ if (socket.readyState === WebSocket.OPEN) {
 - [#6256](https://github.com/grafana/k6/pull/6256), [#6271](https://github.com/grafana/k6/pull/6271) Improves contributor acknowledgments and the release checklist.
 - [#6270](https://github.com/grafana/k6/pull/6270) Restores Debian package publishing after `bzip2` was removed from the packaging base image.
 - [#6301](https://github.com/grafana/k6/pull/6301), [#6373](https://github.com/grafana/k6/pull/6373) Corrects the TC39 test-package path and built-in module locations in contributor documentation. Thanks, @umekikazuya and @ashrafiucse!
-- [#6312](https://github.com/grafana/k6/pull/6312), [#6380](https://github.com/grafana/k6/pull/6380) Updates the shared CI workflow and adopts its centrally maintained lint configuration.
+- [#6312](https://github.com/grafana/k6/pull/6312), [#6380](https://github.com/grafana/k6/pull/6380), [#6394](https://github.com/grafana/k6/pull/6394) Updates the shared CI workflow, adopts its centrally maintained lint configuration, and fixes findings from the newer linter.
 - [#6325](https://github.com/grafana/k6/pull/6325) Moves browser option parsing into the JavaScript mapping layer without changing script behavior. Thanks, @Shobhit-Nagpal!
 - [#6265](https://github.com/grafana/k6/pull/6265), [#6267](https://github.com/grafana/k6/pull/6267), [#6303](https://github.com/grafana/k6/pull/6303), [#6304](https://github.com/grafana/k6/pull/6304), [#6331](https://github.com/grafana/k6/pull/6331), [#6332](https://github.com/grafana/k6/pull/6332), [#6357](https://github.com/grafana/k6/pull/6357), [#6358](https://github.com/grafana/k6/pull/6358), [#6363](https://github.com/grafana/k6/pull/6363), [#6367](https://github.com/grafana/k6/pull/6367), [#6383](https://github.com/grafana/k6/pull/6383) Updates the Docker build image to Go 1.27.0, raises the module's minimum Go version to 1.26.0, and updates gRPC to v1.83.2 (including the example server), OpenTelemetry to v1.46.0, Brotli to v1.2.3, esbuild to v0.28.2, Testify to v1.12.1, Protobuf to v1.36.12, `golang.org/x/crypto` to v0.56.0, and related Go dependencies.
 
 ## External contributors
 
-Thanks to @adarshsm, @ashrafiucse, @djedi-knight, @GourangaDasSamrat, @mem, @moko-poi, @o6ivp, @rohan-patnaik, @Shobhit-Nagpal, @Swapnil-Biswas, @umekikazuya, and @vtorosyan for their contributions.
+Thanks to @adarshsm, @ashrafiucse, @cuishuang, @djedi-knight, @GourangaDasSamrat, @HwangRock, @mem, @moko-poi, @o6ivp, @rohan-patnaik, @Shobhit-Nagpal, @Swapnil-Biswas, @umekikazuya, and @vtorosyan for their contributions.

--- a/release notes/v2.3.0.md
+++ b/release notes/v2.3.0.md
@@ -1,47 +1,112 @@
 k6 `v2.3.0` is here 🎉! This release includes:
 
-- (_optional_) `<highlight of breaking changes>`
-- `<Summary of new features>` (_one or multiple bullets_)
-
-## Breaking changes
-
-- `#pr`, `<small_break_1>`
-- `#pr`, `<small_break_2>`
-
-### (_optional h3_) `<big_breaking_change>` `#pr`
+- A `--once` flag to reuse load-test scripts for smoke and functional testing.
+- Opt-in fetching of missing TLS certificates for servers that work in browsers but fail in k6.
+- Static labels for Prometheus remote write, nanosecond log timestamps, and WebSocket ready-state constants.
 
 ## New features
 
-_optional intro here_
+### Run a script once with `--once` [#6338](https://github.com/grafana/k6/pull/6338)
 
-### `<big_feature_1>` `#pr`
+The `--once` flag is now the recommended way to run a script once, for both protocol and browser tests. It runs one VU for one iteration while keeping your scenario's function, environment, tags, and browser options, so browser tests can also run once without rewriting their configuration.
 
-_what, why, and what this means for the user_
+For example, a script might configure its `checkout()` function to run 100 iterations across ten VUs:
 
-### `<big_feature_n>` `#pr`
+```js
+export const options = {
+  scenarios: {
+    checkout: {
+      executor: 'shared-iterations',
+      exec: 'checkout',
+      vus: 10,
+      iterations: 100,
+      tags: { flow: 'checkout' },
+    },
+  },
+};
+// The rest of the script defines checkout().
+```
 
-_what, why, and what this means for the user_
+```shell
+k6 run --once script.js
+```
+
+This calls `checkout()` once with one VU instead of running 100 iterations, and keeps the `flow: checkout` tag. For a browser scenario, its browser options are kept too, so Chromium can still launch.
+
+It supports scripts with at most one scenario and also works with `k6 cloud run` and `k6 archive`.
+
+Previously, using shortcuts such as `--vus 1 --iterations 1` replaced the script's scenarios with a default scenario, discarding settings such as the selected function and browser options. Browser scripts then failed because the configuration needed to launch Chromium was missing.
+
+### Fetch missing TLS certificates [#6137](https://github.com/grafana/k6/pull/6137)
+
+Some HTTPS servers work in browsers but fail in k6 because they omit an intermediate certificate. The new `tlsAIAFetch` option lets k6 fetch that missing certificate while still verifying the server's identity:
+
+```js
+export const options = {
+  tlsAIAFetch: true,
+};
+```
+
+This is opt-in and works with HTTP and gRPC connections. Thanks, @vtorosyan!
+
+### Static labels for Prometheus remote write [#6071](https://github.com/grafana/k6/pull/6071)
+
+When several k6 instances send metrics to the same Prometheus server, labels let you tell their results apart. Use `K6_PROMETHEUS_RW_LABELS` to identify the job, environment, or server on every time series sent by that output:
+
+```shell
+K6_PROMETHEUS_RW_LABELS="environment=production,server=srv1" \
+k6 run --out experimental-prometheus-rw script.js
+```
+
+Thanks, @rohan-patnaik!
+
+### Nanosecond log timestamps [#6310](https://github.com/grafana/k6/pull/6310)
+
+Logs with second-precision timestamps can lose their order when a log service sorts messages emitted within the same second. Enable nanosecond timestamps with `--log-ns-timestamps` to make those messages easier to order and correlate:
+
+```shell
+k6 --log-ns-timestamps --log-format=json run script.js
+```
+
+This also works with plain-text logs when `--no-color` is set.
+
+### WebSocket ready-state constants [#6306](https://github.com/grafana/k6/pull/6306)
+
+The `WebSocket` constructor and its instances now expose the same connection-state constants as browsers: `CONNECTING`, `OPEN`, `CLOSING`, and `CLOSED`. For an existing socket, you can check its state before sending a message:
+
+```js
+if (socket.readyState === WebSocket.OPEN) {
+  socket.send('hello');
+}
+```
 
 ## UX improvements and enhancements
 
-_Format as `<number> <present_verb> <object>. <credit>`_:
-
-- _`#999` Gives terminal output prettier printing. Thanks to `@person` for the help!_
-- `#pr` `<description>`
-- `#pr` `<description>`
+- [#6339](https://github.com/grafana/k6/pull/6339) Adds login and token-configuration guidance when Grafana Cloud commands return an authentication error. Thanks, @Swapnil-Biswas!
 
 ## Bug fixes
 
-_Format as `<number> <present_verb> <object>. <credit>`_:
-
-- _`#111` Fixes race condition in runtime_
+- [#5949](https://github.com/grafana/k6/pull/5949) Supports sending metrics to InfluxDB behind a reverse proxy with a URL path prefix, such as `https://host/influxdb/database`. Thanks, @o6ivp!
+- [#6235](https://github.com/grafana/k6/pull/6235) Uses forward slashes in remote screenshot paths on Windows. Thanks, @adarshsm!
+- [#6238](https://github.com/grafana/k6/pull/6238) Sends `null` and `undefined` form fields as empty values instead of the string `<nil>`, and warns when a nested object cannot be encoded as a form field. Thanks, @djedi-knight!
+- [#6279](https://github.com/grafana/k6/pull/6279) Fixes browser tests stalling when VUs share a remote Chrome instance, so pages can run concurrently.
+- [#6298](https://github.com/grafana/k6/pull/6298) Preserves browser trace spans that were lost when a test ended. Thanks, @mem!
+- [#6385](https://github.com/grafana/k6/pull/6385) Fixes an integer overflow that prevented compilation on 32-bit ARM and x86 systems. Thanks, @GourangaDasSamrat!
 
 ## Maintenance and internal improvements
 
-_Format as `<number> <present_verb> <object>. <credit>`_:
+- [#6369](https://github.com/grafana/k6/pull/6369), [#6370](https://github.com/grafana/k6/pull/6370) Adds the binary's build origin and a locally stored random installation ID to usage reports, helping distinguish build sources and measure active installations. Both respect `--no-usage-report`.
+- [#6209](https://github.com/grafana/k6/pull/6209) Simplifies the internal handling of Cloud commands. Thanks, @moko-poi!
+- [#6236](https://github.com/grafana/k6/pull/6236) Adds a smoke test before publishing browser Docker images to catch missing or broken Chromium installations.
+- [#6245](https://github.com/grafana/k6/pull/6245) Enables CI on the v1 maintenance branch.
+- [#6246](https://github.com/grafana/k6/pull/6246), [#6277](https://github.com/grafana/k6/pull/6277) Automates approvals and merging for eligible dependency updates.
+- [#6256](https://github.com/grafana/k6/pull/6256), [#6271](https://github.com/grafana/k6/pull/6271) Improves contributor acknowledgments and the release checklist.
+- [#6270](https://github.com/grafana/k6/pull/6270) Restores Debian package publishing after `bzip2` was removed from the packaging base image.
+- [#6301](https://github.com/grafana/k6/pull/6301), [#6373](https://github.com/grafana/k6/pull/6373) Corrects the TC39 test-package path and built-in module locations in contributor documentation. Thanks, @umekikazuya and @ashrafiucse!
+- [#6312](https://github.com/grafana/k6/pull/6312), [#6380](https://github.com/grafana/k6/pull/6380) Updates the shared CI workflow and adopts its centrally maintained lint configuration.
+- [#6325](https://github.com/grafana/k6/pull/6325) Moves browser option parsing into the JavaScript mapping layer without changing script behavior. Thanks, @Shobhit-Nagpal!
+- [#6265](https://github.com/grafana/k6/pull/6265), [#6267](https://github.com/grafana/k6/pull/6267), [#6303](https://github.com/grafana/k6/pull/6303), [#6304](https://github.com/grafana/k6/pull/6304), [#6331](https://github.com/grafana/k6/pull/6331), [#6332](https://github.com/grafana/k6/pull/6332), [#6357](https://github.com/grafana/k6/pull/6357), [#6358](https://github.com/grafana/k6/pull/6358), [#6363](https://github.com/grafana/k6/pull/6363), [#6367](https://github.com/grafana/k6/pull/6367), [#6383](https://github.com/grafana/k6/pull/6383) Updates the Docker build image to Go 1.27.0, raises the module's minimum Go version to 1.26.0, and updates gRPC to v1.83.2 (including the example server), OpenTelemetry to v1.46.0, Brotli to v1.2.3, esbuild to v0.28.2, Testify to v1.12.1, Protobuf to v1.36.12, `golang.org/x/crypto` to v0.56.0, and related Go dependencies.
 
-- _`#2770` Refactors parts of the JS module._
+## External contributors
 
-## _Optional_ Roadmap
-
-_Discussion of future plans_
+Thanks to @adarshsm, @ashrafiucse, @djedi-knight, @GourangaDasSamrat, @mem, @moko-poi, @o6ivp, @rohan-patnaik, @Shobhit-Nagpal, @Swapnil-Biswas, @umekikazuya, and @vtorosyan for their contributions.

--- a/release notes/v2.3.0.md
+++ b/release notes/v2.3.0.md
@@ -8,19 +8,16 @@ k6 `v2.3.0` is here 🎉! This release includes:
 
 ### Run a script once with `--once` [#6338](https://github.com/grafana/k6/pull/6338)
 
-The `--once` flag is now the recommended way to run a script once, for both protocol and browser tests. It runs one VU for one iteration while keeping your scenario's function, environment, tags, and browser options, so browser tests can also run once without rewriting their configuration.
-
-For example, a script might configure its `checkout()` function to run 100 iterations across ten VUs:
+The `--once` flag is now the recommended way to run a script once, for both protocol and browser tests, while preserving the scenario's function and browser configuration. It supports scripts with at most one scenario and works with `k6 run`, `k6 cloud run`, and `k6 archive`. For example, this configuration runs `checkout()` repeatedly with ten VUs for 30 seconds:
 
 ```js
 export const options = {
   scenarios: {
     checkout: {
-      executor: 'shared-iterations',
+      executor: 'constant-vus',
       exec: 'checkout',
       vus: 10,
-      iterations: 100,
-      tags: { flow: 'checkout' },
+      duration: '30s',
     },
   },
 };
@@ -31,11 +28,7 @@ export const options = {
 k6 run --once script.js
 ```
 
-This calls `checkout()` once with one VU instead of running 100 iterations, and keeps the `flow: checkout` tag. For a browser scenario, its browser options are kept too, so Chromium can still launch.
-
-It supports scripts with at most one scenario and also works with `k6 cloud run` and `k6 archive`.
-
-Previously, using shortcuts such as `--vus 1 --iterations 1` replaced the script's scenarios with a default scenario, discarding settings such as the selected function and browser options. Browser scripts then failed because the configuration needed to launch Chromium was missing.
+With `--once`, k6 changes this scenario to `shared-iterations` with one VU and one iteration, calling `checkout()` once instead of repeatedly for 30 seconds. Previously, shortcuts such as `--vus 1 --iterations 1` replaced the script's scenarios with a default scenario, discarding settings such as the selected function and browser options. This broke browser scripts because the configuration needed to launch Chromium was missing; `--once` keeps that configuration.
 
 ### Fetch missing TLS certificates [#6137](https://github.com/grafana/k6/pull/6137)
 

--- a/release notes/v2.3.0.md
+++ b/release notes/v2.3.0.md
@@ -1,14 +1,66 @@
 k6 `v2.3.0` is here 🎉! This release includes:
 
+- A `--scenario` flag to run selected parts of a test without editing the script.
 - A `--once` flag to reuse load-test scripts for smoke and functional testing.
 - Opt-in fetching of missing TLS certificates for servers that work in browsers but fail in k6.
 - Static labels for Prometheus remote write, nanosecond log timestamps, and WebSocket ready-state constants.
 
 ## New features
 
+### Run selected scenarios [#6360](https://github.com/grafana/k6/pull/6360)
+
+When a script tests several services or user journeys, you may only need to run the part you are working on. The new `--scenario` flag lets you select named scenarios without editing the script, adding environment-variable selection code, or splitting it into separate scripts. This addresses the long-standing [request to run a subset of scenarios](https://github.com/grafana/k6/issues/2780).
+
+For example, this script defines two workloads:
+
+```js
+import http from 'k6/http';
+
+export const options = {
+  scenarios: {
+    homepage: {
+      executor: 'shared-iterations',
+      exec: 'homepage',
+      vus: 2,
+      iterations: 10,
+    },
+    contacts: {
+      executor: 'shared-iterations',
+      exec: 'contacts',
+      vus: 1,
+      iterations: 5,
+    },
+  },
+};
+
+export function homepage() {
+  http.get('https://test.k6.io/');
+}
+
+export function contacts() {
+  http.get('https://test.k6.io/contacts.php');
+}
+```
+
+Run only the homepage workload, keeping its two VUs and ten total iterations:
+
+```shell
+k6 run --scenario homepage script.js
+```
+
+Select multiple scenarios with comma-separated names:
+
+```shell
+k6 run --scenario homepage,contacts script.js
+```
+
+Each selected scenario keeps its executor, load, timing, function, environment, tags, and browser options. Without the flag, k6 runs all configured scenarios. Selection also works with `k6 cloud run` and `k6 archive`; archives retain the selected configuration.
+
+Names must match configured scenarios. Load shortcuts such as `--vus` and `--duration` cannot be combined with selection; set the workload in each scenario instead. k6 warns and skips thresholds tagged for configured scenarios you exclude, while keeping global thresholds and other filters. See the [scenario documentation](https://grafana.com/docs/k6/next/using-k6/scenarios/#run-selected-scenarios) for details.
+
 ### Run a script once with `--once` [#6338](https://github.com/grafana/k6/pull/6338)
 
-The `--once` flag is now the recommended way to run a script once, for both protocol and browser tests, while preserving the scenario's function and browser configuration. It supports scripts with at most one scenario and works with `k6 run`, `k6 cloud run`, and `k6 archive`. For example, this configuration runs `checkout()` repeatedly with ten VUs for 30 seconds:
+The `--once` flag is now the recommended way to run a script once, for both protocol and browser tests, while preserving the scenario's function and browser configuration. Used alone, it supports scripts with at most one scenario and works with `k6 run`, `k6 cloud run`, and `k6 archive`. For example, this configuration runs `checkout()` repeatedly with ten VUs for 30 seconds:
 
 ```js
 export const options = {
@@ -29,6 +81,17 @@ k6 run --once script.js
 ```
 
 With `--once`, k6 changes this scenario to `shared-iterations` with one VU and one iteration, calling `checkout()` once instead of repeatedly for 30 seconds. Previously, shortcuts such as `--vus 1 --iterations 1` replaced the script's scenarios with a default scenario, discarding settings such as the selected function and browser options. This broke browser scripts because the configuration needed to launch Chromium was missing; `--once` keeps that configuration.
+
+#### Combine scenario selection with `--once`
+
+After choosing which scenarios to run, add `--once` for a smoke or functional test. Using the two-scenario script above:
+
+```shell
+k6 run --scenario homepage --once script.js
+k6 run --scenario homepage,contacts --once script.js
+```
+
+The first command runs `homepage()` once with one VU. The second runs each selected scenario once with its own VU, for two iterations in total. Each keeps its function, environment, tags, and browser options, so you can also reuse browser scenarios this way. `--once` replaces their load and timing settings; selection alone preserves them. Bare `--once` still rejects scripts with multiple scenarios until you select which ones to run.
 
 ### Fetch missing TLS certificates [#6137](https://github.com/grafana/k6/pull/6137)
 

--- a/release notes/v2.3.0.md
+++ b/release notes/v2.3.0.md
@@ -58,9 +58,20 @@ Each selected scenario keeps its executor, load, timing, function, environment, 
 
 Names must match configured scenarios. Load shortcuts such as `--vus` and `--duration` cannot be combined with selection; set the workload in each scenario instead. k6 warns and skips thresholds tagged for configured scenarios you exclude, while keeping global thresholds and other filters. See the [scenario documentation](https://grafana.com/docs/k6/next/using-k6/scenarios/#run-selected-scenarios) for details.
 
+#### Combine scenario selection with `--once`
+
+After choosing which scenarios to run, add `--once` for a smoke or functional test. Using the two-scenario script above:
+
+```shell
+k6 run --scenario homepage --once script.js
+k6 run --scenario homepage,contacts --once script.js
+```
+
+The first command runs `homepage()` once with one VU. The second runs each selected scenario once with its own VU, for two iterations in total. Each keeps its function, environment, tags, and browser options, so you can also reuse browser scenarios this way. `--once` replaces their load and timing settings; selection alone preserves them. Bare `--once` still rejects scripts with multiple scenarios until you select which ones to run.
+
 ### Run a script once with `--once` [#6338](https://github.com/grafana/k6/pull/6338)
 
-The `--once` flag is now the recommended way to run a script once, for both protocol and browser tests, while preserving the scenario's function and browser configuration. Used alone, it supports scripts with at most one scenario and works with `k6 run`, `k6 cloud run`, and `k6 archive`. For example, this configuration runs `checkout()` repeatedly with ten VUs for 30 seconds:
+The `--once` flag is now the recommended way to run a script once, for both protocol and browser tests, while preserving the scenario's function and browser configuration. It supports scripts with at most one scenario and works with `k6 run`, `k6 cloud run`, and `k6 archive`. For example, this configuration runs `checkout()` repeatedly with ten VUs for 30 seconds:
 
 ```js
 export const options = {
@@ -81,17 +92,6 @@ k6 run --once script.js
 ```
 
 With `--once`, k6 changes this scenario to `shared-iterations` with one VU and one iteration, calling `checkout()` once instead of repeatedly for 30 seconds. Previously, shortcuts such as `--vus 1 --iterations 1` replaced the script's scenarios with a default scenario, discarding settings such as the selected function and browser options. This broke browser scripts because the configuration needed to launch Chromium was missing; `--once` keeps that configuration.
-
-#### Combine scenario selection with `--once`
-
-After choosing which scenarios to run, add `--once` for a smoke or functional test. Using the two-scenario script above:
-
-```shell
-k6 run --scenario homepage --once script.js
-k6 run --scenario homepage,contacts --once script.js
-```
-
-The first command runs `homepage()` once with one VU. The second runs each selected scenario once with its own VU, for two iterations in total. Each keeps its function, environment, tags, and browser options, so you can also reuse browser scenarios this way. `--once` replaces their load and timing settings; selection alone preserves them. Bare `--once` still rejects scripts with multiple scenarios until you select which ones to run.
 
 ### Fetch missing TLS certificates [#6137](https://github.com/grafana/k6/pull/6137)
 


### PR DESCRIPTION
## What?

Documents the changes merged for k6 v2.3.0, with automatic dependency updates grouped last.

## Why?

Keeps the release draft current as changes land and gives reviewers one place to check release coverage.

## Related PR(s)/Issue(s)

- #6255
