### PR TITLE
fix(browser): update Request fields overridden by route.continue 🤖🤖🤖

### DIFF
--- a/internal/js/modules/k6/browser/common/http.go
+++ b/internal/js/modules/k6/browser/common/http.go
@@ -70,18 +70,22 @@ type RequestFailure struct {
 
 // Request represents a browser HTTP request.
 type Request struct {
-	ctx            context.Context
-	frame          *Frame
-	responseMu     sync.RWMutex
-	response       *Response
-	redirectChain  []*Request
-	requestID      network.RequestID
-	documentID     string
-	url            *url.URL
-	method         string
-	headers        map[string][]string
-	extraHeaders   map[string][]string
-	extraHeadersMu sync.RWMutex
+	ctx           context.Context
+	frame         *Frame
+	responseMu    sync.RWMutex
+	response      *Response
+	redirectChain []*Request
+	requestID     network.RequestID
+	documentID    string
+	url           *url.URL
+	method        string
+	headers       map[string][]string
+	extraHeaders  map[string][]string
+	// mu guards headers, extraHeaders, method, postDataEntries and url: an
+	// ExtraInfo CDP event can set the raw headers, and route.continue can
+	// override any of these fields, potentially from a different goroutine
+	// than the one reading them.
+	mu sync.RWMutex
 	// rawHeadersCh is closed once the raw (ExtraInfo) headers have been
 	// resolved: either applied, or known not to arrive. Readers that need the
 	// raw headers wait on it; see waitForRawHeaders.
@@ -223,10 +227,38 @@ func validateResourceType(logger *log.Logger, t string) string {
 }
 
 func (r *Request) addExtraHeaders(extra map[string][]string) {
-	r.extraHeadersMu.Lock()
+	r.mu.Lock()
 	r.extraHeaders = extra
-	r.extraHeadersMu.Unlock()
+	r.mu.Unlock()
 	r.resolveRawHeaders()
+}
+
+// applyContinueOverrides updates the request's in-memory representation with
+// the values overridden through route.continue, so that later reads (e.g.
+// from a "response" event handler) reflect what was actually sent to the
+// server instead of the request's original, unmodified values.
+func (r *Request) applyContinueOverrides(opts ContinueOptions) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if len(opts.Headers) > 0 {
+		headers := make(map[string][]string, len(opts.Headers))
+		for _, h := range opts.Headers {
+			headers[h.Name] = append(headers[h.Name], h.Value)
+		}
+		r.headers = headers
+	}
+	if opts.Method != "" {
+		r.method = opts.Method
+	}
+	if len(opts.PostData) > 0 {
+		r.postDataEntries = []string{string(opts.PostData)}
+	}
+	if opts.URL != "" {
+		if u, err := url.Parse(opts.URL); err == nil {
+			r.url = u
+		}
+	}
 }
 
 // resolveRawHeaders unblocks readers waiting for the raw (ExtraInfo) headers.
@@ -257,12 +289,13 @@ func (r *Request) getDocumentID() string {
 	return r.documentID
 }
 
-func (r *Request) headersSize() int64 {
+// headersSizeLocked computes the header size and requires the caller to
+// already hold r.mu (for reading).
+func (r *Request) headersSizeLocked() int64 {
 	size := 4 // 4 = 2 spaces + 2 line breaks (GET /path \r\n)
 	size += len(r.method)
 	size += len(r.url.Path)
 	size += 8 // httpVersion
-	r.extraHeadersMu.RLock()
 	if len(r.extraHeaders) != 0 {
 		for name, values := range r.extraHeaders {
 			for _, value := range values {
@@ -276,7 +309,6 @@ func (r *Request) headersSize() int64 {
 			}
 		}
 	}
-	r.extraHeadersMu.RUnlock()
 	return int64(size)
 }
 
@@ -299,7 +331,7 @@ func (r *Request) setLoadedFromCache(fromMemoryCache bool) {
 // AllHeaders returns all the request headers.
 func (r *Request) AllHeaders() map[string]string {
 	headers := make(map[string]string)
-	r.extraHeadersMu.RLock()
+	r.mu.RLock()
 	if len(r.extraHeaders) != 0 {
 		for name, values := range r.extraHeaders {
 			headers[strings.ToLower(name)] = strings.Join(values, "\n")
@@ -309,7 +341,7 @@ func (r *Request) AllHeaders() map[string]string {
 			headers[strings.ToLower(name)] = strings.Join(values, "\n")
 		}
 	}
-	r.extraHeadersMu.RUnlock()
+	r.mu.RUnlock()
 	return headers
 }
 
@@ -327,6 +359,9 @@ func (r *Request) HeaderValue(name string) (string, bool) {
 
 // Headers returns the request headers.
 func (r *Request) Headers() map[string]string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	headers := make(map[string]string)
 	for n, v := range r.headers {
 		headers[n] = strings.Join(v, ",")
@@ -337,7 +372,7 @@ func (r *Request) Headers() map[string]string {
 // HeadersArray returns the request headers as an array of objects.
 func (r *Request) HeadersArray() []HTTPHeader {
 	headers := make([]HTTPHeader, 0)
-	r.extraHeadersMu.RLock()
+	r.mu.RLock()
 	source := r.headers
 	if len(r.extraHeaders) != 0 {
 		source = r.extraHeaders
@@ -347,7 +382,7 @@ func (r *Request) HeadersArray() []HTTPHeader {
 			headers = append(headers, HTTPHeader{Name: name, Value: v})
 		}
 	}
-	r.extraHeadersMu.RUnlock()
+	r.mu.RUnlock()
 	return headers
 }
 
@@ -358,6 +393,8 @@ func (r *Request) IsNavigationRequest() bool {
 
 // Method returns the request method.
 func (r *Request) Method() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.method
 }
 
@@ -370,6 +407,9 @@ func (r *Request) Method() string {
 // TODO: Create a PostDataEntries API when we have a better idea of when that
 // is needed.
 func (r *Request) PostData() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	if len(r.postDataEntries) > 0 {
 		return r.postDataEntries[0]
 	}
@@ -386,6 +426,9 @@ func (r *Request) PostData() string {
 // TODO: Create a PostDataEntries API when we have a better idea of when that
 // is needed.
 func (r *Request) PostDataBuffer() []byte {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	if len(r.postDataEntries) > 0 {
 		return []byte(r.postDataEntries[0])
 	}
@@ -405,13 +448,16 @@ func (r *Request) Response() *Response {
 
 // Size returns the size of the request.
 func (r *Request) Size() HTTPMessageSize {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
 	var b int64
 	for _, p := range r.postDataEntries {
 		b += int64(len(p))
 	}
 	return HTTPMessageSize{
 		Body:    b,
-		Headers: r.headersSize(),
+		Headers: r.headersSizeLocked(),
 	}
 }
 
@@ -451,7 +497,17 @@ func (r *Request) Timing() *resourceTiming {
 
 // URL returns the request URL.
 func (r *Request) URL() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.url.String()
+}
+
+// parsedURL returns the request's URL, guarded by the same lock that
+// protects it against a concurrent route.continue override.
+func (r *Request) parsedURL() *url.URL {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.url
 }
 
 // RemoteAddress contains informationa about a remote target.
@@ -681,7 +737,7 @@ func (r *Response) bodySize() int64 {
 
 	if err := r.fetchBody(); err != nil {
 		r.logger.Debugf("Response:bodySize:fetchBody",
-			"url:%s method:%s err:%s", r.url, r.request.method, err)
+			"url:%s method:%s err:%s", r.url, r.request.Method(), err)
 	}
 
 	r.bodyMu.RLock()
@@ -891,7 +947,13 @@ func (r *Route) Continue(opts ContinueOptions) error {
 		return err
 	}
 
-	return r.networkManager.ContinueRequest(r.request.interceptionID, opts, r.request.HeadersArray())
+	if err := r.networkManager.ContinueRequest(r.request.interceptionID, opts, r.request.HeadersArray()); err != nil {
+		return err
+	}
+
+	r.request.applyContinueOverrides(opts)
+
+	return nil
 }
 
 // Fulfill fulfills the request with the given options for the response.

--- a/internal/js/modules/k6/browser/common/http_test.go
+++ b/internal/js/modules/k6/browser/common/http_test.go
@@ -95,6 +95,73 @@ func TestRequest(t *testing.T) {
 	})
 }
 
+func TestRequestApplyContinueOverrides(t *testing.T) {
+	t.Parallel()
+
+	ts := cdp.MonotonicTime(time.Now())
+	wt := cdp.TimeSinceEpoch(time.Now())
+	evt := &network.EventRequestWillBeSent{
+		RequestID: network.RequestID("1234"),
+		Request: &network.Request{
+			URL:     "https://test/original",
+			Method:  "GET",
+			Headers: network.Headers(map[string]any{"key": "value"}),
+		},
+		Timestamp: &ts,
+		WallTime:  &wt,
+	}
+	vu := k6test.NewVU(t)
+	req, err := NewRequest(vu.Context(), log.NewNullLogger(), NewRequestParams{
+		event:          evt,
+		interceptionID: "intercept",
+	})
+	require.NoError(t, err)
+
+	req.applyContinueOverrides(ContinueOptions{
+		Headers:  []HTTPHeader{{Name: "foo", Value: "bar"}},
+		Method:   "POST",
+		PostData: []byte(`{"a":1}`),
+		URL:      "https://test/overridden",
+	})
+
+	assert.Equal(t, "POST", req.Method())
+	assert.Equal(t, `{"a":1}`, req.PostData())
+	assert.Equal(t, "https://test/overridden", req.URL())
+	assert.Equal(t, map[string]string{"foo": "bar"}, req.Headers())
+}
+
+func TestRequestApplyContinueOverridesNoop(t *testing.T) {
+	t.Parallel()
+
+	ts := cdp.MonotonicTime(time.Now())
+	wt := cdp.TimeSinceEpoch(time.Now())
+	evt := &network.EventRequestWillBeSent{
+		RequestID: network.RequestID("1234"),
+		Request: &network.Request{
+			URL:     "https://test/original",
+			Method:  "GET",
+			Headers: network.Headers(map[string]any{"key": "value"}),
+		},
+		Timestamp: &ts,
+		WallTime:  &wt,
+	}
+	vu := k6test.NewVU(t)
+	req, err := NewRequest(vu.Context(), log.NewNullLogger(), NewRequestParams{
+		event:          evt,
+		interceptionID: "intercept",
+	})
+	require.NoError(t, err)
+
+	// An empty ContinueOptions (e.g. route.continue() with no overrides)
+	// must leave the request's original values untouched.
+	req.applyContinueOverrides(ContinueOptions{})
+
+	assert.Equal(t, "GET", req.Method())
+	assert.Equal(t, "", req.PostData())
+	assert.Equal(t, "https://test/original", req.URL())
+	assert.Equal(t, map[string]string{"key": "value"}, req.Headers())
+}
+
 func TestResponse(t *testing.T) {
 	t.Parallel()
 

--- a/internal/js/modules/k6/browser/common/network_manager.go
+++ b/internal/js/modules/k6/browser/common/network_manager.go
@@ -215,10 +215,10 @@ func (m *NetworkManager) emitRequestMetrics(req *Request) {
 
 	tags := state.Tags.GetCurrentValues().Tags
 	if state.Options.SystemTags.Has(k6metrics.TagMethod) {
-		tags = tags.With("method", req.method)
+		tags = tags.With("method", req.Method())
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		tags = handleURLTag(m.eventInterceptor, req.URL(), req.method, tags)
+		tags = handleURLTag(m.eventInterceptor, req.URL(), req.Method(), tags)
 	}
 	tags = tags.With("resource_type", req.ResourceType())
 
@@ -243,7 +243,7 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 		status, bodySize                    int64
 		ipAddress, protocol                 string
 		fromCache, fromPreCache, fromSvcWrk bool
-		url                                 = req.url.String()
+		url                                 = req.URL()
 		wallTime                            = time.Now()
 		failed                              float64
 	)
@@ -264,15 +264,15 @@ func (m *NetworkManager) emitResponseMetrics(resp *Response, req *Request) {
 		}
 	} else {
 		m.logger.Debugf("NetworkManager:emitResponseMetrics",
-			"response is nil url:%s method:%s", req.url, req.method)
+			"response is nil url:%s method:%s", req.URL(), req.Method())
 	}
 
 	tags := state.Tags.GetCurrentValues().Tags
 	if state.Options.SystemTags.Has(k6metrics.TagMethod) {
-		tags = tags.With("method", req.method)
+		tags = tags.With("method", req.Method())
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagURL) {
-		tags = handleURLTag(m.eventInterceptor, url, req.method, tags)
+		tags = handleURLTag(m.eventInterceptor, url, req.Method(), tags)
 	}
 	if state.Options.SystemTags.Has(k6metrics.TagIP) {
 		tags = tags.With("ip", ipAddress)
@@ -469,7 +469,7 @@ func (m *NetworkManager) onLoadingFinished(event *network.EventLoadingFinished) 
 	m.eventInterceptor.onRequestFinished(req)
 
 	// Skip data and blob URLs when emitting metrics, since they're internal to the browser.
-	if isInternalURL(req.url) {
+	if isInternalURL(req.parsedURL()) {
 		return
 	}
 	// Emit the response metrics in a separate goroutine, once the raw headers


### PR DESCRIPTION
## What?

Updates the browser module's in-memory `Request` object with the header,
method, post data, and URL values overridden through `route.continue()`, and
adds the locking needed to read/write those fields safely now that they can
change after the request is created.

## Why?

When a `page.route()` handler called `route.continue({...})` to override a
request's headers/method/postData/url, the overridden request was correctly
sent to the server via CDP, but k6's own `Request` object (e.g. the one
returned by `response.request()` in a `page.on('response', ...)` handler)
kept showing the original, pre-override values. This made it impossible to
assert on what was actually sent when using request interception.

This only addresses `route.continue()`, which is what the issue's
reproduction script exercises. `route.fulfill()` never sends a request at
all, so it is a separate case not covered by this change.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- Report: https://github.com/grafana/k6/issues/5012

Fixes #5012