### PR TITLE
webcrypto: fix ecdsa X/Y/D staticcheck deprecations

### DIFF
--- a/internal/js/modules/k6/webcrypto/elliptic_curve.go
+++ b/internal/js/modules/k6/webcrypto/elliptic_curve.go
@@ -225,16 +225,12 @@ func importECDSAPublicKey(curve EllipticCurveKind, keyData []byte) (any, CryptoK
 		return nil, UnknownCryptoKeyType, NewError(NotSupportedError, "invalid elliptic curve "+string(curve))
 	}
 
-	x, y := elliptic.Unmarshal(c, keyData) //nolint:staticcheck // we need to use the Unmarshal function
-	if x == nil {
+	pk, err := ecdsa.ParseUncompressedPublicKey(c, keyData)
+	if err != nil {
 		return nil, UnknownCryptoKeyType, NewError(DataError, "unable to import ECDSA public key data")
 	}
 
-	return &ecdsa.PublicKey{
-		Curve: c,
-		X:     x,
-		Y:     y,
-	}, PublicCryptoKeyType, nil
+	return pk, PublicCryptoKeyType, nil
 }
 
 // ECKeyGenParams  represents the object that should be passed as the algorithm
@@ -480,7 +476,12 @@ func extractPublicKeyBytes(alg string, handle any) ([]byte, error) {
 			return nil, NewError(OperationError, "key data isn't a valid elliptic curve public key")
 		}
 
-		return elliptic.Marshal(k.Curve, k.X, k.Y), nil //nolint:staticcheck // we need to use the Marshal function
+		b, err := k.Bytes()
+		if err != nil {
+			return nil, fmt.Errorf("marshaling ECDSA public key: %w", err)
+		}
+
+		return b, nil
 	}
 
 	return nil, errors.New("unsupported algorithm " + alg)
@@ -682,40 +683,45 @@ func (edsa *ECDSAParams) Verify(key CryptoKey, signature []byte, data []byte) (b
 }
 
 func convertECDHtoECDSAKey(k *ecdh.PrivateKey) (*ecdsa.PrivateKey, error) {
-	pk, err := convertPublicECDHtoECDSA(k.PublicKey())
+	crv, err := ecdhToEllipticCurve(k.Curve())
 	if err != nil {
 		return nil, err
 	}
 
-	return &ecdsa.PrivateKey{
-		PublicKey: *pk,
-		D:         new(big.Int).SetBytes(k.Bytes()),
-	}, nil
+	pk, err := ecdsa.ParseRawPrivateKey(crv, k.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("unable to convert ECDH private key to ECDSA private key, curve: %s", crv.Params().Name)
+	}
+
+	return pk, nil
 }
 
 func convertPublicECDHtoECDSA(k *ecdh.PublicKey) (*ecdsa.PublicKey, error) {
-	var crv elliptic.Curve
-	switch k.Curve() {
-	case ecdh.P256():
-		crv = elliptic.P256()
-	case ecdh.P384():
-		crv = elliptic.P384()
-	case ecdh.P521():
-		crv = elliptic.P521()
-	default:
-		return nil, errors.New("curve not supported for converting to ECDSA key")
+	crv, err := ecdhToEllipticCurve(k.Curve())
+	if err != nil {
+		return nil, err
 	}
 
-	x, y := elliptic.Unmarshal(crv, k.Bytes()) //nolint:staticcheck // we need to use the Unmarshal function
-	if x == nil {
+	pk, err := ecdsa.ParseUncompressedPublicKey(crv, k.Bytes())
+	if err != nil {
 		return nil, fmt.Errorf("unable to convert ECDH public key to ECDSA public key, curve: %s", crv.Params().Name)
 	}
 
-	return &ecdsa.PublicKey{
-		Curve: crv,
-		X:     x,
-		Y:     y,
-	}, nil
+	return pk, nil
+}
+
+// ecdhToEllipticCurve maps an ecdh.Curve to its elliptic.Curve equivalent.
+func ecdhToEllipticCurve(c ecdh.Curve) (elliptic.Curve, error) {
+	switch c {
+	case ecdh.P256():
+		return elliptic.P256(), nil
+	case ecdh.P384():
+		return elliptic.P384(), nil
+	case ecdh.P521():
+		return elliptic.P521(), nil
+	default:
+		return nil, errors.New("curve not supported for converting to ECDSA key")
+	}
 }
 
 func ensureKeysUseSameCurve(k1, k2 CryptoKey) error {

--- a/internal/js/modules/k6/webcrypto/jwk.go
+++ b/internal/js/modules/k6/webcrypto/jwk.go
@@ -3,7 +3,6 @@ package webcrypto
 import (
 	"crypto/ecdh"
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"crypto/rsa"
 	"encoding/json"
 	"errors"
@@ -144,75 +143,71 @@ func (jwk *ecJWK) validate() error {
 	return nil
 }
 
-// encodeCurveBigInt encodes the private scalar D of an ECDSA key with padding.
-func encodeCurveBigInt(data *big.Int, curveBits int) string {
-	// Determine the expected byte length for the curve
-	byteLength := curveBits / 8
-	// Add one more byte if the bits are not a multiple of 8
-	if curveBits%8 != 0 {
-		byteLength++
-	}
-
-	dBytes := data.Bytes()
-	dPadded := padLeft(dBytes, byteLength) // Pad if necessary
-
-	return base64URLEncode(dPadded)
-}
-
 // padLeft pads the byte slice with zeros to the left to ensure it has a specific length.
 func padLeft(bytes []byte, size int) []byte {
 	padding := make([]byte, size-len(bytes), size)
 	return append(padding, bytes...)
 }
 
+// toFixedLength pads bytes to size with leading zeros, or returns an error
+// if bytes is already longer than size.
+func toFixedLength(bytes []byte, size int) ([]byte, error) {
+	if len(bytes) > size {
+		return nil, fmt.Errorf("value is %d bytes, want at most %d", len(bytes), size)
+	}
+	return padLeft(bytes, size), nil
+}
+
 func exportECJWK(key *CryptoKey) (any, error) {
 	exported := &JsonWebKey{}
 	exported.Set("kty", JWKECKeyType)
 
-	var x, y, d *big.Int
-	var curveParams *elliptic.CurveParams
+	var pub *ecdsa.PublicKey
+	var priv *ecdsa.PrivateKey
 
 	switch k := key.handle.(type) {
 	case *ecdsa.PrivateKey:
-		x = k.X
-		y = k.Y
-		d = k.D
-		curveParams = k.Params()
+		priv = k
+		pub = &k.PublicKey
 	case *ecdsa.PublicKey:
-		x = k.X
-		y = k.Y
-		curveParams = k.Params()
+		pub = k
 	case *ecdh.PrivateKey:
 		ecdsaKey, err := convertECDHtoECDSAKey(k)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert ECDH key to ECDSA key: %w", err)
 		}
 
-		x = ecdsaKey.X
-		y = ecdsaKey.Y
-		d = ecdsaKey.D
-		curveParams = ecdsaKey.Params()
+		priv = ecdsaKey
+		pub = &ecdsaKey.PublicKey
 	case *ecdh.PublicKey:
 		ecdsaKey, err := convertPublicECDHtoECDSA(k)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert ECDH key to ECDSA key: %w", err)
 		}
 
-		x = ecdsaKey.X
-		y = ecdsaKey.Y
-		curveParams = ecdsaKey.Params()
+		pub = ecdsaKey
 	default:
 		return nil, errors.New("key's handle isn't an ECDSA/ECDH public/private key")
 	}
 
-	exported.Set("crv", curveParams.Name)
-	curveBits := curveParams.BitSize
+	exported.Set("crv", pub.Params().Name)
 
-	exported.Set("x", base64URLEncode(x.Bytes()))
-	exported.Set("y", base64URLEncode(y.Bytes()))
+	// pubBytes is the SEC1 uncompressed point encoding: 0x04 || X || Y,
+	// with X and Y already padded to the curve's coordinate byte length.
+	pubBytes, err := pub.Bytes()
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode public key: %w", err)
+	}
+	coordLen := (len(pubBytes) - 1) / 2
+	exported.Set("x", base64URLEncode(pubBytes[1:1+coordLen]))
+	exported.Set("y", base64URLEncode(pubBytes[1+coordLen:]))
 
-	if d != nil {
-		exported.Set("d", encodeCurveBigInt(d, curveBits))
+	if priv != nil {
+		privBytes, err := priv.Bytes()
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode private key: %w", err)
+		}
+		exported.Set("d", base64URLEncode(privBytes))
 	}
 
 	return exported, nil
@@ -243,10 +238,21 @@ func importECDSAJWK(_ EllipticCurveKind, jsonKeyData []byte) (any, CryptoKeyType
 		return nil, UnknownCryptoKeyType, fmt.Errorf("failed to decode Y coordinate: %w", err)
 	}
 
-	pk := &ecdsa.PublicKey{
-		Curve: crv,
-		X:     new(big.Int).SetBytes(x),
-		Y:     new(big.Int).SetBytes(y),
+	coordLen := (crv.Params().BitSize + 7) / 8
+
+	xPadded, err := toFixedLength(x, coordLen)
+	if err != nil {
+		return nil, UnknownCryptoKeyType, fmt.Errorf("invalid X coordinate: %w", err)
+	}
+	yPadded, err := toFixedLength(y, coordLen)
+	if err != nil {
+		return nil, UnknownCryptoKeyType, fmt.Errorf("invalid Y coordinate: %w", err)
+	}
+
+	uncompressed := append([]byte{0x04}, append(xPadded, yPadded...)...)
+	pk, err := ecdsa.ParseUncompressedPublicKey(crv, uncompressed)
+	if err != nil {
+		return nil, UnknownCryptoKeyType, fmt.Errorf("invalid EC public key coordinates: %w", err)
 	}
 
 	// if the key is a public key, return it
@@ -259,10 +265,17 @@ func importECDSAJWK(_ EllipticCurveKind, jsonKeyData []byte) (any, CryptoKeyType
 		return nil, UnknownCryptoKeyType, fmt.Errorf("failed to decode D: %w", err)
 	}
 
-	return &ecdsa.PrivateKey{
-		PublicKey: *pk,
-		D:         new(big.Int).SetBytes(d),
-	}, PrivateCryptoKeyType, nil
+	dPadded, err := toFixedLength(d, coordLen)
+	if err != nil {
+		return nil, UnknownCryptoKeyType, fmt.Errorf("invalid D: %w", err)
+	}
+
+	priv, err := ecdsa.ParseRawPrivateKey(crv, dPadded)
+	if err != nil {
+		return nil, UnknownCryptoKeyType, fmt.Errorf("invalid EC private key: %w", err)
+	}
+
+	return priv, PrivateCryptoKeyType, nil
 }
 
 func importECDHJWK(_ EllipticCurveKind, jsonKeyData []byte) (any, CryptoKeyType, error) {


### PR DESCRIPTION
## Summary
Stacked on #6394 per review feedback - separates the riskier ECDSA/ECDH refactor from the mechanical lint fixes so it can be reviewed on its own.