### PR TITLE
browser: recover panics from background CDP event goroutines 🤖🤖🤖

### DIFF
--- a/internal/js/modules/k6/browser/common/browser.go
+++ b/internal/js/modules/k6/browser/common/browser.go
@@ -222,6 +222,7 @@ func (b *Browser) initEvents() error {
 	}, chHandler)
 
 	go func() {
+		defer recoverGoroutinePanic(b.logger, "Browser:initEvents:go")
 		defer func() {
 			b.browserProc.didLoseConnection()
 			// Closing the vuCtx incase it hasn't already been closed. Very likely

--- a/internal/js/modules/k6/browser/common/frame_session.go
+++ b/internal/js/modules/k6/browser/common/frame_session.go
@@ -251,6 +251,7 @@ func (fs *FrameSession) initEvents() {
 	fs.wg.Go(func() {
 		fs.logger.Debugf("NewFrameSession:initEvents:go",
 			"sid:%v tid:%v", fs.session.ID(), fs.targetID)
+		defer recoverGoroutinePanic(fs.logger, "FrameSession:initEvents:go")
 		defer func() {
 			// If there is an active span for main frame,
 			// end it before exiting so it can be flushed
@@ -276,7 +277,6 @@ func (fs *FrameSession) initEvents() {
 			case <-fs.ctx.Done():
 				fs.logger.Debugf("FrameSession:initEvents:go:ctx.Done",
 					"sid:%v tid:%v", fs.session.ID(), fs.targetID)
-
 				return
 			case event := <-fs.eventCh:
 				switch ev := event.data.(type) {

--- a/internal/js/modules/k6/browser/common/helpers.go
+++ b/internal/js/modules/k6/browser/common/helpers.go
@@ -305,6 +305,20 @@ func hasSourceURL(js string) bool {
 	return sourceURLRegex.MatchString(js[lastNewLineBeforeLastLineIndex:])
 }
 
+// recoverGoroutinePanic recovers from a panic on the goroutine it's deferred
+// on and logs it instead of letting it propagate. It must be deferred
+// directly by long-running background goroutines that process CDP events
+// (e.g. FrameSession's and Browser's event loops), which don't run within a
+// sobek call stack and so can't rely on the JS runtime to catch a panic
+// raised by k6ext.Panicf/k6ext.Abortf when a CDP event handler fails.
+// Without this, such a panic is unrecovered anywhere and crashes the whole
+// k6 process, aborting every VU rather than just the affected iteration.
+func recoverGoroutinePanic(logger *log.Logger, category string) {
+	if r := recover(); r != nil {
+		logger.Errorf(category, "recovered from a panic on a background goroutine: %v", r)
+	}
+}
+
 // pushIfNotDone preserves PushIfNotDone semantics and logs when
 // a metric drop is observed because the provided context is done.
 func pushIfNotDone(

--- a/internal/js/modules/k6/browser/common/helpers_test.go
+++ b/internal/js/modules/k6/browser/common/helpers_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/cdproto/runtime"
+	logtest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"go.k6.io/k6/v2/internal/js/modules/k6/browser/log"
@@ -263,4 +265,28 @@ func TestHasSourceURL(t *testing.T) {
 			require.Equal(t, c.result, hasSourceURL(c.js))
 		})
 	}
+}
+
+func TestRecoverGoroutinePanic(t *testing.T) {
+	t.Parallel()
+
+	logrusLogger, hook := logtest.NewNullLogger()
+	logger := log.New(logrusLogger, "")
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		defer recoverGoroutinePanic(logger, "test:category")
+		panic("boom")
+	}()
+
+	// If recoverGoroutinePanic didn't stop the panic, this goroutine (and
+	// the whole test binary) would have already crashed by now instead of
+	// reaching this point.
+	<-done
+
+	entry := hook.LastEntry()
+	require.NotNil(t, entry)
+	assert.Equal(t, "test:category", entry.Data["category"])
+	assert.Contains(t, entry.Message, "boom")
 }


### PR DESCRIPTION
## What?

Recover panics raised from the two background CDP-event-dispatch goroutines in the browser module (`FrameSession.initEvents`'s `fs.wg.Go(...)` loop in `internal/js/modules/k6/browser/common/frame_session.go`, and `Browser.initEvents`'s `go func() {...}` loop in `internal/js/modules/k6/browser/common/browser.go`), instead of letting them crash the entire k6 process.

## Why?

`k6ext.Panicf` (`internal/js/modules/k6/browser/k6ext/panic.go`) kills the browser's OS process(es) and then does a raw Go `panic()`, which is designed to be caught by the sobek JS runtime's own call-stack unwinding when `Panicf` is invoked from JS-mapping code. However, `Panicf` is also called from several handlers (`onFrameDetached`, `onFrameNavigated`, `onAttachedToTarget`'s error path, etc.) that run on dedicated background goroutines which never execute any JS. In Go, an unrecovered panic on any goroutine crashes the whole process, not just that goroutine — so a single internal CDP bookkeeping error in one VU's browser session (for example while a navigation is stalled waiting on `networkidle`, as in the reproduction) can currently abort the entire k6 test run for every VU, not just fail the one affected iteration. This also explains why the failure could not be caught with `try`/`catch`/`finally` in the reported script: the panic never touches the JS call stack at all.

This change does not touch the `networkidle` timeout itself, which is legitimate Chromium behavior (the CDP `networkIdle` lifecycle event genuinely may not fire while background requests keep the network non-idle) and is not a bug. It also does not make the resulting browser-session failure surface as a catchable rejection in the user's script — recovering the panic here only prevents it from taking down the whole k6 process; the affected iteration may still fail or hang until its own timeout, since the browser process backing it is already gone. That is a narrower, but still real and worthwhile, improvement: a recovered panic that masks the underlying error rather than crashing unrelated VUs, not a full fix for graceful error propagation.

Report: https://github.com/grafana/k6/issues/5092

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] I have added tests for my changes.
- [x] I have run linter and tests locally (`make check`) and all pass.

## Checklist: Documentation (only for k6 maintainers and if relevant)

**Please do not merge this PR until the following items are filled out.**

- [ ] I have added the correct milestone and labels to the PR.
- [ ] I have updated the release notes: _link_
- [ ] I have updated or added an issue to the [k6-documentation](https://github.com/grafana/k6-docs): grafana/k6-docs#NUMBER if applicable
- [ ] I have updated or added an issue to the [TypeScript definitions](https://github.com/grafana/k6-DefinitelyTyped/tree/master/types/k6): grafana/k6-DefinitelyTyped#NUMBER if applicable

## Related PR(s)/Issue(s)

- https://github.com/grafana/k6/issues/5092

Fixes #5092